### PR TITLE
Refactor D3D12 buffer updating

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -26,6 +26,7 @@ executable("aquarium") {
     "src/aquarium-optimized/ContextFactory.cpp",
     "src/aquarium-optimized/ContextFactory.h",
     "src/aquarium-optimized/FishModel.h",
+    "src/aquarium-optimized/FishModel.cpp",
     "src/aquarium-optimized/Main.cpp",
     "src/aquarium-optimized/Matrix.h",
     "src/aquarium-optimized/Model.cpp",

--- a/src/aquarium-optimized/Aquarium.cpp
+++ b/src/aquarium-optimized/Aquarium.cpp
@@ -764,11 +764,12 @@ void Aquarium::updateGlobalUniforms()
 
 void Aquarium::render()
 {
-    updateGlobalUniforms();
-
     matrix::resetPseudoRandom();
 
     mContext->preFrame();
+
+    // Global Uniforms should update after command reallocation.
+    updateGlobalUniforms();
 
     drawBackground();
 

--- a/src/aquarium-optimized/Aquarium.h
+++ b/src/aquarium-optimized/Aquarium.h
@@ -439,6 +439,15 @@ struct FogUniforms
     float fogColor[4];
 };
 
+struct FishPer
+{
+    float worldPosition[3];
+    float scale;
+    float nextPosition[3];
+    float time;
+    float padding[56];  // TODO(yizhou): the padding is to align with 256 byte offset.
+};
+
 class Aquarium
 {
   public:

--- a/src/aquarium-optimized/Context.h
+++ b/src/aquarium-optimized/Context.h
@@ -90,6 +90,8 @@ class Context
 
     int mClientWidth;
     int mClientHeight;
+    int mPreTotalInstance;
+    int mCurTotalInstance;
 
     ResourceHelper *mResourceHelper;
 

--- a/src/aquarium-optimized/FishModel.cpp
+++ b/src/aquarium-optimized/FishModel.cpp
@@ -1,0 +1,21 @@
+//
+// Copyright (c) 2019 The Aquarium Project Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+// FishModel.cpp: Implement common functions of sun class of fish models.
+
+#include "FishModel.h"
+
+void FishModel::prepareForDraw()
+{
+    mFishPerOffset = 0;
+    for (int i = 0; i < mName - MODELNAME::MODELSMALLFISHA; i++)
+    {
+        const Fish &fishInfo = fishTable[i];
+        mFishPerOffset += mAquarium->fishCount[fishInfo.modelName - MODELNAME::MODELSMALLFISHA];
+    }
+
+    const Fish &fishInfo = fishTable[mName - MODELNAME::MODELSMALLFISHA];
+    mCurInstance         = mAquarium->fishCount[fishInfo.modelName - MODELNAME::MODELSMALLFISHA];
+}

--- a/src/aquarium-optimized/FishModel.h
+++ b/src/aquarium-optimized/FishModel.h
@@ -14,8 +14,12 @@
 class FishModel : public Model
 {
   public:
-    FishModel(MODELGROUP type, MODELNAME name, bool blend)
-        : Model(type, name, blend), mPreInstance(0), mCurInstance(0)
+    FishModel(MODELGROUP type, MODELNAME name, bool blend, Aquarium *aquarium)
+        : Model(type, name, blend),
+          mPreInstance(0),
+          mCurInstance(0),
+          mFishPerOffset(0),
+          mAquarium(aquarium)
     {
     }
 
@@ -28,10 +32,14 @@ class FishModel : public Model
                                        float scale,
                                        float time,
                                        int index) = 0;
+    void prepareForDraw();
 
   protected:
     int mPreInstance;
     int mCurInstance;
+    int mFishPerOffset;
+
+    Aquarium *mAquarium;
 };
 
 #endif

--- a/src/aquarium-optimized/d3d12/ContextD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.cpp
@@ -330,7 +330,7 @@ bool ContextD3D12::GetHardwareAdapter(
             if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0,
                                             _uuidof(ID3D12Device), nullptr)))
             {
-                std::wstring str = desc.Description;
+                std::wstring str     = desc.Description;
                 std::string renderer = std::string(str.begin(), str.end());
                 std::cout << renderer << std::endl;
                 mResourceHelper->setRenderer(renderer);
@@ -681,12 +681,6 @@ void ContextD3D12::updateConstantBufferSync(ComPtr<ID3D12Resource> &defaultBuffe
 
     UpdateSubresources<1>(mCommandList.Get(), defaultBuffer.Get(), uploadBuffer.Get(), 0, 0, 1,
                           &subResourceData);
-
-    mFenceValue++;
-    // Signal and increment the fence value.
-    const UINT64 fence = mFenceValue;
-    ThrowIfFailed(mCommandQueue->Signal(mFence.Get(), fence));
-    mBufferSerias[m_frameIndex] = mFenceValue;
 
     stateTransition(defaultBuffer, D3D12_RESOURCE_STATE_COPY_DEST,
                     D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER);

--- a/src/aquarium-optimized/d3d12/ContextD3D12.h
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.h
@@ -18,7 +18,7 @@ using Microsoft::WRL::ComPtr;
 
 enum BACKENDTYPE : short;
 
-constexpr int cbvsrvCount = 193;
+constexpr int cbvsrvCount = 88;
 
 class ContextD3D12 : public Context
 {
@@ -128,6 +128,11 @@ class ContextD3D12 : public Context
 
     std::vector<CD3DX12_STATIC_SAMPLER_DESC> staticSamplers;
 
+    D3D12_CONSTANT_BUFFER_VIEW_DESC mFishPersBufferView;
+    ComPtr<ID3D12Resource> mFishPersBuffer;
+    ComPtr<ID3D12Resource> stagingBuffer;
+    FishPer *fishPers;
+
   private:
     bool GetHardwareAdapter(
         IDXGIFactory2 *pFactory,
@@ -139,6 +144,7 @@ class ContextD3D12 : public Context
                          D3D12_RESOURCE_STATES preState,
                          D3D12_RESOURCE_STATES transferState) const;
     void initAvailableToggleBitset(BACKENDTYPE backendType) override;
+    void destoryFishResource();
 
     GLFWwindow *mWindow;
     ComPtr<ID3D12Device> mDevice;

--- a/src/aquarium-optimized/d3d12/ContextD3D12.h
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.h
@@ -18,7 +18,7 @@ using Microsoft::WRL::ComPtr;
 
 enum BACKENDTYPE : short;
 
-constexpr int cbvsrvCount = 88;
+constexpr int cbvsrvCount = 193;
 
 class ContextD3D12 : public Context
 {

--- a/src/aquarium-optimized/d3d12/ContextD3D12.h
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.h
@@ -18,7 +18,7 @@ using Microsoft::WRL::ComPtr;
 
 enum BACKENDTYPE : short;
 
-constexpr int cbvsrvCount = 87;
+constexpr int cbvsrvCount = 88;
 
 class ContextD3D12 : public Context
 {
@@ -108,15 +108,21 @@ class ContextD3D12 : public Context
                          bool enableDynamicBufferOffset) override;
     void updateAllFishData(
         const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset) override;
+    void updateConstantBufferSync(ComPtr<ID3D12Resource> &defaultBuffer,
+                                  const ComPtr<ID3D12Resource> &uploadBuffer,
+                                  const void *initData,
+                                  UINT64 byteSize);
 
     Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList> mCommandList;
 
     CD3DX12_DESCRIPTOR_RANGE1 rangeGeneral[2];
     CD3DX12_ROOT_PARAMETER1 rootParameterGeneral;
+    CD3DX12_DESCRIPTOR_RANGE1 rangeLightWorldPosition;
     CD3DX12_ROOT_PARAMETER1 rootParameterWorld;
     D3D12_GPU_DESCRIPTOR_HANDLE fogGPUHandle;
     D3D12_GPU_DESCRIPTOR_HANDLE lightGPUHandle;
     D3D12_CONSTANT_BUFFER_VIEW_DESC lightWorldPositionView;
+    D3D12_GPU_DESCRIPTOR_HANDLE lightWorldPositionGPUHandle;
     CD3DX12_CPU_DESCRIPTOR_HANDLE cbvsrvCPUHandle;
     CD3DX12_GPU_DESCRIPTOR_HANDLE cbvsrvGPUHandle;
 
@@ -165,6 +171,7 @@ class ContextD3D12 : public Context
 
     // General Resources
     ComPtr<ID3D12Resource> mLightWorldPositionBuffer;
+    ComPtr<ID3D12Resource> mLightWorldPositionUploadBuffer;
 
     D3D12_CONSTANT_BUFFER_VIEW_DESC mLightView;
     ComPtr<ID3D12Resource> mLightBuffer;

--- a/src/aquarium-optimized/d3d12/FishModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/FishModelD3D12.cpp
@@ -165,8 +165,7 @@ void FishModelD3D12::draw()
     commandList->SetGraphicsRootSignature(mRootSignature.Get());
 
     commandList->SetGraphicsRootDescriptorTable(0, mContextD3D12->lightGPUHandle);
-    commandList->SetGraphicsRootConstantBufferView(
-        1, mContextD3D12->lightWorldPositionView.BufferLocation);
+    commandList->SetGraphicsRootDescriptorTable(1, mContextD3D12->lightWorldPositionGPUHandle);
     commandList->SetGraphicsRootDescriptorTable(2, mFishVertexGPUHandle);
     commandList->SetGraphicsRootDescriptorTable(3, mDiffuseTexture->getTextureGPUHandle());
 

--- a/src/aquarium-optimized/d3d12/FishModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/FishModelD3D12.h
@@ -84,7 +84,9 @@ class FishModelD3D12 : public FishModel
 
   private:
     D3D12_CONSTANT_BUFFER_VIEW_DESC mFishPersBufferView;
+    D3D12_GPU_DESCRIPTOR_HANDLE mFishPersGPUHandle;
     ComPtr<ID3D12Resource> mFishPersBuffer;
+    ComPtr<ID3D12Resource> mFishPersUploadBuffer;
 
     D3D12_CONSTANT_BUFFER_VIEW_DESC mLightFactorView;
     D3D12_GPU_DESCRIPTOR_HANDLE mLightFactorGPUHandle;

--- a/src/aquarium-optimized/d3d12/FishModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/FishModelD3D12.h
@@ -29,7 +29,6 @@ class FishModelD3D12 : public FishModel
     ~FishModelD3D12();
 
     void init() override;
-    void prepareForDraw() override;
     void draw() override;
 
     void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
@@ -43,9 +42,6 @@ class FishModelD3D12 : public FishModel
                                float time,
                                int index) override;
 
-    void reallocResource();
-    void destoryFishResource();
-
     struct FishVertexUniforms
     {
         float fishLength;
@@ -58,16 +54,6 @@ class FishModelD3D12 : public FishModel
         float shininess;
         float specularFactor;
     } mLightFactorUniforms;
-
-    struct FishPer
-    {
-        float worldPosition[3];
-        float scale;
-        float nextPosition[3];
-        float time;
-        float padding[56];  // TODO(yizhou): the padding is to align with 256 byte offset.
-    };
-    FishPer *mFishPers;
 
     TextureD3D12 *mDiffuseTexture;
     TextureD3D12 *mNormalTexture;
@@ -83,11 +69,6 @@ class FishModelD3D12 : public FishModel
     BufferD3D12 *mIndicesBuffer;
 
   private:
-    D3D12_CONSTANT_BUFFER_VIEW_DESC mFishPersBufferView;
-    D3D12_GPU_DESCRIPTOR_HANDLE mFishPersGPUHandle;
-    ComPtr<ID3D12Resource> mFishPersBuffer;
-    ComPtr<ID3D12Resource> mFishPersUploadBuffer;
-
     D3D12_CONSTANT_BUFFER_VIEW_DESC mLightFactorView;
     D3D12_GPU_DESCRIPTOR_HANDLE mLightFactorGPUHandle;
     ComPtr<ID3D12Resource> mLightFactorBuffer;
@@ -108,7 +89,6 @@ class FishModelD3D12 : public FishModel
 
     ProgramD3D12 *mProgramD3D12;
     ContextD3D12 *mContextD3D12;
-    Aquarium *mAquarium;
 };
 
 #endif

--- a/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.cpp
@@ -170,8 +170,7 @@ void FishModelInstancedDrawD3D12::draw()
     commandList->SetGraphicsRootSignature(mRootSignature.Get());
 
     commandList->SetGraphicsRootDescriptorTable(0, mContextD3D12->lightGPUHandle);
-    commandList->SetGraphicsRootConstantBufferView(
-        1, mContextD3D12->lightWorldPositionView.BufferLocation);
+    commandList->SetGraphicsRootDescriptorTable(1, mContextD3D12->lightWorldPositionGPUHandle);
     commandList->SetGraphicsRootDescriptorTable(2, mFishVertexGPUHandle);
     commandList->SetGraphicsRootDescriptorTable(3, mDiffuseTexture->getTextureGPUHandle());
 

--- a/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.cpp
@@ -13,7 +13,7 @@ FishModelInstancedDrawD3D12::FishModelInstancedDrawD3D12(Context *context,
                                                          MODELGROUP type,
                                                          MODELNAME name,
                                                          bool blend)
-    : FishModel(type, name, blend), instance(0)
+    : FishModel(type, name, blend, aquarium), instance(0)
 {
     mContextD3D12 = static_cast<ContextD3D12 *>(context);
 

--- a/src/aquarium-optimized/d3d12/GenericModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/GenericModelD3D12.cpp
@@ -163,8 +163,7 @@ void GenericModelD3D12::draw()
     commandList->SetGraphicsRootSignature(mRootSignature.Get());
 
     commandList->SetGraphicsRootDescriptorTable(0, mContextD3D12->lightGPUHandle);
-    commandList->SetGraphicsRootConstantBufferView(
-        1, mContextD3D12->lightWorldPositionView.BufferLocation);
+    commandList->SetGraphicsRootDescriptorTable(1, mContextD3D12->lightWorldPositionGPUHandle);
     commandList->SetGraphicsRootDescriptorTable(2, mLightFactorGPUHandle);
     commandList->SetGraphicsRootDescriptorTable(3, mDiffuseTexture->getTextureGPUHandle());
     commandList->SetGraphicsRootConstantBufferView(4, mWorldBufferView.BufferLocation);

--- a/src/aquarium-optimized/d3d12/InnerModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/InnerModelD3D12.cpp
@@ -111,8 +111,7 @@ void InnerModelD3D12::draw()
     commandList->SetGraphicsRootSignature(mRootSignature.Get());
 
     commandList->SetGraphicsRootDescriptorTable(0, mContextD3D12->lightGPUHandle);
-    commandList->SetGraphicsRootConstantBufferView(
-        1, mContextD3D12->lightWorldPositionView.BufferLocation);
+    commandList->SetGraphicsRootDescriptorTable(1, mContextD3D12->lightWorldPositionGPUHandle);
     commandList->SetGraphicsRootDescriptorTable(2, mInnerGPUHandle);
     commandList->SetGraphicsRootDescriptorTable(3, mDiffuseTexture->getTextureGPUHandle());
     commandList->SetGraphicsRootConstantBufferView(4, mWorldBufferView.BufferLocation);

--- a/src/aquarium-optimized/d3d12/OutsideModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/OutsideModelD3D12.cpp
@@ -103,8 +103,7 @@ void OutsideModelD3D12::draw()
     commandList->SetGraphicsRootSignature(mRootSignature.Get());
 
     commandList->SetGraphicsRootDescriptorTable(0, mContextD3D12->lightGPUHandle);
-    commandList->SetGraphicsRootConstantBufferView(
-        1, mContextD3D12->lightWorldPositionView.BufferLocation);
+    commandList->SetGraphicsRootDescriptorTable(1, mContextD3D12->lightWorldPositionGPUHandle);
     commandList->SetGraphicsRootDescriptorTable(2, mLightFactorGPUHandle);
     commandList->SetGraphicsRootDescriptorTable(3, mDiffuseTexture->getTextureGPUHandle());
     commandList->SetGraphicsRootConstantBufferView(4, mWorldBufferView.BufferLocation);

--- a/src/aquarium-optimized/d3d12/SeaweedModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/SeaweedModelD3D12.cpp
@@ -123,8 +123,7 @@ void SeaweedModelD3D12::draw()
     commandList->SetGraphicsRootSignature(mRootSignature.Get());
 
     commandList->SetGraphicsRootDescriptorTable(0, mContextD3D12->lightGPUHandle);
-    commandList->SetGraphicsRootConstantBufferView(
-        1, mContextD3D12->lightWorldPositionView.BufferLocation);
+    commandList->SetGraphicsRootDescriptorTable(1, mContextD3D12->lightWorldPositionGPUHandle);
     commandList->SetGraphicsRootDescriptorTable(2, mLightFactorGPUHandle);
     commandList->SetGraphicsRootDescriptorTable(3, mDiffuseTexture->getTextureGPUHandle());
     commandList->SetGraphicsRootConstantBufferView(4, mWorldBufferView.BufferLocation);

--- a/src/aquarium-optimized/dawn/ContextDawn.cpp
+++ b/src/aquarium-optimized/dawn/ContextDawn.cpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <vector>
 
+#include "../FishModel.h"
 #include "BufferDawn.h"
 #include "ContextDawn.h"
 #include "FishModelDawn.h"

--- a/src/aquarium-optimized/dawn/ContextDawn.h
+++ b/src/aquarium-optimized/dawn/ContextDawn.h
@@ -122,16 +122,6 @@ class ContextDawn : public Context
     wgpu::BindGroup *bindGroupFishPers;
 
     wgpu::Buffer stagingBuffer;
-
-    struct FishPer
-    {
-        float worldPosition[3];
-        float scale;
-        float nextPosition[3];
-        float time;
-        float padding[56];  // TODO(yizhou): the padding is to align with 256 byte offset.
-    };
-
     FishPer *fishPers;
 
     wgpu::Device mDevice;
@@ -175,8 +165,6 @@ class ContextDawn : public Context
     wgpu::Buffer mFogBuffer;
 
     bool mEnableMSAA;
-    int mPreTotalInstance;
-    int mCurTotalInstance;
     bool mEnableDynamicBufferOffset;
 
     void *mappedData;

--- a/src/aquarium-optimized/dawn/FishModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/FishModelDawn.cpp
@@ -15,7 +15,7 @@ FishModelDawn::FishModelDawn(Context *context,
                              MODELGROUP type,
                              MODELNAME name,
                              bool blend)
-    : FishModel(type, name, blend), mAquarium(aquarium), mFishPerOffset(0)
+    : FishModel(type, name, blend, aquarium)
 {
     mContextDawn = static_cast<ContextDawn *>(context);
 
@@ -158,19 +158,6 @@ void FishModelDawn::init()
                                 &mLightFactorUniforms);
     mContextDawn->setBufferData(mFishVertexBuffer, 0, sizeof(FishVertexUniforms),
                                 &mFishVertexUniforms);
-}
-
-void FishModelDawn::prepareForDraw()
-{
-    mFishPerOffset = 0;
-    for (int i = 0; i < mName - MODELNAME::MODELSMALLFISHA; i++)
-    {
-        const Fish &fishInfo = fishTable[i];
-        mFishPerOffset += mAquarium->fishCount[fishInfo.modelName - MODELNAME::MODELSMALLFISHA];
-    }
-
-    const Fish &fishInfo = fishTable[mName - MODELNAME::MODELSMALLFISHA];
-    mCurInstance         = mAquarium->fishCount[fishInfo.modelName - MODELNAME::MODELSMALLFISHA];
 }
 
 void FishModelDawn::draw()

--- a/src/aquarium-optimized/dawn/FishModelDawn.h
+++ b/src/aquarium-optimized/dawn/FishModelDawn.h
@@ -29,7 +29,6 @@ class FishModelDawn : public FishModel
     ~FishModelDawn();
 
     void init() override;
-    void prepareForDraw() override;
     void draw() override;
 
     void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
@@ -85,9 +84,6 @@ class FishModelDawn : public FishModel
     ContextDawn *mContextDawn;
 
     bool mEnableDynamicBufferOffset;
-    Aquarium *mAquarium;
-
-    int mFishPerOffset;
 };
 
 #endif

--- a/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.cpp
+++ b/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.cpp
@@ -13,7 +13,7 @@ FishModelInstancedDrawDawn::FishModelInstancedDrawDawn(const Context *context,
                                                        MODELGROUP type,
                                                        MODELNAME name,
                                                        bool blend)
-    : FishModel(type, name, blend), instance(0)
+    : FishModel(type, name, blend, aquarium), instance(0)
 {
     mContextDawn = static_cast<const ContextDawn *>(context);
 

--- a/src/aquarium-optimized/opengl/FishModelGL.cpp
+++ b/src/aquarium-optimized/opengl/FishModelGL.cpp
@@ -14,7 +14,7 @@ FishModelGL::FishModelGL(const ContextGL *mContextGL,
                          MODELGROUP type,
                          MODELNAME name,
                          bool blend)
-    : FishModel(type, name, blend), mContextGL(mContextGL)
+    : FishModel(type, name, blend, aquarium), mContextGL(mContextGL)
 {
     mViewInverseUniform.first    = aquarium->lightWorldPositionUniform.viewInverse;
     mLightWorldPosUniform.first  = aquarium->lightWorldPositionUniform.lightWorldPos;


### PR DESCRIPTION
Aquarium D3D12 backend binded staging buffer to pipelines. This not
only impact on performance but also blocking from implementing
render pass, buffer pool or buffer mapping async. A more optimized
method is to copy data to staging buffer firstly and then copy from
staging buffer to device buffer.