### PR TITLE
Implement buffer manager

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -21,6 +21,8 @@ executable("aquarium") {
     "src/aquarium-optimized/Aquarium.cpp",
     "src/aquarium-optimized/Aquarium.h",
     "src/aquarium-optimized/Buffer.h",
+    "src/aquarium-optimized/BufferManager.h",
+    "src/aquarium-optimized/BufferManager.cpp",
     "src/aquarium-optimized/Context.h",
     "src/aquarium-optimized/Context.cpp",
     "src/aquarium-optimized/ContextFactory.cpp",
@@ -139,6 +141,8 @@ executable("aquarium") {
       "src/aquarium-optimized/dawn/TextureDawn.h",
       "src/aquarium-optimized/dawn/imgui_impl_dawn.cpp",
       "src/aquarium-optimized/dawn/imgui_impl_dawn.h",
+      "src/aquarium-optimized/dawn/BufferManagerDawn.h",
+      "src/aquarium-optimized/dawn/BufferManagerDawn.cpp",
     ]
 
     deps += [

--- a/src/aquarium-optimized/Aquarium.cpp
+++ b/src/aquarium-optimized/Aquarium.cpp
@@ -785,7 +785,10 @@ void Aquarium::render()
             calculateFishCount();
             bool enableDynamicBufferOffset =
                 toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEDYNAMICBUFFEROFFSET));
-            mContext->reallocResource(mPreFishCount, mCurFishCount, enableDynamicBufferOffset);
+            bool enableBufferMappingAsync =
+                toggleBitset.test(static_cast<size_t>(TOGGLE::BUFFERMAPPINGASYNC));
+            mContext->reallocResource(mPreFishCount, mCurFishCount, enableDynamicBufferOffset,
+                                      !enableBufferMappingAsync);
             mPreFishCount = mCurFishCount;
 
             resetFpsTime();
@@ -1021,3 +1024,4 @@ void Aquarium::updateWorldMatrix(Model *model)
 
     model->prepareForDraw();
 }
+

--- a/src/aquarium-optimized/BufferManager.cpp
+++ b/src/aquarium-optimized/BufferManager.cpp
@@ -1,0 +1,89 @@
+#include "BufferManager.h"
+
+#include "common/AQUARIUM_ASSERT.h"
+
+BufferManager::BufferManager()
+    : mBufferPoolSize(BUFFER_POOL_MAX_SIZE), mUsedSize(0)
+{
+}
+
+BufferManager::~BufferManager()
+{
+    destroyBufferPool();
+}
+
+bool BufferManager::resetBuffer(RingBuffer *ringBuffer, size_t size)
+{
+    size_t index = find(ringBuffer);
+
+    if (index >= mBufferPool.size())
+    {
+        return false;
+    }
+
+    size_t oldSize = ringBuffer->getSize(); 
+
+    bool result = ringBuffer->reset(size);
+	// If the size is larger than the ring buffer size, reset fails and the ring
+	// buffer retains.
+	// If the size is equal or smaller than the ring buffer size, reset success
+	// and the used size need to be updated.
+    if (!result)
+    {
+        return false;
+    } else
+	{
+        mUsedSize = mUsedSize- oldSize + size;
+	}
+
+	return true;
+}
+
+bool BufferManager::destoryBuffer(RingBuffer *ringBuffer)
+{
+	size_t index = find(ringBuffer);
+
+    if (index >= mBufferPool.size())
+    {
+        return false;
+    }
+
+    mUsedSize -= ringBuffer->getSize();
+    ringBuffer->destory();
+    mBufferPool.erase(mBufferPool.begin() + index);
+
+	return true;
+}
+
+size_t BufferManager::find(RingBuffer *ringBuffer)
+{
+    size_t index = 0;
+    for (auto buffer : mBufferPool)
+    {
+        if (buffer == ringBuffer)
+        {
+            break;
+        }
+        index++;
+    }
+    return index;
+}
+
+void BufferManager::destroyBufferPool()
+{
+    for (auto ringBuffer: mBufferPool)
+	{
+        ringBuffer->destory();
+	}
+    mBufferPool.clear();
+}
+
+// Flush copy commands in buffer pool
+void BufferManager::flush()
+{
+    for (auto buffer : mBufferPool)
+    {
+        buffer->flush();
+    }
+}
+

