### PR TITLE
Update all fish data in one big buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,10 @@ aquarium.exe --num-fish 10000 --backend dawn_vulkan --disable-dynamic-buffer-off
 aquarium.exe --num-fish 10000 --backend dawn_d3d12 --integrated-gpu
 aquarium.exe --num-fish 10000 --backend dawn_vulkan --discrete-gpu
 
+# "--buffer-mapping-aync" : Test buffer mapping async mode to update fish positions.
+# This mode is only implemented for Dawn backend.
+aquarium.exe --num-fish 10000 --backend dawn_d3d12 --buffer-mapping-async
+
 # aquarium-direct-map only has OpenGL backend
 # Enable MSAA
 ./aquarium-direct-map  --num-fish 10000 --backend opengl --enable-msaa

--- a/src/aquarium-optimized/Aquarium.cpp
+++ b/src/aquarium-optimized/Aquarium.cpp
@@ -302,6 +302,16 @@ bool Aquarium::init(int argc, char **argv)
                 return false;
             }
         }
+        else if (cmd == "--buffer-mapping-async")
+        {
+            if (!availableToggleBitset.test(static_cast<size_t>(TOGGLE::BUFFERMAPPINGASYNC)))
+            {
+                std::cerr << "Full screen mode isn't supported for the backend." << std::endl;
+                return false;
+            }
+
+            toggleBitset.set(static_cast<size_t>(TOGGLE::BUFFERMAPPINGASYNC));
+        }
         else
         {
         }
@@ -329,7 +339,7 @@ bool Aquarium::init(int argc, char **argv)
 
     setupModelEnumMap();
     loadReource();
-    mContext->FlushInit();
+    mContext->Flush();
 
     std::cout << "End loading.\nCost " << getElapsedTime() << "s totally." << std::endl;
     mContext->showWindow();
@@ -814,7 +824,7 @@ void Aquarium::drawFishes()
     // Update all fish data by buffer mapping for Dawn backend except instanced draw.
     if (toggleBitset.test(static_cast<size_t>(TOGGLE::BUFFERMAPPINGASYNC)))
     {
-        mContext->updateAllFishData();
+        mContext->updateAllFishData(toggleBitset);
     }
 }
 

--- a/src/aquarium-optimized/Aquarium.h
+++ b/src/aquarium-optimized/Aquarium.h
@@ -125,6 +125,8 @@ enum TOGGLE : short
     ENABLEFULLSCREENMODE,
     // Log fps frequency
     RECORDFPSFREQUENCY,
+    // Use async buffer mapping to upload data
+    BUFFERMAPPINGASYNC,
     TOGGLEMAX
 };
 
@@ -433,6 +435,8 @@ class Aquarium
     bool init(int argc, char **argv);
     void display();
     Texture *getSkybox() { return mTextureMap["skybox"]; }
+    int getCurFishCount() const { return mCurFishCount; }
+    int getPreFishCount() const { return mPreFishCount; }
 
     std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> toggleBitset;
     LightWorldPositionUniform lightWorldPositionUniform;

--- a/src/aquarium-optimized/Context.h
+++ b/src/aquarium-optimized/Context.h
@@ -53,7 +53,7 @@ class Context
     virtual void KeyBoardQuit()                                                               = 0;
     virtual void DoFlush()                                                                    = 0;
     virtual void Terminate()                                                                  = 0;
-    virtual void FlushInit() {}
+    virtual void Flush() {}
     virtual void preFrame()   = 0;
     virtual void showWindow() = 0;
     virtual void showFPS(const FPSTimer &fpsTimer, int *fishCount) = 0;
@@ -61,7 +61,8 @@ class Context
     virtual void reallocResource(int preTotalInstance,
                                  int curTotalInstance,
                                  bool enableDynamicBufferOffset)   = 0;
-    virtual void updateAllFishData()                               = 0;
+    virtual void updateAllFishData(
+        const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset) = 0;
 
     int getClientWidth() const { return mClientWidth; }
     int getclientHeight() const { return mClientHeight; }

