### PR TITLE
Turn off vsync for D3D12 backend

### DIFF
--- a/src/aquarium-optimized/d3d12/ContextD3D12.h
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.h
@@ -177,6 +177,7 @@ class ContextD3D12 : public Context
     D3D12_RENDER_TARGET_VIEW_DESC mSceneRenderTargetView;
 
     bool mEnableMSAA;
+    UINT mVsync;
 };
 
 #endif


### PR DESCRIPTION
Use toggle to turn off vsync for D3D12 backend.

./aquarium --backend d3d12 --turn-off-vsync