### PR TITLE
Add toggle to control rendering time

### DIFF
--- a/src/aquarium-optimized/Aquarium.cpp
+++ b/src/aquarium-optimized/Aquarium.cpp
@@ -328,6 +328,7 @@ bool Aquarium::init(int argc, char **argv)
         {
 
             mTestTime = strtol(argv[i++ + 1], &pNext, 10);
+            toggleBitset.set(static_cast<size_t>(TOGGLE::AUTOSTOP));
         }
         else if (cmd.find("--window-size") != std::string::npos)
         {
@@ -399,7 +400,8 @@ void Aquarium::display()
 
         mContext->DoFlush(toggleBitset);
 
-        if (g.then - g.start > mTestTime)
+        if (toggleBitset.test(static_cast<size_t>(TOGGLE::AUTOSTOP)) &&
+            (g.then - g.start) > mTestTime)
         {
             break;
         }

--- a/src/aquarium-optimized/Aquarium.h
+++ b/src/aquarium-optimized/Aquarium.h
@@ -108,6 +108,8 @@ enum FISHENUM : short
 
 enum TOGGLE : short
 {
+    // Stop rendering after specified time.
+    AUTOSTOP,
     // Enable 4 times MSAA.
     ENABLEMSAAx4,
     // Go through instanced draw.


### PR DESCRIPTION
By specify '--test-time [xxs]', the application will stop
rendering after specified time while by default it will
keeping rendering.