### PR TITLE
Specify fish count in the render loop for dawn backend

### DIFF
--- a/src/aquarium-optimized/Aquarium.h
+++ b/src/aquarium-optimized/Aquarium.h
@@ -468,7 +468,8 @@ class Aquarium
     Model *mAquariumModels[MODELNAME::MODELMAX];
     Context *mContext;
     FPSTimer mFpsTimer;  // object to measure frames per second;
-    int mFishCount;
+    int mCurFishCount;
+    int mPreFishCount;
     int logCount;
     BACKENDTYPE mBackendType;
     ContextFactory *mFactory;

--- a/src/aquarium-optimized/Context.h
+++ b/src/aquarium-optimized/Context.h
@@ -55,7 +55,7 @@ class Context
     virtual void FlushInit() {}
     virtual void preFrame()   = 0;
     virtual void showWindow() = 0;
-    virtual void showFPS(const FPSTimer& fpsTimer)    = 0;
+    virtual void showFPS(const FPSTimer &fpsTimer, int *fishCount) = 0;
     virtual void destoryImgUI() = 0;
 
     int getClientWidth() const { return mClientWidth; }

--- a/src/aquarium-optimized/FishModel.h
+++ b/src/aquarium-optimized/FishModel.h
@@ -14,7 +14,10 @@
 class FishModel : public Model
 {
   public:
-    FishModel(MODELGROUP type, MODELNAME name, bool blend) : Model(type, name, blend){}
+    FishModel(MODELGROUP type, MODELNAME name, bool blend)
+        : Model(type, name, blend), mPreInstance(0), mCurInstance(0)
+    {
+    }
 
     virtual void updateFishPerUniforms(float x,
                                        float y,
@@ -25,6 +28,13 @@ class FishModel : public Model
                                        float scale,
                                        float time,
                                        int index) = 0;
+
+    virtual void reallocResource()     = 0;
+    virtual void destoryFishResource() = 0;
+
+  protected:
+    int mPreInstance;
+    int mCurInstance;
 };
 
 #endif

--- a/src/aquarium-optimized/Model.h
+++ b/src/aquarium-optimized/Model.h
@@ -32,7 +32,7 @@ class Model
     Model(MODELGROUP type, MODELNAME name, bool blend)
         : mProgram(nullptr), mBlend(blend), mName(name) {}
     virtual ~Model();
-    virtual void prepareForDraw() const     = 0;
+    virtual void prepareForDraw()                                              = 0;
     virtual void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) = 0;
     virtual void draw() = 0;
 

--- a/src/aquarium-optimized/d3d12/ContextD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.cpp
@@ -466,7 +466,7 @@ void ContextD3D12::showWindow()
     glfwShowWindow(mWindow);
 }
 
-void ContextD3D12::showFPS(const FPSTimer &fpsTimer)
+void ContextD3D12::showFPS(const FPSTimer &fpsTimer, int *fishCount)
 {
     // Start the Dear ImGui frame
     ImGui_ImplDX12_NewFrame();

--- a/src/aquarium-optimized/d3d12/ContextD3D12.h
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.h
@@ -34,7 +34,7 @@ class ContextD3D12 : public Context
     void DoFlush() override;
     void Terminate() override;
     void showWindow() override;
-    void showFPS(const FPSTimer &fpsTimer) override;
+    void showFPS(const FPSTimer &fpsTimer, int *fishCount) override;
     void destoryImgUI() override;
 
     void FlushInit() override;

--- a/src/aquarium-optimized/d3d12/FishModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/FishModelD3D12.cpp
@@ -143,7 +143,7 @@ void FishModelD3D12::init()
         mProgramD3D12->getFSModule(), mPipelineState, mBlend);
 }
 
-void FishModelD3D12::prepareForDraw() const {}
+void FishModelD3D12::prepareForDraw() {}
 
 void FishModelD3D12::draw()
 {
@@ -199,3 +199,7 @@ void FishModelD3D12::updateFishPerUniforms(float x,
     mFishPers[index].scale            = scale;
     mFishPers[index].time             = time;
 }
+
+void FishModelD3D12::reallocResource() {}
+
+void FishModelD3D12::destoryFishResource() {}

--- a/src/aquarium-optimized/d3d12/FishModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/FishModelD3D12.h
@@ -29,7 +29,7 @@ class FishModelD3D12 : public FishModel
     ~FishModelD3D12();
 
     void init() override;
-    void prepareForDraw() const override;
+    void prepareForDraw() override;
     void draw() override;
 
     void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
@@ -42,6 +42,9 @@ class FishModelD3D12 : public FishModel
                                float scale,
                                float time,
                                int index) override;