--- a/src/aquarium-optimized/Context.h
+++ b/src/aquarium-optimized/Context.h
@@ -58,6 +58,10 @@ class Context
     virtual void showWindow() = 0;
     virtual void showFPS(const FPSTimer &fpsTimer, int *fishCount) = 0;
     virtual void destoryImgUI() = 0;
+    virtual void reallocResource(int preTotalInstance,
+                                 int curTotalInstance,
+                                 bool enableDynamicBufferOffset)   = 0;
+    virtual void updateAllFishData()                               = 0;
 
     int getClientWidth() const { return mClientWidth; }
     int getclientHeight() const { return mClientHeight; }

--- a/src/aquarium-optimized/FishModel.h
+++ b/src/aquarium-optimized/FishModel.h
@@ -29,9 +29,6 @@ class FishModel : public Model
                                        float time,
                                        int index) = 0;
 
-    virtual void reallocResource()     = 0;
-    virtual void destoryFishResource() = 0;
-
   protected:
     int mPreInstance;
     int mCurInstance;

--- a/src/aquarium-optimized/d3d12/ContextD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.cpp
@@ -761,6 +761,14 @@ void ContextD3D12::FlushPreviousFrames()
     m_frameIndex = mSwapChain->GetCurrentBackBufferIndex();
 }
 
+void ContextD3D12::reallocResource(int preTotalInstance,
+                                   int curTotalInstance,
+                                   bool enableDynamicBufferOffset)
+{
+}
+
+void ContextD3D12::updateAllFishData() {}
+
 void ContextD3D12::createDepthStencilView()
 {
     D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilViewDesc = {};

--- a/src/aquarium-optimized/d3d12/ContextD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.cpp
@@ -416,7 +416,7 @@ void ContextD3D12::DoFlush()
     glfwPollEvents();
 }
 
