### PR TITLE
Specify fish count in the render loop for D3D12 backend

### DIFF
--- a/src/aquarium-optimized/Aquarium.cpp
+++ b/src/aquarium-optimized/Aquarium.cpp
@@ -697,16 +697,10 @@ void Aquarium::render()
     mContext->showFPS(mFpsTimer, &mCurFishCount);
 
     // TODO(yizhou): Functionality of reallocate fish count during rendering
-    // is implemented for Aquarium Dawn, OpenGL and ANGLE backend, and instanced draw isn't
-    // implemented yet.
+    // isn't supported for instanced draw.
     // To try this functionality now, use composition of "--backend dawn_xxx", or
     // "--backend dawn_xxx --disable-dyanmic-buffer-offset"
-    if ((mBackendType == BACKENDTYPE::BACKENDTYPEDAWND3D12 ||
-         mBackendType == BACKENDTYPE::BACKENDTYPEDAWNVULKAN ||
-         mBackendType == BACKENDTYPE::BACKENDTYPEDAWNMETAL ||
-         mBackendType == BACKENDTYPE::BACKENDTYPEOPENGL ||
-         mBackendType == BACKENDTYPE::BACKENDTYPEANGLE) &&
-        !toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS)))
+    if (!toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS)))
         if (mCurFishCount != mPreFishCount)
         {
             calculateFishCount();

--- a/src/aquarium-optimized/d3d12/ContextD3D12.h
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.h
@@ -99,6 +99,7 @@ class ContextD3D12 : public Context
                        int TexturePixelSize,
                        int mipLevels,
                        int arraySize);
+    void FlushPreviousFrames();
 
     Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList> mCommandList;
 
@@ -169,7 +170,6 @@ class ContextD3D12 : public Context
     D3D12_RENDER_TARGET_VIEW_DESC mSceneRenderTargetView;
 
     bool mEnableMSAA;
-    std::string mRenderer;
 };
 
 #endif

--- a/src/aquarium-optimized/d3d12/FishModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/FishModelD3D12.h
@@ -104,10 +104,9 @@ class FishModelD3D12 : public FishModel
 
     ComPtr<ID3D12PipelineState> mPipelineState;
 
-    int instance;
-
     ProgramD3D12 *mProgramD3D12;
     ContextD3D12 *mContextD3D12;
+    Aquarium *mAquarium;
 };
 
 #endif


### PR DESCRIPTION
This patch implements fish number selection for D3D12 backend.
If fish count is changed, the application will destory and
reallocate fish buffer. Take care to flush the command lists
before destory resource by signal mechanism, otherwise D3D12
driver will report 'OBJECT_DELETED_WHILE_STILL_IN_USE' error.