### PR TITLE
Use sync method to upload fish uniforms by default

### DIFF
--- a/src/aquarium-optimized/Aquarium.cpp
+++ b/src/aquarium-optimized/Aquarium.cpp
@@ -197,10 +197,6 @@ bool Aquarium::init(int argc, char **argv)
     {
         toggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEDYNAMICBUFFEROFFSET));
     }
-    if (availableToggleBitset.test(static_cast<size_t>(TOGGLE::BUFFERMAPPINGASYNC)))
-    {
-        toggleBitset.set(static_cast<size_t>(TOGGLE::BUFFERMAPPINGASYNC));
-    }
 
     for (int i = 1; i < argc; ++i)
     {
@@ -360,7 +356,7 @@ void Aquarium::display()
         mContext->KeyBoardQuit();
         render();
 
-        mContext->DoFlush();
+        mContext->DoFlush(toggleBitset);
 
         if (g.then - g.start > 600)
         {
@@ -821,11 +817,7 @@ void Aquarium::drawFishes()
         }
     }
 
-    // Update all fish data by buffer mapping for Dawn backend except instanced draw.
-    if (toggleBitset.test(static_cast<size_t>(TOGGLE::BUFFERMAPPINGASYNC)))
-    {
-        mContext->updateAllFishData(toggleBitset);
-    }
+    mContext->updateAllFishData(toggleBitset);
 }
 
 void Aquarium::drawInner()

--- a/src/aquarium-optimized/Context.h
+++ b/src/aquarium-optimized/Context.h
@@ -51,7 +51,8 @@ class Context
     virtual void setWindowTitle(const std::string &text)                                      = 0;
     virtual bool ShouldQuit()                                                                 = 0;
     virtual void KeyBoardQuit()                                                               = 0;
-    virtual void DoFlush()                                                                    = 0;
+    virtual void DoFlush(
+        const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset) = 0;
     virtual void Terminate()                                                                  = 0;
     virtual void Flush() {}
     virtual void preFrame()   = 0;

--- a/src/aquarium-optimized/d3d12/ContextD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.cpp
@@ -377,7 +377,7 @@ void ContextD3D12::initAvailableToggleBitset(BACKENDTYPE backendType)
     mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEFULLSCREENMODE));
 }
 
-void ContextD3D12::DoFlush()
+void ContextD3D12::DoFlush(const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset)
 {
     // Resolve MSAA texture to non MSAA texture, and then present.
     if (mEnableMSAA)

--- a/src/aquarium-optimized/d3d12/ContextD3D12.h
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.h
@@ -31,7 +31,7 @@ class ContextD3D12 : public Context
     void setWindowTitle(const std::string &text) override;
     bool ShouldQuit() override;
     void KeyBoardQuit() override;
-    void DoFlush() override;
+    void DoFlush(const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset) override;
     void Terminate() override;
     void showWindow() override;
     void showFPS(const FPSTimer &fpsTimer, int *fishCount) override;

--- a/src/aquarium-optimized/dawn/ContextDawn.cpp
+++ b/src/aquarium-optimized/dawn/ContextDawn.cpp
@@ -613,20 +613,23 @@ void ContextDawn::KeyBoardQuit()
 }
 
 // Submit commands of the frame
-void ContextDawn::DoFlush()
+void ContextDawn::DoFlush(const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset)
 {
     mRenderPass.EndPass();
     dawn::CommandBuffer cmd = mCommandEncoder.Finish();
     mCommandBuffers.emplace_back(cmd);
 
     // Wait for staging buffer uploading
-    while (mappedData == nullptr)
+    if (toggleBitset.test(static_cast<size_t>(TOGGLE::BUFFERMAPPINGASYNC)))
     {
-        WaitABit();
-    }
-    mappedData = nullptr;
+        while (mappedData == nullptr)
+        {
+            WaitABit();
+        }
+        mappedData = nullptr;
 
-    stagingBuffer.Unmap();
+        stagingBuffer.Unmap();
+    }
 
     Flush();
 

--- a/src/aquarium-optimized/dawn/ContextDawn.h
+++ b/src/aquarium-optimized/dawn/ContextDawn.h
@@ -33,7 +33,7 @@ class ContextDawn : public Context
     void setWindowTitle(const std::string &text) override;
     bool ShouldQuit() override;
     void KeyBoardQuit() override;
-    void DoFlush() override;
+    void DoFlush(const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset) override;
     void Flush() override;
     void Terminate() override;
     void showWindow() override;

--- a/src/aquarium-optimized/opengl/ContextGL.cpp
+++ b/src/aquarium-optimized/opengl/ContextGL.cpp
@@ -447,7 +447,7 @@ void ContextGL::KeyBoardQuit()
         glfwSetWindowShouldClose(mWindow, GL_TRUE);
 }
 
-void ContextGL::DoFlush()
+void ContextGL::DoFlush(const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset)
 {
 #ifdef GL_GLEXT_PROTOTYPES
     eglSwapBuffers(mDisplay, mSurface);

--- a/src/aquarium-optimized/opengl/ContextGL.h
+++ b/src/aquarium-optimized/opengl/ContextGL.h
@@ -41,7 +41,7 @@ class ContextGL : public Context
     void setWindowTitle(const std::string &text) override;
     bool ShouldQuit() override;
     void KeyBoardQuit() override;
-    void DoFlush() override;
+    void DoFlush(const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset) override;
     void Terminate() override;
     void showWindow() override;
     void showFPS(const FPSTimer &fpsTimer, int *fishCount) override;


### PR DESCRIPTION
This patch use setSubData to upload fish uniforms by default.
To test buffer mapping sync, pass arg "--buffer-mapping-async".
The fps of the async method is not expected, and we will
improve the path in the next step.