-void ContextD3D12::FlushInit()
+void ContextD3D12::Flush()
 {
     // Close the command list and execute it to begin the initial GPU setup.
     ThrowIfFailed(mCommandList->Close());
@@ -767,7 +767,10 @@ void ContextD3D12::reallocResource(int preTotalInstance,
 {
 }
 
-void ContextD3D12::updateAllFishData() {}
+void ContextD3D12::updateAllFishData(
+    const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset)
+{
+}
 
 void ContextD3D12::createDepthStencilView()
 {

--- a/src/aquarium-optimized/d3d12/ContextD3D12.h
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.h
@@ -37,7 +37,7 @@ class ContextD3D12 : public Context
     void showFPS(const FPSTimer &fpsTimer, int *fishCount) override;
     void destoryImgUI() override;
 
-    void FlushInit() override;
+    void Flush() override;
     void preFrame() override;
 
     Model *createModel(Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend) override;
@@ -103,7 +103,8 @@ class ContextD3D12 : public Context
     void reallocResource(int preTotalInstance,
                          int curTotalInstance,
                          bool enableDynamicBufferOffset) override;
-    void updateAllFishData() override;
+    void updateAllFishData(
+        const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset) override;
 
     Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList> mCommandList;
 

--- a/src/aquarium-optimized/d3d12/ContextD3D12.h
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.h
@@ -100,6 +100,10 @@ class ContextD3D12 : public Context
                        int mipLevels,
                        int arraySize);
     void FlushPreviousFrames();
+    void reallocResource(int preTotalInstance,
+                         int curTotalInstance,
+                         bool enableDynamicBufferOffset) override;
+    void updateAllFishData() override;
 
     Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList> mCommandList;
 

--- a/src/aquarium-optimized/d3d12/FishModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/FishModelD3D12.h
@@ -43,8 +43,8 @@ class FishModelD3D12 : public FishModel
                                float time,
                                int index) override;
 
-    void reallocResource() override;
-    void destoryFishResource() override;
+    void reallocResource();
+    void destoryFishResource();
 
     struct FishVertexUniforms
     {

--- a/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.cpp
@@ -204,6 +204,3 @@ void FishModelInstancedDrawD3D12::updateFishPerUniforms(float x,
     mFishPers[index].time             = time;
 }
 
-void FishModelInstancedDrawD3D12::reallocResource() {}
-
-void FishModelInstancedDrawD3D12::destoryFishResource() {}

--- a/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.h
+++ b/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.h
@@ -42,8 +42,6 @@ class FishModelInstancedDrawD3D12 : public FishModel
                                float scale,
                                float time,
                                int index) override;
-    void reallocResource() override;
-    void destoryFishResource() override;
 
     struct FishVertexUniforms
     {

--- a/src/aquarium-optimized/dawn/ContextDawn.h
+++ b/src/aquarium-optimized/dawn/ContextDawn.h
@@ -91,6 +91,11 @@ class ContextDawn : public Context
     const dawn::Device &getDevice() const { return mDevice; }
     const dawn::RenderPassEncoder &getRenderPass() const { return mRenderPass; }
 
+    void reallocResource(int preTotalInstance,
+                         int curTotalInstance,
+                         bool enableDynamicBufferOffset) override;
+    void updateAllFishData() override;
+
     std::vector<dawn::CommandBuffer> mCommandBuffers;
     dawn::Queue queue;
 
@@ -98,6 +103,21 @@ class ContextDawn : public Context
     dawn::BindGroup bindGroupGeneral;
     dawn::BindGroupLayout groupLayoutWorld;
     dawn::BindGroup bindGroupWorld;
+
+    dawn::BindGroupLayout groupLayoutFishPer;
+    dawn::Buffer fishPersBuffer;
+    dawn::BindGroup *bindGroupFishPers;
+
+    struct FishPer
+    {
+        float worldPosition[3];
+        float scale;
+        float nextPosition[3];
+        float time;
+        float padding[56];  // TODO(yizhou): the padding is to align with 256 byte offset.
+    };
+
+    FishPer *fishPers;
 
     dawn::Device mDevice;
 
@@ -109,6 +129,7 @@ class ContextDawn : public Context
         const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset);
     void initAvailableToggleBitset(BACKENDTYPE backendType) override;
     static void framebufferResizeCallback(GLFWwindow *window, int width, int height);
+    void destoryFishResource();
 
     // TODO(jiawei.shao@intel.com): remove dawn::TextureUsageBit::CopyDst when the bug in Dawn is
     // fixed.
@@ -136,6 +157,9 @@ class ContextDawn : public Context
     dawn::Buffer mFogBuffer;
 
     bool mEnableMSAA;
+    int mPreTotalInstance;
+    int mCurTotalInstance;
+    bool mEnableDynamicBufferOffset;
 };
 
 #endif

--- a/src/aquarium-optimized/dawn/ContextDawn.h
+++ b/src/aquarium-optimized/dawn/ContextDawn.h
@@ -34,7 +34,7 @@ class ContextDawn : public Context
     bool ShouldQuit() override;
     void KeyBoardQuit() override;
     void DoFlush() override;
-    void FlushInit() override;
+    void Flush() override;
     void Terminate() override;
     void showWindow() override;
     void showFPS(const FPSTimer &fpsTimer, int *fishCount) override;
@@ -62,6 +62,11 @@ class ContextDawn : public Context
     dawn::CommandBuffer copyBufferToTexture(const dawn::BufferCopyView &bufferCopyView,
                                             const dawn::TextureCopyView &textureCopyView,
                                             const dawn::Extent3D &ext3D) const;
