### PR TITLE
Compile OpenGL path to WASM by emscripten

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -101,7 +101,8 @@ executable("aquarium") {
     deps += [ "third_party:glad" ]
 
     include_dirs += [ "third_party/glad/include" ]
-    defines += [ "IMGUI_IMPL_OPENGL_LOADER_GLAD", ]
+    defines += [ "IMGUI_IMPL_OPENGL_LOADER_GLAD",
+                 "ENABLE_OPENGL_BACKEND", ]
   }
 
   if (enable_dawn) {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,117 @@
+#
+# Copyright (c) 2019 The Aquarium Project Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+#
+cmake_minimum_required(VERSION 3.0)
+set (CMAKE_CXX_STANDARD 11)
+set(CMAKE_BUILD_TYPE Release)
+
+OPTION(_NDEBUG "skip ASSERT of the project" ON)
+if(_NDEBUG)
+  ADD_DEFINITIONS(-D_NDEBUG)
+endif(_NDEBUG)
+
+if (UNIX AND NOT APPLE)
+	set (LINUX TRUE)
+endif()
+
+project( aquarium )
+
+include_directories(${CMAKE_SOURCE_DIR}/third_party/stb)
+#include_directories(${CMAKE_SOURCE_DIR}/third_party/glfw/include)
+#include_directories(${CMAKE_SOURCE_DIR}/third_party/glad/include)`
+include_directories(${CMAKE_SOURCE_DIR}/third_party/rapidjson/include)
+#include_directories(${CMAKE_SOURCE_DIR}/src/common)
+#include_directories(${CMAKE_SOURCE_DIR}/src/include)
+include_directories(${CMAKE_SOURCE_DIR}/src)
+include_directories(${CMAKE_SOURCE_DIR}/third_party/imgui)
+include_directories(${CMAKE_SOURCE_DIR}/third_party/imgui/examples)
+
+# Glad
+#add_library(glad STATIC
+#  ${CMAKE_SOURCE_DIR}/third_party/glad/src/glad.c
+#  ${CMAKE_SOURCE_DIR}/third_party/glad/include/glad/glad.h
+#  ${CMAKE_SOURCE_DIR}/third_party/glad/include/KHR/khrplatform.h
+#)
+#set(GLAD_INCLUDE_DIR third_party/glad/include)
+
+# GLFW
+#set(GLFW_BUILD_DOCS OFF CACHE BOOL "" FORCE)
+#set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+#set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+#set(GLFW_INSTALL OFF CACHE BOOL "" FORCE)
+#add_subdirectory(${CMAKE_SOURCE_DIR}/third_party/glfw ${CMAKE_BINARY_DIR}/glfw)
+
+#target_include_directories(glad SYSTEM PUBLIC ${GLAD_INCLUDE_DIR})
+
+#list(APPEND THIRDPARTY_LIBS
+#  glad
+#)
+
+#imgui
+add_library(imgui STATIC
+  ${CMAKE_SOURCE_DIR}/third_party/imgui/imconfig.h
+  ${CMAKE_SOURCE_DIR}/third_party/imgui/imgui_draw.cpp
+  ${CMAKE_SOURCE_DIR}/third_party/imgui/imgui_internal.h
+  ${CMAKE_SOURCE_DIR}/third_party/imgui/imgui_widgets.cpp
+  ${CMAKE_SOURCE_DIR}/third_party/imgui/imgui.cpp
+  ${CMAKE_SOURCE_DIR}/third_party/imgui/imgui.h
+  ${CMAKE_SOURCE_DIR}/third_party/imgui/examples/imgui_impl_glfw.h
+  ${CMAKE_SOURCE_DIR}/third_party/imgui/examples/imgui_impl_glfw.cpp
+)
+
+list(APPEND THIRDPARTY_LIBS
+  imgui
+)
+
+include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/third_party/rapidjson)
+
+add_executable( aquarium
+src/common/AQUARIUM_ASSERT.h
+src/aquarium-optimized/opengl/BufferGL.h
+src/aquarium-optimized/opengl/BufferGL.cpp
+src/common/FPSTimer.h
+src/common/FPSTimer.cpp
+src/aquarium-optimized/opengl/ContextGL.h
+src/aquarium-optimized/opengl/ContextGL.cpp
+src/aquarium-optimized/opengl/FishModelGL.h
+src/aquarium-optimized/opengl/FishModelGL.cpp
+src/aquarium-optimized/opengl/GenericModelGL.h
+src/aquarium-optimized/opengl/GenericModelGL.cpp
+src/aquarium-optimized/opengl/InnerModelGL.h
+src/aquarium-optimized/opengl/InnerModelGL.cpp
+src/aquarium-optimized/opengl/OutsideModelGL.h
+src/aquarium-optimized/opengl/OutsideModelGL.cpp
+src/aquarium-optimized/opengl/ProgramGL.h
+src/aquarium-optimized/opengl/ProgramGL.cpp
+src/aquarium-optimized/opengl/SeaweedModelGL.h
+src/aquarium-optimized/opengl/SeaweedModelGL.cpp
+src/aquarium-optimized/opengl/TextureGL.h
+src/aquarium-optimized/opengl/TextureGL.cpp
+src/aquarium-optimized/Aquarium.h
+src/aquarium-optimized/Aquarium.cpp
+src/aquarium-optimized/Buffer.h
+src/aquarium-optimized/Context.h
+src/aquarium-optimized/Context.cpp
+src/aquarium-optimized/ContextFactory.h
+src/aquarium-optimized/ContextFactory.cpp
+src/aquarium-optimized/FishModel.h
+src/aquarium-optimized/Main.cpp
+src/aquarium-optimized/Matrix.h
+src/aquarium-optimized/Model.h
+src/aquarium-optimized/Model.cpp
+src/aquarium-optimized/Program.h
+src/aquarium-optimized/ResourceHelper.h
+src/aquarium-optimized/ResourceHelper.cpp
+src/aquarium-optimized/SeaweedModel.h
+src/aquarium-optimized/Texture.h
+src/aquarium-optimized/Texture.cpp
+src/aquarium-optimized/opengl/imgui_impl_opengl3.h
+src/aquarium-optimized/opengl/imgui_impl_opengl3.cpp
+)
+
+#target_compile_options(aquarium PRIVATE -s USE_SDL=2)
+target_link_libraries(aquarium ${THIRDPARTY_LIBS})
+SET_PROPERTY(TARGET aquarium APPEND_STRING PROPERTY LINK_FLAGS "-s USE_GLFW=3 -s USE_SDL=0 -s STRICT=1 -s USE_WEBGL2=1 -lGL -lglfw -s MAIN_MODULE=1 -s FULL_ES3=1 --preload-file ../../assets --preload-file ../../shaders -s TOTAL_MEMORY=512MB -s DISABLE_EXCEPTION_CATCHING=0")
+SET_PROPERTY(TARGET aquarium PROPERTY SUFFIX ".html")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,5 +113,5 @@ src/aquarium-optimized/opengl/imgui_impl_opengl3.cpp
 
 #target_compile_options(aquarium PRIVATE -s USE_SDL=2)
 target_link_libraries(aquarium ${THIRDPARTY_LIBS})