+
+    void reallocResource() override;
+    void destoryFishResource() override;
 
     struct FishVertexUniforms
     {

--- a/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.cpp
@@ -152,7 +152,7 @@ void FishModelInstancedDrawD3D12::init()
         mProgramD3D12->getFSModule(), mPipelineState, mBlend);
 }
 
-void FishModelInstancedDrawD3D12::prepareForDraw() const {}
+void FishModelInstancedDrawD3D12::prepareForDraw() {}
 
 void FishModelInstancedDrawD3D12::draw()
 {
@@ -203,3 +203,7 @@ void FishModelInstancedDrawD3D12::updateFishPerUniforms(float x,
     mFishPers[index].scale            = scale;
     mFishPers[index].time             = time;
 }
+
+void FishModelInstancedDrawD3D12::reallocResource() {}
+
+void FishModelInstancedDrawD3D12::destoryFishResource() {}

--- a/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.h
+++ b/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.h
@@ -29,7 +29,7 @@ class FishModelInstancedDrawD3D12 : public FishModel
     ~FishModelInstancedDrawD3D12();
 
     void init() override;
-    void prepareForDraw() const override;
+    void prepareForDraw() override;
     void draw() override;
 
     void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
@@ -42,6 +42,8 @@ class FishModelInstancedDrawD3D12 : public FishModel
                                float scale,
                                float time,
                                int index) override;
+    void reallocResource() override;
+    void destoryFishResource() override;
 
     struct FishVertexUniforms
     {

--- a/src/aquarium-optimized/d3d12/GenericModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/GenericModelD3D12.cpp
@@ -147,7 +147,7 @@ void GenericModelD3D12::init()
 }
 
 // Update constant buffer per frame
-void GenericModelD3D12::prepareForDraw() const
+void GenericModelD3D12::prepareForDraw()
 {
     CD3DX12_RANGE readRange(0, 0);
     UINT8 *m_pCbvDataBegin;

--- a/src/aquarium-optimized/d3d12/GenericModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/GenericModelD3D12.h
@@ -29,7 +29,7 @@ class GenericModelD3D12 : public Model
                       bool blend);
 
     void init() override;
-    void prepareForDraw() const override;
+    void prepareForDraw() override;
     void draw() override;
 
     void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;

--- a/src/aquarium-optimized/d3d12/InnerModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/InnerModelD3D12.cpp
@@ -101,7 +101,7 @@ void InnerModelD3D12::init()
         mProgramD3D12->getFSModule(), mPipelineState, mBlend);
 }
 
-void InnerModelD3D12::prepareForDraw() const {}
+void InnerModelD3D12::prepareForDraw() {}
 
 void InnerModelD3D12::draw()
 {

--- a/src/aquarium-optimized/d3d12/InnerModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/InnerModelD3D12.h
@@ -26,7 +26,7 @@ class InnerModelD3D12 : public Model
                     bool blend);
 
     void init() override;
-    void prepareForDraw() const override;
+    void prepareForDraw() override;
     void draw() override;
     void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
 

--- a/src/aquarium-optimized/d3d12/OutsideModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/OutsideModelD3D12.cpp
@@ -93,7 +93,7 @@ void OutsideModelD3D12::init()
         mProgramD3D12->getFSModule(), mPipelineState, mBlend);
 }
 
-void OutsideModelD3D12::prepareForDraw() const {}
+void OutsideModelD3D12::prepareForDraw() {}
 
 void OutsideModelD3D12::draw()
 {

--- a/src/aquarium-optimized/d3d12/OutsideModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/OutsideModelD3D12.h
@@ -28,7 +28,7 @@ class OutsideModelD3D12 : public Model
                       bool blend);
 
     void init() override;
-    void prepareForDraw() const override;
+    void prepareForDraw() override;
     void draw() override;
 
     void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;

--- a/src/aquarium-optimized/d3d12/SeaweedModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/SeaweedModelD3D12.cpp
@@ -102,7 +102,7 @@ void SeaweedModelD3D12::init()
         mProgramD3D12->getFSModule(), mPipelineState, mBlend);
 }
 