+    dawn::CommandBuffer copyBufferToBuffer(dawn::Buffer const &srcBuffer,
+                                           uint64_t srcOffset,
+                                           dawn::Buffer const &destBuffer,
+                                           uint64_t destOffset,
+                                           uint64_t size);
 
     dawn::TextureCopyView createTextureCopyView(dawn::Texture texture,
                                                 uint32_t level,
@@ -94,7 +99,8 @@ class ContextDawn : public Context
     void reallocResource(int preTotalInstance,
                          int curTotalInstance,
                          bool enableDynamicBufferOffset) override;
-    void updateAllFishData() override;
+    void updateAllFishData(
+        const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset) override;
 
     std::vector<dawn::CommandBuffer> mCommandBuffers;
     dawn::Queue queue;
@@ -107,6 +113,8 @@ class ContextDawn : public Context
     dawn::BindGroupLayout groupLayoutFishPer;
     dawn::Buffer fishPersBuffer;
     dawn::BindGroup *bindGroupFishPers;
+
+    dawn::Buffer stagingBuffer;
 
     struct FishPer
     {
@@ -130,6 +138,9 @@ class ContextDawn : public Context
     void initAvailableToggleBitset(BACKENDTYPE backendType) override;
     static void framebufferResizeCallback(GLFWwindow *window, int width, int height);
     void destoryFishResource();
+
+    static void MapWriteCallback(DawnBufferMapAsyncStatus status, void *, uint64_t, void *userdata);
+    void WaitABit();
 
     // TODO(jiawei.shao@intel.com): remove dawn::TextureUsageBit::CopyDst when the bug in Dawn is
     // fixed.
@@ -160,6 +171,8 @@ class ContextDawn : public Context
     int mPreTotalInstance;
     int mCurTotalInstance;
     bool mEnableDynamicBufferOffset;
+
+    void *mappedData;
 };
 
 #endif

--- a/src/aquarium-optimized/dawn/FishModelDawn.h
+++ b/src/aquarium-optimized/dawn/FishModelDawn.h
@@ -16,10 +16,12 @@
 
 #include "../FishModel.h"
 
+struct FishPer;
+
 class FishModelDawn : public FishModel
 {
   public:
-    FishModelDawn(const Context *context,
+    FishModelDawn(Context *context,
                   Aquarium *aquarium,
                   MODELGROUP type,
                   MODELNAME name,
@@ -41,9 +43,6 @@ class FishModelDawn : public FishModel
                                float time,
                                int index) override;
 
-    void reallocResource() override;
-    void destoryFishResource() override;
-
     struct FishVertexUniforms
     {
         float fishLength;
@@ -56,16 +55,6 @@ class FishModelDawn : public FishModel
         float shininess;
         float specularFactor;
     } mLightFactorUniforms;
-
-    struct FishPer
-    {
-        float worldPosition[3];
-        float scale;
-        float nextPosition[3];
-        float time;
-        float padding[56];  // TODO(yizhou): the padding is to align with 256 byte offset.
-    };
-    FishPer *mFishPers;
 
     TextureDawn *mDiffuseTexture;
     TextureDawn *mNormalTexture;
@@ -85,22 +74,20 @@ class FishModelDawn : public FishModel
     dawn::RenderPipeline mPipeline;
 
     dawn::BindGroupLayout mGroupLayoutModel;
-    dawn::BindGroupLayout mGroupLayoutPer;
     dawn::PipelineLayout mPipelineLayout;
 
     dawn::BindGroup mBindGroupModel;
-    dawn::BindGroup *mBindGroupPers;
 
     dawn::Buffer mFishVertexBuffer;
     dawn::Buffer mLightFactorBuffer;
 
-    dawn::Buffer mFishPersBuffer;
-
     ProgramDawn *mProgramDawn;
-    const ContextDawn *mContextDawn;
+    ContextDawn *mContextDawn;
 
     bool mEnableDynamicBufferOffset;
     Aquarium *mAquarium;
+
+    int mFishPerOffset;
 };
 
 #endif

--- a/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.cpp
+++ b/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.cpp
@@ -223,10 +223,6 @@ void FishModelInstancedDrawDawn::updateFishPerUniforms(float x,
     mFishPers[index].time             = time;
 }
 
-void FishModelInstancedDrawDawn::reallocResource() {}
-
-void FishModelInstancedDrawDawn::destoryFishResource() {}
-
 FishModelInstancedDrawDawn::~FishModelInstancedDrawDawn()
 {
     mPipeline          = nullptr;

--- a/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.h
+++ b/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.h
@@ -41,9 +41,6 @@ class FishModelInstancedDrawDawn : public FishModel
                                float time,
                                int index) override;
 
-    void reallocResource() override;
-    void destoryFishResource() override;
-
     struct FishVertexUniforms
     {
         float fishLength;

--- a/src/aquarium-optimized/opengl/ContextGL.cpp
+++ b/src/aquarium-optimized/opengl/ContextGL.cpp
@@ -383,7 +383,10 @@ void ContextGL::reallocResource(int preTotalInstance,
 {
 }
 
-void ContextGL::updateAllFishData() {}
+void ContextGL::updateAllFishData(
+    const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset)
+{
+}
 
 void ContextGL::initState()
 {

--- a/src/aquarium-optimized/opengl/ContextGL.cpp
+++ b/src/aquarium-optimized/opengl/ContextGL.cpp
@@ -377,6 +377,14 @@ void ContextGL::generateMipmap(unsigned int target)
     glGenerateMipmap(target);
 }
 
+void ContextGL::reallocResource(int preTotalInstance,
+                                int curTotalInstance,
+                                bool enableDynamicBufferOffset)
+{
+}
+
+void ContextGL::updateAllFishData() {}
+
 void ContextGL::initState()
 {
     glEnable(GL_DEPTH_TEST);

--- a/src/aquarium-optimized/opengl/ContextGL.h
+++ b/src/aquarium-optimized/opengl/ContextGL.h
@@ -95,7 +95,8 @@ class ContextGL : public Context
     void reallocResource(int preTotalInstance,
                          int curTotalInstance,
                          bool enableDynamicBufferOffset) override;
-    void updateAllFishData() override;
+    void updateAllFishData(
+        const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset) override;
 
   private:
     void initState();

--- a/src/aquarium-optimized/opengl/ContextGL.h
+++ b/src/aquarium-optimized/opengl/ContextGL.h
@@ -92,6 +92,10 @@ class ContextGL : public Context
                        unsigned char *pixel);
     void setParameter(unsigned int target, unsigned int pname, int param);
     void generateMipmap(unsigned int target);
+    void reallocResource(int preTotalInstance,
+                         int curTotalInstance,
+                         bool enableDynamicBufferOffset) override;
+    void updateAllFishData() override;
 
   private:
     void initState();

--- a/src/aquarium-optimized/opengl/FishModelGL.cpp
+++ b/src/aquarium-optimized/opengl/FishModelGL.cpp
@@ -180,6 +180,3 @@ void FishModelGL::updateFishPerUniforms(float x,
     mTimeUniform.first             = time;
 }
 
-void FishModelGL::reallocResource() {}
-
-void FishModelGL::destoryFishResource() {}

--- a/src/aquarium-optimized/opengl/FishModelGL.h
+++ b/src/aquarium-optimized/opengl/FishModelGL.h
@@ -35,9 +35,6 @@ class FishModelGL : public FishModel
                                float time,
                                int index) override;
 
-    void reallocResource() override;
-    void destoryFishResource() override;
-
     std::pair<float *, int> mViewInverseUniform;
     std::pair<float *, int> mLightWorldPosUniform;
     std::pair<float *, int> mLightColorUniform;


### PR DESCRIPTION
Merge the fish uniform buffers to a big buffer, and update the fish data
once per frame. This patch advantages in reduces buffer update per frame.
Each type of fishes, in another word, each fish model instance uses offset
to access to the big buffer.

In the next step, we will implement fish come and go senario and consider fish buffer allocation in the render loop. We also replace setsubdata by map buffer async.