### PR TITLE
Recreate swapchain when window is resized on dawn_vulkan backend

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -8,7 +8,7 @@ vars = {
   'chromium_git': 'https://chromium.googlesource.com',
   'github_git': 'https://github.com',
   'dawn_git': 'https://dawn.googlesource.com',
-  'dawn_revision': '49aae0f3bde201d10f1b17d362b0d5b8f85dceb4',
+  'dawn_revision': '9d2ccaf65c2a370c5f203e119e194a44fa039481',
   'imgui_git': 'https://github.com/ocornut',
   'imgui_revision': 'e16564e67a2e88d4cbe3afa6594650712790fba3',
   'angle_root': 'third_party/angle',

--- a/src/aquarium-optimized/dawn/ContextDawn.h
+++ b/src/aquarium-optimized/dawn/ContextDawn.h
@@ -77,6 +77,7 @@ class ContextDawn : public Context
         ProgramDawn *mProgramDawn,
         const dawn::VertexInputDescriptor &mVertexInputDescriptor,
         bool enableBlend) const;
+    dawn::TextureView createMultisampledRenderTargetView() const;
     dawn::TextureView createDepthStencilView() const;
     dawn::Buffer createBuffer(uint32_t size, dawn::BufferUsageBit bit) const;
     void setBufferData(const dawn::Buffer &buffer, uint32_t start, uint32_t size, const void* pixels) const;
@@ -106,7 +107,14 @@ class ContextDawn : public Context
         dawn_native::BackendType backendType,
         const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset);
     void initAvailableToggleBitset(BACKENDTYPE backendType) override;
+    static void framebufferResizeCallback(GLFWwindow *window, int width, int height);
 
+    // TODO(jiawei.shao@intel.com): remove dawn::TextureUsageBit::CopyDst when the bug in Dawn is
+    // fixed.
+    static constexpr dawn::TextureUsageBit kSwapchainBackBufferUsageBit =
+        dawn::TextureUsageBit::OutputAttachment | dawn::TextureUsageBit::CopyDst;
+
+    bool mIsSwapchainOutOfDate = false;
     GLFWwindow *mWindow;
     std::unique_ptr<dawn_native::Instance> mInstance;
 


### PR DESCRIPTION
This patch adds the recreation of the swap chain when we detect the
window is resized on dawn_vulkan backend to workaround a crash issue
when the window is resized but we don't recreate the swap chain.

The swap chain recreation will be enabled on all backends when the
code is ready in Dawn.

Note that Aquarium will crash on Linux when using dawn_vulkan
backend, which needs further investigation.