-void SeaweedModelD3D12::prepareForDraw() const
+void SeaweedModelD3D12::prepareForDraw()
 {
     CD3DX12_RANGE readRangeView(0, 0);
     UINT8 *m_pCbvDataBeginView;

--- a/src/aquarium-optimized/d3d12/SeaweedModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/SeaweedModelD3D12.h
@@ -26,7 +26,7 @@ class SeaweedModelD3D12 : public SeaweedModel
                       bool blend);
 
     void init() override;
-    void prepareForDraw() const override;
+    void prepareForDraw() override;
     void draw() override;
 
     void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;

--- a/src/aquarium-optimized/dawn/ContextDawn.cpp
+++ b/src/aquarium-optimized/dawn/ContextDawn.cpp
@@ -32,6 +32,7 @@
 #include "imgui.h"
 #include "imgui_impl_dawn.h"
 #include "imgui_impl_glfw.h"
+#include "imgui_internal.h"
 #include "utils/BackendBinding.h"
 #include "utils/ComboRenderPipelineDescriptor.h"
 
@@ -52,7 +53,8 @@ ContextDawn::ContextDawn(BACKENDTYPE backendType)
       mPipeline(nullptr),
       mBindGroup(nullptr),
       mPreferredSwapChainFormat(dawn::TextureFormat::RGBA8Unorm),
-      mEnableMSAA(false)
+      mEnableMSAA(false),
+      show_option_window(false)
 {
     mResourceHelper = new ResourceHelper("dawn", "");
     initAvailableToggleBitset(backendType);
@@ -589,12 +591,47 @@ void ContextDawn::showWindow()
     glfwShowWindow(mWindow);
 }
 
-void ContextDawn::showFPS(const FPSTimer &fpsTimer)
+void ContextDawn::showFPS(const FPSTimer &fpsTimer, int *fishCount)
 {
     // Start the Dear ImGui frame
     ImGui_ImplDawn_NewFrame();
     ImGui_ImplGlfw_NewFrame();
     ImGui::NewFrame();
+
+    if (show_option_window)
+    {
+        ImGui::SetNextWindowPos(ImVec2(500, 30), ImGuiCond_Appearing);
+        ImGui::SetNextWindowSize(ImVec2(300, 500), ImGuiCond_Appearing);
+
+        ImGuiWindowFlags window_flags = 0;
+        ImGui::Begin("Option Window", &show_option_window, window_flags);
+
+        ImGui::Text("Number of Fish");
+        static int selected  = -1;
+        int fishSelection[6] = {1, 10000, 20000, 30000, 50000, 100000};
+        char buf[6][32];
+        for (int n = 0; n < 6; n++)
+        {
+            sprintf(buf[n], "%d", fishSelection[n]);
+            if (ImGui::Selectable(buf[n], selected == n))
+            {
+                selected   = n;
+                *fishCount = fishSelection[selected];
+                memset(buf2, 0, 64);
+            }
+        }
+
+        char *pNext;
+        ImGui::InputText("Specify fish count", buf2, 64, ImGuiInputTextFlags_CharsDecimal);
+        int inputFishCount = strtol(buf2, &pNext, 10);
+
+        if (inputFishCount != 0)
+        {
+            *fishCount = inputFishCount;
+        }
+
+        ImGui::End();
+    }
 
     {
         ImGui::Begin("Aquarium Native");
@@ -618,6 +655,9 @@ void ContextDawn::showFPS(const FPSTimer &fpsTimer)
 
         ImGui::Text("Application average %.3f ms/frame (%.1f FPS)",
                     1000.0f / fpsTimer.getAverageFPS(), fpsTimer.getAverageFPS());
+
+        ImGui::Checkbox("Option Window", &show_option_window);
+
         ImGui::End();
     }
 

--- a/src/aquarium-optimized/dawn/ContextDawn.h
+++ b/src/aquarium-optimized/dawn/ContextDawn.h
@@ -22,6 +22,8 @@ class BufferDawn;
 class ProgramDawn;
 enum BACKENDTYPE: short;
 
+static char buf2[64];
+
 class ContextDawn : public Context
 {
   public:
@@ -37,7 +39,7 @@ class ContextDawn : public Context
     void FlushInit() override;
     void Terminate() override;
     void showWindow() override;
-    void showFPS(const FPSTimer &fpsTimer) override;
+    void showFPS(const FPSTimer &fpsTimer, int *fishCount) override;
     void destoryImgUI() override;
 
     void preFrame() override;
@@ -137,6 +139,8 @@ class ContextDawn : public Context
     bool mEnableMSAA;
     std::string mRenderer;
     std::string mBackendType;
+
+    bool show_option_window;
 };
 
 #endif

--- a/src/aquarium-optimized/dawn/FishModelDawn.h
+++ b/src/aquarium-optimized/dawn/FishModelDawn.h
@@ -27,7 +27,7 @@ class FishModelDawn : public FishModel
     ~FishModelDawn();
 
     void init() override;
-    void prepareForDraw() const override;
+    void prepareForDraw() override;
     void draw() override;
 
     void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
@@ -40,6 +40,9 @@ class FishModelDawn : public FishModel
                                float scale,
                                float time,
                                int index) override;
