### PR TITLE
Update Dawn to the latest revision

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -138,15 +138,15 @@ executable("aquarium") {
       "third_party/dawn:dawn_utils",
       "third_party/dawn/src/dawn:libdawn",
       "third_party/dawn:libdawn_native",
+      "third_party/dawn:dawn_bindings",
       "third_party/dawn/third_party/shaderc:libshaderc",
     ]
 
     include_dirs += [
-      "third_party/dawn/third_party/glfw/include",
       "third_party/dawn/third_party/shaderc/libshaderc/include",
     ]
   } else {
-      deps += [ "third_party:glfw" ]
+    deps += [ "third_party:glfw" ]
 
     include_dirs += [
       "third_party/glfw/include",

--- a/DEPS
+++ b/DEPS
@@ -8,7 +8,7 @@ vars = {
   'chromium_git': 'https://chromium.googlesource.com',
   'github_git': 'https://github.com',
   'dawn_git': 'https://dawn.googlesource.com',
-  'dawn_revision': 'bb10a9187623469df7d90db59c88de13fc9a0c5f',
+  'dawn_revision': '40618d0b93aa46edc2906ef318d50fb1cf4fe80a',
   'imgui_git': 'https://github.com/ocornut',
   'imgui_revision': 'e16564e67a2e88d4cbe3afa6594650712790fba3',
   'angle_root': 'third_party/angle',


### PR DESCRIPTION
This patch updates Dawn to the latest revision.
1. dawn_bindings now becomes a separate library.
2. GLFW is removed by default for Dawn D3D12, Metal and Vulkan backends