### PR TITLE
Rebase Dawn

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -41,6 +41,7 @@ executable("aquarium") {
   deps = [
     "third_party:stb",
     "third_party:imgui",
+    "third_party:glfw",
   ]
 
   include_dirs = [
@@ -49,6 +50,7 @@ executable("aquarium") {
     "src",
     "third_party/imgui",
     "third_party/imgui/examples",
+    "third_party/glfw/include",
   ]
 
   if(enable_angle || enable_opengl) {
@@ -145,12 +147,6 @@ executable("aquarium") {
 
     include_dirs += [
       "third_party/dawn/third_party/shaderc/libshaderc/include",
-    ]
-  } else {
-    deps += [ "third_party:glfw" ]
-
-    include_dirs += [
-      "third_party/glfw/include",
     ]
   }
 

--- a/DEPS
+++ b/DEPS
@@ -8,7 +8,7 @@ vars = {
   'chromium_git': 'https://chromium.googlesource.com',
   'github_git': 'https://github.com',
   'dawn_git': 'https://dawn.googlesource.com',
-  'dawn_revision': '321c12255e731a9343b337fd6f5a8bb1c8fa34e5',
+  'dawn_revision': '4d15609d269eb551fc73d27e75a498c1ab8f999d',
   'imgui_git': 'https://github.com/ocornut',
   'imgui_revision': 'e16564e67a2e88d4cbe3afa6594650712790fba3',
   'angle_root': 'third_party/angle',

--- a/build_overrides/dawn.gni
+++ b/build_overrides/dawn.gni
@@ -4,6 +4,8 @@
 # found in the LICENSE file.
 #
 
+dawn_standalone = true
+
 dawn_glfw_dir = "//third_party/dawn/third_party/glfw"
 dawn_jinja2_dir = "//third_party/dawn/third_party/jinja2"
 dawn_googletest_dir = "//third_party/dawn/third_party/googletest"


### PR DESCRIPTION
Two glfw conflicts in Aquarium thirdparty and Dawn thirdpaty.
This bug is resolved by this Dawn patch.
Add dawn_standalone = true in build overrides to link dawn_binding.
Only build dawn_bindings in standalone
https://dawn-review.googlesource.com/c/dawn/+/13820