--- a/src/aquarium-optimized/BufferManager.cpp
+++ b/src/aquarium-optimized/BufferManager.cpp
@@ -16,7 +16,7 @@ bool BufferManager::resetBuffer(RingBuffer *ringBuffer, size_t size)
 {
     size_t index = find(ringBuffer);
 
-    if (index >= mBufferPool.size())
+    if (index >= mEnqueuedBufferList.size())
     {
         return false;
     }
@@ -31,10 +31,11 @@ bool BufferManager::resetBuffer(RingBuffer *ringBuffer, size_t size)
     if (!result)
     {
         return false;
-    } else
+    }
+	else
 	{
-        mUsedSize = mUsedSize- oldSize + size;
-	}
+        mUsedSize = mUsedSize - oldSize + size;
+    }
 
 	return true;
 }
@@ -43,22 +44,22 @@ bool BufferManager::destoryBuffer(RingBuffer *ringBuffer)
 {
 	size_t index = find(ringBuffer);
 
-    if (index >= mBufferPool.size())
+    if (index >= mEnqueuedBufferList.size())
     {
         return false;
     }
 
     mUsedSize -= ringBuffer->getSize();
     ringBuffer->destory();
-    mBufferPool.erase(mBufferPool.begin() + index);
+    mEnqueuedBufferList.erase(mEnqueuedBufferList.begin() + index);
 
-	return true;
+    return true;
 }
 
 size_t BufferManager::find(RingBuffer *ringBuffer)
 {
     size_t index = 0;
-    for (auto buffer : mBufferPool)
+    for (auto buffer : mEnqueuedBufferList)
     {
         if (buffer == ringBuffer)
         {
@@ -69,19 +70,10 @@ size_t BufferManager::find(RingBuffer *ringBuffer)
     return index;
 }
 
-void BufferManager::destroyBufferPool()
-{
-    for (auto ringBuffer: mBufferPool)
-	{
-        ringBuffer->destory();
-	}
-    mBufferPool.clear();
-}
-
 // Flush copy commands in buffer pool
 void BufferManager::flush()
 {
-    for (auto buffer : mBufferPool)
+    for (auto buffer : mEnqueuedBufferList)
     {
         buffer->flush();
     }

--- a/src/aquarium-optimized/BufferManager.h
+++ b/src/aquarium-optimized/BufferManager.h
@@ -7,10 +7,11 @@
 // recycle.
 #pragma once
 
+#include <queue>
 #include <vector>
 #include "Context.h"
 
-constexpr size_t BUFFER_POOL_MAX_SIZE = 1048576;
+constexpr size_t BUFFER_POOL_MAX_SIZE = 409600000;
 
 class RingBuffer
 {
@@ -34,18 +35,20 @@ class BufferManager
 {
   public:
     BufferManager();
-    ~BufferManager();
+    virtual ~BufferManager();
 
     size_t GetSize() const { return mBufferPoolSize; }
     bool resetBuffer(RingBuffer *ringBuffer, size_t size);
     bool destoryBuffer(RingBuffer *ringBuffer);
-    void destroyBufferPool();
-    void flush();
+    virtual void destroyBufferPool() {}
+    virtual void flush();
 
-    virtual RingBuffer *allocate(size_t size) { return nullptr; }
+    virtual RingBuffer *allocate(size_t size, bool sync) { return nullptr; }
+
+    std::queue<RingBuffer *> mMappedBufferList;
 
   protected:
-    std::vector<RingBuffer *> mBufferPool;
+    std::vector<RingBuffer *> mEnqueuedBufferList;
     size_t mBufferPoolSize;
     size_t mUsedSize;
 

--- a/src/aquarium-optimized/BufferManager.h
+++ b/src/aquarium-optimized/BufferManager.h
@@ -1,0 +1,54 @@
+//
+// Copyright (c) 2019 The Aquarium Project Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+// BufferManager.h: Implements buffer pool to manage buffer allocation and
+// recycle.
+#pragma once
+
+#include <vector>
+#include "Context.h"
+
+constexpr size_t BUFFER_POOL_MAX_SIZE = 1048576;
+
+class RingBuffer
+{
+  public:
+    RingBuffer(size_t size) : mHead(0), mTail(size), mSize(size) {}
+    ~RingBuffer() {}
+
+    size_t getSize() const { return mSize; }
+
+    virtual bool reset(size_t size) { return false; }
+    virtual void flush() {}
+    virtual void destory() {}
+
+  protected:
+    size_t mHead;
+    size_t mTail;
+    size_t mSize;
+};
+
+class BufferManager
+{
+  public:
+    BufferManager();
+    ~BufferManager();
+
+    size_t GetSize() const { return mBufferPoolSize; }
+    bool resetBuffer(RingBuffer *ringBuffer, size_t size);
+    bool destoryBuffer(RingBuffer *ringBuffer);
+    void destroyBufferPool();
+    void flush();
+
+    virtual RingBuffer *allocate(size_t size) { return nullptr; }
+
+  protected:
+    std::vector<RingBuffer *> mBufferPool;
+    size_t mBufferPoolSize;
+    size_t mUsedSize;
+
+  private:
+    size_t find(RingBuffer *ringBuffer);
+};

--- a/src/aquarium-optimized/Context.cpp
+++ b/src/aquarium-optimized/Context.cpp
@@ -137,6 +137,15 @@ void Context::renderImgui(const FPSTimer &fpsTimer,
             {
                 ImGui::Text("VALIDATION: ON");
             }
+
+            if (toggleBitset->test(static_cast<size_t>(TOGGLE::BUFFERMAPPINGASYNC)))
+            {
+                ImGui::Text("BUFFERMAPPINGASNC: ON");
+            }
+            else
+            {
+                ImGui::Text("BUFFERMAPPINGASNC: OFF");
+            }
         }
 
         ImGui::Checkbox("Option Window", &show_option_window);

--- a/src/aquarium-optimized/Context.h
+++ b/src/aquarium-optimized/Context.h
@@ -54,8 +54,9 @@ class Context
     virtual void KeyBoardQuit()                                                               = 0;
     virtual void DoFlush(
         const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset) = 0;
-    virtual void Terminate()                                                                  = 0;
+    virtual void Terminate()                                                     = 0;
     virtual void Flush() {}
+
     virtual void preFrame()   = 0;
     virtual void showWindow() = 0;
     virtual void updateFPS(const FPSTimer &fpsTimer,
@@ -65,7 +66,10 @@ class Context
     virtual void destoryImgUI() = 0;
     virtual void reallocResource(int preTotalInstance,
                                  int curTotalInstance,
-                                 bool enableDynamicBufferOffset)   = 0;
+                                 bool enableDynamicBufferOffset,
+                                 bool enableBufferMappingAsync)
+    {
+    }
     virtual void updateAllFishData(
         const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset) = 0;
     virtual void beginRenderPass() {}

--- a/src/aquarium-optimized/d3d12/ContextD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.cpp
@@ -1240,7 +1240,8 @@ UINT ContextD3D12::CalcConstantBufferByteSize(UINT byteSize)
 
 void ContextD3D12::reallocResource(int preTotalInstance,
                                    int curTotalInstance,
-                                   bool enableDynamicBufferOffset)
+                                   bool enableDynamicBufferOffset,
+                                   bool enableBufferMappingAsync)
 {
     mPreTotalInstance = preTotalInstance;
     mCurTotalInstance = curTotalInstance;

--- a/src/aquarium-optimized/d3d12/ContextD3D12.h
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.h
@@ -105,7 +105,8 @@ class ContextD3D12 : public Context
     void FlushPreviousFrames();
     void reallocResource(int preTotalInstance,
                          int curTotalInstance,
-                         bool enableDynamicBufferOffset) override;
+                         bool enableDynamicBufferOffset,
+                         bool enableBufferMappingAsync) override;
     void updateAllFishData(
         const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset) override;
     void updateConstantBufferSync(ComPtr<ID3D12Resource> defaultBuffer,

--- a/src/aquarium-optimized/dawn/BufferManagerDawn.cpp
+++ b/src/aquarium-optimized/dawn/BufferManagerDawn.cpp
@@ -1,0 +1,128 @@
+#include "BufferManagerDawn.h"
+
+#include "common/AQUARIUM_ASSERT.h"
+
+RingBufferDawn::RingBufferDawn(ContextDawn* context, size_t size)
+    : RingBuffer(size), mSync(true), mContext(context), mappedData(nullptr)
+{
+    reset(size);
+}
+
+bool RingBufferDawn::push(wgpu::Buffer &destBuffer,
+                                     size_t dest_offset,
+	                                 void *pixels,
+                                     size_t size)
+{
+    mTail = mHead + size;
+    if (mTail > mSize)
+    {
+        return false;
+    }
+
+	if (mSync)
+    {
+        // TODO(yizhou): The mapped buffer sync can only be used once, we should try to use map write async.
+		memcpy(mBufferMappedResult.data, pixels, size);
+		mBufferMappedResult.buffer.Unmap();
+		mEncoder.CopyBufferToBuffer(mBufferMappedResult.buffer, mHead, destBuffer, dest_offset, size);
+	}
+    else
+	{
+		memcpy(mappedData, pixels, size);
+        mStagingBuffer.Unmap();
+        mEncoder.CopyBufferToBuffer(mStagingBuffer, mHead, destBuffer, dest_offset, size);
+	}
+
+    mHead = mTail;
+    return true;
+}
+
+// Reset current buffer and reuse the buffer.
+bool RingBufferDawn::reset(size_t size)
+{
+    if (size > mSize)
+        return false;
+
+    mEncoder = mContext->getDevice().CreateCommandEncoder();
+    mHead    = 0;
+    mTail    = 0;
+
+    if (mSync)
+    {
+        mBufferMappedResult = mContext->CreateBufferMapped(
+            wgpu::BufferUsage::MapWrite | wgpu::BufferUsage::CopySrc, size);
+    }
+    else  // buffer mapping async
+    {
+        // mStagingBuffer.Release();
+        mStagingBuffer =
+            mContext->createBuffer(size, wgpu::BufferUsage::MapWrite | wgpu::BufferUsage::CopySrc);
+    }
+    return true;
+}
+
+void RingBufferDawn::MapWriteCallback(WGPUBufferMapAsyncStatus status,
+                                                 void *data,
+                                                 uint64_t,
+                                                 void *userdata)
+{
+    ASSERT(status == WGPUBufferMapAsyncStatus_Success);
+    ASSERT(data != nullptr);
+    RingBufferDawn *ringBuffer = static_cast<RingBufferDawn *>(userdata);
+
+    wgpu::CommandBuffer copy = ringBuffer->mEncoder.Finish();
+    ringBuffer->mContext->queue.Submit(1, &copy);
+}
+
+void * RingBufferDawn::MapWriteAsyncAndWait(const wgpu::Buffer &buffer)
+{
+    buffer.MapWriteAsync(MapWriteCallback, this);
+
+    while (mappedData == nullptr)
+    {
+        mContext->WaitABit();
+    }
+
+    void *resultPointer = mappedData;
+    mappedData          = nullptr;
+
+    return resultPointer;
+}
+
+void RingBufferDawn::flush()
+{
+    mHead = 0;
+    mTail = 0;
+    if (mSync)
+    {
+        wgpu::CommandBuffer copy = mEncoder.Finish();
+        mContext->mCommandBuffers.emplace_back(copy);
+    }
+    else
+    {
+        MapWriteAsyncAndWait(mStagingBuffer);
+    }
+}
+
+void RingBufferDawn::destory()
+{
+    mStagingBuffer = nullptr;
+    mEncoder       = nullptr;
+}
+
+// Allocate new buffer from buffer pool.
+RingBufferDawn *BufferManagerDawn::allocate(size_t size)
+{
+    if (mUsedSize + size > mBufferPoolSize)
+    {
+        return nullptr;
+    }
+    mUsedSize += size;
+
+    // TODO(yizhou): Refactor ring buffer allocation. Get the last one and check if the ring buffer
+    // is full. If the buffer can hold extra size space, use the last one directly.
+    RingBufferDawn* ringBuffer = new RingBufferDawn(mContext, size);
+    mBufferPool.emplace_back(ringBuffer);
+
+    return ringBuffer;
+}

--- a/src/aquarium-optimized/dawn/BufferManagerDawn.cpp
+++ b/src/aquarium-optimized/dawn/BufferManagerDawn.cpp
@@ -1,17 +1,20 @@
 #include "BufferManagerDawn.h"
 
+#include <iostream>
+#include <thread>
 #include "common/AQUARIUM_ASSERT.h"
 
-RingBufferDawn::RingBufferDawn(ContextDawn* context, size_t size)
-    : RingBuffer(size), mSync(true), mContext(context), mappedData(nullptr)
+RingBufferDawn::RingBufferDawn(BufferManagerDawn *bufferManager, size_t size)
+    : RingBuffer(size), mBufferManager(bufferManager), mappedData(nullptr), mPixels(nullptr)
 {
     reset(size);
 }
 
-bool RingBufferDawn::push(wgpu::Buffer &destBuffer,
-                                     size_t dest_offset,
-	                                 void *pixels,
-                                     size_t size)
+bool RingBufferDawn::push(const wgpu::CommandEncoder &encoder,
+                          wgpu::Buffer &destBuffer,
+                          size_t dest_offset,
+                          void *pixels,
+                          size_t size)
 {
     mTail = mHead + size;
     if (mTail > mSize)
@@ -19,19 +22,8 @@ bool RingBufferDawn::push(wgpu::Buffer &destBuffer,
         return false;
     }
 
-	if (mSync)
-    {
-        // TODO(yizhou): The mapped buffer sync can only be used once, we should try to use map write async.
-		memcpy(mBufferMappedResult.data, pixels, size);
-		mBufferMappedResult.buffer.Unmap();
-		mEncoder.CopyBufferToBuffer(mBufferMappedResult.buffer, mHead, destBuffer, dest_offset, size);
-	}
-    else
-	{
-		memcpy(mappedData, pixels, size);
-        mStagingBuffer.Unmap();
-        mEncoder.CopyBufferToBuffer(mStagingBuffer, mHead, destBuffer, dest_offset, size);
-	}
+    memcpy(mPixels, pixels, size);
+    encoder.CopyBufferToBuffer(mBufferMappedResult.buffer, mHead, destBuffer, dest_offset, size);
 
     mHead = mTail;
     return true;
@@ -43,86 +35,161 @@ bool RingBufferDawn::reset(size_t size)
     if (size > mSize)
         return false;
 
-    mEncoder = mContext->getDevice().CreateCommandEncoder();
-    mHead    = 0;
-    mTail    = 0;
+    mHead = 0;
+    mTail = 0;
 
-    if (mSync)
-    {
-        mBufferMappedResult = mContext->CreateBufferMapped(
-            wgpu::BufferUsage::MapWrite | wgpu::BufferUsage::CopySrc, size);
-    }
-    else  // buffer mapping async
-    {
-        // mStagingBuffer.Release();
-        mStagingBuffer =
-            mContext->createBuffer(size, wgpu::BufferUsage::MapWrite | wgpu::BufferUsage::CopySrc);
-    }
+    mBufferMappedResult = mBufferManager->mContext->CreateBufferMapped(
+        wgpu::BufferUsage::MapWrite | wgpu::BufferUsage::CopySrc, mSize);
+    mPixels = mBufferMappedResult.data;
+
     return true;
 }
 
 void RingBufferDawn::MapWriteCallback(WGPUBufferMapAsyncStatus status,
-                                                 void *data,
-                                                 uint64_t,
-                                                 void *userdata)
+                                      void *data,
+                                      uint64_t,
+                                      void *userdata)
 {
     ASSERT(status == WGPUBufferMapAsyncStatus_Success);
     ASSERT(data != nullptr);
+
     RingBufferDawn *ringBuffer = static_cast<RingBufferDawn *>(userdata);
+    ringBuffer->mappedData     = data;
 
-    wgpu::CommandBuffer copy = ringBuffer->mEncoder.Finish();
-    ringBuffer->mContext->queue.Submit(1, &copy);
-}
-
-void * RingBufferDawn::MapWriteAsyncAndWait(const wgpu::Buffer &buffer)
-{
-    buffer.MapWriteAsync(MapWriteCallback, this);
-
-    while (mappedData == nullptr)
-    {
-        mContext->WaitABit();
-    }
-
-    void *resultPointer = mappedData;
-    mappedData          = nullptr;
-
-    return resultPointer;
+    ringBuffer->mBufferManager->mMappedBufferList.push(ringBuffer);
 }
 
 void RingBufferDawn::flush()
 {
     mHead = 0;
     mTail = 0;
-    if (mSync)
-    {
-        wgpu::CommandBuffer copy = mEncoder.Finish();
-        mContext->mCommandBuffers.emplace_back(copy);
-    }
-    else
-    {
-        MapWriteAsyncAndWait(mStagingBuffer);
-    }
+
+    mBufferMappedResult.buffer.Unmap();
 }
 
 void RingBufferDawn::destory()
 {
-    mStagingBuffer = nullptr;
-    mEncoder       = nullptr;
+    mBufferMappedResult.buffer = nullptr;
+}
+
+void RingBufferDawn::reMap()
+{
+    mBufferMappedResult.buffer.MapWriteAsync(MapWriteCallback, this);
+}
+
+BufferManagerDawn::BufferManagerDawn(ContextDawn *context) : mContext(context)
+{
+    mEncoder = context->createCommandEncoder();
+}
+
+BufferManagerDawn::~BufferManagerDawn()
+{
+    mEncoder = nullptr;
 }
 
 // Allocate new buffer from buffer pool.
-RingBufferDawn *BufferManagerDawn::allocate(size_t size)
+RingBufferDawn *BufferManagerDawn::allocate(size_t size, bool sync)
 {
-    if (mUsedSize + size > mBufferPoolSize)
-    {
-        return nullptr;
-    }
-    mUsedSize += size;
-
     // TODO(yizhou): Refactor ring buffer allocation. Get the last one and check if the ring buffer
     // is full. If the buffer can hold extra size space, use the last one directly.
-    RingBufferDawn* ringBuffer = new RingBufferDawn(mContext, size);
-    mBufferPool.emplace_back(ringBuffer);
+    // If update data by sync method, create new buffer to upload every frame.
+    // If updaye data by async method, get new buffer from pool if available. If no available
+    // buffer, create a new buffer.
+    mSync = sync;
+
+    RingBufferDawn *ringBuffer = nullptr;
+    if (sync)
+    {
+        if (mUsedSize + size > mBufferPoolSize)
+        {
+            return nullptr;
+        }
+
+        ringBuffer = new RingBufferDawn(this, size);
+        mEnqueuedBufferList.emplace_back(ringBuffer);
+    }
+    else
+    {
+        while (!mMappedBufferList.empty())
+        {
+            ringBuffer = static_cast<RingBufferDawn *>(mMappedBufferList.front());
+            mMappedBufferList.pop();
+            if (ringBuffer->getSize() < size)
+            {
+                mUsedSize += ringBuffer->getSize();
+                ringBuffer->destory();
+                ringBuffer = nullptr;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        if (ringBuffer == nullptr)
+        {
+            if (mUsedSize + size > mBufferPoolSize)
+            {
+                return nullptr;
+            }
+            mUsedSize += size;
+            std::cout << mUsedSize << std::endl;
+            ringBuffer = new RingBufferDawn(this, size);
+        }
+
+        if (mEnqueuedBufferList.empty() || mEnqueuedBufferList.back() != ringBuffer)
+        {
+            mEnqueuedBufferList.emplace_back(ringBuffer);
+        }
+    }
 
     return ringBuffer;
+}
+
+void BufferManagerDawn::flush()
+{
+    for (auto buffer : mEnqueuedBufferList)
+    {
+        buffer->flush();
+    }
+
+    wgpu::CommandBuffer copy = mEncoder.Finish();
+    mContext->queue.Submit(1, &copy);
+
+    // Async function
+    if (!mSync)
+    {
+        for (size_t index = 0; index < mEnqueuedBufferList.size(); index++)
+        {
+            RingBufferDawn *ringBuffer = static_cast<RingBufferDawn *>(mEnqueuedBufferList[index]);
+            ringBuffer->reMap();
+        }
+    }
+    else
+    {
+        // All buffers are used once in buffer sync mode.
+        for (size_t index = 0; index < mEnqueuedBufferList.size(); index++)
+        {
+            RingBufferDawn *ringBuffer = static_cast<RingBufferDawn *>(mEnqueuedBufferList[index]);
+            delete ringBuffer;
+        }
+        mUsedSize = 0;
+    }
+
+    mEnqueuedBufferList.clear();
+    mEncoder = mContext->createCommandEncoder();
+}
+
+void BufferManagerDawn::destroyBufferPool()
+{
+    if (!mSync)
+    {
+        return;
+    }
+
+    for (auto ringBuffer : mEnqueuedBufferList)
+    {
+        ringBuffer->destory();
+    }
+    mEnqueuedBufferList.clear();
 }

--- a/src/aquarium-optimized/dawn/BufferManagerDawn.h
+++ b/src/aquarium-optimized/dawn/BufferManagerDawn.h
@@ -1,0 +1,57 @@
+//
+// Copyright (c) 2019 The Aquarium Project Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+// BufferManager.h: Implements buffer pool to manage buffer allocation and
+// recycle.
+#pragma once
+
+#include <dawn/webgpu_cpp.h>
+#include <vector>
+#include "../BufferManager.h"
+#include "ContextDawn.h"
+
+class ContextDawn;
+
+class RingBufferDawn : public RingBuffer
+{
+  public:
+    RingBufferDawn(ContextDawn *context, size_t size);
+
+    bool push(wgpu::Buffer &destBuffer, size_t dest_offset, void* pixels, size_t size);
+    bool reset(size_t size) override;
+    void flush() override;
+    void destory() override;
+
+    wgpu::CreateBufferMappedResult getCreateBufferMappedResult() const
+    {
+        return mBufferMappedResult;
+    }
+    wgpu::Buffer getStagingBuffer() const { return mStagingBuffer; }
+
+  private:
+    static void MapWriteCallback(WGPUBufferMapAsyncStatus status,
+                                 void *data,
+                                 uint64_t,
+                                 void *userdata);
+    void *MapWriteAsyncAndWait(const wgpu::Buffer &buffer);
+
+    bool mSync;
+    wgpu::CreateBufferMappedResult mBufferMappedResult;
+    wgpu::Buffer mStagingBuffer;
+    wgpu::CommandEncoder mEncoder;
+    ContextDawn *mContext;
+    void *mappedData;
+};
+
+class BufferManagerDawn: public BufferManager
+{
+  public:
+    BufferManagerDawn(ContextDawn *context) : mContext(context) {}
+
+    RingBufferDawn *allocate(size_t size) override;
+
+  private:
+    ContextDawn *mContext;
+};

--- a/src/aquarium-optimized/dawn/ContextDawn.h
+++ b/src/aquarium-optimized/dawn/ContextDawn.h
@@ -9,18 +9,20 @@
 #ifndef CONTEXTDAWN_H
 #define CONTEXTDAWN_H
 
+#include "../Context.h"
+
 #include <dawn/webgpu_cpp.h>
 #include <dawn_native/DawnNative.h>
 
 #include "GLFW/glfw3.h"
 #include "utils/WGPUHelpers.h"
-
-#include "../Context.h"
+#include "BufferManagerDawn.h"
 
 class TextureDawn;
 class BufferDawn;
 class ProgramDawn;
-enum BACKENDTYPE: short;
+class BufferManagerDawn;
+enum BACKENDTYPE : short;
 
 class ContextDawn : public Context
 {
@@ -46,7 +48,7 @@ class ContextDawn : public Context
 
     void preFrame() override;
 
-    Model *createModel(Aquarium* aquarium, MODELGROUP type, MODELNAME name, bool blend) override;
+    Model *createModel(Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend) override;
     Buffer *createBuffer(int numComponents, std::vector<float> *buffer, bool isIndex) override;
     Buffer *createBuffer(int numComponents,
                          std::vector<unsigned short> *buffer,
@@ -70,7 +72,7 @@ class ContextDawn : public Context
                                            uint64_t srcOffset,
                                            wgpu::Buffer const &destBuffer,
                                            uint64_t destOffset,
-                                           uint64_t size);
+                                           uint64_t size) const;
 
     wgpu::TextureCopyView createTextureCopyView(wgpu::Texture texture,
                                                 uint32_t level,
@@ -98,8 +100,8 @@ class ContextDawn : public Context
         const wgpu::BindGroupLayout &layout,
         std::initializer_list<utils::BindingInitializationHelper> bindingsInitializer) const;
 
-    void initGeneralResources(Aquarium* aquarium) override;
-    void updateWorldlUniforms(Aquarium* aquarium) override;
+    void initGeneralResources(Aquarium *aquarium) override;
+    void updateWorldlUniforms(Aquarium *aquarium) override;
     const wgpu::Device &getDevice() const { return mDevice; }
     const wgpu::RenderPassEncoder &getRenderPass() const { return mRenderPass; }
 
@@ -108,7 +110,8 @@ class ContextDawn : public Context
                          bool enableDynamicBufferOffset) override;
     void updateAllFishData(
         const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset) override;
-    wgpu::CreateBufferMappedResult CreateBufferMapped(wgpu::BufferUsage usage, uint64_t size);
+    wgpu::CreateBufferMappedResult CreateBufferMapped(wgpu::BufferUsage usage, uint64_t size) const;
+    void WaitABit();
 
     std::vector<wgpu::CommandBuffer> mCommandBuffers;
     wgpu::Queue queue;
@@ -138,7 +141,6 @@ class ContextDawn : public Context
     void destoryFishResource();
 
     static void MapWriteCallback(WGPUBufferMapAsyncStatus status, void *, uint64_t, void *userdata);
-    void WaitABit();
 
     // TODO(jiawei.shao@intel.com): remove wgpu::TextureUsageBit::CopyDst when the bug in Dawn is
     // fixed.
@@ -167,6 +169,8 @@ class ContextDawn : public Context
 
     bool mEnableMSAA;
     bool mEnableDynamicBufferOffset;
+
+	BufferManagerDawn *bufferManager;
 
     void *mappedData;
 };

--- a/src/aquarium-optimized/dawn/ContextDawn.h
+++ b/src/aquarium-optimized/dawn/ContextDawn.h
@@ -14,13 +14,14 @@
 #include <dawn/webgpu_cpp.h>
 #include <dawn_native/DawnNative.h>
 
+#include "BufferManagerDawn.h"
 #include "GLFW/glfw3.h"
 #include "utils/WGPUHelpers.h"
-#include "BufferManagerDawn.h"
 
 class TextureDawn;
 class BufferDawn;
 class ProgramDawn;
+class RingBufferDawn;
 class BufferManagerDawn;
 enum BACKENDTYPE : short;
 
@@ -107,11 +108,13 @@ class ContextDawn : public Context
 
     void reallocResource(int preTotalInstance,
                          int curTotalInstance,
-                         bool enableDynamicBufferOffset) override;
+                         bool enableDynamicBufferOffset,
+                         bool enableBufferMappingAsync) override;
     void updateAllFishData(
         const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset) override;
     wgpu::CreateBufferMappedResult CreateBufferMapped(wgpu::BufferUsage usage, uint64_t size) const;
     void WaitABit();
+    wgpu::CommandEncoder createCommandEncoder() const;
 
     std::vector<wgpu::CommandBuffer> mCommandBuffers;
     wgpu::Queue queue;
@@ -125,7 +128,6 @@ class ContextDawn : public Context
     wgpu::Buffer fishPersBuffer;
     wgpu::BindGroup *bindGroupFishPers;
 
-    wgpu::Buffer stagingBuffer;
     FishPer *fishPers;
 
     wgpu::Device mDevice;
@@ -139,8 +141,6 @@ class ContextDawn : public Context
     void initAvailableToggleBitset(BACKENDTYPE backendType) override;
     static void framebufferResizeCallback(GLFWwindow *window, int width, int height);
     void destoryFishResource();
-
-    static void MapWriteCallback(WGPUBufferMapAsyncStatus status, void *, uint64_t, void *userdata);
 
     // TODO(jiawei.shao@intel.com): remove wgpu::TextureUsageBit::CopyDst when the bug in Dawn is
     // fixed.
@@ -170,9 +170,7 @@ class ContextDawn : public Context
     bool mEnableMSAA;
     bool mEnableDynamicBufferOffset;
 
-	BufferManagerDawn *bufferManager;
-
-    void *mappedData;
+    BufferManagerDawn *bufferManager;
 };
 
 #endif

--- a/src/aquarium-optimized/opengl/ContextGL.cpp
+++ b/src/aquarium-optimized/opengl/ContextGL.cpp
@@ -381,12 +381,6 @@ void ContextGL::generateMipmap(unsigned int target)
     glGenerateMipmap(target);
 }
 
-void ContextGL::reallocResource(int preTotalInstance,
-                                int curTotalInstance,
-                                bool enableDynamicBufferOffset)
-{
-}
-
 void ContextGL::updateAllFishData(
     const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset)
 {

--- a/src/aquarium-optimized/opengl/ContextGL.h
+++ b/src/aquarium-optimized/opengl/ContextGL.h
@@ -95,9 +95,6 @@ class ContextGL : public Context
                        unsigned char *pixel);
     void setParameter(unsigned int target, unsigned int pname, int param);
     void generateMipmap(unsigned int target);
-    void reallocResource(int preTotalInstance,
-                         int curTotalInstance,
-                         bool enableDynamicBufferOffset) override;
     void updateAllFishData(
         const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset) override;
 


### PR DESCRIPTION
Use a buffer pool to manage all buffers for allocation and deallocation,
define a maximum memory for the buffer pool. A buffer pool can allocate
many ring buffers until the max limit. Every ring buffer is reponsible for
push, reset, destory or flush copy cmds to command buffer.
This patch refactor buffer updating method by the buffer pool for Dawn
backend and implements both sync and async method to upload fish data.