+
+    void reallocResource() override;
+    void destoryFishResource() override;
 
     struct FishVertexUniforms
     {
@@ -93,12 +96,11 @@ class FishModelDawn : public FishModel
 
     dawn::Buffer mFishPersBuffer;
 
-    int instance;
-
     ProgramDawn *mProgramDawn;
     const ContextDawn *mContextDawn;
 
     bool mEnableDynamicBufferOffset;
+    Aquarium *mAquarium;
 };
 
 #endif

--- a/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.cpp
+++ b/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.cpp
@@ -175,7 +175,7 @@ void FishModelInstancedDrawDawn::init()
                                 &mFishVertexUniforms);
 }
 
-void FishModelInstancedDrawDawn::prepareForDraw() const {}
+void FishModelInstancedDrawDawn::prepareForDraw() {}
 
 void FishModelInstancedDrawDawn::draw()
 {
@@ -222,6 +222,10 @@ void FishModelInstancedDrawDawn::updateFishPerUniforms(float x,
     mFishPers[index].scale            = scale;
     mFishPers[index].time             = time;
 }
+
+void FishModelInstancedDrawDawn::reallocResource() {}
+
+void FishModelInstancedDrawDawn::destoryFishResource() {}
 
 FishModelInstancedDrawDawn::~FishModelInstancedDrawDawn()
 {

--- a/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.h
+++ b/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.h
@@ -27,7 +27,7 @@ class FishModelInstancedDrawDawn : public FishModel
     ~FishModelInstancedDrawDawn();
 
     void init() override;
-    void prepareForDraw() const override;
+    void prepareForDraw() override;
     void draw() override;
 
     void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
@@ -40,6 +40,9 @@ class FishModelInstancedDrawDawn : public FishModel
                                float scale,
                                float time,
                                int index) override;
+
+    void reallocResource() override;
+    void destoryFishResource() override;
 
     struct FishVertexUniforms
     {

--- a/src/aquarium-optimized/dawn/GenericModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/GenericModelDawn.cpp
@@ -205,7 +205,7 @@ void GenericModelDawn::init()
                                 &mLightFactorUniforms);
 }
 
-void GenericModelDawn::prepareForDraw() const
+void GenericModelDawn::prepareForDraw()
 {
     mContextDawn->setBufferData(mWorldBuffer, 0, sizeof(WorldUniformPer), &mWorldUniformPer);
 }

--- a/src/aquarium-optimized/dawn/GenericModelDawn.h
+++ b/src/aquarium-optimized/dawn/GenericModelDawn.h
@@ -27,7 +27,7 @@ class GenericModelDawn : public Model
     ~GenericModelDawn();
 
     void init() override;
-    void prepareForDraw() const override;
+    void prepareForDraw() override;
     void draw() override;
 
     void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;

--- a/src/aquarium-optimized/dawn/InnerModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/InnerModelDawn.cpp
@@ -130,9 +130,7 @@ void InnerModelDawn::init()
     mContextDawn->setBufferData(mInnerBuffer, 0, sizeof(InnerUniforms), &mInnerUniforms);
 }
 
-void InnerModelDawn::prepareForDraw() const
-{
-}
+void InnerModelDawn::prepareForDraw() {}
 
 void InnerModelDawn::draw()
 {

--- a/src/aquarium-optimized/dawn/InnerModelDawn.h
+++ b/src/aquarium-optimized/dawn/InnerModelDawn.h
@@ -23,7 +23,7 @@ class InnerModelDawn : public Model
     ~InnerModelDawn();
 
     void init() override;
-    void prepareForDraw() const override;
+    void prepareForDraw() override;
     void draw() override;
     void updatePerInstanceUniforms(const WorldUniforms &WorldUniforms) override;
 

--- a/src/aquarium-optimized/dawn/OutsideModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/OutsideModelDawn.cpp
@@ -123,9 +123,7 @@ void OutsideModelDawn::init()
                                 &mLightFactorUniforms);
 }
 
