### PR TITLE
Fix bug of updating fps of aquarium direct map

### DIFF
--- a/src/aquarium-direct-map/Main.cpp
+++ b/src/aquarium-direct-map/Main.cpp
@@ -499,7 +499,7 @@ void render() {
     }
     then = now;
 
-    g_fpsTimer.update(elapsedTime);
+    g_fpsTimer.update(elapsedTime, 0, 1);
     std::string text =
         "Aquarium FPS: " + std::to_string(static_cast<unsigned int>(g_fpsTimer.getAverageFPS()));
     glfwSetWindowTitle(window, text.c_str());


### PR DESCRIPTION
FPS update need to pass 3 params after last patch though fps
log isn't support for direct map version now.