### PR TITLE
Match 4 bytes alignment of Dawn Metal Backend

### DIFF
--- a/src/aquarium-optimized/dawn/BufferDawn.cpp
+++ b/src/aquarium-optimized/dawn/BufferDawn.cpp
@@ -20,14 +20,7 @@ BufferDawn::BufferDawn(ContextDawn *context,
       mOffset(nullptr)
 {
     mSize = numComponents * sizeof(float);
-    if (mTotoalComponents % 4 != 0)
-    {
-        int dummyCount = 4 - mTotoalComponents % 4;
-        for (int i = 0; i < dummyCount; i++)
-        {
-            buffer->push_back(0.0f);
-        }
-    }
+    // Create buffer for vertex buffer. Because float is multiple of 4 bytes, dummy padding isnt' needed.
     mBuf = context->createBufferFromData(buffer->data(), sizeof(float) * static_cast<int>(buffer->size()), mUsageBit);
 }
 
@@ -42,13 +35,11 @@ BufferDawn::BufferDawn(ContextDawn *context,
       mOffset(nullptr)
 {
     mSize = numComponents * sizeof(unsigned short);
-    if (mTotoalComponents % 4 != 0)
+    // Create buffer for index buffer. Because unsigned short is multiple of 2 bytes, in order to align
+    // with 4 bytes of dawn metal, dummy padding need to be added.
+    if (mTotoalComponents % 2 != 0)
     {
-        int dummyCount = 4 - mTotoalComponents % 4;
-        for (int i = 0; i < dummyCount; i++)
-        {
-            buffer->push_back(0.0f);
-        }
+        buffer->push_back(0.0f);
     }
     mBuf = context->createBufferFromData(
         buffer->data(), sizeof(unsigned short) * static_cast<int>(buffer->size()), mUsageBit);

--- a/src/aquarium-optimized/dawn/OutsideModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/OutsideModelDawn.cpp
@@ -104,7 +104,7 @@ void OutsideModelDawn::init()
         &mLightFactorUniforms, sizeof(mLightFactorUniforms),
         dawn::BufferUsageBit::CopyDst | dawn::BufferUsageBit::Uniform);
     mViewBuffer = mContextDawn->createBufferFromData(
-        &mWorldUniformPer, sizeof(WorldUniforms),
+        &mWorldUniformPer, sizeof(WorldUniforms) * 20,
         dawn::BufferUsageBit::CopyDst | dawn::BufferUsageBit::Uniform);
 
     mBindGroupModel = mContextDawn->makeBindGroup(

--- a/src/aquarium-optimized/dawn/SeaweedModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/SeaweedModelDawn.cpp
@@ -90,7 +90,7 @@ void SeaweedModelDawn::init()
         &mLightFactorUniforms, sizeof(mLightFactorUniforms),
         dawn::BufferUsageBit::CopyDst | dawn::BufferUsageBit::Uniform);
     mTimeBuffer = mContextDawn->createBufferFromData(
-        &mSeaweedPer, sizeof(mSeaweedPer),
+        &mSeaweedPer, sizeof(mSeaweedPer) * 4,
         dawn::BufferUsageBit::CopyDst | dawn::BufferUsageBit::Uniform);
     mViewBuffer = mContextDawn->createBufferFromData(
         &mWorldUniformPer, sizeof(WorldUniformPer),


### PR DESCRIPTION
Remove dummy paddings of vertex buffer and index buffer.
float is already a multiple of 4 bytes while unsigned short
is 2 bytes.

Match vec4 alignment of std 140
TimeBuffer of seaweed model should match vec4 alignment of std 140.

World uniforms of outside model is not big enough, and should match
the size in vertex shader.