-void OutsideModelDawn::prepareForDraw() const
-{
-}
+void OutsideModelDawn::prepareForDraw() {}
 
 void OutsideModelDawn::draw()
 {

--- a/src/aquarium-optimized/dawn/OutsideModelDawn.h
+++ b/src/aquarium-optimized/dawn/OutsideModelDawn.h
@@ -23,7 +23,7 @@ public:
     ~OutsideModelDawn();
 
     void init() override;
-    void prepareForDraw() const override;
+    void prepareForDraw() override;
     void draw() override;
 
     void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
@@ -47,7 +47,7 @@ public:
         float specularFactor;
     } mLightFactorUniforms;
 
-    WorldUniforms mWorldUniformPer;
+    WorldUniforms mWorldUniformPer[20];
 
   private:
     utils::ComboVertexInputDescriptor mVertexInputDescriptor;

--- a/src/aquarium-optimized/dawn/SeaweedModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/SeaweedModelDawn.cpp
@@ -113,7 +113,7 @@ void SeaweedModelDawn::init()
                                 &mLightFactorUniforms);
 }
 
-void SeaweedModelDawn::prepareForDraw() const
+void SeaweedModelDawn::prepareForDraw()
 {
     mContextDawn->setBufferData(mViewBuffer, 0, sizeof(WorldUniformPer), &mWorldUniformPer);
     mContextDawn->setBufferData(mTimeBuffer, 0, sizeof(SeaweedPer), &mSeaweedPer);

--- a/src/aquarium-optimized/dawn/SeaweedModelDawn.h
+++ b/src/aquarium-optimized/dawn/SeaweedModelDawn.h
@@ -23,7 +23,7 @@ class SeaweedModelDawn : public SeaweedModel
     ~SeaweedModelDawn();
 
     void init() override;
-    void prepareForDraw() const override;
+    void prepareForDraw() override;
     void draw() override;
 
     void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;

--- a/src/aquarium-optimized/opengl/ContextGL.cpp
+++ b/src/aquarium-optimized/opengl/ContextGL.cpp
@@ -457,7 +457,7 @@ void ContextGL::showWindow()
     glfwShowWindow(mWindow);
 }
 
-void ContextGL::showFPS(const FPSTimer &fpsTimer)
+void ContextGL::showFPS(const FPSTimer &fpsTimer, int *fishCount)
 {
     // Start the Dear ImGui frame
     ImGui_ImplOpenGL3_NewFrame();

--- a/src/aquarium-optimized/opengl/ContextGL.h
+++ b/src/aquarium-optimized/opengl/ContextGL.h
@@ -44,7 +44,7 @@ class ContextGL : public Context
     void DoFlush() override;
     void Terminate() override;
     void showWindow() override;
-    void showFPS(const FPSTimer &fpsTimer) override;
+    void showFPS(const FPSTimer &fpsTimer, int *fishCount) override;
     void destoryImgUI() override;
 
     void preFrame() override;

--- a/src/aquarium-optimized/opengl/FishModelGL.cpp
+++ b/src/aquarium-optimized/opengl/FishModelGL.cpp
@@ -104,7 +104,7 @@ void FishModelGL::draw()
     mContextGL->drawElements(*mIndicesBuffer);
 }
 
-void FishModelGL::prepareForDraw() const
+void FishModelGL::prepareForDraw()
 {
     mProgram->setProgram();
     mContextGL->enableBlend(mBlend);
@@ -179,3 +179,7 @@ void FishModelGL::updateFishPerUniforms(float x,
     mScaleUniform.first            = scale;
     mTimeUniform.first             = time;
 }
+
+void FishModelGL::reallocResource() {}
+
+void FishModelGL::destoryFishResource() {}

--- a/src/aquarium-optimized/opengl/FishModelGL.h
+++ b/src/aquarium-optimized/opengl/FishModelGL.h
@@ -19,7 +19,7 @@ class FishModelGL : public FishModel
 {
   public:
     FishModelGL(const ContextGL *context, Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend);
-    void prepareForDraw() const override;
+    void prepareForDraw() override;
     void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
 
     void init() override;
@@ -34,6 +34,9 @@ class FishModelGL : public FishModel
                                float scale,
                                float time,
                                int index) override;
+
+    void reallocResource() override;
+    void destoryFishResource() override;
 
     std::pair<float *, int> mViewInverseUniform;
     std::pair<float *, int> mLightWorldPosUniform;

--- a/src/aquarium-optimized/opengl/GenericModelGL.cpp
+++ b/src/aquarium-optimized/opengl/GenericModelGL.cpp
@@ -82,7 +82,7 @@ void GenericModelGL::draw()
     mContextGL->drawElements(*mIndicesBuffer);
 }
 