-SET_PROPERTY(TARGET aquarium APPEND_STRING PROPERTY LINK_FLAGS "-s USE_GLFW=3 -s USE_SDL=0 -s STRICT=1 -s USE_WEBGL2=1 -lGL -lglfw -s MAIN_MODULE=1 -s FULL_ES3=1 --preload-file ../../assets --preload-file ../../shaders -s TOTAL_MEMORY=512MB -s DISABLE_EXCEPTION_CATCHING=0")
+SET_PROPERTY(TARGET aquarium APPEND_STRING PROPERTY LINK_FLAGS "-s USE_GLFW=3 -s USE_SDL=0 -s STRICT=1 -s USE_WEBGL2=1 -lGL -lglfw -s --preload-file ../../assets --preload-file ../../shaders -s TOTAL_MEMORY=512MB -s DISABLE_EXCEPTION_CATCHING=0 --profiling -g4")
 SET_PROPERTY(TARGET aquarium PROPERTY SUFFIX ".html")

--- a/README.md
+++ b/README.md
@@ -308,9 +308,8 @@ aquarium.exe --num-fish 10000 --backend dawn_d3d12 --record-fps-frequency [count
 # "--test-time [second]" : Render the application for some second and then exit, and the application will run 5 min by default.
 aquarium.exe --num-fish 10000 --backend dawn_d3d12 --test-time 30
 
-#"--window-width [width])" : Set window width.
-#"--window-height [height]" : Set window height.
-aquarium.exe --num-fish 10000 --backend dawn_d3d12 --window-width 1024 --window-height 1024
+#"--window-size=[width],[height]" : Set window size.
+aquarium.exe --num-fish 10000 --backend dawn_d3d12 --window-size=2560,1440
 
 # aquarium-direct-map only has OpenGL backend
 # Enable MSAA

--- a/src/aquarium-optimized/Aquarium.cpp
+++ b/src/aquarium-optimized/Aquarium.cpp
@@ -329,13 +329,17 @@ bool Aquarium::init(int argc, char **argv)
 
             mTestTime = strtol(argv[i++ + 1], &pNext, 10);
         }
