### PR TITLE
Add toggle to turn off render pass on Dawn_D3D12

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,14 @@ aquarium.exe --num-fish 10000 --backend dawn_d3d12 --test-time 30
 #"--window-size=[width],[height]" : Set window size.
 aquarium.exe --num-fish 10000 --backend dawn_d3d12 --window-size=2560,1440
 
+#“--turn-off-vsync” : Unlimit 60 fps.
+aquarium.exe --num-fish 10000 --backend dawn_vulkan --turn-off-vsync
+
+#“--disable-renderpass” : Turn off render pass for dawn_d3d12 backend. Render pass is only supported on Intel gen 10
+# or more advanced platforms. This feature is supported on versions of Windows prior to build 1809, or dawn will
+# emulate a render pass.
+aquarium.exe --num-fish 10000 --backend dawn_d3d12 --disable-renderpass
+
 # aquarium-direct-map only has OpenGL backend
 # Enable MSAA
 ./aquarium-direct-map  --num-fish 10000 --backend opengl --enable-msaa

--- a/src/aquarium-optimized/Aquarium.cpp
+++ b/src/aquarium-optimized/Aquarium.cpp
@@ -342,6 +342,19 @@ bool Aquarium::init(int argc, char **argv)
                              "'--window-size=[width],[height].' ";
             }
         }
+        else if (cmd == "--disable-renderpass")
+        {
+            if (!availableToggleBitset.test(static_cast<size_t>(TOGGLE::DISABLERENDERPASS)))
+            {
+                std::cerr << "Render pass is only supported for dawn_d3d12 backend. This feature "
+                             "is only supported on Intel gen 10 or more advanced platforms. "
+                             "Windows 1809 or prior version is also required."
+                          << std::endl;
+                return false;
+            }
+
+            toggleBitset.set(static_cast<size_t>(TOGGLE::DISABLERENDERPASS));
+        }
         else
         {
         }

--- a/src/aquarium-optimized/Aquarium.h
+++ b/src/aquarium-optimized/Aquarium.h
@@ -118,6 +118,8 @@ enum TOGGLE : short
     // By default, the app will enable dynamic buffer offset.
     // The toggle is to disable dbo feature.
     ENABLEDYNAMICBUFFEROFFSET,
+    // Turn off render pass on dawn_d3d12
+    DISABLERENDERPASS,
     // Select integrated gpu if available.
     INTEGRATEDGPU,
     // Select discrete gpu if available.

--- a/src/aquarium-optimized/Context.cpp
+++ b/src/aquarium-optimized/Context.cpp
@@ -6,6 +6,7 @@
 
 #include "Context.h"
 
+#include "Aquarium.h"
 #include "imgui.h"
 #include "imgui_impl_glfw.h"
 #include "imgui_internal.h"
@@ -100,6 +101,18 @@ void Context::renderImgui(const FPSTimer &fpsTimer,
         else
         {
             ImGui::Text("INSTANCEDDRAWS: OFF");
+        }
+
+        if (mResourceHelper->getBackendType() == BACKENDTYPE::BACKENDTYPEDAWND3D12)
+        {
+            if (toggleBitset->test(static_cast<size_t>(TOGGLE::DISABLERENDERPASS)))
+            {
+                ImGui::Text("RENDERPASS: OFF");
+            }
+            else
+            {
+                ImGui::Text("RENDERPASS: ON");
+            }
         }
 
         ImGui::Checkbox("Option Window", &show_option_window);

--- a/src/aquarium-optimized/ResourceHelper.h
+++ b/src/aquarium-optimized/ResourceHelper.h
@@ -22,6 +22,7 @@ class ResourceHelper
     std::string getModelPath(const std::string &modelName) const;
     const std::string &getProgramPath() const;
     const std::string &getBackendName() const { return mBackendName; }
+    BACKENDTYPE getBackendType() const { return mBackendType; }
     const std::string &getShaderVersion() const { return mShaderVersion; }
     const std::string &getRendererInfo() const;
     void setRenderer(const std::string &renderer);

--- a/src/aquarium-optimized/dawn/ContextDawn.cpp
+++ b/src/aquarium-optimized/dawn/ContextDawn.cpp
@@ -194,17 +194,18 @@ bool ContextDawn::initialize(
     }
 
     WGPUDevice backendDevice;
+    dawn_native::DeviceDescriptor descriptor;
     if (toggleBitset.test(static_cast<size_t>(TOGGLE::TURNOFFVSYNC)))
     {
         const char *kValidToggleName = "turn_off_vsync";
-        dawn_native::DeviceDescriptor descriptor;
         descriptor.forceEnabledToggles.push_back(kValidToggleName);
-        backendDevice = backendAdapter.CreateDevice(&descriptor);
     }
-    else
+    else if (toggleBitset.test(static_cast<size_t>(TOGGLE::DISABLERENDERPASS)))
     {
-        backendDevice = backendAdapter.CreateDevice();
+        const char *kValidToggleName = "use_d3d12_render_pass";
+        descriptor.forceDisabledToggles.push_back(kValidToggleName);
     }
+    backendDevice = backendAdapter.CreateDevice(&descriptor);
 
     DawnProcTable backendProcs = dawn_native::GetProcs();
 
@@ -318,6 +319,7 @@ void ContextDawn::initAvailableToggleBitset(BACKENDTYPE backendType)
     mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEFULLSCREENMODE));
     mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::BUFFERMAPPINGASYNC));
     mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::TURNOFFVSYNC));
+    mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::DISABLERENDERPASS));
 }
 
 Texture *ContextDawn::createTexture(const std::string &name, const std::string &url)

--- a/src/include/CmdArgsHelper.h
+++ b/src/include/CmdArgsHelper.h
@@ -21,6 +21,8 @@ const char *cmdArgsStrAquarium = R"(Options and arguments:
 --num-fish [count]      : specifies how many fishes will be rendered.
 --record-fps-frequency [count]  : Record fps every count frame and print fps log when exit.
 --test-time [second]    : Render the application for some second and then exit, and the application will run 5 min by default.
+--turn-off-vsync        : Unlimit 60 fps. 
+--disable-renderpass   : Turn off render pass for dawn_d3d12 backend.
 --window-size=[width],[height]  : Input window size.";
 
 


### PR DESCRIPTION
Render pass is a new feature supported on Windows 1809 or prior version,
and is hardware supported on Intel gen 10 or more advanced hardware.
By deafult, this feature is enabled if it's supported by the system
environment.
1.Pass args "--disable-renderpass" to turn off this feature.
2.Show RENDERPASS on imgui.