### PR TITLE
Refactor D3D12 buffer updating II

### DIFF
--- a/src/aquarium-optimized/Aquarium.cpp
+++ b/src/aquarium-optimized/Aquarium.cpp
@@ -227,14 +227,16 @@ bool Aquarium::init(int argc, char **argv)
         }
         else if (cmd == "--enable-instanced-draws")
         {
-            if (!availableToggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS)))
+            /*if (!availableToggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS)))
             {
                 std::cerr << "Instanced draw path isn't implemented for the backend." << std::endl;
                 return false;
             }
             toggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS));
             // Disable map write aync for instanced draw mode
-            toggleBitset.reset(static_cast<size_t>(TOGGLE::BUFFERMAPPINGASYNC));
+            toggleBitset.reset(static_cast<size_t>(TOGGLE::BUFFERMAPPINGASYNC));*/
+            std::cerr << "Instanced draw path is deprecated." << std::endl;
+            return false;
         }
         else if (cmd == "--disable-dynamic-buffer-offset")
         {

--- a/src/aquarium-optimized/d3d12/ContextD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.cpp
@@ -891,24 +891,6 @@ ComPtr<ID3D12Resource> ContextD3D12::createDefaultBuffer(const void *initData,
     return defaultBuffer;
 }
 
-ComPtr<ID3D12Resource> ContextD3D12::createUploadBuffer(const void *initData, UINT64 byteSize) const
-{
-    // create an uploadBuffer for dynamic data.
-    ComPtr<ID3D12Resource> uploadBuffer;
-    CD3DX12_RESOURCE_DESC resourceDesc = CD3DX12_RESOURCE_DESC::Buffer(byteSize);
-    mDevice->CreateCommittedResource(&uploadheapProperties, D3D12_HEAP_FLAG_NONE, &resourceDesc,
-                                     D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
-                                     IID_PPV_ARGS(uploadBuffer.GetAddressOf()));
-
-    // Copy the triangle data to the vertex buffer.
-    UINT8 *pVertexDataBegin;
-    CD3DX12_RANGE readRange(0, 0);  // We do not intend to read from this resource on the CPU.
-    uploadBuffer->Map(0, &readRange, reinterpret_cast<void **>(&pVertexDataBegin));
-    memcpy(pVertexDataBegin, initData, byteSize);
-    uploadBuffer->Unmap(0, nullptr);
-    return uploadBuffer;
-}
-
 void ContextD3D12::createRootSignature(
     const D3D12_VERSIONED_ROOT_SIGNATURE_DESC &pRootSignatureDesc,
     ComPtr<ID3D12RootSignature> &rootSignature) const

--- a/src/aquarium-optimized/d3d12/ContextD3D12.h
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.h
@@ -77,7 +77,6 @@ class ContextD3D12 : public Context
     ComPtr<ID3D12Resource> createDefaultBuffer(const void *initData,
                                                UINT64 byteSize,
                                                ComPtr<ID3D12Resource> &uploadBuffer) const;
-    ComPtr<ID3D12Resource> createUploadBuffer(const void *initData, UINT64 byteSize) const;
     void createRootSignature(const D3D12_VERSIONED_ROOT_SIGNATURE_DESC &pRootSignatureDesc,
                              ComPtr<ID3D12RootSignature> &rootSignature) const;
     void createGraphicsPipelineState(

--- a/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.cpp
@@ -59,8 +59,9 @@ void FishModelInstancedDrawD3D12::init()
     mVertexBufferView[3] = mTangentBuffer->mVertexBufferView;
     mVertexBufferView[4] = mBiNormalBuffer->mVertexBufferView;
 
-    mFishPersBuffer = mContextD3D12->createUploadBuffer(
-        mFishPers, mContextD3D12->CalcConstantBufferByteSize(sizeof(FishPer) * instance));
+    mFishPersBuffer = mContextD3D12->createDefaultBuffer(
+        mFishPers, mContextD3D12->CalcConstantBufferByteSize(sizeof(FishPer) * instance),
+        mFishPersUploadBuffer);
     mFishPersBufferView.BufferLocation = mFishPersBuffer->GetGPUVirtualAddress();
     mFishPersBufferView.SizeInBytes =
         mContextD3D12->CalcConstantBufferByteSize(sizeof(FishPer) * instance);
@@ -152,17 +153,16 @@ void FishModelInstancedDrawD3D12::init()
         mProgramD3D12->getFSModule(), mPipelineState, mBlend);
 }
 