-        else if (cmd == "--window-width")
+        else if (cmd.find("--window-size") != std::string::npos)
         {
-            windowWidth = strtol(argv[i++ + 1], &pNext, 10);
-        }
-        else if (cmd == "--window-height")
-        {
-            windowHeight = strtol(argv[i++ + 1], &pNext, 10);
+            size_t pos1  = cmd.find("=");
+            size_t pos2  = cmd.find(",");
+            windowWidth  = strtol(cmd.substr(pos1 + 1, pos2 - pos1).c_str(), &pNext, 10);
+            windowHeight = strtol(cmd.substr(pos2 + 1).c_str(), &pNext, 10);
+            if (windowWidth == 0 || windowHeight == 0)
+            {
+                std::cerr << "Please input window size with the format: "
+                             "'--window-size=[width],[height].' ";
+            }
         }
         else
         {

--- a/src/aquarium-optimized/Aquarium.cpp
+++ b/src/aquarium-optimized/Aquarium.cpp
@@ -155,6 +155,7 @@ bool Aquarium::init(int argc, char **argv)
     mBackendType = BACKENDTYPE::BACKENDTYPEANGLE;
     mContext = mFactory->createContext(mBackendType);
     toggleBitset.set(static_cast<size_t>(TOGGLE::UPATEANDDRAWFOREACHMODEL));
+    mCurFishCount = 30000;
 #else
     // Create context of different backends through the cmd args.
     // "--backend" {backend}: create different backends. currently opengl is supported.

--- a/src/aquarium-optimized/Aquarium.h
+++ b/src/aquarium-optimized/Aquarium.h
@@ -443,6 +443,8 @@ class Aquarium
     Texture *getSkybox() { return mTextureMap["skybox"]; }
     int getCurFishCount() const { return mCurFishCount; }
     int getPreFishCount() const { return mPreFishCount; }
+    void render();
+    Context *getContext() { return mContext; }
 
     std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> toggleBitset;
     LightWorldPositionUniform lightWorldPositionUniform;
@@ -453,7 +455,6 @@ class Aquarium
     int fishCount[5];
 
   private:
-    void render();
     void loadReource();
     void loadPlacement();
     void loadModels();

--- a/src/aquarium-optimized/ResourceHelper.cpp
+++ b/src/aquarium-optimized/ResourceHelper.cpp
@@ -53,6 +53,20 @@ ResourceHelper::ResourceHelper(const std::string &mBackendName,
     pathStream << mPath.substr(0, nPos) << slash << ".." << slash << ".." << slash;
     mPath = pathStream.str();
 
+    std::ostringstream programStream;
+    programStream << mPath << shaderFolder << slash << mBackendName << slash << mShaderVersion
+                  << slash;
+    mProgramPath = programStream.str();
+
+#ifdef __EMSCRIPTEN__
+    std::ostringstream placementStream;
+    placementStream << resourceFolder << slash << "PropPlacement.js";
+    mPropPlacementPath = placementStream.str();
+
+    std::ostringstream imageStream;
+    imageStream << resourceFolder << slash;
+    mImagePath = imageStream.str();
+#else
     std::ostringstream placementStream;
     placementStream << mPath << resourceFolder << slash << "PropPlacement.js";
     mPropPlacementPath = placementStream.str();
@@ -60,11 +74,9 @@ ResourceHelper::ResourceHelper(const std::string &mBackendName,
     std::ostringstream imageStream;
     imageStream << mPath << resourceFolder << slash;
     mImagePath = imageStream.str();
+#endif
 
-    std::ostringstream programStream;
-    programStream << mPath << shaderFolder << slash << mBackendName << slash << mShaderVersion
-                  << slash;
-    mProgramPath = programStream.str();
+
 
     switch (mBackendType)
     {

--- a/src/aquarium-optimized/opengl/BufferGL.h
+++ b/src/aquarium-optimized/opengl/BufferGL.h
@@ -17,6 +17,9 @@
 #include "EGL/eglext_angle.h"
 #include "EGL/eglplatform.h"
 #include "EGLWindow.h"
+#elif __EMSCRIPTEN__
+#include <GLES3/gl3.h>
+#include <emscripten.h>
 #else
 #include "glad/glad.h"
 #endif

--- a/src/aquarium-optimized/opengl/ContextGL.h
+++ b/src/aquarium-optimized/opengl/ContextGL.h
@@ -16,6 +16,10 @@
 #include "EGL/eglext_angle.h"
 #include <memory>
 #include "EGLWindow.h"
+#elif __EMSCRIPTEN__
+#include <GLES3/gl3.h>
+#include <emscripten.h>
+#include <emscripten/html5.h>
 #else
 #include "glad/glad.h"
 #endif

--- a/src/aquarium-optimized/opengl/ProgramGL.cpp
+++ b/src/aquarium-optimized/opengl/ProgramGL.cpp
@@ -16,6 +16,9 @@
 #include "EGL/eglext_angle.h"
 #include "EGL/eglplatform.h"
 #include "EGLWindow.h"
+#elif __EMSCRIPTEN__
+#include <GLES3/gl3.h>
+#include <emscripten.h>
 #else
 #include "glad/glad.h"
 #endif

--- a/src/aquarium-optimized/opengl/TextureGL.h
+++ b/src/aquarium-optimized/opengl/TextureGL.h
@@ -21,6 +21,9 @@
 #include "EGL/eglext_angle.h"
 #include "EGL/eglplatform.h"
 #include "EGLWindow.h"
+#elif __EMSCRIPTEN__
+#include <GLES3/gl3.h>
+#include <emscripten.h>
 #else
 #include "glad/glad.h"
 #endif

--- a/src/include/CmdArgsHelper.h
+++ b/src/include/CmdArgsHelper.h
@@ -21,8 +21,7 @@ const char *cmdArgsStrAquarium = R"(Options and arguments:
 --num-fish [count]      : specifies how many fishes will be rendered.
 --record-fps-frequency [count]  : Record fps every count frame and print fps log when exit.
 --test-time [second]    : Render the application for some second and then exit, and the application will run 5 min by default.
---window-width [width]) : Set window width.
---window-height [height]: Set window height.";
+--window-size=[width],[height]  : Input window size.";
 
 
 const char *cmdArgsStrAquariumDirectMap = R"(Options and arguments:


### PR DESCRIPTION
Use emscripten with cmakeList to compile the application. When the
logic is different from OpenGL, use marco to differentiate them.
Remove unnecessary queries from imgui_impl_opengl3.cpp because the
queries impact on performance especially in WebGL. The states can
be set directly by the app.