### PR TITLE
Stablize FPS

### DIFF
--- a/src/aquarium-optimized/Aquarium.h
+++ b/src/aquarium-optimized/Aquarium.h
@@ -26,6 +26,8 @@ class Model;
 #include "math.h"
 #endif
 
+constexpr double FPSUPDATEINTERVAL = 0.05;
+
 enum BACKENDTYPE : short
 {
     BACKENDTYPEANGLE,
@@ -392,8 +394,10 @@ struct Global
     float m4t2[16];
     float m4t3[16];
     float colorMult[4] = {1, 1, 1, 1};
-    float then;
-    float start;
+    double then;
+    double start;
+    double lastUpdateFps;
+    int fpsCount;
     float mclock;
     float eyeClock;
 };
@@ -465,8 +469,9 @@ class Aquarium
     void drawOutside();
     void updateWorldProjections(const std::vector<float> &w);
     BACKENDTYPE getBackendType(const std::string &backendPath);
-    float getElapsedTime();
+    double getElapsedTime();
     void printRecordFps();
+    void resetFpsTime();
 
     std::unordered_map<std::string, MODELNAME> mModelEnumMap;
     std::unordered_map<std::string, Texture *> mTextureMap;

--- a/src/common/FPSTimer.cpp
+++ b/src/common/FPSTimer.cpp
@@ -12,42 +12,23 @@
 #include <cmath>
 
 FPSTimer::FPSTimer()
-    : mTotalTime(static_cast<float>(NUM_FRAMES_TO_AVERAGE)),
-      mTimeTable(NUM_FRAMES_TO_AVERAGE, 1.0f),
-      mHistoryFPS(NUM_HISTORY_DATA, 1.0f),
-      mHistoryFrameTime(NUM_HISTORY_DATA, 100.0f),
-      mTimeTableCursor(0),
+    : mHistoryFPS(NUM_HISTORY_DATA, 1.0),
+      mHistoryFrameTime(NUM_HISTORY_DATA, 100.0),
       mRecordFpsFrequencyCursor(0),
-      mInstantaneousFPS(0.0f),
-      mAverageFPS(0.0f)
+      mAverageFPS(0.0)
 {}
 
-void FPSTimer::update(float elapsedTime, float renderingTime, int logCount)
+void FPSTimer::update(double renderingTime, int fpsCount, int logCount)
 {
-    mTotalTime += elapsedTime - mTimeTable[mTimeTableCursor];
-    mTimeTable[mTimeTableCursor] = elapsedTime;
-
-    ++mTimeTableCursor;
-    if (mTimeTableCursor == NUM_FRAMES_TO_AVERAGE)
-    {
-        mTimeTableCursor = 0;
-    }
-
-    mInstantaneousFPS = floor(1.0f / elapsedTime + 0.5f);
-    mAverageFPS = floor((1.0f / (mTotalTime / static_cast<float>(NUM_FRAMES_TO_AVERAGE))) + 0.5f);
+    mAverageFPS = floor((1.0 / (renderingTime / fpsCount)) + 0.5);
 
     for (int i = 0; i < NUM_HISTORY_DATA; i++)
     {
         mHistoryFPS[i]       = mHistoryFPS[i + 1];
         mHistoryFrameTime[i] = mHistoryFrameTime[i + 1];
     }
-
     mHistoryFPS[NUM_HISTORY_DATA - 1]       = mAverageFPS;
-    mHistoryFrameTime[NUM_HISTORY_DATA - 1] = 1000.0f / mAverageFPS;
-
-    ++mRecordFpsFrequencyCursor;
-    if (renderingTime < 5)
-        return;
+    mHistoryFrameTime[NUM_HISTORY_DATA - 1] = 1000.0 / mAverageFPS;
 
     ASSERT(logCount != 0);
     if (mRecordFpsFrequencyCursor % logCount == 0)
@@ -55,4 +36,5 @@ void FPSTimer::update(float elapsedTime, float renderingTime, int logCount)
         mRecordFps.push_back(mAverageFPS);
         mRecordFpsFrequencyCursor = 0;
     }
+    mRecordFpsFrequencyCursor++;
 }

--- a/src/common/FPSTimer.h
+++ b/src/common/FPSTimer.h
@@ -11,7 +11,6 @@
 
 #include <vector>
 
-constexpr int NUM_FRAMES_TO_AVERAGE = 16;
 constexpr int NUM_HISTORY_DATA = 100;
 
 class FPSTimer
@@ -19,23 +18,18 @@ class FPSTimer
 public:
   FPSTimer();
 
-  void update(float elapsedTime, float renderingTime, int logCount);
-  float getAverageFPS() const { return mAverageFPS; }
-  float getInstantaneousFPS() const { return mInstantaneousFPS; }
+  void update(double renderingTime, int fpsCount, int logCount);
+  double getAverageFPS() const { return mAverageFPS; }
   const float *getHistoryFps() const { return mHistoryFPS.data(); }
   const float *getHistoryFrameTime() const { return mHistoryFrameTime.data(); }
   std::vector<float> &getRecordFps() { return mRecordFps; }
 
 private:
-  float mTotalTime;
-  std::vector<float> mTimeTable;
   std::vector<float> mHistoryFPS;
   std::vector<float> mHistoryFrameTime;
   std::vector<float> mRecordFps;
-  int mTimeTableCursor;
   int mRecordFpsFrequencyCursor;
-  float mInstantaneousFPS;
-  float mAverageFPS;
+  double mAverageFPS;
 };
 
 #endif


### PR DESCRIPTION
 Because type of time was float which is not precise enough,
 elapse was 0 between 2 frames when rendering small amount of
 fishes, thus, the value was wrong. So in this patch, float is
 replaced by double to calculate fps. In addition, fps is
 calculated by average of every 50ms to eliminate divisor is
 almost 0.