### PR TITLE
Enable Dynamic Buffer Offset on Dawn D3D12

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -8,7 +8,7 @@ vars = {
   'chromium_git': 'https://chromium.googlesource.com',
   'github_git': 'https://github.com',
   'dawn_git': 'https://dawn.googlesource.com',
-  'dawn_revision': '9d2ccaf65c2a370c5f203e119e194a44fa039481',
+  'dawn_revision': 'bb10a9187623469df7d90db59c88de13fc9a0c5f',
   'imgui_git': 'https://github.com/ocornut',
   'imgui_revision': 'e16564e67a2e88d4cbe3afa6594650712790fba3',
   'angle_root': 'third_party/angle',

--- a/src/aquarium-optimized/dawn/ContextDawn.cpp
+++ b/src/aquarium-optimized/dawn/ContextDawn.cpp
@@ -278,11 +278,7 @@ void ContextDawn::initAvailableToggleBitset(BACKENDTYPE backendType)
 {
     mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEMSAAx4));
     mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS));
-    // DBO on dawn is not supported yet
-    if (backendType != BACKENDTYPE::BACKENDTYPEDAWND3D12)
-    {
-        mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEDYNAMICBUFFEROFFSET));
-    }
+    mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEDYNAMICBUFFEROFFSET));
     mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::DISCRETEGPU));
     mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::INTEGRATEDGPU));
     mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEFULLSCREENMODE));


### PR DESCRIPTION
This patch enables Dynamic Buffer Offset by default on Dawn D3D12
backends because all the required features and bug fixes have been
merged.