-void FishModelInstancedDrawD3D12::prepareForDraw() {}
+void FishModelInstancedDrawD3D12::prepareForDraw()
+{
+    mContextD3D12->updateConstantBufferSync(mFishPersBuffer, mFishPersUploadBuffer, mFishPers,
+                                            sizeof(FishPer) * instance);
+}
 
 void FishModelInstancedDrawD3D12::draw()
 {
     if (instance == 0)
         return;
-
-    CD3DX12_RANGE readRange(0, 0);
-    UINT8 *m_pCbvDataBegin;
-    mFishPersBuffer->Map(0, &readRange, reinterpret_cast<void **>(&m_pCbvDataBegin));
-    memcpy(m_pCbvDataBegin, mFishPers, sizeof(FishPer) * instance);
 
     auto &commandList = mContextD3D12->mCommandList;
 

--- a/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.h
+++ b/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.h
@@ -81,6 +81,7 @@ class FishModelInstancedDrawD3D12 : public FishModel
   private:
     D3D12_VERTEX_BUFFER_VIEW mFishPersBufferView;
     ComPtr<ID3D12Resource> mFishPersBuffer;
+    ComPtr<ID3D12Resource> mFishPersUploadBuffer;
 
     D3D12_CONSTANT_BUFFER_VIEW_DESC mLightFactorView;
     D3D12_GPU_DESCRIPTOR_HANDLE mLightFactorGPUHandle;

--- a/src/aquarium-optimized/d3d12/GenericModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/GenericModelD3D12.h
@@ -62,6 +62,7 @@ class GenericModelD3D12 : public Model
   private:
     D3D12_CONSTANT_BUFFER_VIEW_DESC mWorldBufferView;
     ComPtr<ID3D12Resource> mWorldBuffer;
+    ComPtr<ID3D12Resource> mWorldUploadBuffer;
 
     D3D12_CONSTANT_BUFFER_VIEW_DESC mLightFactorView;
     D3D12_GPU_DESCRIPTOR_HANDLE mLightFactorGPUHandle;

--- a/src/aquarium-optimized/d3d12/InnerModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/InnerModelD3D12.h
@@ -56,6 +56,7 @@ class InnerModelD3D12 : public Model
   private:
     D3D12_CONSTANT_BUFFER_VIEW_DESC mWorldBufferView;
     ComPtr<ID3D12Resource> mWorldBuffer;
+    ComPtr<ID3D12Resource> mWorldUploadBuffer;
 
     D3D12_CONSTANT_BUFFER_VIEW_DESC mInnerView;
     D3D12_GPU_DESCRIPTOR_HANDLE mInnerGPUHandle;

--- a/src/aquarium-optimized/d3d12/OutsideModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/OutsideModelD3D12.cpp
@@ -56,8 +56,9 @@ void OutsideModelD3D12::init()
     mLightFactorView.SizeInBytes    = mContextD3D12->CalcConstantBufferByteSize(
         sizeof(LightFactorUniforms));  // CB size is required to be 256-byte aligned.
     mContextD3D12->buildCbvDescriptor(mLightFactorView, &mLightFactorGPUHandle);
-    mWorldBuffer = mContextD3D12->createUploadBuffer(
-        &mWorldUniformPer, mContextD3D12->CalcConstantBufferByteSize(sizeof(WorldUniforms)));
+    mWorldBuffer = mContextD3D12->createDefaultBuffer(
+        &mWorldUniformPer, mContextD3D12->CalcConstantBufferByteSize(sizeof(WorldUniforms)),
+        mWorldUploadBuffer);
     mWorldBufferView.BufferLocation = mWorldBuffer->GetGPUVirtualAddress();
     mWorldBufferView.SizeInBytes = mContextD3D12->CalcConstantBufferByteSize(sizeof(WorldUniforms));
 
@@ -79,7 +80,7 @@ void OutsideModelD3D12::init()
     rootParameters[2].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
     rootParameters[3].InitAsDescriptorTable(1, &ranges[1], D3D12_SHADER_VISIBILITY_PIXEL);
 
-    rootParameters[4].InitAsConstantBufferView(0, 3, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC,
+    rootParameters[4].InitAsConstantBufferView(0, 3, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_VOLATILE,
                                                D3D12_SHADER_VISIBILITY_VERTEX);
 
     rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 2u,
@@ -93,7 +94,12 @@ void OutsideModelD3D12::init()
         mProgramD3D12->getFSModule(), mPipelineState, mBlend);
 }
 