-void GenericModelGL::prepareForDraw() const
+void GenericModelGL::prepareForDraw()
 {
     mProgram->setProgram();
     mContextGL->enableBlend(mBlend);

--- a/src/aquarium-optimized/opengl/GenericModelGL.h
+++ b/src/aquarium-optimized/opengl/GenericModelGL.h
@@ -22,7 +22,7 @@ class GenericModelGL : public Model
                    MODELGROUP type,
                    MODELNAME name,
                    bool blend);
-    void prepareForDraw() const override;
+    void prepareForDraw() override;
     void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
     void init() override;
     void draw() override;

--- a/src/aquarium-optimized/opengl/InnerModelGL.cpp
+++ b/src/aquarium-optimized/opengl/InnerModelGL.cpp
@@ -86,7 +86,7 @@ void InnerModelGL::draw()
     mContextGL->drawElements(*mIndicesBuffer);
 }
 
-void InnerModelGL::prepareForDraw() const
+void InnerModelGL::prepareForDraw()
 {
     mProgram->setProgram();
     mContextGL->enableBlend(mBlend);

--- a/src/aquarium-optimized/opengl/InnerModelGL.h
+++ b/src/aquarium-optimized/opengl/InnerModelGL.h
@@ -18,7 +18,7 @@ class InnerModelGL : public Model
 {
   public:
     InnerModelGL(const ContextGL *context, Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend);
-    void prepareForDraw() const override;
+    void prepareForDraw() override;
     void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
     void init() override;
     void draw() override;

--- a/src/aquarium-optimized/opengl/OutsideModelGL.cpp
+++ b/src/aquarium-optimized/opengl/OutsideModelGL.cpp
@@ -76,7 +76,7 @@ void OutsideModelGL::draw()
     mContextGL->drawElements(*mIndicesBuffer);
 }
 
-void OutsideModelGL::prepareForDraw() const
+void OutsideModelGL::prepareForDraw()
 {
     mProgram->setProgram();
     mContextGL->enableBlend(mBlend);

--- a/src/aquarium-optimized/opengl/OutsideModelGL.h
+++ b/src/aquarium-optimized/opengl/OutsideModelGL.h
@@ -22,7 +22,7 @@ class OutsideModelGL : public Model
                    MODELGROUP type,
                    MODELNAME name,
                    bool blend);
-    void prepareForDraw() const override;
+    void prepareForDraw() override;
     void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
     void init() override;
     void draw() override;

--- a/src/aquarium-optimized/opengl/SeaweedModelGL.cpp
+++ b/src/aquarium-optimized/opengl/SeaweedModelGL.cpp
@@ -75,7 +75,7 @@ void SeaweedModelGL::draw()
     mContextGL->drawElements(*mIndicesBuffer);
 }
 
-void SeaweedModelGL::prepareForDraw() const
+void SeaweedModelGL::prepareForDraw()
 {
     mProgram->setProgram();
     mContextGL->enableBlend(mBlend);

--- a/src/aquarium-optimized/opengl/SeaweedModelGL.h
+++ b/src/aquarium-optimized/opengl/SeaweedModelGL.h
@@ -22,7 +22,7 @@ class SeaweedModelGL : public SeaweedModel
                    MODELGROUP type,
                    MODELNAME name,
                    bool blend);
-    void prepareForDraw() const override;
+    void prepareForDraw() override;
     void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
     void init() override;
     void draw() override;


### PR DESCRIPTION
Specify fish count during rendering by imgui. Click the option check box
and specify fish count. If the fish count is modified, the application will
destory and reallocate binding resources.
This patch add the functionality to dawn backend except instanced draw
path. This functionality will add to the other backends soon.