-void OutsideModelD3D12::prepareForDraw() {}
+void OutsideModelD3D12::prepareForDraw()
+{
+    mContextD3D12->updateConstantBufferSync(
+        mWorldBuffer, mWorldUploadBuffer, &mWorldUniformPer,
+        mContextD3D12->CalcConstantBufferByteSize(sizeof(WorldUniforms)));
+}
 
 void OutsideModelD3D12::draw()
 {
@@ -119,9 +125,4 @@ void OutsideModelD3D12::draw()
 void OutsideModelD3D12::updatePerInstanceUniforms(const WorldUniforms &worldUniforms)
 {
     memcpy(&mWorldUniformPer, &worldUniforms, sizeof(WorldUniforms));
-
-    CD3DX12_RANGE readRange(0, 0);
-    UINT8 *m_pCbvDataBegin;
-    mWorldBuffer->Map(0, &readRange, reinterpret_cast<void **>(&m_pCbvDataBegin));
-    memcpy(m_pCbvDataBegin, &mWorldUniformPer, sizeof(WorldUniforms));
 }

--- a/src/aquarium-optimized/d3d12/OutsideModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/OutsideModelD3D12.h
@@ -57,6 +57,7 @@ class OutsideModelD3D12 : public Model
   private:
     D3D12_CONSTANT_BUFFER_VIEW_DESC mWorldBufferView;
     ComPtr<ID3D12Resource> mWorldBuffer;
+    ComPtr<ID3D12Resource> mWorldUploadBuffer;
 
     D3D12_CONSTANT_BUFFER_VIEW_DESC mLightFactorView;
     D3D12_GPU_DESCRIPTOR_HANDLE mLightFactorGPUHandle;

--- a/src/aquarium-optimized/d3d12/SeaweedModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/SeaweedModelD3D12.h
@@ -68,8 +68,10 @@ class SeaweedModelD3D12 : public SeaweedModel
   private:
     D3D12_CONSTANT_BUFFER_VIEW_DESC mWorldBufferView;
     ComPtr<ID3D12Resource> mWorldBuffer;
+    ComPtr<ID3D12Resource> mWorldUploadBuffer;
     D3D12_CONSTANT_BUFFER_VIEW_DESC mSeaweedBufferView;
     ComPtr<ID3D12Resource> mSeaweedBuffer;
+    ComPtr<ID3D12Resource> mSeaweedUploadBuffer;
 
     D3D12_CONSTANT_BUFFER_VIEW_DESC mLightFactorView;
     D3D12_GPU_DESCRIPTOR_HANDLE mLightFactorGPUHandle;


### PR DESCRIPTION
Use copy buffer region to update uniforms for world matrix and
seaweed uniform.
Instanced draw is deprecated after code refactor of fish buffer
reallocation.