### PR TITLE
Implement alpha blending toggle for Aquarium

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 # Third party libraries
 third_party/*
 !third_party/glad
+!third_party/imgui
 !third_party/BUILD.gn
 
 # Gn build dummy folders

--- a/DEPS
+++ b/DEPS
@@ -9,7 +9,6 @@ vars = {
   'github_git': 'https://github.com',
   'dawn_git': 'https://dawn.googlesource.com',
   'dawn_revision': 'ce8bf128ec1327b28d933a15e055bda286f31231',
-  'imgui_revision': 'e16564e67a2e88d4cbe3afa6594650712790fba3',
   'angle_root': 'third_party/angle',
   'angle_revision': '6c824a1bc17b286b86cf05a0228ec549875351eb',
   'glslang_revision': '38b4db48f98c4e3a9cc405de3a76547b857e1c37',
@@ -66,9 +65,6 @@ deps = {
   },
   'third_party/SPIRV-Tools': {
     'url': '{chromium_git}/external/github.com/KhronosGroup/SPIRV-Tools@{spirv_tools_revision}',
-  },
-  'third_party/imgui': {
-    'url': '{github_git}/ocornut/imgui.git@{imgui_revision}',
   },
   'third_party/jsoncpp': {
     'url': '{chromium_git}/chromium/src/third_party/jsoncpp@{jsoncpp_revision}',

--- a/README.md
+++ b/README.md
@@ -325,8 +325,10 @@ aquarium.exe --num-fish 10000 --backend dawn_d3d12 --disable-d3d12-render-pass
 #“--disable-dawn-validation” : Disable Dawn validation.
 aquarium.exe --num-fish 10000 --backend dawn_d3d12 --disable-dawn-validation
 
-#"--enable-alpha-blending" : Force enable alpha blending for all models.
-aquarium.exe --num-fish 10000 --backend opengl --enable-alpha-blending
+#"--enable-alpha-blending=[0, 1]" : Force enable alpha blending for all models. By default, alpha blending is disabled.
+#Imgui uses stb truetype to render characters to gray bitmaps with format alpha8. The alpha value of the bitmap is 255 #or 0. When alpha blending is enabled, the pixels of the glyphs shows only if alpha is 255, while the other pixels are #rendered as background color. When alpha blending is disabled, the pixels are set to white if alpha is 255, and black
+#if alpha is 0.
+aquarium.exe --num-fish 10000 --backend opengl --enable-alpha-blending=0.5
 
 # aquarium-direct-map only has OpenGL backend
 # Enable MSAA

--- a/shaders/dawn/imguiFragmentShader
+++ b/shaders/dawn/imguiFragmentShader
@@ -5,8 +5,8 @@ layout(location = 2) in vec4 v_color;
 
 layout(set = 0, binding = 1) uniform sampler samplerTex2D;
 layout(set = 0, binding = 2) uniform texture2D tex;
-layout(location = 0) out vec4 Out_Color;
+layout(location = 0) out vec4 diffuseColor;
 void main()
 {
-    Out_Color = v_color * texture(sampler2D(tex, samplerTex2D), v_uv.st);
+    diffuseColor = v_color * texture(sampler2D(tex, samplerTex2D), v_uv.st);
 }

--- a/src/aquarium-optimized/Aquarium.cpp
+++ b/src/aquarium-optimized/Aquarium.cpp
@@ -51,6 +51,7 @@ Aquarium::Aquarium()
     g.eyeClock      = 0.0;
     g.lastUpdateFps = 0.0;
     g.fpsCount      = 0;
+    g.alpha         = "1";
 
     lightUniforms.lightColor[0] = 1.0f;
     lightUniforms.lightColor[1] = 1.0f;
@@ -367,8 +368,18 @@ bool Aquarium::init(int argc, char **argv)
 
             toggleBitset.set(static_cast<size_t>(TOGGLE::DISABLEDAWNVALIDATION));
         }
-        else if (cmd == "--enable-alpha-blending")
+        else if (cmd.find("--enable-alpha-blending") != std::string::npos)
         {
+            size_t pos = cmd.find("=");
+            if (pos != std::string::npos)
+            {
+                g.alpha = cmd.substr(pos + 1).c_str();
+            }
+            else
+            {
+                g.alpha = "0.8";
+            }
+
             toggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEALPHABLENDING));
         }
         else
@@ -630,11 +641,11 @@ void Aquarium::loadModel(const G_sceneInfo &info)
             if (toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEALPHABLENDING)) &&
                 info.type != MODELGROUP::INNER && info.type != MODELGROUP::OUTSIDE)
             {
-                program->compileProgram(true);
+                program->compileProgram(true, g.alpha);
             }
             else
             {
-                program->compileProgram(false);
+                program->compileProgram(false, g.alpha);
             }
             mProgramMap[vsId + fsId] = program;
         }

--- a/src/aquarium-optimized/Aquarium.h
+++ b/src/aquarium-optimized/Aquarium.h
@@ -226,14 +226,12 @@ const G_sceneInfo g_sceneInfo[] = {
      MODELNAME::MODELSEAWEEDA,
      {"seaweedVertexShader", "seaweedFragmentShader"},
      false,
-     MODELGROUP::SEAWEED,
-     true},
+     MODELGROUP::SEAWEED},
     {"SeaweedB",
      MODELNAME::MODELSEAWEEDB,
      {"seaweedVertexShader", "seaweedFragmentShader"},
      false,
-     MODELGROUP::SEAWEED,
-     true},
+     MODELGROUP::SEAWEED},
     {"Skybox",
      MODELNAME::MODELSKYBOX,
      {"diffuseVertexShader", "diffuseFragmentShader"},
@@ -408,6 +406,7 @@ struct Global
     int fpsCount;
     float mclock;
     float eyeClock;
+    std::string alpha;
 };
 
 struct LightWorldPositionUniform

--- a/src/aquarium-optimized/Context.cpp
+++ b/src/aquarium-optimized/Context.cpp
@@ -85,6 +85,15 @@ void Context::renderImgui(const FPSTimer &fpsTimer,
             ImGui::Text("MSAAx4: OFF");
         }
 
+        if (toggleBitset->test(static_cast<size_t>(TOGGLE::ENABLEALPHABLENDING)))
+        {
+            ImGui::Text("ALPHABLENDING: ON");
+        }
+        else
+        {
+            ImGui::Text("ALPHABLENDING: OFF");
+        }
+
         if (toggleBitset->test(static_cast<size_t>(TOGGLE::ENABLEDYNAMICBUFFEROFFSET)))
         {
             ImGui::Text("DBO: ON");

--- a/src/aquarium-optimized/Program.h
+++ b/src/aquarium-optimized/Program.h
@@ -22,7 +22,7 @@ class Program
     }
     virtual ~Program() {}
     virtual void setProgram() {}
-    virtual void compileProgram(bool enableAlphaBlending) = 0;
+    virtual void compileProgram(bool enableAlphaBlending, const std::string &alpha) = 0;
 
   protected:
     void loadProgram();

--- a/src/aquarium-optimized/d3d12/ContextD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.cpp
@@ -508,7 +508,8 @@ void ContextD3D12::updateFPS(const FPSTimer &fpsTimer,
                              std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> *toggleBitset)
 {
     // Start the Dear ImGui frame
-    ImGui_ImplDX12_NewFrame(mEnableMSAA);
+    ImGui_ImplDX12_NewFrame(toggleBitset->test(static_cast<TOGGLE>(TOGGLE::ENABLEMSAAx4)),
+                            toggleBitset->test(static_cast<TOGGLE>(TOGGLE::ENABLEALPHABLENDING)));
     renderImgui(fpsTimer, fishCount, toggleBitset);
     ImGui_ImplDX12_RenderDrawData(ImGui::GetDrawData(), mCommandList.Get());
 }

--- a/src/aquarium-optimized/d3d12/ProgramD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/ProgramD3D12.cpp
@@ -16,14 +16,14 @@ ProgramD3D12::ProgramD3D12(ContextD3D12 *context, const std::string &mVId, const
 
 ProgramD3D12::~ProgramD3D12() {}
 
-void ProgramD3D12::compileProgram(bool enableBlending)
+void ProgramD3D12::compileProgram(bool enableBlending, const std::string& alpha)
 {
     loadProgram();
 
     if (enableBlending)
     {
         FragmentShaderCode =
-            std::regex_replace(FragmentShaderCode, std::regex(R"(diffuseColor.w)"), "0.5");
+            std::regex_replace(FragmentShaderCode, std::regex(R"(diffuseColor.w)"), alpha);
     }
 
     mVertexShader = context->createShaderModule("VS", VertexShaderCode);

--- a/src/aquarium-optimized/d3d12/ProgramD3D12.h
+++ b/src/aquarium-optimized/d3d12/ProgramD3D12.h
@@ -29,7 +29,7 @@ class ProgramD3D12 : public Program
     ProgramD3D12(ContextD3D12 *context, const std::string &mVId, const std::string &mFId);
     ~ProgramD3D12() override;
 
-    void compileProgram(bool enableAlphaBlending) override;
+    void compileProgram(bool enableAlphaBlending, const std::string &alpha) override;
     ComPtr<ID3DBlob> getVSModule() { return mVertexShader; }
     ComPtr<ID3DBlob> getFSModule() { return mPixelShader; }
 

--- a/src/aquarium-optimized/d3d12/imgui_impl_dx12.cpp
+++ b/src/aquarium-optimized/d3d12/imgui_impl_dx12.cpp
@@ -268,13 +268,13 @@ void ImGui_ImplDX12_Draw(ImDrawData *draw_data, ID3D12GraphicsCommandList *ctx)
     }
 }
 
-static void ImGui_ImplDX12_CreateFontsTexture()
+static void ImGui_ImplDX12_CreateFontsTexture(bool enableAlphaBlending)
 {
     // Build texture atlas
     ImGuiIO &io = ImGui::GetIO();
     unsigned char *pixels;
     int width, height;
-    io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
+    io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height, enableAlphaBlending);
 
     // Upload texture to graphics system
     {
@@ -425,7 +425,7 @@ static void ImGui_ImplDX12_CreateFontsTexture()
     io.Fonts->TexID = (ImTextureID)g_hFontSrvGpuDescHandle.ptr;
 }
 
-bool ImGui_ImplDX12_CreateDeviceObjects(bool enableMSAA)
+bool ImGui_ImplDX12_CreateDeviceObjects(bool enableMSAA, bool enableAlphaBlending)
 {
     if (!g_pd3dDevice)
         return false;
@@ -589,7 +589,7 @@ bool ImGui_ImplDX12_CreateDeviceObjects(bool enableMSAA)
     {
         D3D12_BLEND_DESC &desc                     = psoDesc.BlendState;
         desc.AlphaToCoverageEnable                 = false;
-        desc.RenderTarget[0].BlendEnable           = true;
+        desc.RenderTarget[0].BlendEnable           = enableAlphaBlending;
         desc.RenderTarget[0].SrcBlend              = D3D12_BLEND_SRC_ALPHA;
         desc.RenderTarget[0].DestBlend             = D3D12_BLEND_INV_SRC_ALPHA;
         desc.RenderTarget[0].BlendOp               = D3D12_BLEND_OP_ADD;
@@ -632,7 +632,7 @@ bool ImGui_ImplDX12_CreateDeviceObjects(bool enableMSAA)
         S_OK)
         return false;
 
-    ImGui_ImplDX12_CreateFontsTexture();
+    ImGui_ImplDX12_CreateFontsTexture(enableAlphaBlending);
 
     return true;
 }
@@ -731,8 +731,8 @@ void ImGui_ImplDX12_Shutdown()
     g_frameIndex                = UINT_MAX;
 }
 
-void ImGui_ImplDX12_NewFrame(bool enableMSAA)
+void ImGui_ImplDX12_NewFrame(bool enableMSAA, bool enableAlphaBlending)
 {
     if (!g_pPipelineState)
-        ImGui_ImplDX12_CreateDeviceObjects(enableMSAA);
+        ImGui_ImplDX12_CreateDeviceObjects(enableMSAA, enableAlphaBlending);
 }

--- a/src/aquarium-optimized/d3d12/imgui_impl_dx12.h
+++ b/src/aquarium-optimized/d3d12/imgui_impl_dx12.h
@@ -35,11 +35,11 @@ IMGUI_IMPL_API bool ImGui_ImplDX12_Init(ID3D12Device *device,
                                         D3D12_CPU_DESCRIPTOR_HANDLE font_srv_cpu_desc_handle,
                                         D3D12_GPU_DESCRIPTOR_HANDLE font_srv_gpu_desc_handle);
 IMGUI_IMPL_API void ImGui_ImplDX12_Shutdown();
-IMGUI_IMPL_API void ImGui_ImplDX12_NewFrame(bool enableMSAA);
+IMGUI_IMPL_API void ImGui_ImplDX12_NewFrame(bool enableMSAA, bool enableAlphaBlending);
 IMGUI_IMPL_API void ImGui_ImplDX12_RenderDrawData(ImDrawData *draw_data,
                                                   ID3D12GraphicsCommandList *graphics_command_list);
 IMGUI_IMPL_API void ImGui_ImplDX12_Draw(ImDrawData *draw_data, ID3D12GraphicsCommandList *ctx);
 
 // Use if you want to reset your rendering device without losing ImGui state.
 IMGUI_IMPL_API void ImGui_ImplDX12_InvalidateDeviceObjects();
-IMGUI_IMPL_API bool ImGui_ImplDX12_CreateDeviceObjects(bool enableMSAA);
+IMGUI_IMPL_API bool ImGui_ImplDX12_CreateDeviceObjects(bool enableMSAA, bool enableAlphaBlending);

--- a/src/aquarium-optimized/dawn/ContextDawn.cpp
+++ b/src/aquarium-optimized/dawn/ContextDawn.cpp
@@ -690,7 +690,8 @@ void ContextDawn::updateFPS(const FPSTimer &fpsTimer,
                             std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> *toggleBitset)
 {
     // Start the Dear ImGui frame
-    ImGui_ImplDawn_NewFrame(mEnableMSAA);
+    ImGui_ImplDawn_NewFrame(toggleBitset->test(static_cast<TOGGLE>(TOGGLE::ENABLEMSAAx4)),
+                            toggleBitset->test(static_cast<TOGGLE>(TOGGLE::ENABLEALPHABLENDING)));
     renderImgui(fpsTimer, fishCount, toggleBitset);
     ImGui_ImplDawn_RenderDrawData(ImGui::GetDrawData());
 }
@@ -730,12 +731,18 @@ void ContextDawn::preFrame()
         mRenderPassDescriptor = utils::ComboRenderPassDescriptor({mSceneRenderTargetView},
                                                                  mSceneDepthStencilView);
         mRenderPassDescriptor.cColorAttachments[0].resolveTarget = mBackbufferView;
+        mRenderPassDescriptor.cColorAttachments[0].loadOp        = wgpu::LoadOp::Clear;
+        mRenderPassDescriptor.cColorAttachments[0].storeOp       = wgpu::StoreOp::Clear;
+        mRenderPassDescriptor.cColorAttachments[0].clearColor    = {0.f, 0.8f, 1.f, 0.f};
     }
     else
     {
         // When MSAA is off, we render directly to the backbuffer
         mRenderPassDescriptor =
             utils::ComboRenderPassDescriptor({mBackbufferView}, mSceneDepthStencilView);
+        mRenderPassDescriptor.cColorAttachments[0].loadOp     = wgpu::LoadOp::Clear;
+        mRenderPassDescriptor.cColorAttachments[0].storeOp    = wgpu::StoreOp::Store;
+        mRenderPassDescriptor.cColorAttachments[0].clearColor = {0.f, 0.8f, 1.f, 0.f};
     }
 
     mRenderPass = mCommandEncoder.BeginRenderPass(&mRenderPassDescriptor);

--- a/src/aquarium-optimized/dawn/ProgramDawn.cpp
+++ b/src/aquarium-optimized/dawn/ProgramDawn.cpp
@@ -23,7 +23,7 @@ ProgramDawn::~ProgramDawn()
     mFsModule = nullptr;
 }
 
-void ProgramDawn::compileProgram(bool enableBlending)
+void ProgramDawn::compileProgram(bool enableBlending, const std::string &alpha)
 {
     loadProgram();
 
@@ -35,7 +35,7 @@ void ProgramDawn::compileProgram(bool enableBlending)
     if (enableBlending)
     {
         FragmentShaderCode =
-            std::regex_replace(FragmentShaderCode, std::regex(R"(diffuseColor.a)"), "0.5");
+            std::regex_replace(FragmentShaderCode, std::regex(R"(diffuseColor.a)"), alpha);
     }
 
     mVsModule = context->createShaderModule(utils::SingleShaderStage::Vertex, VertexShaderCode);

--- a/src/aquarium-optimized/dawn/ProgramDawn.h
+++ b/src/aquarium-optimized/dawn/ProgramDawn.h
@@ -29,7 +29,7 @@ public:
     ProgramDawn(ContextDawn *context, const std::string &mVId, const std::string &mFId);
     ~ProgramDawn() override;
 
-    void compileProgram(bool enableAlphaBlending) override;
+    void compileProgram(bool enableAlphaBlending, const std::string& alpha) override;
     wgpu::ShaderModule getVSModule() { return mVsModule; }
     wgpu::ShaderModule getFSModule() { return mFsModule; }
 

--- a/src/aquarium-optimized/dawn/imgui_impl_dawn.h
+++ b/src/aquarium-optimized/dawn/imgui_impl_dawn.h
@@ -12,9 +12,11 @@
 
 IMGUI_IMPL_API bool ImGui_ImplDawn_Init(ContextDawn *context, wgpu::TextureFormat rtv_format);
 IMGUI_IMPL_API void ImGui_ImplDawn_Shutdown();
-IMGUI_IMPL_API void ImGui_ImplDawn_NewFrame(bool enableMSAA);
+IMGUI_IMPL_API void ImGui_ImplDawn_NewFrame(bool enableMSAA,
+                                            bool enableAlphaBlending);
 IMGUI_IMPL_API void ImGui_ImplDawn_RenderDrawData(ImDrawData *draw_data);
 IMGUI_IMPL_API void ImGui_ImplDawn_Draw(ImDrawData *draw_data);
 
 // Use if you want to reset your rendering mDevice without losing ImGui state.
-IMGUI_IMPL_API bool ImGui_ImplDawn_CreateDeviceObjects();
+IMGUI_IMPL_API bool ImGui_ImplDawn_CreateDeviceObjects(bool enableMSAA,
+                                                       bool enableAlphaBlending);

--- a/src/aquarium-optimized/opengl/ContextGL.cpp
+++ b/src/aquarium-optimized/opengl/ContextGL.cpp
@@ -396,9 +396,6 @@ void ContextGL::initState()
 {
     glEnable(GL_DEPTH_TEST);
     glColorMask(true, true, true, true);
-    glClearColor(0, 0.8f, 1, 0);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glBlendEquation(GL_FUNC_ADD);
     glEnable(GL_CULL_FACE);
     glDepthMask(true);
 }
@@ -477,7 +474,9 @@ void ContextGL::updateFPS(const FPSTimer &fpsTimer,
                           std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> *toggleBitset)
 {
     // Start the Dear ImGui frame
-    ImGui_ImplOpenGL3_NewFrame();
+    ImGui_ImplOpenGL3_NewFrame(
+        toggleBitset->test(static_cast<TOGGLE>(TOGGLE::ENABLEMSAAx4)),
+        toggleBitset->test(static_cast<TOGGLE>(TOGGLE::ENABLEALPHABLENDING)));
     renderImgui(fpsTimer, fishCount, toggleBitset);
     ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 }
@@ -509,6 +508,8 @@ void ContextGL::enableBlend(bool flag) const
     if (flag)
     {
         glEnable(GL_BLEND);
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        glBlendEquation(GL_FUNC_ADD);
     }
     else
     {
@@ -555,7 +556,7 @@ Model *ContextGL::createModel(Aquarium *aquarium, MODELGROUP type, MODELNAME nam
 
 void ContextGL::preFrame()
 {
-    glClearColor(0.0f, 1.0f, 0.0f, 1.0f);
+    glClearColor(0, 0.8, 1, 0);
     glEnable(GL_DEPTH_TEST);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 

--- a/src/aquarium-optimized/opengl/ProgramGL.cpp
+++ b/src/aquarium-optimized/opengl/ProgramGL.cpp
@@ -45,7 +45,7 @@ ProgramGL::~ProgramGL()
     mContext->deleteProgram(mProgramId);
 }
 
-void ProgramGL::compileProgram(bool enableBlending)
+void ProgramGL::compileProgram(bool enableBlending, const std::string &alpha)
 {
     loadProgram();
 
@@ -79,7 +79,7 @@ void ProgramGL::compileProgram(bool enableBlending)
     if (enableBlending)
     {
         FragmentShaderCode =
-            std::regex_replace(FragmentShaderCode, std::regex(R"(diffuseColor.a)"), "0.5");
+            std::regex_replace(FragmentShaderCode, std::regex(R"(diffuseColor.a)"), alpha);
     }
 
     bool status = mContext->compileProgram(mProgramId, VertexShaderCode, FragmentShaderCode);

--- a/src/aquarium-optimized/opengl/ProgramGL.h
+++ b/src/aquarium-optimized/opengl/ProgramGL.h
@@ -32,7 +32,7 @@ public:
     void setProgram() override;
     GLuint getProgramId() const { return mProgramId; }
     GLuint getVAOId() { return mVAO; }
-    void compileProgram(bool enableAlphaBlending) override;
+    void compileProgram(bool enableAlphaBlending, const std::string& alpha) override;
 
   private:
     GLuint mProgramId;

--- a/src/aquarium-optimized/opengl/imgui_impl_opengl3.h
+++ b/src/aquarium-optimized/opengl/imgui_impl_opengl3.h
@@ -40,11 +40,12 @@
 
 IMGUI_IMPL_API bool ImGui_ImplOpenGL3_Init(const char *glsl_version = NULL);
 IMGUI_IMPL_API void ImGui_ImplOpenGL3_Shutdown();
-IMGUI_IMPL_API void ImGui_ImplOpenGL3_NewFrame();
+IMGUI_IMPL_API void ImGui_ImplOpenGL3_NewFrame(bool enableMSAA, bool enableAlphaBlending);
 IMGUI_IMPL_API void ImGui_ImplOpenGL3_RenderDrawData(ImDrawData *draw_data);
 
 // Called by Init/NewFrame/Shutdown
-IMGUI_IMPL_API bool ImGui_ImplOpenGL3_CreateFontsTexture();
+IMGUI_IMPL_API bool ImGui_ImplOpenGL3_CreateFontsTexture(bool enableAlphaBlending);
 IMGUI_IMPL_API void ImGui_ImplOpenGL3_DestroyFontsTexture();
-IMGUI_IMPL_API bool ImGui_ImplOpenGL3_CreateDeviceObjects();
+IMGUI_IMPL_API bool ImGui_ImplOpenGL3_CreateDeviceObjects(bool enableMSAA,
+                                                          bool enableAlphaBlending);
 IMGUI_IMPL_API void ImGui_ImplOpenGL3_DestroyDeviceObjects();

--- a/src/include/CmdArgsHelper.h
+++ b/src/include/CmdArgsHelper.h
@@ -14,7 +14,7 @@ const char *cmdArgsStrAquarium = R"(Options and arguments:
 --buffer-mapping-async  : Upload uniforms by buffer mapping async for Dawn backend.
 --disable-dynamic-buffer-offset : The path is to test individual draw by creating many binding groups on dawn backend. By default, dynamic buffer offset is enabled. This option is only supported on dawn backend.
 --discrete-gpu          : Choose discrete gpu to render the application. This is only supported on Dawn and D3D12 backend.
---enable-alpha-blending : Force enable alpha blending for all models. By default, only seaweed enables alpha blending.
+--enable-alpha-blending=[0, 1] : Force enable alpha blending for all models. By default, alpha blending is disabled.
 --enable-instanced-draws : specifies rendering fishes by instanced draw. By default, fishes are rendered by individual draw.Instanced rendering is only supported on dawn and d3d12 backend now.
 --enable-msaa           : Enable 4 samples MSAA. MSAA of angle backend is not supported now.
 --enable-full-screen-mode       : Render aquarium in full screen mode instead of window mode.

--- a/third_party/BUILD.gn
+++ b/third_party/BUILD.gn
@@ -182,6 +182,9 @@ source_set("imgui") {
     "imgui/imgui_draw.cpp",
     "imgui/imgui_internal.h",
     "imgui/imgui_widgets.cpp",
+    "imgui/imstb_rectpack.h",
+    "imgui/imstb_textedit.h",
+    "imgui/imstb_truetype.h",
     "imgui/examples/imgui_impl_glfw.h",
     "imgui/examples/imgui_impl_glfw.cpp",
   ]
@@ -191,3 +194,4 @@ source_set("imgui") {
     "-Wno-unused-result",
   ]
 }
+

--- a/third_party/imgui/LICENSE.txt
+++ b/third_party/imgui/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 Omar Cornut
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/imgui/examples/imgui_impl_glfw.cpp
+++ b/third_party/imgui/examples/imgui_impl_glfw.cpp
@@ -1,0 +1,367 @@
+// dear imgui: Platform Binding for GLFW
+// This needs to be used along with a Renderer (e.g. OpenGL3, Vulkan..)
+// (Info: GLFW is a cross-platform general purpose library for handling windows, inputs,
+// OpenGL/Vulkan graphics context creation, etc.) (Requires: GLFW 3.1+)
+
+// Implemented features:
+//  [X] Platform: Clipboard support.
+//  [X] Platform: Gamepad support. Enable with 'io.ConfigFlags |=
+//  ImGuiConfigFlags_NavEnableGamepad'. [x] Platform: Mouse cursor shape and visibility. Disable
+//  with 'io.ConfigFlags |= ImGuiConfigFlags_NoMouseCursorChange'. FIXME: 3 cursors types are
+//  missing from GLFW. [X] Platform: Keyboard arrays indexed using GLFW_KEY_* codes, e.g.
+//  ImGui::IsKeyPressed(GLFW_KEY_SPACE).
+
+// You can copy and use unmodified imgui_impl_* files in your project. See main.cpp for an example
+// of using this. If you are new to dear imgui, read examples/README.txt and read the documentation
+// at the top of imgui.cpp. https://github.com/ocornut/imgui
+
+// CHANGELOG
+// (minor and older changes stripped away, please see git history for details)
+//  2019-05-11: Inputs: Don't filter value from character callback before calling
+//  AddInputCharacter(). 2019-03-12: Misc: Preserve DisplayFramebufferScale when main window is
+//  minimized. 2018-11-30: Misc: Setting up io.BackendPlatformName so it can be displayed in the
+//  About Window. 2018-11-07: Inputs: When installing our GLFW callbacks, we save user's previously
+//  installed ones - if any - and chain call them. 2018-08-01: Inputs: Workaround for Emscripten
+//  which doesn't seem to handle focus related calls. 2018-06-29: Inputs: Added support for the
+//  ImGuiMouseCursor_Hand cursor. 2018-06-08: Misc: Extracted imgui_impl_glfw.cpp/.h away from the
+//  old combined GLFW+OpenGL/Vulkan examples. 2018-03-20: Misc: Setup io.BackendFlags
+//  ImGuiBackendFlags_HasMouseCursors flag + honor ImGuiConfigFlags_NoMouseCursorChange flag.
+//  2018-02-20: Inputs: Added support for mouse cursors (ImGui::GetMouseCursor() value, passed to
+//  glfwSetCursor()). 2018-02-06: Misc: Removed call to ImGui::Shutdown() which is not available
+//  from 1.60 WIP, user needs to call CreateContext/DestroyContext themselves. 2018-02-06: Inputs:
+//  Added mapping for ImGuiKey_Space. 2018-01-25: Inputs: Added gamepad support if
+//  ImGuiConfigFlags_NavEnableGamepad is set. 2018-01-25: Inputs: Honoring the io.WantSetMousePos by
+//  repositioning the mouse (when using navigation and ImGuiConfigFlags_NavMoveMouse is set).
+//  2018-01-20: Inputs: Added Horizontal Mouse Wheel support.
+//  2018-01-18: Inputs: Added mapping for ImGuiKey_Insert.
+//  2017-08-25: Inputs: MousePos set to -FLT_MAX,-FLT_MAX when mouse is unavailable/missing (instead
+//  of -1,-1). 2016-10-15: Misc: Added a void* user_data parameter to Clipboard function handlers.
+
+#include "imgui_impl_glfw.h"
+
+// GLFW
+#include <GLFW/glfw3.h>
+#ifdef _WIN32
+#undef APIENTRY
+#define GLFW_EXPOSE_NATIVE_WIN32
+#include <GLFW/glfw3native.h>  // for glfwGetWin32Window
+#endif
+#define GLFW_HAS_WINDOW_TOPMOST \
+    (GLFW_VERSION_MAJOR * 1000 + GLFW_VERSION_MINOR * 100 >= 3200)  // 3.2+ GLFW_FLOATING
+#define GLFW_HAS_WINDOW_HOVERED \
+    (GLFW_VERSION_MAJOR * 1000 + GLFW_VERSION_MINOR * 100 >= 3300)  // 3.3+ GLFW_HOVERED
+#define GLFW_HAS_WINDOW_ALPHA \
+    (GLFW_VERSION_MAJOR * 1000 + GLFW_VERSION_MINOR * 100 >= 3300)  // 3.3+ glfwSetWindowOpacity
+#define GLFW_HAS_PER_MONITOR_DPI                             \
+    (GLFW_VERSION_MAJOR * 1000 + GLFW_VERSION_MINOR * 100 >= \
+     3300)  // 3.3+ glfwGetMonitorContentScale
+#define GLFW_HAS_VULKAN \
+    (GLFW_VERSION_MAJOR * 1000 + GLFW_VERSION_MINOR * 100 >= 3200)  // 3.2+ glfwCreateWindowSurface
+
+// Data
+enum GlfwClientApi
+{
+    GlfwClientApi_Unknown,
+    GlfwClientApi_OpenGL,
+    GlfwClientApi_Vulkan
+};
+static GLFWwindow *g_Window                               = NULL;  // Main window
+static GlfwClientApi g_ClientApi                          = GlfwClientApi_Unknown;
+static double g_Time                                      = 0.0;
+static bool g_MouseJustPressed[5]                         = {false, false, false, false, false};
+static GLFWcursor *g_MouseCursors[ImGuiMouseCursor_COUNT] = {0};
+
+// Chain GLFW callbacks: our callbacks will call the user's previously installed callbacks, if any.
+static GLFWmousebuttonfun g_PrevUserCallbackMousebutton = NULL;
+static GLFWscrollfun g_PrevUserCallbackScroll           = NULL;
+static GLFWkeyfun g_PrevUserCallbackKey                 = NULL;
+static GLFWcharfun g_PrevUserCallbackChar               = NULL;
+
+static const char *ImGui_ImplGlfw_GetClipboardText(void *user_data)
+{
+    return glfwGetClipboardString((GLFWwindow *)user_data);
+}
+
+static void ImGui_ImplGlfw_SetClipboardText(void *user_data, const char *text)
+{
+    glfwSetClipboardString((GLFWwindow *)user_data, text);
+}
+
+void ImGui_ImplGlfw_MouseButtonCallback(GLFWwindow *window, int button, int action, int mods)
+{
+    if (g_PrevUserCallbackMousebutton != NULL)
+        g_PrevUserCallbackMousebutton(window, button, action, mods);
+
+    if (action == GLFW_PRESS && button >= 0 && button < IM_ARRAYSIZE(g_MouseJustPressed))
+        g_MouseJustPressed[button] = true;
+}
+
+void ImGui_ImplGlfw_ScrollCallback(GLFWwindow *window, double xoffset, double yoffset)
+{
+    if (g_PrevUserCallbackScroll != NULL)
+        g_PrevUserCallbackScroll(window, xoffset, yoffset);
+
+    ImGuiIO &io = ImGui::GetIO();
+    io.MouseWheelH += (float)xoffset;
+    io.MouseWheel += (float)yoffset;
+}
+
+void ImGui_ImplGlfw_KeyCallback(GLFWwindow *window, int key, int scancode, int action, int mods)
+{
+    if (g_PrevUserCallbackKey != NULL)
+        g_PrevUserCallbackKey(window, key, scancode, action, mods);
+
+    ImGuiIO &io = ImGui::GetIO();
+    if (action == GLFW_PRESS)
+        io.KeysDown[key] = true;
+    if (action == GLFW_RELEASE)
+        io.KeysDown[key] = false;
+
+    // Modifiers are not reliable across systems
+    io.KeyCtrl  = io.KeysDown[GLFW_KEY_LEFT_CONTROL] || io.KeysDown[GLFW_KEY_RIGHT_CONTROL];
+    io.KeyShift = io.KeysDown[GLFW_KEY_LEFT_SHIFT] || io.KeysDown[GLFW_KEY_RIGHT_SHIFT];
+    io.KeyAlt   = io.KeysDown[GLFW_KEY_LEFT_ALT] || io.KeysDown[GLFW_KEY_RIGHT_ALT];
+    io.KeySuper = io.KeysDown[GLFW_KEY_LEFT_SUPER] || io.KeysDown[GLFW_KEY_RIGHT_SUPER];
+}
+
+void ImGui_ImplGlfw_CharCallback(GLFWwindow *window, unsigned int c)
+{
+    if (g_PrevUserCallbackChar != NULL)
+        g_PrevUserCallbackChar(window, c);
+
+    ImGuiIO &io = ImGui::GetIO();
+    io.AddInputCharacter(c);
+}
+
+static bool ImGui_ImplGlfw_Init(GLFWwindow *window,
+                                bool install_callbacks,
+                                GlfwClientApi client_api)
+{
+    g_Window = window;
+    g_Time   = 0.0;
+
+    // Setup back-end capabilities flags
+    ImGuiIO &io = ImGui::GetIO();
+    io.BackendFlags |=
+        ImGuiBackendFlags_HasMouseCursors;  // We can honor GetMouseCursor() values (optional)
+    io.BackendFlags |= ImGuiBackendFlags_HasSetMousePos;  // We can honor io.WantSetMousePos
+                                                          // requests (optional, rarely used)
+    io.BackendPlatformName = "imgui_impl_glfw";
+
+    // Keyboard mapping. ImGui will use those indices to peek into the io.KeysDown[] array.
+    io.KeyMap[ImGuiKey_Tab]        = GLFW_KEY_TAB;
+    io.KeyMap[ImGuiKey_LeftArrow]  = GLFW_KEY_LEFT;
+    io.KeyMap[ImGuiKey_RightArrow] = GLFW_KEY_RIGHT;
+    io.KeyMap[ImGuiKey_UpArrow]    = GLFW_KEY_UP;
+    io.KeyMap[ImGuiKey_DownArrow]  = GLFW_KEY_DOWN;
+    io.KeyMap[ImGuiKey_PageUp]     = GLFW_KEY_PAGE_UP;
+    io.KeyMap[ImGuiKey_PageDown]   = GLFW_KEY_PAGE_DOWN;
+    io.KeyMap[ImGuiKey_Home]       = GLFW_KEY_HOME;
+    io.KeyMap[ImGuiKey_End]        = GLFW_KEY_END;
+    io.KeyMap[ImGuiKey_Insert]     = GLFW_KEY_INSERT;
+    io.KeyMap[ImGuiKey_Delete]     = GLFW_KEY_DELETE;
+    io.KeyMap[ImGuiKey_Backspace]  = GLFW_KEY_BACKSPACE;
+    io.KeyMap[ImGuiKey_Space]      = GLFW_KEY_SPACE;
+    io.KeyMap[ImGuiKey_Enter]      = GLFW_KEY_ENTER;
+    io.KeyMap[ImGuiKey_Escape]     = GLFW_KEY_ESCAPE;
+    io.KeyMap[ImGuiKey_A]          = GLFW_KEY_A;
+    io.KeyMap[ImGuiKey_C]          = GLFW_KEY_C;
+    io.KeyMap[ImGuiKey_V]          = GLFW_KEY_V;
+    io.KeyMap[ImGuiKey_X]          = GLFW_KEY_X;
+    io.KeyMap[ImGuiKey_Y]          = GLFW_KEY_Y;
+    io.KeyMap[ImGuiKey_Z]          = GLFW_KEY_Z;
+
+    io.SetClipboardTextFn = ImGui_ImplGlfw_SetClipboardText;
+    io.GetClipboardTextFn = ImGui_ImplGlfw_GetClipboardText;
+    io.ClipboardUserData  = g_Window;
+#if defined(_WIN32)
+    io.ImeWindowHandle = (void *)glfwGetWin32Window(g_Window);
+#endif
+
+    g_MouseCursors[ImGuiMouseCursor_Arrow]     = glfwCreateStandardCursor(GLFW_ARROW_CURSOR);
+    g_MouseCursors[ImGuiMouseCursor_TextInput] = glfwCreateStandardCursor(GLFW_IBEAM_CURSOR);
+    g_MouseCursors[ImGuiMouseCursor_ResizeAll] =
+        glfwCreateStandardCursor(GLFW_ARROW_CURSOR);  // FIXME: GLFW doesn't have this.
+    g_MouseCursors[ImGuiMouseCursor_ResizeNS] = glfwCreateStandardCursor(GLFW_VRESIZE_CURSOR);
+    g_MouseCursors[ImGuiMouseCursor_ResizeEW] = glfwCreateStandardCursor(GLFW_HRESIZE_CURSOR);
+    g_MouseCursors[ImGuiMouseCursor_ResizeNESW] =
+        glfwCreateStandardCursor(GLFW_ARROW_CURSOR);  // FIXME: GLFW doesn't have this.
+    g_MouseCursors[ImGuiMouseCursor_ResizeNWSE] =
+        glfwCreateStandardCursor(GLFW_ARROW_CURSOR);  // FIXME: GLFW doesn't have this.
+    g_MouseCursors[ImGuiMouseCursor_Hand] = glfwCreateStandardCursor(GLFW_HAND_CURSOR);
+
+    // Chain GLFW callbacks: our callbacks will call the user's previously installed callbacks, if
+    // any.
+    g_PrevUserCallbackMousebutton = NULL;
+    g_PrevUserCallbackScroll      = NULL;
+    g_PrevUserCallbackKey         = NULL;
+    g_PrevUserCallbackChar        = NULL;
+    if (install_callbacks)
+    {
+        g_PrevUserCallbackMousebutton =
+            glfwSetMouseButtonCallback(window, ImGui_ImplGlfw_MouseButtonCallback);
+        g_PrevUserCallbackScroll = glfwSetScrollCallback(window, ImGui_ImplGlfw_ScrollCallback);
+        g_PrevUserCallbackKey    = glfwSetKeyCallback(window, ImGui_ImplGlfw_KeyCallback);
+        g_PrevUserCallbackChar   = glfwSetCharCallback(window, ImGui_ImplGlfw_CharCallback);
+    }
+
+    g_ClientApi = client_api;
+    return true;
+}
+
+bool ImGui_ImplGlfw_InitForOpenGL(GLFWwindow *window, bool install_callbacks)
+{
+    return ImGui_ImplGlfw_Init(window, install_callbacks, GlfwClientApi_OpenGL);
+}
+
+bool ImGui_ImplGlfw_InitForVulkan(GLFWwindow *window, bool install_callbacks)
+{
+    return ImGui_ImplGlfw_Init(window, install_callbacks, GlfwClientApi_Vulkan);
+}
+
+void ImGui_ImplGlfw_Shutdown()
+{
+    for (ImGuiMouseCursor cursor_n = 0; cursor_n < ImGuiMouseCursor_COUNT; cursor_n++)
+    {
+        glfwDestroyCursor(g_MouseCursors[cursor_n]);
+        g_MouseCursors[cursor_n] = NULL;
+    }
+    g_ClientApi = GlfwClientApi_Unknown;
+}
+
+static void ImGui_ImplGlfw_UpdateMousePosAndButtons()
+{
+    // Update buttons
+    ImGuiIO &io = ImGui::GetIO();
+    for (int i = 0; i < IM_ARRAYSIZE(io.MouseDown); i++)
+    {
+        // If a mouse press event came, always pass it as "mouse held this frame", so we don't miss
+        // click-release events that are shorter than 1 frame.
+        io.MouseDown[i]       = g_MouseJustPressed[i] || glfwGetMouseButton(g_Window, i) != 0;
+        g_MouseJustPressed[i] = false;
+    }
+
+    // Update mouse position
+    const ImVec2 mouse_pos_backup = io.MousePos;
+    io.MousePos                   = ImVec2(-FLT_MAX, -FLT_MAX);
+#ifdef __EMSCRIPTEN__
+    const bool focused = true;  // Emscripten
+#else
+    const bool focused = glfwGetWindowAttrib(g_Window, GLFW_FOCUSED) != 0;
+#endif
+    if (focused)
+    {
+        if (io.WantSetMousePos)
+        {
+            glfwSetCursorPos(g_Window, (double)mouse_pos_backup.x, (double)mouse_pos_backup.y);
+        }
+        else
+        {
+            double mouse_x, mouse_y;
+            glfwGetCursorPos(g_Window, &mouse_x, &mouse_y);
+            io.MousePos = ImVec2((float)mouse_x, (float)mouse_y);
+        }
+    }
+}
+
+static void ImGui_ImplGlfw_UpdateMouseCursor()
+{
+    ImGuiIO &io = ImGui::GetIO();
+    if ((io.ConfigFlags & ImGuiConfigFlags_NoMouseCursorChange) ||
+        glfwGetInputMode(g_Window, GLFW_CURSOR) == GLFW_CURSOR_DISABLED)
+        return;
+
+    ImGuiMouseCursor imgui_cursor = ImGui::GetMouseCursor();
+    if (imgui_cursor == ImGuiMouseCursor_None || io.MouseDrawCursor)
+    {
+        // Hide OS mouse cursor if imgui is drawing it or if it wants no cursor
+        glfwSetInputMode(g_Window, GLFW_CURSOR, GLFW_CURSOR_HIDDEN);
+    }
+    else
+    {
+        // Show OS mouse cursor
+        // FIXME-PLATFORM: Unfocused windows seems to fail changing the mouse cursor with GLFW 3.2,
+        // but 3.3 works here.
+        glfwSetCursor(g_Window, g_MouseCursors[imgui_cursor]
+                                    ? g_MouseCursors[imgui_cursor]
+                                    : g_MouseCursors[ImGuiMouseCursor_Arrow]);
+        glfwSetInputMode(g_Window, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
+    }
+}
+
+static void ImGui_ImplGlfw_UpdateGamepads()
+{
+    ImGuiIO &io = ImGui::GetIO();
+    memset(io.NavInputs, 0, sizeof(io.NavInputs));
+    if ((io.ConfigFlags & ImGuiConfigFlags_NavEnableGamepad) == 0)
+        return;
+
+// Update gamepad inputs
+#define MAP_BUTTON(NAV_NO, BUTTON_NO)                                      \
+    {                                                                      \
+        if (buttons_count > BUTTON_NO && buttons[BUTTON_NO] == GLFW_PRESS) \
+            io.NavInputs[NAV_NO] = 1.0f;                                   \
+    }
+#define MAP_ANALOG(NAV_NO, AXIS_NO, V0, V1)                    \
+    {                                                          \
+        float v = (axes_count > AXIS_NO) ? axes[AXIS_NO] : V0; \
+        v       = (v - V0) / (V1 - V0);                        \
+        if (v > 1.0f)                                          \
+            v = 1.0f;                                          \
+        if (io.NavInputs[NAV_NO] < v)                          \
+            io.NavInputs[NAV_NO] = v;                          \
+    }
+    int axes_count = 0, buttons_count = 0;
+    const float *axes            = glfwGetJoystickAxes(GLFW_JOYSTICK_1, &axes_count);
+    const unsigned char *buttons = glfwGetJoystickButtons(GLFW_JOYSTICK_1, &buttons_count);
+    MAP_BUTTON(ImGuiNavInput_Activate, 0);    // Cross / A
+    MAP_BUTTON(ImGuiNavInput_Cancel, 1);      // Circle / B
+    MAP_BUTTON(ImGuiNavInput_Menu, 2);        // Square / X
+    MAP_BUTTON(ImGuiNavInput_Input, 3);       // Triangle / Y
+    MAP_BUTTON(ImGuiNavInput_DpadLeft, 13);   // D-Pad Left
+    MAP_BUTTON(ImGuiNavInput_DpadRight, 11);  // D-Pad Right
+    MAP_BUTTON(ImGuiNavInput_DpadUp, 10);     // D-Pad Up
+    MAP_BUTTON(ImGuiNavInput_DpadDown, 12);   // D-Pad Down
+    MAP_BUTTON(ImGuiNavInput_FocusPrev, 4);   // L1 / LB
+    MAP_BUTTON(ImGuiNavInput_FocusNext, 5);   // R1 / RB
+    MAP_BUTTON(ImGuiNavInput_TweakSlow, 4);   // L1 / LB
+    MAP_BUTTON(ImGuiNavInput_TweakFast, 5);   // R1 / RB
+    MAP_ANALOG(ImGuiNavInput_LStickLeft, 0, -0.3f, -0.9f);
+    MAP_ANALOG(ImGuiNavInput_LStickRight, 0, +0.3f, +0.9f);
+    MAP_ANALOG(ImGuiNavInput_LStickUp, 1, +0.3f, +0.9f);
+    MAP_ANALOG(ImGuiNavInput_LStickDown, 1, -0.3f, -0.9f);
+#undef MAP_BUTTON
+#undef MAP_ANALOG
+    if (axes_count > 0 && buttons_count > 0)
+        io.BackendFlags |= ImGuiBackendFlags_HasGamepad;
+    else
+        io.BackendFlags &= ~ImGuiBackendFlags_HasGamepad;
+}
+
+void ImGui_ImplGlfw_NewFrame()
+{
+    ImGuiIO &io = ImGui::GetIO();
+    IM_ASSERT(io.Fonts->IsBuilt() &&
+              "Font atlas not built! It is generally built by the renderer back-end. Missing call "
+              "to renderer _NewFrame() function? e.g. ImGui_ImplOpenGL3_NewFrame().");
+
+    // Setup display size (every frame to accommodate for window resizing)
+    int w, h;
+    int display_w, display_h;
+    glfwGetWindowSize(g_Window, &w, &h);
+    glfwGetFramebufferSize(g_Window, &display_w, &display_h);
+    io.DisplaySize = ImVec2((float)w, (float)h);
+    if (w > 0 && h > 0)
+        io.DisplayFramebufferScale = ImVec2((float)display_w / w, (float)display_h / h);
+
+    // Setup time step
+    double current_time = glfwGetTime();
+    io.DeltaTime        = g_Time > 0.0 ? (float)(current_time - g_Time) : (float)(1.0f / 60.0f);
+    g_Time              = current_time;
+
+    ImGui_ImplGlfw_UpdateMousePosAndButtons();
+    ImGui_ImplGlfw_UpdateMouseCursor();
+
+    // Update game controllers (if enabled and available)
+    ImGui_ImplGlfw_UpdateGamepads();
+}

--- a/third_party/imgui/examples/imgui_impl_glfw.h
+++ b/third_party/imgui/examples/imgui_impl_glfw.h
@@ -1,0 +1,48 @@
+// dear imgui: Platform Binding for GLFW
+// This needs to be used along with a Renderer (e.g. OpenGL3, Vulkan..)
+// (Info: GLFW is a cross-platform general purpose library for handling windows, inputs,
+// OpenGL/Vulkan graphics context creation, etc.)
+
+// Implemented features:
+//  [X] Platform: Clipboard support.
+//  [X] Platform: Gamepad support. Enable with 'io.ConfigFlags |=
+//  ImGuiConfigFlags_NavEnableGamepad'. [x] Platform: Mouse cursor shape and visibility. Disable
+//  with 'io.ConfigFlags |= ImGuiConfigFlags_NoMouseCursorChange'. FIXME: 3 cursors types are
+//  missing from GLFW. [X] Platform: Keyboard arrays indexed using GLFW_KEY_* codes, e.g.
+//  ImGui::IsKeyPressed(GLFW_KEY_SPACE).
+
+// You can copy and use unmodified imgui_impl_* files in your project. See main.cpp for an example
+// of using this. If you are new to dear imgui, read examples/README.txt and read the documentation
+// at the top of imgui.cpp. https://github.com/ocornut/imgui
+
+// About GLSL version:
+// The 'glsl_version' initialization parameter defaults to "#version 150" if NULL.
+// Only override if your GL version doesn't handle this GLSL version. Keep NULL if unsure!
+
+#pragma once
+
+#include "imgui.h"
+
+struct GLFWwindow;
+
+IMGUI_IMPL_API bool ImGui_ImplGlfw_InitForOpenGL(GLFWwindow *window, bool install_callbacks);
+IMGUI_IMPL_API bool ImGui_ImplGlfw_InitForVulkan(GLFWwindow *window, bool install_callbacks);
+IMGUI_IMPL_API void ImGui_ImplGlfw_Shutdown();
+IMGUI_IMPL_API void ImGui_ImplGlfw_NewFrame();
+
+// InitXXX function with 'install_callbacks=true': install GLFW callbacks. They will call user's
+// previously installed callbacks, if any. InitXXX function with 'install_callbacks=false': do not
+// install GLFW callbacks. You will need to call them yourself from your own GLFW callbacks.
+IMGUI_IMPL_API void ImGui_ImplGlfw_MouseButtonCallback(GLFWwindow *window,
+                                                       int button,
+                                                       int action,
+                                                       int mods);
+IMGUI_IMPL_API void ImGui_ImplGlfw_ScrollCallback(GLFWwindow *window,
+                                                  double xoffset,
+                                                  double yoffset);
+IMGUI_IMPL_API void ImGui_ImplGlfw_KeyCallback(GLFWwindow *window,
+                                               int key,
+                                               int scancode,
+                                               int action,
+                                               int mods);
+IMGUI_IMPL_API void ImGui_ImplGlfw_CharCallback(GLFWwindow *window, unsigned int c);

--- a/third_party/imgui/imconfig.h
+++ b/third_party/imgui/imconfig.h
@@ -1,0 +1,106 @@
+//-----------------------------------------------------------------------------
+// COMPILE-TIME OPTIONS FOR DEAR IMGUI
+// Runtime options (clipboard callbacks, enabling various features, etc.) can generally be set via
+// the ImGuiIO structure. You can use ImGui::SetAllocatorFunctions() before calling
+// ImGui::CreateContext() to rewire memory allocation functions.
+//-----------------------------------------------------------------------------
+// A) You may edit imconfig.h (and not overwrite it when updating Dear ImGui, or maintain a
+// patch/branch with your modifications to imconfig.h) B) or add configuration directives in your
+// own file and compile with #define IMGUI_USER_CONFIG "myfilename.h" If you do so you need to make
+// sure that configuration settings are defined consistently _everywhere_ Dear ImGui is used, which
+// include the imgui*.cpp files but also _any_ of your code that uses Dear ImGui. This is because
+// some compile-time options have an affect on data structures. Defining those options in imconfig.h
+// will ensure every compilation unit gets to see the same data structure layouts. Call
+// IMGUI_CHECKVERSION() from your .cpp files to verify that the data structures your files are using
+// are matching the ones imgui.cpp is using.
+//-----------------------------------------------------------------------------
+
+#pragma once
+
+//---- Define assertion handler. Defaults to calling assert().
+//#define IM_ASSERT(_EXPR)  MyAssert(_EXPR)
+//#define IM_ASSERT(_EXPR)  ((void)(_EXPR))     // Disable asserts
+
+//---- Define attributes of all API symbols declarations, e.g. for DLL under Windows
+// Using dear imgui via a shared library is not recommended, because of function call overhead and
+// because we don't guarantee backward nor forward ABI compatibility.
+//#define IMGUI_API __declspec( dllexport )
+//#define IMGUI_API __declspec( dllimport )
+
+//---- Don't define obsolete functions/enums names. Consider enabling from time to time after
+// updating to avoid using soon-to-be obsolete function/names. #define
+// IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+
+//---- Don't implement demo windows functionality
+//(ShowDemoWindow()/ShowStyleEditor()/ShowUserGuide() methods will be empty)
+// It is very strongly recommended to NOT disable the demo windows during development. Please read
+// the comments in imgui_demo.cpp.
+//#define IMGUI_DISABLE_DEMO_WINDOWS
+//#define IMGUI_DISABLE_METRICS_WINDOW
+
+//---- Don't implement some functions to reduce linkage requirements.
+//#define IMGUI_DISABLE_WIN32_DEFAULT_CLIPBOARD_FUNCTIONS   // [Win32] Don't implement default
+// clipboard handler. Won't use and link with OpenClipboard/GetClipboardData/CloseClipboard etc.
+//#define IMGUI_DISABLE_WIN32_DEFAULT_IME_FUNCTIONS         // [Win32] Don't implement default IME
+// handler. Won't use and link with ImmGetContext/ImmSetCompositionWindow. #define
+// IMGUI_DISABLE_WIN32_FUNCTIONS                     // [Win32] Won't use and link with any Win32
+// function (clipboard, ime). #define IMGUI_DISABLE_OSX_FUNCTIONS                       // [OSX]
+// Won't use and link with any OSX function (clipboard). #define
+// IMGUI_DISABLE_FORMAT_STRING_FUNCTIONS             // Don't implement
+// ImFormatString/ImFormatStringV so you can implement them yourself if you don't want to link with
+// vsnprintf. #define IMGUI_DISABLE_MATH_FUNCTIONS                      // Don't implement
+// ImFabs/ImSqrt/ImPow/ImFmod/ImCos/ImSin/ImAcos/ImAtan2 wrapper so you can implement them yourself.
+// Declare your prototypes in imconfig.h. #define IMGUI_DISABLE_DEFAULT_ALLOCATORS // Don't
+// implement default allocators calling malloc()/free() to avoid linking with them. You will need to
+// call ImGui::SetAllocatorFunctions().
+
+//---- Include imgui_user.h at the end of imgui.h as a convenience
+//#define IMGUI_INCLUDE_IMGUI_USER_H
+
+//---- Pack colors to BGRA8 instead of RGBA8 (to avoid converting from one to another)
+//#define IMGUI_USE_BGRA_PACKED_COLOR
+
+//---- Avoid multiple STB libraries implementations, or redefine path/filenames to prioritize
+// another version
+// By default the embedded implementations are declared static and not available outside of imgui
+// cpp files.
+//#define IMGUI_STB_TRUETYPE_FILENAME   "my_folder/stb_truetype.h"
+//#define IMGUI_STB_RECT_PACK_FILENAME  "my_folder/stb_rect_pack.h"
+//#define IMGUI_DISABLE_STB_TRUETYPE_IMPLEMENTATION
+//#define IMGUI_DISABLE_STB_RECT_PACK_IMPLEMENTATION
+
+//---- Define constructor and implicit cast operators to convert back<>forth between your math types
+// and ImVec2/ImVec4.
+// This will be inlined as part of ImVec2 and ImVec4 class declarations.
+/*
+#define IM_VEC2_CLASS_EXTRA                                                 \
+        ImVec2(const MyVec2& f) { x = f.x; y = f.y; }                       \
+        operator MyVec2() const { return MyVec2(x,y); }
+
+#define IM_VEC4_CLASS_EXTRA                                                 \
+        ImVec4(const MyVec4& f) { x = f.x; y = f.y; z = f.z; w = f.w; }     \
+        operator MyVec4() const { return MyVec4(x,y,z,w); }
+*/
+
+//---- Using 32-bits vertex indices (default is 16-bits) is one way to allow large meshes with more
+// than 64K vertices.
+// Your renderer back-end will need to support it (most example renderer back-ends support both
+// 16/32-bits indices). Another way to allow large meshes while keeping 16-bits indices is to handle
+// ImDrawCmd::VtxOffset in your renderer. Read about ImGuiBackendFlags_RendererHasVtxOffset for
+// details.
+//#define ImDrawIdx unsigned int
+
+//---- Override ImDrawCallback signature (will need to modify renderer back-ends accordingly)
+// struct ImDrawList;
+// struct ImDrawCmd;
+// typedef void (*MyImDrawCallback)(const ImDrawList* draw_list, const ImDrawCmd* cmd, void*
+// my_renderer_user_data); #define ImDrawCallback MyImDrawCallback
+
+//---- Tip: You can add extra functions within the ImGui:: namespace, here or in your own headers
+// files.
+/*
+namespace ImGui
+{
+    void MyFunction(const char* name, const MyMatrix44& v);
+}
+*/

--- a/third_party/imgui/imgui.cpp
+++ b/third_party/imgui/imgui.cpp
@@ -1,0 +1,12359 @@
+// dear imgui, v1.72 WIP
+// (main code and documentation)
+
+// Call and read ImGui::ShowDemoWindow() in imgui_demo.cpp for demo code.
+// Newcomers, read 'Programmer guide' below for notes on how to setup Dear ImGui in your codebase.
+// Get latest version at https://github.com/ocornut/imgui
+// Releases change-log at https://github.com/ocornut/imgui/releases
+// Technical Support for Getting Started https://discourse.dearimgui.org/c/getting-started
+// Gallery (please post your screenshots/video there!): https://github.com/ocornut/imgui/issues/1269
+
+// Developed by Omar Cornut and every direct or indirect contributors to the GitHub.
+// See LICENSE.txt for copyright and licensing details (standard MIT License).
+// This library is free but I need your support to sustain development and maintenance.
+// Businesses: you can support continued maintenance and development via support contracts or
+// sponsoring, see docs/README. Individuals: you can support continued maintenance and development
+// via donations or Patreon https://www.patreon.com/imgui.
+
+// It is recommended that you don't modify imgui.cpp! It will become difficult for you to update the
+// library. Note that 'ImGui::' being a namespace, you can add functions into the namespace from
+// your own source files, without modifying imgui.h or imgui.cpp. You may include imgui_internal.h
+// to access internal data structures, but it doesn't come with any guarantee of forward
+// compatibility. Discussing your changes on the GitHub Issue Tracker may lead you to a better
+// solution or official support for them.
+
+/*
+
+Index of this file:
+
+DOCUMENTATION
+
+- MISSION STATEMENT
+- END-USER GUIDE
+- PROGRAMMER GUIDE (read me!)
+  - Read first.
+  - How to update to a newer version of Dear ImGui.
+  - Getting started with integrating Dear ImGui in your code/engine.
+  - This is how a simple application may look like (2 variations).
+  - This is how a simple rendering function may look like.
+  - Using gamepad/keyboard navigation controls.
+- API BREAKING CHANGES (read me when you update!)
+- FREQUENTLY ASKED QUESTIONS (FAQ), TIPS
+  - Where is the documentation?
+  - Which version should I get?
+  - Who uses Dear ImGui?
+  - Why the odd dual naming, "Dear ImGui" vs "ImGui"?
+  - How can I tell whether to dispatch mouse/keyboard to imgui or to my application?
+  - How can I display an image? What is ImTextureID, how does it works?
+  - Why are multiple widgets reacting when I interact with a single one? How can I have
+    multiple widgets with the same label or with an empty label? A primer on labels and the ID
+Stack...
+  - How can I use my own math types instead of ImVec2/ImVec4?
+  - How can I load a different font than the default?
+  - How can I easily use icons in my application?
+  - How can I load multiple fonts?
+  - How can I display and input non-latin characters such as Chinese, Japanese, Korean, Cyrillic?
+  - How can I interact with standard C++ types (such as std::string and std::vector)?
+  - How can I use the drawing facilities without a Dear ImGui window? (using ImDrawList API)
+  - How can I use Dear ImGui on a platform that doesn't have a mouse or a keyboard? (input share,
+remoting, gamepad)
+  - I integrated Dear ImGui in my engine and the text or lines are blurry..
+  - I integrated Dear ImGui in my engine and some elements are clipping or disappearing when I move
+windows around..
+  - How can I help?
+
+CODE
+(search for "[SECTION]" in the code to find them)
+
+// [SECTION] FORWARD DECLARATIONS
+// [SECTION] CONTEXT AND MEMORY ALLOCATORS
+// [SECTION] MAIN USER FACING STRUCTURES (ImGuiStyle, ImGuiIO)
+// [SECTION] MISC HELPERS/UTILITIES (Maths, String, Format, Hash, File functions)
+// [SECTION] MISC HELPERS/UTILITIES (ImText* functions)
+// [SECTION] MISC HELPERS/UTILITIES (Color functions)
+// [SECTION] ImGuiStorage
+// [SECTION] ImGuiTextFilter
+// [SECTION] ImGuiTextBuffer
+// [SECTION] ImGuiListClipper
+// [SECTION] RENDER HELPERS
+// [SECTION] MAIN CODE (most of the code! lots of stuff, needs tidying up!)
+// [SECTION] TOOLTIPS
+// [SECTION] POPUPS
+// [SECTION] KEYBOARD/GAMEPAD NAVIGATION
+// [SECTION] COLUMNS
+// [SECTION] DRAG AND DROP
+// [SECTION] LOGGING/CAPTURING
+// [SECTION] SETTINGS
+// [SECTION] PLATFORM DEPENDENT HELPERS
+// [SECTION] METRICS/DEBUG WINDOW
+
+*/
+
+//-----------------------------------------------------------------------------
+// DOCUMENTATION
+//-----------------------------------------------------------------------------
+
+/*
+
+ MISSION STATEMENT
+ =================
+
+ - Easy to use to create code-driven and data-driven tools.
+ - Easy to use to create ad hoc short-lived tools and long-lived, more elaborate tools.
+ - Easy to hack and improve.
+ - Minimize screen real-estate usage.
+ - Minimize setup and maintenance.
+ - Minimize state storage on user side.
+ - Portable, minimize dependencies, run on target (consoles, phones, etc.).
+ - Efficient runtime and memory consumption (NB- we do allocate when "growing" content e.g. creating
+ a window,. opening a tree node for the first time, etc. but a typical frame should not allocate
+ anything).
+
+ Designed for developers and content-creators, not the typical end-user! Some of the weaknesses
+ includes:
+ - Doesn't look fancy, doesn't animate.
+ - Limited layout features, intricate layouts are typically crafted in code.
+
+
+ END-USER GUIDE
+ ==============
+
+ - Double-click on title bar to collapse window.
+ - Click upper right corner to close a window, available when 'bool* p_open' is passed to
+ ImGui::Begin().
+ - Click and drag on lower right corner to resize window (double-click to auto fit window to its
+ contents).
+ - Click and drag on any empty space to move window.
+ - TAB/SHIFT+TAB to cycle through keyboard editable fields.
+ - CTRL+Click on a slider or drag box to input value as text.
+ - Use mouse wheel to scroll.
+ - Text editor:
+   - Hold SHIFT or use mouse to select text.
+   - CTRL+Left/Right to word jump.
+   - CTRL+Shift+Left/Right to select words.
+   - CTRL+A our Double-Click to select all.
+   - CTRL+X,CTRL+C,CTRL+V to use OS clipboard/
+   - CTRL+Z,CTRL+Y to undo/redo.
+   - ESCAPE to revert text to its original value.
+   - You can apply arithmetic operators +,*,/ on numerical values. Use +- to subtract (because -
+ would set a negative value!)
+   - Controls are automatically adjusted for OSX to match standard OSX text editing operations.
+ - General Keyboard controls: enable with ImGuiConfigFlags_NavEnableKeyboard.
+ - General Gamepad controls: enable with ImGuiConfigFlags_NavEnableGamepad. See suggested mappings
+ in imgui.h ImGuiNavInput_ + download PNG/PSD at http://goo.gl/9LgVZW
+
+
+ PROGRAMMER GUIDE
+ ================
+
+ READ FIRST:
+
+ - Read the FAQ below this section!
+ - Your code creates the UI, if your code doesn't run the UI is gone! The UI can be highly dynamic,
+ there are no construction or destruction steps, less superfluous data retention on your side, less
+ state duplication, less state synchronization, less bugs.
+ - Call and read ImGui::ShowDemoWindow() for demo code demonstrating most features.
+ - The library is designed to be built from sources. Avoid pre-compiled binaries and packaged
+ versions. See imconfig.h to configure your build.
+ - Dear ImGui is an implementation of the IMGUI paradigm (immediate-mode graphical user interface, a
+ term coined by Casey Muratori). You can learn about IMGUI principles at
+ http://www.johno.se/book/imgui.html, http://mollyrocket.com/861 & more links docs/README.md.
+ - Dear ImGui is a "single pass" rasterizing implementation of the IMGUI paradigm, aimed at ease of
+ use and high-performances. For every application frame your UI code will be called only once. This
+ is in contrast to e.g. Unity's own implementation of an IMGUI, where the UI code is called multiple
+ times ("multiple passes") from a single entry point. There are pros and cons to both approaches.
+ - Our origin are on the top-left. In axis aligned bounding boxes, Min = top-left, Max =
+ bottom-right.
+ - This codebase is also optimized to yield decent performances with typical "Debug" builds
+ settings.
+ - Please make sure you have asserts enabled (IM_ASSERT redirects to assert() by default, but can be
+ redirected). If you get an assert, read the messages and comments around the assert.
+ - C++: this is a very C-ish codebase: we don't rely on C++11, we don't include any C++ headers, and
+ ImGui:: is a namespace.
+ - C++: ImVec2/ImVec4 do not expose math operators by default, because it is expected that you use
+ your own math types. See FAQ "How can I use my own math types instead of ImVec2/ImVec4?" for
+ details about setting up imconfig.h for that. However, imgui_internal.h can optionally export math
+ operators for ImVec2/ImVec4, which we use in this codebase.
+ - C++: pay attention that ImVector<> manipulates plain-old-data and does not honor
+ construction/destruction (avoid using it in your code!).
+
+ HOW TO UPDATE TO A NEWER VERSION OF DEAR IMGUI:
+
+ - Overwrite all the sources files except for imconfig.h (if you have made modification to your copy
+ of imconfig.h)
+ - Or maintain your own branch where you have imconfig.h modified.
+ - Read the "API BREAKING CHANGES" section (below). This is where we list occasional API breaking
+ changes. If a function/type has been renamed / or marked obsolete, try to fix the name in your code
+ before it is permanently removed from the public API. If you have a problem with a missing
+ function/symbols, search for its name in the code, there will likely be a comment about it. Please
+ report any issue to the GitHub page!
+ - Try to keep your copy of dear imgui reasonably up to date.
+
+ GETTING STARTED WITH INTEGRATING DEAR IMGUI IN YOUR CODE/ENGINE:
+
+ - Run and study the examples and demo in imgui_demo.cpp to get acquainted with the library.
+ - Add the Dear ImGui source files to your projects or using your preferred build system.
+   It is recommended you build and statically link the .cpp files as part of your project and not as
+ shared library (DLL).
+ - You can later customize the imconfig.h file to tweak some compile-time behavior, such as
+ integrating Dear ImGui types with your own maths types.
+ - When using Dear ImGui, your programming IDE is your friend: follow the declaration of variables,
+ functions and types to find comments about them.
+ - Dear ImGui never touches or knows about your GPU state. The only function that knows about GPU is
+ the draw function that you provide. Effectively it means you can create widgets at any time in your
+ code, regardless of considerations of being in "update" vs "render" phases of your own application.
+ All rendering informatioe are stored into command-lists that you will retrieve after calling
+ ImGui::Render().
+ - Refer to the bindings and demo applications in the examples/ folder for instruction on how to
+ setup your code.
+ - If you are running over a standard OS with a common graphics API, you should be able to use
+ unmodified imgui_impl_*** files from the examples/ folder.
+
+ HOW A SIMPLE APPLICATION MAY LOOK LIKE:
+ EXHIBIT 1: USING THE EXAMPLE BINDINGS (imgui_impl_XXX.cpp files from the examples/ folder).
+
+     // Application init: create a dear imgui context, setup some options, load fonts
+     ImGui::CreateContext();
+     ImGuiIO& io = ImGui::GetIO();
+     // TODO: Set optional io.ConfigFlags values, e.g. 'io.ConfigFlags |=
+ ImGuiConfigFlags_NavEnableKeyboard' to enable keyboard controls.
+     // TODO: Fill optional fields of the io structure later.
+     // TODO: Load TTF/OTF fonts if you don't want to use the default font.
+
+     // Initialize helper Platform and Renderer bindings (here we are using imgui_impl_win32 and
+ imgui_impl_dx11) ImGui_ImplWin32_Init(hwnd); ImGui_ImplDX11_Init(g_pd3dDevice,
+ g_pd3dDeviceContext);
+
+     // Application main loop
+     while (true)
+     {
+         // Feed inputs to dear imgui, start new frame
+         ImGui_ImplDX11_NewFrame();
+         ImGui_ImplWin32_NewFrame();
+         ImGui::NewFrame();
+
+         // Any application code here
+         ImGui::Text("Hello, world!");
+
+         // Render dear imgui into screen
+         ImGui::Render();
+         ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
+         g_pSwapChain->Present(1, 0);
+     }
+
+     // Shutdown
+     ImGui_ImplDX11_Shutdown();
+     ImGui_ImplWin32_Shutdown();
+     ImGui::DestroyContext();
+
+ HOW A SIMPLE APPLICATION MAY LOOK LIKE:
+ EXHIBIT 2: IMPLEMENTING CUSTOM BINDING / CUSTOM ENGINE.
+
+     // Application init: create a dear imgui context, setup some options, load fonts
+     ImGui::CreateContext();
+     ImGuiIO& io = ImGui::GetIO();
+     // TODO: Set optional io.ConfigFlags values, e.g. 'io.ConfigFlags |=
+ ImGuiConfigFlags_NavEnableKeyboard' to enable keyboard controls.
+     // TODO: Fill optional fields of the io structure later.
+     // TODO: Load TTF/OTF fonts if you don't want to use the default font.
+
+     // Build and load the texture atlas into a texture
+     // (In the examples/ app this is usually done within the ImGui_ImplXXX_Init() function from one
+ of the demo Renderer) int width, height; unsigned char* pixels = NULL;
+     io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
+
+     // At this point you've got the texture data and you need to upload that your your graphic
+ system:
+     // After we have created the texture, store its pointer/identifier (_in whichever format your
+ engine uses_) in 'io.Fonts->TexID'.
+     // This will be passed back to your via the renderer. Basically ImTextureID == void*. Read FAQ
+ below for details about ImTextureID. MyTexture* texture =
+ MyEngine::CreateTextureFromMemoryPixels(pixels, width, height, TEXTURE_TYPE_RGBA32) io.Fonts->TexID
+ = (void*)texture;
+
+     // Application main loop
+     while (true)
+     {
+        // Setup low-level inputs, e.g. on Win32: calling GetKeyboardState(), or write to those
+ fields from your Windows message handlers, etc.
+        // (In the examples/ app this is usually done within the ImGui_ImplXXX_NewFrame() function
+ from one of the demo Platform bindings) io.DeltaTime = 1.0f/60.0f;              // set the time
+ elapsed since the previous frame (in seconds) io.DisplaySize.x = 1920.0f;             // set the
+ current display width io.DisplaySize.y = 1280.0f;             // set the current display height
+ here io.MousePos = my_mouse_pos;             // set the mouse position io.MouseDown[0] =
+ my_mouse_buttons[0];  // set the mouse button states io.MouseDown[1] = my_mouse_buttons[1];
+
+        // Call NewFrame(), after this point you can use ImGui::* functions anytime
+        // (So you want to try calling NewFrame() as early as you can in your mainloop to be able to
+ use Dear ImGui everywhere) ImGui::NewFrame();
+
+        // Most of your application code here
+        ImGui::Text("Hello, world!");
+        MyGameUpdate(); // may use any Dear ImGui functions, e.g. ImGui::Begin("My window");
+ ImGui::Text("Hello, world!"); ImGui::End(); MyGameRender(); // may use any Dear ImGui functions as
+ well!
+
+        // Render dear imgui, swap buffers
+        // (You want to try calling EndFrame/Render as late as you can, to be able to use Dear ImGui
+ in your own game rendering code) ImGui::EndFrame(); ImGui::Render(); ImDrawData* draw_data =
+ ImGui::GetDrawData(); MyImGuiRenderFunction(draw_data); SwapBuffers();
+     }
+
+     // Shutdown
+     ImGui::DestroyContext();
+
+ HOW A SIMPLE RENDERING FUNCTION MAY LOOK LIKE:
+
+    void void MyImGuiRenderFunction(ImDrawData* draw_data)
+    {
+       // TODO: Setup render state: alpha-blending enabled, no face culling, no depth testing,
+ scissor enabled
+       // TODO: Setup viewport covering draw_data->DisplayPos to draw_data->DisplayPos +
+ draw_data->DisplaySize
+       // TODO: Setup orthographic projection matrix cover draw_data->DisplayPos to
+ draw_data->DisplayPos + draw_data->DisplaySize
+       // TODO: Setup shader: vertex { float2 pos, float2 uv, u32 color }, fragment shader sample
+ color from 1 texture, multiply by vertex color. for (int n = 0; n < draw_data->CmdListsCount; n++)
+       {
+          const ImDrawList* cmd_list = draw_data->CmdLists[n];
+          const ImDrawVert* vtx_buffer = cmd_list->VtxBuffer.Data;  // vertex buffer generated by
+ Dear ImGui const ImDrawIdx* idx_buffer = cmd_list->IdxBuffer.Data;   // index buffer generated by
+ Dear ImGui for (int cmd_i = 0; cmd_i < cmd_list->CmdBuffer.Size; cmd_i++)
+          {
+             const ImDrawCmd* pcmd = &cmd_list->CmdBuffer[cmd_i];
+             if (pcmd->UserCallback)
+             {
+                 pcmd->UserCallback(cmd_list, pcmd);
+             }
+             else
+             {
+                 // The texture for the draw call is specified by pcmd->TextureId.
+                 // The vast majority of draw calls will use the Dear ImGui texture atlas, which
+ value you have set yourself during initialization.
+                 MyEngineBindTexture((MyTexture*)pcmd->TextureId);
+
+                 // We are using scissoring to clip some objects. All low-level graphics API should
+ supports it.
+                 // - If your engine doesn't support scissoring yet, you may ignore this at first.
+ You will get some small glitches
+                 //   (some elements visible outside their bounds) but you can fix that once
+ everything else works!
+                 // - Clipping coordinates are provided in imgui coordinates space (from
+ draw_data->DisplayPos to draw_data->DisplayPos + draw_data->DisplaySize)
+                 //   In a single viewport application, draw_data->DisplayPos will always be (0,0)
+ and draw_data->DisplaySize will always be == io.DisplaySize.
+                 //   However, in the interest of supporting multi-viewport applications in the
+ future (see 'viewport' branch on github),
+                 //   always subtract draw_data->DisplayPos from clipping bounds to convert them to
+ your viewport space.
+                 // - Note that pcmd->ClipRect contains Min+Max bounds. Some graphics API may use
+ Min+Max, other may use Min+Size (size being Max-Min) ImVec2 pos = draw_data->DisplayPos;
+                 MyEngineScissor((int)(pcmd->ClipRect.x - pos.x), (int)(pcmd->ClipRect.y - pos.y),
+ (int)(pcmd->ClipRect.z - pos.x), (int)(pcmd->ClipRect.w - pos.y));
+
+                 // Render 'pcmd->ElemCount/3' indexed triangles.
+                 // By default the indices ImDrawIdx are 16-bits, you can change them to 32-bits in
+ imconfig.h if your engine doesn't support 16-bits indices.
+                 MyEngineDrawIndexedTriangles(pcmd->ElemCount, sizeof(ImDrawIdx) == 2 ?
+ GL_UNSIGNED_SHORT : GL_UNSIGNED_INT, idx_buffer, vtx_buffer);
+             }
+             idx_buffer += pcmd->ElemCount;
+          }
+       }
+    }
+
+ - The examples/ folders contains many actual implementation of the pseudo-codes above.
+ - When calling NewFrame(), the 'io.WantCaptureMouse', 'io.WantCaptureKeyboard' and
+ 'io.WantTextInput' flags are updated. They tell you if Dear ImGui intends to use your inputs. When
+ a flag is set you want to hide the corresponding inputs from the rest of your application. In every
+ cases you need to pass on the inputs to Dear ImGui. Refer to the FAQ for more information.
+ - Please read the FAQ below!. Amusingly, it is called a FAQ because people frequently run into the
+ same issues!
+
+ USING GAMEPAD/KEYBOARD NAVIGATION CONTROLS
+
+ - The gamepad/keyboard navigation is fairly functional and keeps being improved.
+ - Gamepad support is particularly useful to use dear imgui on a console system (e.g. PS4, Switch,
+ XB1) without a mouse!
+ - You can ask questions and report issues at https://github.com/ocornut/imgui/issues/787
+ - The initial focus was to support game controllers, but keyboard is becoming increasingly and
+ decently usable.
+ - Gamepad:
+    - Set io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad to enable.
+    - Backend: Set io.BackendFlags |= ImGuiBackendFlags_HasGamepad + fill the io.NavInputs[] fields
+ before calling NewFrame(). Note that io.NavInputs[] is cleared by EndFrame().
+    - See 'enum ImGuiNavInput_' in imgui.h for a description of inputs. For each entry of
+ io.NavInputs[], set the following values: 0.0f= not held. 1.0f= fully held. Pass intermediate
+ 0.0f..1.0f values for analog triggers/sticks.
+    - We uses a simple >0.0f test for activation testing, and won't attempt to test for a dead-zone.
+      Your code will probably need to transform your raw inputs (such as e.g. remapping your
+ 0.2..0.9 raw input range to 0.0..1.0 imgui range, etc.).
+    - You can download PNG/PSD files depicting the gamepad controls for common controllers at:
+ http://goo.gl/9LgVZW.
+    - If you need to share inputs between your game and the imgui parts, the easiest approach is to
+ go all-or-nothing, with a buttons combo to toggle the target. Please reach out if you think the
+ game vs navigation input sharing could be improved.
+ - Keyboard:
+    - Set io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard to enable.
+      NewFrame() will automatically fill io.NavInputs[] based on your io.KeysDown[] + io.KeyMap[]
+ arrays.
+    - When keyboard navigation is active (io.NavActive + ImGuiConfigFlags_NavEnableKeyboard), the
+ io.WantCaptureKeyboard flag will be set. For more advanced uses, you may want to read from:
+       - io.NavActive: true when a window is focused and it doesn't have the
+ ImGuiWindowFlags_NoNavInputs flag set.
+       - io.NavVisible: true when the navigation cursor is visible (and usually goes false when
+ mouse is used).
+       - or query focus information with e.g. IsWindowFocused(ImGuiFocusedFlags_AnyWindow),
+ IsItemFocused() etc. functions. Please reach out if you think the game vs navigation input sharing
+ could be improved.
+ - Mouse:
+    - PS4 users: Consider emulating a mouse cursor with DualShock4 touch pad or a spare analog stick
+ as a mouse-emulation fallback.
+    - Consoles/Tablet/Phone users: Consider using a Synergy 1.x server (on your PC) + uSynergy.c (on
+ your console/tablet/phone app) to share your PC mouse/keyboard.
+    - On a TV/console system where readability may be lower or mouse inputs may be awkward, you may
+ want to set the ImGuiConfigFlags_NavEnableSetMousePos flag. Enabling
+ ImGuiConfigFlags_NavEnableSetMousePos + ImGuiBackendFlags_HasSetMousePos instructs dear imgui to
+ move your mouse cursor along with navigation movements. When enabled, the NewFrame() function may
+ alter 'io.MousePos' and set 'io.WantSetMousePos' to notify you that it wants the mouse cursor to be
+ moved. When that happens your back-end NEEDS to move the OS or underlying mouse cursor on the next
+ frame. Some of the binding in examples/ do that. (If you set the NavEnableSetMousePos flag but
+ don't honor 'io.WantSetMousePos' properly, imgui will misbehave as it will see your mouse as moving
+ back and forth!) (In a setup when you may not have easy control over the mouse cursor, e.g.
+ uSynergy.c doesn't expose moving remote mouse cursor, you may want to set a boolean to ignore your
+ other external mouse positions until the external source is moved again.)
+
+
+ API BREAKING CHANGES
+ ====================
+
+ Occasionally introducing changes that are breaking the API. We try to make the breakage minor and
+ easy to fix. Below is a change-log of API breaking changes only. If you are using one of the
+ functions listed, expect to have to fix some code. When you are not sure about a old symbol or
+ function name, try using the Search/Find function of your IDE to look for comments or references in
+ all imgui files. You can read releases logs https://github.com/ocornut/imgui/releases for more
+ details.
+
+ - 2019/06/14 (1.72) - removed redirecting functions/enums names that were marked obsolete in 1.51
+ (June 2017): ImGuiCol_Column*, ImGuiSetCond_*, IsItemHoveredRect(), IsPosHoveringAnyWindow(),
+ IsMouseHoveringAnyWindow(), IsMouseHoveringWindow(), IMGUI_ONCE_UPON_A_FRAME. Grep this log for
+ details and new names.
+ - 2019/06/07 (1.71) - rendering of child window outer decorations (bg color, border, scrollbars) is
+ now performed as part of the parent window. If you have overlapping child windows in a same parent,
+ and relied on their relative z-order to be mapped to their submission order, this will affect your
+ rendering. This optimization is disabled if the parent window has no visual output, because it
+ appears to be the most common situation leading to the creation of overlapping child windows.
+                       Please reach out if you are affected.
+ - 2019/05/13 (1.71) - renamed SetNextTreeNodeOpen() to SetNextItemOpen(). Kept inline redirection
+ function (will obsolete).
+ - 2019/05/11 (1.71) - changed io.AddInputCharacter(unsigned short c) signature to
+ io.AddInputCharacter(unsigned int c).
+ - 2019/04/29 (1.70) - improved ImDrawList thick strokes (>1.0f) preserving correct thickness up to
+ 90 degrees angles (e.g. rectangles). If you have custom rendering using thick lines, they will
+ appear thicker now.
+ - 2019/04/29 (1.70) - removed GetContentRegionAvailWidth(), use GetContentRegionAvail().x instead.
+ Kept inline redirection function (will obsolete).
+ - 2019/03/04 (1.69) - renamed GetOverlayDrawList() to GetForegroundDrawList(). Kept redirection
+ function (will obsolete).
+ - 2019/02/26 (1.69) - renamed
+ ImGuiColorEditFlags_RGB/ImGuiColorEditFlags_HSV/ImGuiColorEditFlags_HEX to
+ ImGuiColorEditFlags_DisplayRGB/ImGuiColorEditFlags_DisplayHSV/ImGuiColorEditFlags_DisplayHex. Kept
+ redirection enums (will obsolete).
+ - 2019/02/14 (1.68) - made it illegal/assert when io.DisplayTime == 0.0f (with an exception for the
+ first frame). If for some reason your time step calculation gives you a zero value, replace it with
+ a dummy small value!
+ - 2019/02/01 (1.68) - removed io.DisplayVisibleMin/DisplayVisibleMax (which were marked obsolete
+ and removed from viewport/docking branch already).
+ - 2019/01/06 (1.67) - renamed io.InputCharacters[], marked internal as was always intended. Please
+ don't access directly, and use AddInputCharacter() instead!
+ - 2019/01/06 (1.67) - renamed ImFontAtlas::GlyphRangesBuilder to ImFontGlyphRangesBuilder. Keep
+ redirection typedef (will obsolete).
+ - 2018/12/20 (1.67) - made it illegal to call Begin("") with an empty string. This somehow
+ half-worked before but had various undesirable side-effects.
+ - 2018/12/10 (1.67) - renamed io.ConfigResizeWindowsFromEdges to io.ConfigWindowsResizeFromEdges as
+ we are doing a large pass on configuration flags.
+ - 2018/10/12 (1.66) - renamed misc/stl/imgui_stl.* to misc/cpp/imgui_stdlib.* in prevision for
+ other C++ helper files.
+ - 2018/09/28 (1.66) - renamed SetScrollHere() to SetScrollHereY(). Kept redirection function (will
+ obsolete).
+ - 2018/09/06 (1.65) - renamed stb_truetype.h to imstb_truetype.h, stb_textedit.h to
+ imstb_textedit.h, and stb_rect_pack.h to imstb_rectpack.h. If you were conveniently using the imgui
+ copy of those STB headers in your project you will have to update your include paths.
+ - 2018/09/05 (1.65) - renamed io.OptCursorBlink/io.ConfigCursorBlink to
+ io.ConfigInputTextCursorBlink. (#1427)
+ - 2018/08/31 (1.64) - added imgui_widgets.cpp file, extracted and moved widgets code out of
+ imgui.cpp into imgui_widgets.cpp. Re-ordered some of the code remaining in imgui.cpp. NONE OF THE
+ FUNCTIONS HAVE CHANGED. THE CODE IS SEMANTICALLY 100% IDENTICAL, BUT _EVERY_ FUNCTION HAS BEEN
+ MOVED. Because of this, any local modifications to imgui.cpp will likely conflict when you update.
+ Read docs/CHANGELOG.txt for suggestions.
+ - 2018/08/22 (1.63) - renamed IsItemDeactivatedAfterChange() to IsItemDeactivatedAfterEdit() for
+ consistency with new IsItemEdited() API. Kept redirection function (will obsolete soonish as
+ IsItemDeactivatedAfterChange() is very recent).
+ - 2018/08/21 (1.63) - renamed ImGuiTextEditCallback to ImGuiInputTextCallback,
+ ImGuiTextEditCallbackData to ImGuiInputTextCallbackData for consistency. Kept redirection types
+ (will obsolete).
+ - 2018/08/21 (1.63) - removed ImGuiInputTextCallbackData::ReadOnly since it is a duplication of
+ (ImGuiInputTextCallbackData::Flags & ImGuiInputTextFlags_ReadOnly).
+ - 2018/08/01 (1.63) - removed per-window ImGuiWindowFlags_ResizeFromAnySide beta flag in favor of a
+ global io.ConfigResizeWindowsFromEdges [update 1.67 renamed to ConfigWindowsResizeFromEdges] to
+ enable the feature.
+ - 2018/08/01 (1.63) - renamed io.OptCursorBlink to io.ConfigCursorBlink [->
+ io.ConfigInputTextCursorBlink in 1.65], io.OptMacOSXBehaviors to ConfigMacOSXBehaviors for
+ consistency.
+ - 2018/07/22 (1.63) - changed ImGui::GetTime() return value from float to double to avoid
+ accumulating floating point imprecisions over time.
+ - 2018/07/08 (1.63) - style: renamed ImGuiCol_ModalWindowDarkening to ImGuiCol_ModalWindowDimBg for
+ consistency with other features. Kept redirection enum (will obsolete).
+ - 2018/06/08 (1.62) - examples: the imgui_impl_xxx files have been split to separate platform
+ (Win32, Glfw, SDL2, etc.) from renderer (DX11, OpenGL, Vulkan,  etc.). old bindings will still work
+ as is, however prefer using the separated bindings as they will be updated to support
+ multi-viewports. when adopting new bindings follow the main.cpp code of your preferred examples/
+ folder to know which functions to call. in particular, note that old bindings called
+ ImGui::NewFrame() at the end of their ImGui_ImplXXXX_NewFrame() function.
+ - 2018/06/06 (1.62) - renamed GetGlyphRangesChinese() to GetGlyphRangesChineseFull() to distinguish
+ other variants and discourage using the full set.
+ - 2018/06/06 (1.62) - TreeNodeEx()/TreeNodeBehavior(): the ImGuiTreeNodeFlags_CollapsingHeader
+ helper now include the ImGuiTreeNodeFlags_NoTreePushOnOpen flag. See Changelog for details.
+ - 2018/05/03 (1.61) - DragInt(): the default compile-time format string has been changed from
+ "%.0f" to "%d", as we are not using integers internally any more. If you used DragInt() with custom
+ format strings, make sure you change them to use %d or an integer-compatible format. To honor
+ backward-compatibility, the DragInt() code will currently parse and modify format strings to
+ replace %*f with %d, giving time to users to upgrade their code. If you have
+ IMGUI_DISABLE_OBSOLETE_FUNCTIONS enabled, the code will instead assert! You may run a reg-exp
+ search on your codebase for e.g. "DragInt.*%f" to help you find them.
+ - 2018/04/28 (1.61) - obsoleted InputFloat() functions taking an optional "int decimal_precision"
+ in favor of an equivalent and more flexible "const char* format", consistent with other functions.
+ Kept redirection functions (will obsolete).
+ - 2018/04/09 (1.61) - IM_DELETE() helper function added in 1.60 doesn't clear the input _pointer_
+ reference, more consistent with expectation and allows passing r-value.
+ - 2018/03/20 (1.60) - renamed io.WantMoveMouse to io.WantSetMousePos for consistency and ease of
+ understanding (was added in 1.52, _not_ used by core and only honored by some binding ahead of
+ merging the Nav branch).
+ - 2018/03/12 (1.60) - removed ImGuiCol_CloseButton, ImGuiCol_CloseButtonActive,
+ ImGuiCol_CloseButtonHovered as the closing cross uses regular button colors now.
+ - 2018/03/08 (1.60) - changed ImFont::DisplayOffset.y to default to 0 instead of +1. Fixed rounding
+ of Ascent/Descent to match TrueType renderer. If you were adding or subtracting to
+ ImFont::DisplayOffset check if your fonts are correctly aligned vertically.
+ - 2018/03/03 (1.60) - renamed ImGuiStyleVar_Count_ to ImGuiStyleVar_COUNT and
+ ImGuiMouseCursor_Count_ to ImGuiMouseCursor_COUNT for consistency with other public enums.
+ - 2018/02/18 (1.60) - BeginDragDropSource(): temporarily removed the optional mouse_button=0
+ parameter because it is not really usable in many situations at the moment.
+ - 2018/02/16 (1.60) - obsoleted the io.RenderDrawListsFn callback, you can call your graphics
+ engine render function after ImGui::Render(). Use ImGui::GetDrawData() to retrieve the ImDrawData*
+ to display.
+ - 2018/02/07 (1.60) - reorganized context handling to be more explicit,
+                       - YOU NOW NEED TO CALL ImGui::CreateContext() AT THE BEGINNING OF YOUR APP,
+ AND CALL ImGui::DestroyContext() AT THE END.
+                       - removed Shutdown() function, as DestroyContext() serve this purpose.
+                       - you may pass a ImFontAtlas* pointer to CreateContext() to share a font
+ atlas between contexts. Otherwise CreateContext() will create its own font atlas instance.
+                       - removed allocator parameters from CreateContext(), they are now setup with
+ SetAllocatorFunctions(), and shared by all contexts.
+                       - removed the default global context and font atlas instance, which were
+ confusing for users of DLL reloading and users of multiple contexts.
+ - 2018/01/31 (1.60) - moved sample TTF files from extra_fonts/ to misc/fonts/. If you loaded files
+ directly from the imgui repo you may need to update your paths.
+ - 2018/01/11 (1.60) - obsoleted IsAnyWindowHovered() in favor of
+ IsWindowHovered(ImGuiHoveredFlags_AnyWindow). Kept redirection function (will obsolete).
+ - 2018/01/11 (1.60) - obsoleted IsAnyWindowFocused() in favor of
+ IsWindowFocused(ImGuiFocusedFlags_AnyWindow). Kept redirection function (will obsolete).
+ - 2018/01/03 (1.60) - renamed ImGuiSizeConstraintCallback to ImGuiSizeCallback,
+ ImGuiSizeConstraintCallbackData to ImGuiSizeCallbackData.
+ - 2017/12/29 (1.60) - removed CalcItemRectClosestPoint() which was weird and not really used by
+ anyone except demo code. If you need it it's easy to replicate on your side.
+ - 2017/12/24 (1.53) - renamed the emblematic ShowTestWindow() function to ShowDemoWindow(). Kept
+ redirection function (will obsolete).
+ - 2017/12/21 (1.53) - ImDrawList: renamed style.AntiAliasedShapes to style.AntiAliasedFill for
+ consistency and as a way to explicitly break code that manipulate those flag at runtime. You can
+ now manipulate ImDrawList::Flags
+ - 2017/12/21 (1.53) - ImDrawList: removed 'bool anti_aliased = true' final parameter of
+ ImDrawList::AddPolyline() and ImDrawList::AddConvexPolyFilled(). Prefer manipulating
+ ImDrawList::Flags if you need to toggle them during the frame.
+ - 2017/12/14 (1.53) - using the ImGuiWindowFlags_NoScrollWithMouse flag on a child window forwards
+ the mouse wheel event to the parent window, unless either ImGuiWindowFlags_NoInputs or
+ ImGuiWindowFlags_NoScrollbar are also set.
+ - 2017/12/13 (1.53) - renamed GetItemsLineHeightWithSpacing() to GetFrameHeightWithSpacing(). Kept
+ redirection function (will obsolete).
+ - 2017/12/13 (1.53) - obsoleted IsRootWindowFocused() in favor of using
+ IsWindowFocused(ImGuiFocusedFlags_RootWindow). Kept redirection function (will obsolete).
+                     - obsoleted IsRootWindowOrAnyChildFocused() in favor of using
+ IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows). Kept redirection function (will obsolete).
+ - 2017/12/12 (1.53) - renamed ImGuiTreeNodeFlags_AllowOverlapMode to
+ ImGuiTreeNodeFlags_AllowItemOverlap. Kept redirection enum (will obsolete).
+ - 2017/12/10 (1.53) - removed SetNextWindowContentWidth(), prefer using SetNextWindowContentSize().
+ Kept redirection function (will obsolete).
+ - 2017/11/27 (1.53) - renamed ImGuiTextBuffer::append() helper to appendf(), appendv() to
+ appendfv(). If you copied the 'Log' demo in your code, it uses appendv() so that needs to be
+ renamed.
+ - 2017/11/18 (1.53) - Style, Begin: removed ImGuiWindowFlags_ShowBorders window flag. Borders are
+ now fully set up in the ImGuiStyle structure (see e.g. style.FrameBorderSize,
+ style.WindowBorderSize). Use ImGui::ShowStyleEditor() to look them up. Please note that the style
+ system will keep evolving (hopefully stabilizing in Q1 2018), and so custom styles will probably
+ subtly break over time. It is recommended you use the StyleColorsClassic(), StyleColorsDark(),
+ StyleColorsLight() functions.
+ - 2017/11/18 (1.53) - Style: removed ImGuiCol_ComboBg in favor of combo boxes using
+ ImGuiCol_PopupBg for consistency.
+ - 2017/11/18 (1.53) - Style: renamed ImGuiCol_ChildWindowBg to ImGuiCol_ChildBg.
+ - 2017/11/18 (1.53) - Style: renamed style.ChildWindowRounding to style.ChildRounding,
+ ImGuiStyleVar_ChildWindowRounding to ImGuiStyleVar_ChildRounding.
+ - 2017/11/02 (1.53) - obsoleted IsRootWindowOrAnyChildHovered() in favor of using
+ IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
+ - 2017/10/24 (1.52) - renamed
+ IMGUI_DISABLE_WIN32_DEFAULT_CLIPBOARD_FUNCS/IMGUI_DISABLE_WIN32_DEFAULT_IME_FUNCS to
+ IMGUI_DISABLE_WIN32_DEFAULT_CLIPBOARD_FUNCTIONS/IMGUI_DISABLE_WIN32_DEFAULT_IME_FUNCTIONS for
+ consistency.
+ - 2017/10/20 (1.52) - changed IsWindowHovered() default parameters behavior to return false if an
+ item is active in another window (e.g. click-dragging item from another window to this window). You
+ can use the newly introduced IsWindowHovered() flags to requests this specific behavior if you need
+ it.
+ - 2017/10/20 (1.52) - marked IsItemHoveredRect()/IsMouseHoveringWindow() as obsolete, in favor of
+ using the newly introduced flags for IsItemHovered() and IsWindowHovered(). See
+ https://github.com/ocornut/imgui/issues/1382 for details. removed the
+ IsItemRectHovered()/IsWindowRectHovered() names introduced in 1.51 since they were merely more
+ consistent names for the two functions we are now obsoleting. IsItemHoveredRect()        -->
+ IsItemHovered(ImGuiHoveredFlags_RectOnly) IsMouseHoveringAnyWindow() -->
+ IsWindowHovered(ImGuiHoveredFlags_AnyWindow) IsMouseHoveringWindow()    -->
+ IsWindowHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup |
+ ImGuiHoveredFlags_AllowWhenBlockedByActiveItem) [weird, old behavior]
+ - 2017/10/17 (1.52) - marked the old 5-parameters version of Begin() as obsolete (still available).
+ Use SetNextWindowSize()+Begin() instead!
+ - 2017/10/11 (1.52) - renamed AlignFirstTextHeightToWidgets() to AlignTextToFramePadding(). Kept
+ inline redirection function (will obsolete).
+ - 2017/09/26 (1.52) - renamed ImFont::Glyph to ImFontGlyph. Keep redirection typedef (will
+ obsolete).
+ - 2017/09/25 (1.52) - removed SetNextWindowPosCenter() because SetNextWindowPos() now has the
+ optional pivot information to do the same and more. Kept redirection function (will obsolete).
+ - 2017/08/25 (1.52) - io.MousePos needs to be set to ImVec2(-FLT_MAX,-FLT_MAX) when mouse is
+ unavailable/missing. Previously ImVec2(-1,-1) was enough but we now accept negative mouse
+ coordinates. In your binding if you need to support unavailable mouse, make sure to replace
+ "io.MousePos = ImVec2(-1,-1)" with "io.MousePos = ImVec2(-FLT_MAX,-FLT_MAX)".
+ - 2017/08/22 (1.51) - renamed IsItemHoveredRect() to IsItemRectHovered(). Kept inline redirection
+ function (will obsolete). -> (1.52) use IsItemHovered(ImGuiHoveredFlags_RectOnly)!
+                     - renamed IsMouseHoveringAnyWindow() to IsAnyWindowHovered() for consistency.
+ Kept inline redirection function (will obsolete).
+                     - renamed IsMouseHoveringWindow() to IsWindowRectHovered() for consistency.
+ Kept inline redirection function (will obsolete).
+ - 2017/08/20 (1.51) - renamed GetStyleColName() to GetStyleColorName() for consistency.
+ - 2017/08/20 (1.51) - added PushStyleColor(ImGuiCol idx, ImU32 col) overload, which _might_ cause
+ an "ambiguous call" compilation error if you are using ImColor() with implicit cast. Cast to ImU32
+ or ImVec4 explicily to fix.
+ - 2017/08/15 (1.51) - marked the weird IMGUI_ONCE_UPON_A_FRAME helper macro as obsolete. prefer
+ using the more explicit ImGuiOnceUponAFrame type.
+ - 2017/08/15 (1.51) - changed parameter order for BeginPopupContextWindow() from (const char*,int
+ buttons,bool also_over_items) to (const char*,int buttons,bool also_over_items). Note that most
+ calls relied on default parameters completely.
+ - 2017/08/13 (1.51) - renamed ImGuiCol_Column to ImGuiCol_Separator, ImGuiCol_ColumnHovered to
+ ImGuiCol_SeparatorHovered, ImGuiCol_ColumnActive to ImGuiCol_SeparatorActive. Kept redirection
+ enums (will obsolete).
+ - 2017/08/11 (1.51) - renamed ImGuiSetCond_Always to ImGuiCond_Always, ImGuiSetCond_Once to
+ ImGuiCond_Once, ImGuiSetCond_FirstUseEver to ImGuiCond_FirstUseEver, ImGuiSetCond_Appearing to
+ ImGuiCond_Appearing. Kept redirection enums (will obsolete).
+ - 2017/08/09 (1.51) - removed ValueColor() helpers, they are equivalent to calling Text(label) +
+ SameLine() + ColorButton().
+ - 2017/08/08 (1.51) - removed ColorEditMode() and ImGuiColorEditMode in favor of
+ ImGuiColorEditFlags and parameters to the various Color*() functions. The SetColorEditOptions()
+ allows to initialize default but the user can still change them with right-click context menu.
+                     - changed prototype of 'ColorEdit4(const char* label, float col[4], bool
+ show_alpha = true)' to 'ColorEdit4(const char* label, float col[4], ImGuiColorEditFlags flags =
+ 0)', where passing flags = 0x01 is a safe no-op (hello dodgy backward compatibility!). - check and
+ run the demo window, under "Color/Picker Widgets", to understand the various new options.
+                     - changed prototype of rarely used 'ColorButton(ImVec4 col, bool small_height =
+ false, bool outline_border = true)' to 'ColorButton(const char* desc_id, ImVec4 col,
+ ImGuiColorEditFlags flags = 0, ImVec2 size = ImVec2(0,0))'
+ - 2017/07/20 (1.51) - removed IsPosHoveringAnyWindow(ImVec2), which was partly broken and
+ misleading. ASSERT + redirect user to io.WantCaptureMouse
+ - 2017/05/26 (1.50) - removed ImFontConfig::MergeGlyphCenterV in favor of a more multipurpose
+ ImFontConfig::GlyphOffset.
+ - 2017/05/01 (1.50) - renamed ImDrawList::PathFill() (rarely used directly) to
+ ImDrawList::PathFillConvex() for clarity.
+ - 2016/11/06 (1.50) - BeginChild(const char*) now applies the stack id to the provided label,
+ consistently with other functions as it should always have been. It shouldn't affect you unless
+ (extremely unlikely) you were appending multiple times to a same child from different locations of
+ the stack id. If that's the case, generate an id with GetId() and use it instead of passing string
+ to BeginChild().
+ - 2016/10/15 (1.50) - avoid 'void* user_data' parameter to
+ io.SetClipboardTextFn/io.GetClipboardTextFn pointers. We pass io.ClipboardUserData to it.
+ - 2016/09/25 (1.50) - style.WindowTitleAlign is now a ImVec2 (ImGuiAlign enum was removed). set to
+ (0.5f,0.5f) for horizontal+vertical centering, (0.0f,0.0f) for upper-left, etc.
+ - 2016/07/30 (1.50) - SameLine(x) with x>0.0f is now relative to left of column/group if any, and
+ not always to left of window. This was sort of always the intent and hopefully breakage should be
+ minimal.
+ - 2016/05/12 (1.49) - title bar (using ImGuiCol_TitleBg/ImGuiCol_TitleBgActive colors) isn't
+ rendered over a window background (ImGuiCol_WindowBg color) anymore. If your TitleBg/TitleBgActive
+ alpha was 1.0f or you are using the default theme it will not affect you. If your
+ TitleBg/TitleBgActive alpha was <1.0f you need to tweak your custom theme to readjust for the fact
+ that we don't draw a WindowBg background behind the title bar. This helper function will convert an
+ old TitleBg/TitleBgActive color into a new one with the same visual output, given the OLD color and
+ the OLD WindowBg color. ImVec4 ConvertTitleBgCol(const ImVec4& win_bg_col, const ImVec4&
+ title_bg_col)
+                           {
+                               float new_a = 1.0f - ((1.0f - win_bg_col.w) * (1.0f -
+ title_bg_col.w)), k = title_bg_col.w / new_a; return ImVec4((win_bg_col.x * win_bg_col.w +
+ title_bg_col.x) * k, (win_bg_col.y * win_bg_col.w + title_bg_col.y) * k, (win_bg_col.z *
+ win_bg_col.w + title_bg_col.z) * k, new_a);
+                           }
+                       If this is confusing, pick the RGB value from title bar from an old
+ screenshot and apply this as TitleBg/TitleBgActive. Or you may just create TitleBgActive from a
+ tweaked TitleBg color.
+ - 2016/05/07 (1.49) - removed confusing set of GetInternalState(), GetInternalStateSize(),
+ SetInternalState() functions. Now using CreateContext(), DestroyContext(), GetCurrentContext(),
+ SetCurrentContext().
+ - 2016/05/02 (1.49) - renamed SetNextTreeNodeOpened() to SetNextTreeNodeOpen(), no redirection.
+ - 2016/05/01 (1.49) - obsoleted old signature of CollapsingHeader(const char* label, const char*
+ str_id = NULL, bool display_frame = true, bool default_open = false) as extra parameters were badly
+ designed and rarely used. You can replace the "default_open = true" flag in new API with
+ CollapsingHeader(label, ImGuiTreeNodeFlags_DefaultOpen).
+ - 2016/04/26 (1.49) - changed ImDrawList::PushClipRect(ImVec4 rect) to
+ ImDrawList::PushClipRect(Imvec2 min,ImVec2 max,bool intersect_with_current_clip_rect=false). Note
+ that higher-level ImGui::PushClipRect() is preferable because it will clip at logic/widget level,
+ whereas ImDrawList::PushClipRect() only affect your renderer.
+ - 2016/04/03 (1.48) - removed style.WindowFillAlphaDefault setting which was redundant. Bake
+ default BG alpha inside style.Colors[ImGuiCol_WindowBg] and all other Bg color values. (ref github
+ issue #337).
+ - 2016/04/03 (1.48) - renamed ImGuiCol_TooltipBg to ImGuiCol_PopupBg, used by popups/menus and
+ tooltips. popups/menus were previously using ImGuiCol_WindowBg. (ref github issue #337)
+ - 2016/03/21 (1.48) - renamed GetWindowFont() to GetFont(), GetWindowFontSize() to GetFontSize().
+ Kept inline redirection function (will obsolete).
+ - 2016/03/02 (1.48) - InputText() completion/history/always callbacks: if you modify the text
+ buffer manually (without using DeleteChars()/InsertChars() helper) you need to maintain the
+ BufTextLen field. added an assert.
+ - 2016/01/23 (1.48) - fixed not honoring exact width passed to PushItemWidth(), previously it would
+ add extra FramePadding.x*2 over that width. if you had manual pixel-perfect alignment in place it
+ might affect you.
+ - 2015/12/27 (1.48) - fixed ImDrawList::AddRect() which used to render a rectangle 1 px too large
+ on each axis.
+ - 2015/12/04 (1.47) - renamed Color() helpers to ValueColor() - dangerously named, rarely used and
+ probably to be made obsolete.
+ - 2015/08/29 (1.45) - with the addition of horizontal scrollbar we made various fixes to
+ inconsistencies with dealing with cursor position. GetCursorPos()/SetCursorPos() functions now
+ include the scrolled amount. It shouldn't affect the majority of users, but take note that
+ SetCursorPosX(100.0f) puts you at +100 from the starting x position which may include scrolling,
+ not at +100 from the window left side.
+                       GetContentRegionMax()/GetWindowContentRegionMin()/GetWindowContentRegionMax()
+ functions allow include the scrolled amount. Typically those were used in cases where no scrolling
+ would happen so it may not be a problem, but watch out!
+ - 2015/08/29 (1.45) - renamed style.ScrollbarWidth to style.ScrollbarSize
+ - 2015/08/05 (1.44) - split imgui.cpp into extra files: imgui_demo.cpp imgui_draw.cpp
+ imgui_internal.h that you need to add to your project.
+ - 2015/07/18 (1.44) - fixed angles in ImDrawList::PathArcTo(), PathArcToFast() (introduced in 1.43)
+ being off by an extra PI for no justifiable reason
+ - 2015/07/14 (1.43) - add new ImFontAtlas::AddFont() API. For the old AddFont***, moved the
+ 'font_no' parameter of ImFontAtlas::AddFont** functions to the ImFontConfig structure. you need to
+ render your textured triangles with bilinear filtering to benefit from sub-pixel positioning of
+ text.
+ - 2015/07/08 (1.43) - switched rendering data to use indexed rendering. this is saving a fair
+ amount of CPU/GPU and enables us to get anti-aliasing for a marginal cost. this necessary change
+ will break your rendering function! the fix should be very easy. sorry for that :(
+                     - if you are using a vanilla copy of one of the imgui_impl_XXXX.cpp provided in
+ the example, you just need to update your copy and you can ignore the rest.
+                     - the signature of the io.RenderDrawListsFn handler has changed!
+                       old: ImGui_XXXX_RenderDrawLists(ImDrawList** const cmd_lists, int
+ cmd_lists_count) new: ImGui_XXXX_RenderDrawLists(ImDrawData* draw_data). parameters: 'cmd_lists'
+ becomes 'draw_data->CmdLists', 'cmd_lists_count' becomes 'draw_data->CmdListsCount' ImDrawList:
+ 'commands' becomes 'CmdBuffer', 'vtx_buffer' becomes 'VtxBuffer', 'IdxBuffer' is new. ImDrawCmd:
+ 'vtx_count' becomes 'ElemCount', 'clip_rect' becomes 'ClipRect', 'user_callback' becomes
+ 'UserCallback', 'texture_id' becomes 'TextureId'.
+                     - each ImDrawList now contains both a vertex buffer and an index buffer. For
+ each command, render ElemCount/3 triangles using indices from the index buffer.
+                     - if you REALLY cannot render indexed primitives, you can call the
+ draw_data->DeIndexAllBuffers() method to de-index the buffers. This is slow and a waste of CPU/GPU.
+ Prefer using indexed rendering!
+                     - refer to code in the examples/ folder or ask on the GitHub if you are unsure
+ of how to upgrade. please upgrade!
+ - 2015/07/10 (1.43) - changed SameLine() parameters from int to float.
+ - 2015/07/02 (1.42) - renamed SetScrollPosHere() to SetScrollFromCursorPos(). Kept inline
+ redirection function (will obsolete).
+ - 2015/07/02 (1.42) - renamed GetScrollPosY() to GetScrollY(). Necessary to reduce confusion along
+ with other scrolling functions, because positions (e.g. cursor position) are not equivalent to
+ scrolling amount.
+ - 2015/06/14 (1.41) - changed ImageButton() default bg_col parameter from (0,0,0,1) (black) to
+ (0,0,0,0) (transparent) - makes a difference when texture have transparence
+ - 2015/06/14 (1.41) - changed Selectable() API from (label, selected, size) to (label, selected,
+ flags, size). Size override should have been rarely be used. Sorry!
+ - 2015/05/31 (1.40) - renamed GetWindowCollapsed() to IsWindowCollapsed() for consistency. Kept
+ inline redirection function (will obsolete).
+ - 2015/05/31 (1.40) - renamed IsRectClipped() to IsRectVisible() for consistency. Note that return
+ value is opposite! Kept inline redirection function (will obsolete).
+ - 2015/05/27 (1.40) - removed the third 'repeat_if_held' parameter from Button() - sorry! it was
+ rarely used and inconsistent. Use PushButtonRepeat(true) / PopButtonRepeat() to enable repeat on
+ desired buttons.
+ - 2015/05/11 (1.40) - changed BeginPopup() API, takes a string identifier instead of a bool. ImGui
+ needs to manage the open/closed state of popups. Call OpenPopup() to actually set the "open" state
+ of a popup. BeginPopup() returns true if the popup is opened.
+ - 2015/05/03 (1.40) - removed style.AutoFitPadding, using style.WindowPadding makes more sense (the
+ default values were already the same).
+ - 2015/04/13 (1.38) - renamed IsClipped() to IsRectClipped(). Kept inline redirection function
+ until 1.50.
+ - 2015/04/09 (1.38) - renamed ImDrawList::AddArc() to ImDrawList::AddArcFast() for compatibility
+ with future API
+ - 2015/04/03 (1.38) - removed ImGuiCol_CheckHovered, ImGuiCol_CheckActive, replaced with the more
+ general ImGuiCol_FrameBgHovered, ImGuiCol_FrameBgActive.
+ - 2014/04/03 (1.38) - removed support for passing -FLT_MAX..+FLT_MAX as the range for a
+ SliderFloat(). Use DragFloat() or Inputfloat() instead.
+ - 2015/03/17 (1.36) - renamed GetItemBoxMin()/GetItemBoxMax()/IsMouseHoveringBox() to
+ GetItemRectMin()/GetItemRectMax()/IsMouseHoveringRect(). Kept inline redirection function
+ until 1.50.
+ - 2015/03/15 (1.36) - renamed style.TreeNodeSpacing to style.IndentSpacing,
+ ImGuiStyleVar_TreeNodeSpacing to ImGuiStyleVar_IndentSpacing
+ - 2015/03/13 (1.36) - renamed GetWindowIsFocused() to IsWindowFocused(). Kept inline redirection
+ function until 1.50.
+ - 2015/03/08 (1.35) - renamed style.ScrollBarWidth to style.ScrollbarWidth (casing)
+ - 2015/02/27 (1.34) - renamed OpenNextNode(bool) to SetNextTreeNodeOpened(bool, ImGuiSetCond). Kept
+ inline redirection function until 1.50.
+ - 2015/02/27 (1.34) - renamed ImGuiSetCondition_*** to ImGuiSetCond_***, and _FirstUseThisSession
+ becomes _Once.
+ - 2015/02/11 (1.32) - changed text input callback ImGuiTextEditCallback return type from
+ void-->int. reserved for future use, return 0 for now.
+ - 2015/02/10 (1.32) - renamed GetItemWidth() to CalcItemWidth() to clarify its evolving behavior
+ - 2015/02/08 (1.31) - renamed GetTextLineSpacing() to GetTextLineHeightWithSpacing()
+ - 2015/02/01 (1.31) - removed IO.MemReallocFn (unused)
+ - 2015/01/19 (1.30) - renamed ImGuiStorage::GetIntPtr()/GetFloatPtr() to GetIntRef()/GetIntRef()
+ because Ptr was conflicting with actual pointer storage functions.
+ - 2015/01/11 (1.30) - big font/image API change! now loads TTF file. allow for multiple fonts. no
+ need for a PNG loader. (1.30) - removed GetDefaultFontData(). uses io.Fonts->GetTextureData*() API
+ to retrieve uncompressed pixels. font init:  { const void* png_data; unsigned int png_size;
+ ImGui::GetDefaultFontData(NULL, NULL, &png_data, &png_size); <..Upload texture to GPU..>; } became:
+ { unsigned char* pixels; int width, height; io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
+ <..Upload texture to GPU>; io.Fonts->TexId = YourTextureIdentifier; } you now have more flexibility
+ to load multiple TTF fonts and manage the texture buffer for internal needs. it is now recommended
+ that you sample the font texture with bilinear interpolation. (1.30) - added texture identifier in
+ ImDrawCmd passed to your render function (we can now render images). make sure to set
+ io.Fonts->TexID. (1.30) - removed IO.PixelCenterOffset (unnecessary, can be handled in user
+ projection matrix) (1.30) - removed ImGui::IsItemFocused() in favor of ImGui::IsItemActive() which
+ handles all widgets
+ - 2014/12/10 (1.18) - removed SetNewWindowDefaultPos() in favor of new generic API
+ SetNextWindowPos(pos, ImGuiSetCondition_FirstUseEver)
+ - 2014/11/28 (1.17) - moved IO.Font*** options to inside the IO.Font-> structure (FontYOffset,
+ FontTexUvForWhite, FontBaseScale, FontFallbackGlyph)
+ - 2014/11/26 (1.17) - reworked syntax of IMGUI_ONCE_UPON_A_FRAME helper macro to increase compiler
+ compatibility
+ - 2014/11/07 (1.15) - renamed IsHovered() to IsItemHovered()
+ - 2014/10/02 (1.14) - renamed IMGUI_INCLUDE_IMGUI_USER_CPP to IMGUI_INCLUDE_IMGUI_USER_INL and
+ imgui_user.cpp to imgui_user.inl (more IDE friendly)
+ - 2014/09/25 (1.13) - removed 'text_end' parameter from IO.SetClipboardTextFn (the string is now
+ always zero-terminated for simplicity)
+ - 2014/09/24 (1.12) - renamed SetFontScale() to SetWindowFontScale()
+ - 2014/09/24 (1.12) - moved IM_MALLOC/IM_REALLOC/IM_FREE preprocessor defines to
+ IO.MemAllocFn/IO.MemReallocFn/IO.MemFreeFn
+ - 2014/08/30 (1.09) - removed IO.FontHeight (now computed automatically)
+ - 2014/08/30 (1.09) - moved IMGUI_FONT_TEX_UV_FOR_WHITE preprocessor define to IO.FontTexUvForWhite
+ - 2014/08/28 (1.09) - changed the behavior of IO.PixelCenterOffset following various rendering
+ fixes
+
+
+ FREQUENTLY ASKED QUESTIONS (FAQ), TIPS
+ ======================================
+
+ Q: Where is the documentation?
+ A: This library is poorly documented at the moment and expects of the user to be acquainted with
+ C/C++.
+    - Run the examples/ and explore them.
+    - See demo code in imgui_demo.cpp and particularly the ImGui::ShowDemoWindow() function.
+    - The demo covers most features of Dear ImGui, so you can read the code and see its output.
+    - See documentation and comments at the top of imgui.cpp + effectively imgui.h.
+    - Dozens of standalone example applications using e.g. OpenGL/DirectX are provided in the
+ examples/ folder to explain how to integrate Dear ImGui with your own engine/application.
+    - Your programming IDE is your friend, find the type or function declaration to find comments
+      associated to it.
+
+ Q: Which version should I get?
+ A: I occasionally tag Releases (https://github.com/ocornut/imgui/releases) but it is generally safe
+    and recommended to sync to master/latest. The library is fairly stable and regressions tend to
+ be fixed fast when reported. You may also peak at the 'docking' branch which includes:
+    - Docking/Merging features (https://github.com/ocornut/imgui/issues/2109)
+    - Multi-viewport features (https://github.com/ocornut/imgui/issues/1542)
+    Many projects are using this branch and it is kept in sync with master regularly.
+
+ Q: Who uses Dear ImGui?
+ A: See "Quotes" (https://github.com/ocornut/imgui/wiki/Quotes) and
+    "Software using Dear ImGui" (https://github.com/ocornut/imgui/wiki/Software-using-dear-imgui)
+ Wiki pages for a list of games/software which are publicly known to use dear imgui. Please add
+ yours if you can!
+
+ Q: Why the odd dual naming, "Dear ImGui" vs "ImGui"?
+ A: The library started its life as "ImGui" due to the fact that I didn't give it a proper name when
+    when I released 1.0, and had no particular expectation that it would take off. However, the term
+ IMGUI (immediate-mode graphical user interface) was coined before and is being used in variety of
+ other situations (e.g. Unity uses it own implementation of the IMGUI paradigm). To reduce the
+ ambiguity without affecting existing code bases, I have decided on an alternate, longer name "Dear
+ ImGui" that people can use to refer to this specific library. Please try to refer to this library
+ as "Dear ImGui".
+
+ Q: How can I tell whether to dispatch mouse/keyboard to Dear ImGui or to my application?
+ A: You can read the 'io.WantCaptureMouse', 'io.WantCaptureKeyboard' and 'io.WantTextInput' flags
+ from the ImGuiIO structure (e.g. if (ImGui::GetIO().WantCaptureMouse) { ... } )
+    - When 'io.WantCaptureMouse' is set, imgui wants to use your mouse state, and you may want to
+ discard/hide the inputs from the rest of your application.
+    - When 'io.WantCaptureKeyboard' is set, imgui wants to use your keyboard state, and you may want
+ to discard/hide the inputs from the rest of your application.
+    - When 'io.WantTextInput' is set to may want to notify your OS to popup an on-screen keyboard,
+ if available (e.g. on a mobile phone, or console OS). Note: you should always pass your
+ mouse/keyboard inputs to imgui, even when the io.WantCaptureXXX flag are set false. This is because
+ imgui needs to detect that you clicked in the void to unfocus its own windows. Note: The
+ 'io.WantCaptureMouse' is more accurate that any attempt to "check if the mouse is hovering a
+ window" (don't do that!). It handle mouse dragging correctly (both dragging that started over your
+ application or over an imgui window) and handle e.g. modal windows blocking inputs. Those flags are
+ updated by ImGui::NewFrame(). Preferably read the flags after calling NewFrame() if you can afford
+ it, but reading them before is also perfectly fine, as the bool toggle fairly rarely. If you have
+ on a touch device, you might find use for an early call to UpdateHoveredWindowAndCaptureFlags().
+    Note: Text input widget releases focus on "Return KeyDown", so the subsequent "Return KeyUp"
+ event that your application receive will typically have 'io.WantCaptureKeyboard=false'. Depending
+ on your application logic it may or not be inconvenient. You might want to track which key-downs
+     were targeted for Dear ImGui, e.g. with an array of bool, and filter out the corresponding
+ key-ups.)
+
+ Q: How can I display an image? What is ImTextureID, how does it works?
+ A: Short explanation:
+    - You may use functions such as ImGui::Image(), ImGui::ImageButton() or lower-level
+ ImDrawList::AddImage() to emit draw calls that will use your own textures.
+    - Actual textures are identified in a way that is up to the user/engine. Those identifiers are
+ stored and passed as ImTextureID (void*) value.
+    - Loading image files from the disk and turning them into a texture is not within the scope of
+ Dear ImGui (for a good reason). Please read documentations or tutorials on your graphics API to
+ understand how to display textures on the screen before moving onward.
+
+    Long explanation:
+    - Dear ImGui's job is to create "meshes", defined in a renderer-agnostic format made of draw
+ commands and vertices. At the end of the frame those meshes (ImDrawList) will be displayed by your
+ rendering function. They are made up of textured polygons and the code to render them is generally
+ fairly short (a few dozen lines). In the examples/ folder we provide functions for popular graphics
+ API (OpenGL, DirectX, etc.).
+    - Each rendering function decides on a data type to represent "textures". The concept of what is
+ a "texture" is entirely tied to your underlying engine/graphics API. We carry the information to
+ identify a "texture" in the ImTextureID type. ImTextureID is nothing more that a void*, aka 4/8
+ bytes worth of data: just enough to store 1 pointer or 1 integer of your choice. Dear ImGui doesn't
+ know or understand what you are storing in ImTextureID, it merely pass ImTextureID values until
+ they reach your rendering function.
+    - In the examples/ bindings, for each graphics API binding we decided on a type that is likely
+ to be a good representation for specifying an image from the end-user perspective. This is what the
+ _examples_ rendering functions are using:
+
+         OpenGL:     ImTextureID = GLuint                       (see
+ ImGui_ImplGlfwGL3_RenderDrawData() function in imgui_impl_glfw_gl3.cpp) DirectX9:   ImTextureID =
+ LPDIRECT3DTEXTURE9           (see ImGui_ImplDX9_RenderDrawData()     function in
+ imgui_impl_dx9.cpp) DirectX11:  ImTextureID = ID3D11ShaderResourceView*    (see
+ ImGui_ImplDX11_RenderDrawData()    function in imgui_impl_dx11.cpp) DirectX12:  ImTextureID =
+ D3D12_GPU_DESCRIPTOR_HANDLE  (see ImGui_ImplDX12_RenderDrawData()    function in
+ imgui_impl_dx12.cpp)
+
+      For example, in the OpenGL example binding we store raw OpenGL texture identifier (GLuint)
+ inside ImTextureID. Whereas in the DirectX11 example binding we store a pointer to
+ ID3D11ShaderResourceView inside ImTextureID, which is a higher-level structure tying together both
+ the texture and information about its format and how to read it.
+    - If you have a custom engine built over e.g. OpenGL, instead of passing GLuint around you may
+ decide to use a high-level data type to carry information about the texture as well as how to
+ display it (shaders, etc.). The decision of what to use as ImTextureID can always be made better
+ knowing how your codebase is designed. If your engine has high-level data types for "textures" and
+ "material" then you may want to use them. If you are starting with OpenGL or DirectX or Vulkan and
+ haven't built much of a rendering engine over them, keeping the default ImTextureID representation
+ suggested by the example bindings is probably the best choice. (Advanced users may also decide to
+ keep a low-level type in ImTextureID, and use ImDrawList callback and pass information to their
+ renderer)
+
+    User code may do:
+
+        // Cast our texture type to ImTextureID / void*
+        MyTexture* texture = g_CoffeeTableTexture;
+        ImGui::Image((void*)texture, ImVec2(texture->Width, texture->Height));
+
+    The renderer function called after ImGui::Render() will receive that same value that the user
+ code passed:
+
+        // Cast ImTextureID / void* stored in the draw command as our texture type
+        MyTexture* texture = (MyTexture*)pcmd->TextureId;
+        MyEngineBindTexture2D(texture);
+
+    Once you understand this design you will understand that loading image files and turning them
+ into displayable textures is not within the scope of Dear ImGui. This is by design and is actually
+ a good thing, because it means your code has full control over your data types and how you display
+ them. If you want to display an image file (e.g. PNG file) into the screen, please refer to
+ documentation and tutorials for the graphics API you are using.
+
+    Here's a simplified OpenGL example using stb_image.h:
+
+        // Use stb_image.h to load a PNG from disk and turn it into raw RGBA pixel data:
+        #define STB_IMAGE_IMPLEMENTATION
+        #include <stb_image.h>
+        [...]
+        int my_image_width, my_image_height;
+        unsigned char* my_image_data = stbi_load("my_image.png", &my_image_width, &my_image_height,
+ NULL, 4);
+
+        // Turn the RGBA pixel data into an OpenGL texture:
+        GLuint my_opengl_texture;
+        glGenTextures(1, &my_opengl_texture);
+        glBindTexture(GL_TEXTURE_2D, my_opengl_texture);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, image_width, image_height, 0, GL_RGBA,
+ GL_UNSIGNED_BYTE, image_data);
+
+        // Now that we have an OpenGL texture, assuming our imgui rendering function
+ (imgui_impl_xxx.cpp file) takes GLuint as ImTextureID, we can display it:
+        ImGui::Image((void*)(intptr_t)my_opengl_texture, ImVec2(my_image_width, my_image_height));
+
+    C/C++ tip: a void* is pointer-sized storage. You may safely store any pointer or integer into it
+ by casting your value to ImTextureID / void*, and vice-versa. Because both end-points (user code
+ and rendering function) are under your control, you know exactly what is stored inside the
+ ImTextureID / void*. Examples:
+
+        GLuint my_tex = XXX;
+        void* my_void_ptr;
+        my_void_ptr = (void*)(intptr_t)my_tex;                  // cast a GLuint into a void* (we
+ don't take its address! we literally store the value inside the pointer) my_tex =
+ (GLuint)(intptr_t)my_void_ptr;                 // cast a void* into a GLuint
+
+        ID3D11ShaderResourceView* my_dx11_srv = XXX;
+        void* my_void_ptr;
+        my_void_ptr = (void*)my_dx11_srv;                       // cast a ID3D11ShaderResourceView*
+ into an opaque void* my_dx11_srv = (ID3D11ShaderResourceView*)my_void_ptr;   // cast a void* into a
+ ID3D11ShaderResourceView*
+
+    Finally, you may call ImGui::ShowMetricsWindow() to explore/visualize/understand how the
+ ImDrawList are generated.
+
+ Q: Why are multiple widgets reacting when I interact with a single one?
+ Q: How can I have multiple widgets with the same label or with an empty label?
+ A: A primer on labels and the ID Stack...
+
+    Dear ImGui internally need to uniquely identify UI elements.
+    Elements that are typically not clickable (such as calls to the Text functions) don't need an
+ ID. Interactive widgets (such as calls to Button buttons) need a unique ID. Unique ID are used
+ internally to track active widgets and occasionally associate state to widgets. Unique ID are
+ implicitly built from the hash of multiple elements that identify the "path" to the UI element.
+
+   - Unique ID are often derived from a string label:
+
+       Button("OK");          // Label = "OK",     ID = hash of (..., "OK")
+       Button("Cancel");      // Label = "Cancel", ID = hash of (..., "Cancel")
+
+   - ID are uniquely scoped within windows, tree nodes, etc. which all pushes to the ID stack.
+ Having two buttons labeled "OK" in different windows or different tree locations is fine. We used
+ "..." above to signify whatever was already pushed to the ID stack previously:
+
+       Begin("MyWindow");
+       Button("OK");          // Label = "OK",     ID = hash of ("MyWindow", "OK")
+       End();
+       Begin("MyOtherWindow");
+       Button("OK");          // Label = "OK",     ID = hash of ("MyOtherWindow", "OK")
+       End();
+
+   - If you have a same ID twice in the same location, you'll have a conflict:
+
+       Button("OK");
+       Button("OK");          // ID collision! Interacting with either button will trigger the first
+ one.
+
+     Fear not! this is easy to solve and there are many ways to solve it!
+
+   - Solving ID conflict in a simple/local context:
+     When passing a label you can optionally specify extra ID information within string itself.
+     Use "##" to pass a complement to the ID that won't be visible to the end-user.
+     This helps solving the simple collision cases when you know e.g. at compilation time which
+ items are going to be created:
+
+       Begin("MyWindow");
+       Button("Play");        // Label = "Play",   ID = hash of ("MyWindow", "Play")
+       Button("Play##foo1");  // Label = "Play",   ID = hash of ("MyWindow", "Play##foo1")  //
+ Different from above Button("Play##foo2");  // Label = "Play",   ID = hash of ("MyWindow",
+ "Play##foo2")  // Different from above End();
+
+   - If you want to completely hide the label, but still need an ID:
+
+       Checkbox("##On", &b);  // Label = "",       ID = hash of (..., "##On")   // No visible label,
+ just a checkbox!
+
+   - Occasionally/rarely you might want change a label while preserving a constant ID. This allows
+     you to animate labels. For example you may want to include varying information in a window
+ title bar, but windows are uniquely identified by their ID. Use "###" to pass a label that isn't
+ part of ID:
+
+       Button("Hello###ID");  // Label = "Hello",  ID = hash of (..., "###ID")
+       Button("World###ID");  // Label = "World",  ID = hash of (..., "###ID")  // Same as above,
+ even though the label looks different
+
+       sprintf(buf, "My game (%f FPS)###MyGame", fps);
+       Begin(buf);            // Variable title,   ID = hash of "MyGame"
+
+   - Solving ID conflict in a more general manner:
+     Use PushID() / PopID() to create scopes and manipulate the ID stack, as to avoid ID conflicts
+     within the same window. This is the most convenient way of distinguishing ID when iterating and
+     creating many UI elements programmatically.
+     You can push a pointer, a string or an integer value into the ID stack.
+     Remember that ID are formed from the concatenation of _everything_ pushed into the ID stack.
+     At each level of the stack we store the seed used for items at this level of the ID stack.
+
+     Begin("Window");
+       for (int i = 0; i < 100; i++)
+       {
+         PushID(i);           // Push i to the id tack
+         Button("Click");     // Label = "Click",  ID = hash of ("Window", i, "Click")
+         PopID();
+       }
+       for (int i = 0; i < 100; i++)
+       {
+         MyObject* obj = Objects[i];
+         PushID(obj);
+         Button("Click");     // Label = "Click",  ID = hash of ("Window", obj pointer, "Click")
+         PopID();
+       }
+       for (int i = 0; i < 100; i++)
+       {
+         MyObject* obj = Objects[i];
+         PushID(obj->Name);
+         Button("Click");     // Label = "Click",  ID = hash of ("Window", obj->Name, "Click")
+         PopID();
+       }
+       End();
+
+   - You can stack multiple prefixes into the ID stack:
+
+       Button("Click");       // Label = "Click",  ID = hash of (..., "Click")
+       PushID("node");
+       Button("Click");       // Label = "Click",  ID = hash of (..., "node", "Click")
+         PushID(my_ptr);
+           Button("Click");   // Label = "Click",  ID = hash of (..., "node", my_ptr, "Click")
+         PopID();
+       PopID();
+
+   - Tree nodes implicitly creates a scope for you by calling PushID().
+
+       Button("Click");       // Label = "Click",  ID = hash of (..., "Click")
+       if (TreeNode("node"))  // <-- this function call will do a PushID() for you (unless
+ instructed not to, with a special flag)
+       {
+         Button("Click");     // Label = "Click",  ID = hash of (..., "node", "Click")
+         TreePop();
+       }
+
+   - When working with trees, ID are used to preserve the open/close state of each tree node.
+     Depending on your use cases you may want to use strings, indices or pointers as ID.
+      e.g. when following a single pointer that may change over time, using a static string as ID
+       will preserve your node open/closed state when the targeted object change.
+      e.g. when displaying a list of objects, using indices or pointers as ID will preserve the
+       node open/closed state differently. See what makes more sense in your situation!
+
+ Q: How can I use my own math types instead of ImVec2/ImVec4?
+ A: You can edit imconfig.h and setup the IM_VEC2_CLASS_EXTRA/IM_VEC4_CLASS_EXTRA macros to add
+ implicit type conversions. This way you'll be able to use your own types everywhere, e.g. passing
+ glm::vec2 to ImGui functions instead of ImVec2.
+
+ Q: How can I load a different font than the default?
+ A: Use the font atlas to load the TTF/OTF file you want:
+      ImGuiIO& io = ImGui::GetIO();
+      io.Fonts->AddFontFromFileTTF("myfontfile.ttf", size_in_pixels);
+      io.Fonts->GetTexDataAsRGBA32() or GetTexDataAsAlpha8()
+    Default is ProggyClean.ttf, monospace, rendered at size 13, embedded in dear imgui's source
+ code. (Tip: monospace fonts are convenient because they allow to facilitate horizontal alignment
+ directly at the string level.) (Read the 'misc/fonts/README.txt' file for more details about font
+ loading.)
+
+    New programmers: remember that in C/C++ and most programming languages if you want to use a
+    backslash \ within a string literal, you need to write it double backslash "\\":
+      io.Fonts->AddFontFromFileTTF("MyDataFolder\MyFontFile.ttf", size_in_pixels);   // WRONG (you
+ are escape the M here!) io.Fonts->AddFontFromFileTTF("MyDataFolder\\MyFontFile.ttf",
+ size_in_pixels);  // CORRECT io.Fonts->AddFontFromFileTTF("MyDataFolder/MyFontFile.ttf",
+ size_in_pixels);   // ALSO CORRECT
+
+ Q: How can I easily use icons in my application?
+ A: The most convenient and practical way is to merge an icon font such as FontAwesome inside you
+    main font. Then you can refer to icons within your strings.
+    You may want to see ImFontConfig::GlyphMinAdvanceX to make your icon look monospace to
+ facilitate alignment. (Read the 'misc/fonts/README.txt' file for more details about icons font
+ loading.) With some extra effort, you may use colorful icon by registering custom rectangle space
+ inside the font atlas, and copying your own graphics data into it. See misc/fonts/README.txt about
+ using the AddCustomRectFontGlyph API.
+
+ Q: How can I load multiple fonts?
+ A: Use the font atlas to pack them into a single texture:
+    (Read the 'misc/fonts/README.txt' file and the code in ImFontAtlas for more details.)
+
+      ImGuiIO& io = ImGui::GetIO();
+      ImFont* font0 = io.Fonts->AddFontDefault();
+      ImFont* font1 = io.Fonts->AddFontFromFileTTF("myfontfile.ttf", size_in_pixels);
+      ImFont* font2 = io.Fonts->AddFontFromFileTTF("myfontfile2.ttf", size_in_pixels);
+      io.Fonts->GetTexDataAsRGBA32() or GetTexDataAsAlpha8()
+      // the first loaded font gets used by default
+      // use ImGui::PushFont()/ImGui::PopFont() to change the font at runtime
+
+      // Options
+      ImFontConfig config;
+      config.OversampleH = 2;
+      config.OversampleV = 1;
+      config.GlyphOffset.y -= 1.0f;      // Move everything by 1 pixels up
+      config.GlyphExtraSpacing.x = 1.0f; // Increase spacing between characters
+      io.Fonts->AddFontFromFileTTF("myfontfile.ttf", size_pixels, &config);
+
+      // Combine multiple fonts into one (e.g. for icon fonts)
+      static ImWchar ranges[] = { 0xf000, 0xf3ff, 0 };
+      ImFontConfig config;
+      config.MergeMode = true;
+      io.Fonts->AddFontDefault();
+      io.Fonts->AddFontFromFileTTF("fontawesome-webfont.ttf", 16.0f, &config, ranges); // Merge icon
+ font io.Fonts->AddFontFromFileTTF("myfontfile.ttf", size_pixels, NULL, &config,
+ io.Fonts->GetGlyphRangesJapanese()); // Merge japanese glyphs
+
+ Q: How can I display and input non-Latin characters such as Chinese, Japanese, Korean, Cyrillic?
+ A: When loading a font, pass custom Unicode ranges to specify the glyphs to load.
+
+      // Add default Japanese ranges
+      io.Fonts->AddFontFromFileTTF("myfontfile.ttf", size_in_pixels, NULL,
+ io.Fonts->GetGlyphRangesJapanese());
+
+      // Or create your own custom ranges (e.g. for a game you can feed your entire game script and
+ only build the characters the game need) ImVector<ImWchar> ranges; ImFontGlyphRangesBuilder
+ builder; builder.AddText("Hello world");                        // Add a string (here "Hello world"
+ contains 7 unique characters) builder.AddChar(0x7262);                               // Add a
+ specific character builder.AddRanges(io.Fonts->GetGlyphRangesJapanese()); // Add one of the default
+ ranges builder.BuildRanges(&ranges);                          // Build the final result (ordered
+ ranges with all the unique characters submitted) io.Fonts->AddFontFromFileTTF("myfontfile.ttf",
+ size_in_pixels, NULL, ranges.Data);
+
+    All your strings needs to use UTF-8 encoding. In C++11 you can encode a string literal in UTF-8
+    by using the u8"hello" syntax. Specifying literal in your source code using a local code page
+    (such as CP-923 for Japanese or CP-1251 for Cyrillic) will NOT work!
+    Otherwise you can convert yourself to UTF-8 or load text data from file already saved as UTF-8.
+
+    Text input: it is up to your application to pass the right character code by calling
+ io.AddInputCharacter(). The applications in examples/ are doing that. Windows: you can use the
+ WM_CHAR or WM_UNICHAR or WM_IME_CHAR message (depending if your app is built using Unicode or
+ MultiByte mode). You may also use MultiByteToWideChar() or ToUnicode() to retrieve Unicode
+ codepoints from MultiByte characters or keyboard state. Windows: if your language is relying on an
+ Input Method Editor (IME), you copy the HWND of your window to io.ImeWindowHandle in order for the
+ default implementation of io.ImeSetInputScreenPosFn() to set your Microsoft IME position correctly.
+
+ Q: How can I interact with standard C++ types (such as std::string and std::vector)?
+ A: - Being highly portable (bindings for several languages, frameworks, programming style, obscure
+ or older platforms/compilers), and aiming for compatibility & performance suitable for every modern
+ real-time game engines, dear imgui does not use any of std C++ types. We use raw types (e.g. char*
+ instead of std::string) because they adapt to more use cases.
+    - To use ImGui::InputText() with a std::string or any resizable string class, see
+ misc/cpp/imgui_stdlib.h.
+    - To use combo boxes and list boxes with std::vector or any other data structure: the
+ BeginCombo()/EndCombo() API lets you iterate and submit items yourself, so does the
+ ListBoxHeader()/ListBoxFooter() API. Prefer using them over the old and awkward Combo()/ListBox()
+ api.
+    - Generally for most high-level types you should be able to access the underlying data type.
+      You may write your own one-liner wrappers to facilitate user code (tip: add new functions in
+ ImGui:: namespace from your code).
+    - Dear ImGui applications often need to make intensive use of strings. It is expected that many
+ of the strings you will pass to the API are raw literals (free in C/C++) or allocated in a manner
+ that won't incur a large cost on your application. Please bear in mind that using std::string on
+ applications with large amount of UI may incur unsatisfactory performances. Modern implementations
+ of std::string often include small-string optimization (which is often a local buffer) but those
+      are not configurable and not the same across implementations.
+    - If you are finding your UI traversal cost to be too large, make sure your string usage is not
+ leading to excessive amount of heap allocations. Consider using literals, statically sized buffers
+ and your own helper functions. A common pattern is that you will need to build lots of strings on
+ the fly, and their maximum length can be easily be scoped ahead. One possible implementation of a
+ helper to facilitate printf-style building of strings: https://github.com/ocornut/Str This is a
+ small helper where you can instance strings with configurable local buffers length. Many game
+ engines will provide similar or better string helpers.
+
+ Q: How can I use the drawing facilities without an ImGui window? (using ImDrawList API)
+ A: - You can create a dummy window. Call Begin() with the NoBackground | NoDecoration |
+ NoSavedSettings | NoInputs flags. (The ImGuiWindowFlags_NoDecoration flag itself is a shortcut for
+ NoTitleBar | NoResize | NoScrollbar | NoCollapse) Then you can retrieve the ImDrawList* via
+ GetWindowDrawList() and draw to it in any way you like.
+    - You can call ImGui::GetBackgroundDrawList() or ImGui::GetForegroundDrawList() and use those
+ draw list to display contents behind or over every other imgui windows (one bg/fg drawlist per
+ viewport).
+    - You can create your own ImDrawList instance. You'll need to initialize them
+ ImGui::GetDrawListSharedData(), or create your own ImDrawListSharedData, and then call your
+ rendered code with your own ImDrawList or ImDrawData data.
+
+ Q: How can I use this without a mouse, without a keyboard or without a screen? (gamepad, input
+ share, remote display) A: - You can control Dear ImGui with a gamepad. Read about navigation in
+ "Using gamepad/keyboard navigation controls". (short version: map gamepad inputs into the
+ io.NavInputs[] array + set io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad)
+    - You can share your computer mouse seamlessly with your console/tablet/phone using Synergy
+ (https://symless.com/synergy) This is the preferred solution for developer productivity. In
+ particular, the "micro-synergy-client" repository (https://github.com/symless/micro-synergy-client)
+ has simple and portable source code (uSynergy.c/.h) for a small embeddable client that you can use
+ on any platform to connect to your host computer, based on the Synergy 1.x protocol. Make sure you
+ download the Synergy 1 server on your computer. Console SDK also sometimes provide equivalent
+ tooling or wrapper for Synergy-like protocols.
+    - You may also use a third party solution such as Remote ImGui
+ (https://github.com/JordiRos/remoteimgui) which sends the vertices to render over the local
+ network, allowing you to use Dear ImGui even on a screen-less machine.
+    - For touch inputs, you can increase the hit box of widgets (via the style.TouchPadding setting)
+ to accommodate for the lack of precision of touch inputs, but it is recommended you use a mouse or
+ gamepad to allow optimizing for screen real-estate and precision.
+
+ Q: I integrated Dear ImGui in my engine and the text or lines are blurry..
+ A: In your Render function, try translating your projection matrix by (0.5f,0.5f) or
+ (0.375f,0.375f). Also make sure your orthographic projection matrix and io.DisplaySize matches your
+ actual framebuffer dimension.
+
+ Q: I integrated Dear ImGui in my engine and some elements are clipping or disappearing when I move
+ windows around.. A: You are probably mishandling the clipping rectangles in your render function.
+    Rectangles provided by ImGui are defined as (x1=left,y1=top,x2=right,y2=bottom) and NOT as
+ (x1,y1,width,height).
+
+ Q: How can I help?
+ A: - If you are experienced with Dear ImGui and C++, look at the github issues, look at the Wiki,
+ read docs/TODO.txt and see how you want to help and can help!
+    - Businesses: convince your company to fund development via support contracts/sponsoring! This
+ is among the most useful thing you can do for dear imgui.
+    - Individuals: you can also become a Patron (http://www.patreon.com/imgui) or donate on PayPal!
+ See README.
+    - Disclose your usage of dear imgui via a dev blog post, a tweet, a screenshot, a mention
+ somewhere etc. You may post screenshot or links in the gallery threads
+ (github.com/ocornut/imgui/issues/1902). Visuals are ideal as they inspire other programmers. But
+ even without visuals, disclosing your use of dear imgui help the library grow credibility, and help
+ other teams and programmers with taking decisions.
+    - If you have issues or if you need to hack into the library, even if you don't expect any
+ support it is useful that you share your issues (on github or privately).
+
+ - tip: you can call Begin() multiple times with the same name during the same frame, it will keep
+ appending to the same window. this is also useful to set yourself in the context of another window
+ (to get/set other settings)
+ - tip: you can create widgets without a Begin()/End() block, they will go in an implicit window
+ called "Debug".
+ - tip: the ImGuiOnceUponAFrame helper will allow run the block of code only once a frame. You can
+ use it to quickly add custom UI in the middle of a deep nested inner loop in your code.
+ - tip: you can call Render() multiple times (e.g for VR renders).
+ - tip: call and read the ShowDemoWindow() code in imgui_demo.cpp for more example of how to use
+ ImGui!
+
+*/
+
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#include "imgui.h"
+#ifndef IMGUI_DEFINE_MATH_OPERATORS
+#define IMGUI_DEFINE_MATH_OPERATORS
+#endif
+#include "imgui_internal.h"
+
+#include <ctype.h>                         // toupper
+#include <stdio.h>                         // vsnprintf, sscanf, printf
+#if defined(_MSC_VER) && _MSC_VER <= 1500  // MSVC 2008 or earlier
+#include <stddef.h>                        // intptr_t
+#else
+#include <stdint.h>  // intptr_t
+#endif
+
+// Debug options
+#define IMGUI_DEBUG_NAV_SCORING \
+    0  // Display navigation scoring preview when hovering items. Display last moving direction
+       // matches when holding CTRL
+#define IMGUI_DEBUG_NAV_RECTS 0  // Display the reference navigation rectangle for each window
+
+// Visual Studio warnings
+#ifdef _MSC_VER
+#pragma warning(disable : 4127)  // condition expression is constant
+#pragma warning(disable : 4996)  // 'This function or variable may be unsafe': strcpy, strdup,
+                                 // sprintf, vsnprintf, sscanf, fopen
+#endif
+
+// Clang/GCC warnings with -Weverything
+#if defined(__clang__)
+#pragma clang diagnostic ignored \
+    "-Wunknown-pragmas"  // warning : unknown warning group '-Wformat-pedantic *'        // not all
+                         // warnings are known by all clang versions.. so ignoring warnings triggers
+                         // new warnings on some configuration. great!
+#pragma clang diagnostic ignored "-Wold-style-cast"  // warning : use of old-style cast // yes, they
+                                                     // are more terse.
+#pragma clang diagnostic ignored \
+    "-Wfloat-equal"  // warning : comparing floating point with == or != is unsafe   // storing and
+                     // comparing against same constants (typically 0.0f) is ok.
+#pragma clang diagnostic ignored \
+    "-Wformat-nonliteral"  // warning : format string is not a string literal              //
+                           // passing non-literal to vsnformat(). yes, user passing incorrect format
+                           // strings can crash the code.
+#pragma clang diagnostic ignored \
+    "-Wexit-time-destructors"  // warning : declaration requires an exit-time destructor       //
+                               // exit-time destruction order is undefined. if MemFree() leads to
+                               // users code that has been disabled before exit it might cause
+                               // problems. ImGui coding style welcomes static/globals.
+#pragma clang diagnostic ignored \
+    "-Wglobal-constructors"  // warning : declaration requires a global destructor           //
+                             // similar to above, not sure what the exact difference is.
+#pragma clang diagnostic ignored \
+    "-Wsign-conversion"  // warning : implicit conversion changes signedness             //
+#pragma clang diagnostic ignored \
+    "-Wformat-pedantic"  // warning : format specifies type 'void *' but the argument has type 'xxxx
+                         // *' // unreasonable, would lead to casting every %p arg to void*.
+                         // probably enabled by -pedantic.
+#pragma clang diagnostic ignored \
+    "-Wint-to-void-pointer-cast"  // warning : cast to 'void *' from smaller integer type 'int'
+#if __has_warning("-Wzero-as-null-pointer-constant")
+#pragma clang diagnostic ignored \
+    "-Wzero-as-null-pointer-constant"  // warning : zero as null pointer constant              //
+                                       // some standard header variations use #define NULL 0
+#endif
+#if __has_warning("-Wdouble-promotion")
+#pragma clang diagnostic ignored \
+    "-Wdouble-promotion"  // warning: implicit conversion from 'float' to 'double' when passing
+                          // argument to function  // using printf() is a misery with this as C++
+                          // va_arg ellipsis changes float to double.
+#endif
+#elif defined(__GNUC__)
+// We disable -Wpragmas because GCC doesn't provide an has_warning equivalent and some forks/patches
+// may not following the warning/version association.
+#pragma GCC diagnostic ignored \
+    "-Wpragmas"  // warning: unknown option after '#pragma GCC diagnostic' kind
+#pragma GCC diagnostic ignored "-Wunused-function"  // warning: 'xxxx' defined but not used
+#pragma GCC diagnostic ignored \
+    "-Wint-to-pointer-cast"  // warning: cast to pointer from integer of different size
+#pragma GCC diagnostic ignored "-Wformat"  // warning: format '%p' expects argument of type 'void*',
+                                           // but argument 6 has type 'ImGuiWindow*'
+#pragma GCC diagnostic ignored "-Wdouble-promotion"  // warning: implicit conversion from 'float' to
+                                                     // 'double' when passing argument to function
+#pragma GCC diagnostic ignored \
+    "-Wconversion"  // warning: conversion to 'xxxx' from 'xxxx' may alter its value
+#pragma GCC diagnostic ignored \
+    "-Wformat-nonliteral"  // warning: format not a string literal, format string not checked
+#pragma GCC diagnostic ignored \
+    "-Wstrict-overflow"  // warning: assuming signed overflow does not occur when assuming that (X -
+                         // c) > X is always false
+#pragma GCC diagnostic ignored \
+    "-Wclass-memaccess"  // [__GNUC__ >= 8] warning: 'memset/memcpy' clearing/writing an object of
+                         // type 'xxxx' with no trivial copy-assignment; use assignment or
+                         // value-initialization instead
+#endif
+
+// When using CTRL+TAB (or Gamepad Square+L/R) we delay the visual a little in order to reduce
+// visual noise doing a fast switch.
+static const float NAV_WINDOWING_HIGHLIGHT_DELAY =
+    0.20f;  // Time before the highlight and screen dimming starts fading in
+static const float NAV_WINDOWING_LIST_APPEAR_DELAY =
+    0.15f;  // Time before the window list starts to appear
+
+// Window resizing from edges (when io.ConfigWindowsResizeFromEdges = true and
+// ImGuiBackendFlags_HasMouseCursors is set in io.BackendFlags by back-end)
+static const float WINDOWS_RESIZE_FROM_EDGES_HALF_THICKNESS =
+    4.0f;  // Extend outside and inside windows. Affect FindHoveredWindow().
+static const float WINDOWS_RESIZE_FROM_EDGES_FEEDBACK_TIMER =
+    0.04f;  // Reduce visual noise by only highlighting the border after a certain time.
+
+//-------------------------------------------------------------------------
+// [SECTION] FORWARD DECLARATIONS
+//-------------------------------------------------------------------------
+
+static void SetCurrentWindow(ImGuiWindow *window);
+static void FindHoveredWindow();
+static ImGuiWindow *CreateNewWindow(const char *name, ImVec2 size, ImGuiWindowFlags flags);
+static void CheckStacksSize(ImGuiWindow *window, bool write);
+static ImVec2 CalcNextScrollFromScrollTargetAndClamp(ImGuiWindow *window, bool snap_on_edges);
+
+static void AddDrawListToDrawData(ImVector<ImDrawList *> *out_list, ImDrawList *draw_list);
+static void AddWindowToSortBuffer(ImVector<ImGuiWindow *> *out_sorted_windows, ImGuiWindow *window);
+
+static ImRect GetViewportRect();
+
+// Settings
+static void *SettingsHandlerWindow_ReadOpen(ImGuiContext *,
+                                            ImGuiSettingsHandler *,
+                                            const char *name);
+static void SettingsHandlerWindow_ReadLine(ImGuiContext *,
+                                           ImGuiSettingsHandler *,
+                                           void *entry,
+                                           const char *line);
+static void SettingsHandlerWindow_WriteAll(ImGuiContext *imgui_ctx,
+                                           ImGuiSettingsHandler *handler,
+                                           ImGuiTextBuffer *buf);
+
+// Platform Dependents default implementation for IO functions
+static const char *GetClipboardTextFn_DefaultImpl(void *user_data);
+static void SetClipboardTextFn_DefaultImpl(void *user_data, const char *text);
+static void ImeSetInputScreenPosFn_DefaultImpl(int x, int y);
+
+namespace ImGui
+{
+static bool BeginChildEx(const char *name,
+                         ImGuiID id,
+                         const ImVec2 &size_arg,
+                         bool border,
+                         ImGuiWindowFlags flags);
+
+// Navigation
+static void NavUpdate();
+static void NavUpdateWindowing();
+static void NavUpdateWindowingList();
+static void NavUpdateMoveResult();
+static float NavUpdatePageUpPageDown(int allowed_dir_flags);
+static inline void NavUpdateAnyRequestFlag();
+static void NavProcessItem(ImGuiWindow *window, const ImRect &nav_bb, ImGuiID id);
+static ImVec2 NavCalcPreferredRefPos();
+static void NavSaveLastChildNavWindowIntoParent(ImGuiWindow *nav_window);
+static ImGuiWindow *NavRestoreLastChildNavWindow(ImGuiWindow *window);
+static int FindWindowFocusIndex(ImGuiWindow *window);
+
+// Misc
+static void UpdateMouseInputs();
+static void UpdateMouseWheel();
+static bool UpdateManualResize(ImGuiWindow *window,
+                               const ImVec2 &size_auto_fit,
+                               int *border_held,
+                               int resize_grip_count,
+                               ImU32 resize_grip_col[4]);
+static void RenderWindowOuterBorders(ImGuiWindow *window);
+static void RenderWindowDecorations(ImGuiWindow *window,
+                                    const ImRect &title_bar_rect,
+                                    bool title_bar_is_highlight,
+                                    int resize_grip_count,
+                                    const ImU32 resize_grip_col[4],
+                                    float resize_grip_draw_size);
+static void RenderWindowTitleBarContents(ImGuiWindow *window,
+                                         const ImRect &title_bar_rect,
+                                         const char *name,
+                                         bool *p_open);
+
+}  // namespace ImGui
+
+//-----------------------------------------------------------------------------
+// [SECTION] CONTEXT AND MEMORY ALLOCATORS
+//-----------------------------------------------------------------------------
+
+// Current context pointer. Implicitly used by all Dear ImGui functions. Always assumed to be !=
+// NULL. ImGui::CreateContext() will automatically set this pointer if it is NULL. Change to a
+// different context by calling ImGui::SetCurrentContext(). 1) Important: globals are not shared
+// across DLL boundaries! If you use DLLs or any form of hot-reloading: you will need to call
+//    SetCurrentContext() (with the pointer you got from CreateContext) from each unique static/DLL
+//    boundary, and after each hot-reloading. In your debugger, add GImGui to your watch window and
+//    notice how its value changes depending on which location you are currently stepping into.
+// 2) Important: Dear ImGui functions are not thread-safe because of this pointer.
+//    If you want thread-safety to allow N threads to access N different contexts, you can:
+//    - Change this variable to use thread local storage so each thread can refer to a different
+//    context, in imconfig.h:
+//          struct ImGuiContext;
+//          extern thread_local ImGuiContext* MyImGuiTLS;
+//          #define GImGui MyImGuiTLS
+//      And then define MyImGuiTLS in one of your cpp file. Note that thread_local is a C++11
+//      keyword, earlier C++ uses compiler-specific keyword.
+//    - Future development aim to make this context pointer explicit to all calls. Also read
+//    https://github.com/ocornut/imgui/issues/586
+//    - If you need a finite number of contexts, you may compile and use multiple instances of the
+//    ImGui code from different namespace.
+#ifndef GImGui
+ImGuiContext *GImGui = NULL;
+#endif
+
+// Memory Allocator functions. Use SetAllocatorFunctions() to change them.
+// If you use DLL hotreloading you might need to call SetAllocatorFunctions() after reloading code
+// from this file. Otherwise, you probably don't want to modify them mid-program, and if you use
+// global/static e.g. ImVector<> instances you may need to keep them accessible during program
+// destruction.
+#ifndef IMGUI_DISABLE_DEFAULT_ALLOCATORS
+static void *MallocWrapper(size_t size, void *user_data)
+{
+    IM_UNUSED(user_data);
+    return malloc(size);
+}
+static void FreeWrapper(void *ptr, void *user_data)
+{
+    IM_UNUSED(user_data);
+    free(ptr);
+}
+#else
+static void *MallocWrapper(size_t size, void *user_data)
+{
+    IM_UNUSED(user_data);
+    IM_UNUSED(size);
+    IM_ASSERT(0);
+    return NULL;
+}
+static void FreeWrapper(void *ptr, void *user_data)
+{
+    IM_UNUSED(user_data);
+    IM_UNUSED(ptr);
+    IM_ASSERT(0);
+}
+#endif
+
+static void *(*GImAllocatorAllocFunc)(size_t size, void *user_data) = MallocWrapper;
+static void (*GImAllocatorFreeFunc)(void *ptr, void *user_data)     = FreeWrapper;
+static void *GImAllocatorUserData                                   = NULL;
+
+//-----------------------------------------------------------------------------
+// [SECTION] MAIN USER FACING STRUCTURES (ImGuiStyle, ImGuiIO)
+//-----------------------------------------------------------------------------
+
+ImGuiStyle::ImGuiStyle()
+{
+    Alpha         = 1.0f;          // Global alpha applies to everything in ImGui
+    WindowPadding = ImVec2(8, 8);  // Padding within a window
+    WindowRounding =
+        7.0f;  // Radius of window corners rounding. Set to 0.0f to have rectangular windows
+    WindowBorderSize = 1.0f;  // Thickness of border around windows. Generally set to 0.0f or 1.0f.
+                              // Other values not well tested.
+    WindowMinSize            = ImVec2(32, 32);      // Minimum window size
+    WindowTitleAlign         = ImVec2(0.0f, 0.5f);  // Alignment for title bar text
+    WindowMenuButtonPosition = ImGuiDir_Left;  // Position of the collapsing/docking button in the
+                                               // title bar (left/right). Defaults to ImGuiDir_Left.
+    ChildRounding = 0.0f;    // Radius of child window corners rounding. Set to 0.0f to have
+                             // rectangular child windows
+    ChildBorderSize = 1.0f;  // Thickness of border around child windows. Generally set to 0.0f
+                             // or 1.0f. Other values not well tested.
+    PopupRounding = 0.0f;    // Radius of popup window corners rounding. Set to 0.0f to have
+                             // rectangular child windows
+    PopupBorderSize = 1.0f;  // Thickness of border around popup or tooltip windows. Generally set
+                             // to 0.0f or 1.0f. Other values not well tested.
+    FramePadding  = ImVec2(4, 3);  // Padding within a framed rectangle (used by most widgets)
+    FrameRounding = 0.0f;    // Radius of frame corners rounding. Set to 0.0f to have rectangular
+                             // frames (used by most widgets).
+    FrameBorderSize = 0.0f;  // Thickness of border around frames. Generally set to 0.0f or 1.0f.
+                             // Other values not well tested.
+    ItemSpacing      = ImVec2(8, 4);  // Horizontal and vertical spacing between widgets/lines
+    ItemInnerSpacing = ImVec2(4, 4);  // Horizontal and vertical spacing between within elements of
+                                      // a composed widget (e.g. a slider and its label)
+    TouchExtraPadding = ImVec2(
+        0, 0);  // Expand reactive bounding box for touch-based system where touch position is not
+                // accurate enough. Unfortunately we don't sort widgets so priority on overlap will
+                // always be given to the first widget. So don't grow this too much!
+    IndentSpacing = 21.0f;  // Horizontal spacing when e.g. entering a tree node. Generally ==
+                            // (FontSize + FramePadding.x*2).
+    ColumnsMinSpacing =
+        6.0f;  // Minimum horizontal spacing between two columns. Preferably > (FramePadding.x + 1).
+    ScrollbarSize = 14.0f;  // Width of the vertical scrollbar, Height of the horizontal scrollbar
+    ScrollbarRounding = 9.0f;   // Radius of grab corners rounding for scrollbar
+    GrabMinSize       = 10.0f;  // Minimum width/height of a grab box for slider/scrollbar
+    GrabRounding =
+        0.0f;  // Radius of grabs corners rounding. Set to 0.0f to have rectangular slider grabs.
+    TabRounding = 4.0f;  // Radius of upper corners of a tab. Set to 0.0f to have rectangular tabs.
+    TabBorderSize = 0.0f;  // Thickness of border around tabs.
+    ButtonTextAlign =
+        ImVec2(0.5f, 0.5f);  // Alignment of button text when button is larger than text.
+    SelectableTextAlign =
+        ImVec2(0.0f, 0.0f);  // Alignment of selectable text when button is larger than text.
+    DisplayWindowPadding =
+        ImVec2(19, 19);  // Window position are clamped to be visible within the display area by at
+                         // least this amount. Only applies to regular windows.
+    DisplaySafeAreaPadding =
+        ImVec2(3, 3);  // If you cannot see the edge of your screen (e.g. on a TV) increase the safe
+                       // area padding. Covers popups/tooltips as well regular windows.
+    MouseCursorScale = 1.0f;  // Scale software rendered mouse cursor (when io.MouseDrawCursor is
+                              // enabled). May be removed later.
+    AntiAliasedLines =
+        true;  // Enable anti-aliasing on lines/borders. Disable if you are really short on CPU/GPU.
+    AntiAliasedFill =
+        true;  // Enable anti-aliasing on filled shapes (rounded rectangles, circles, etc.)
+    CurveTessellationTol =
+        1.25f;  // Tessellation tolerance when using PathBezierCurveTo() without a specific number
+                // of segments. Decrease for highly tessellated curves (higher quality, more
+                // polygons), increase to reduce quality.
+
+    // Default theme
+    ImGui::StyleColorsDark(this);
+}
+
+// To scale your entire UI (e.g. if you want your app to use High DPI or generally be DPI aware) you
+// may use this helper function. Scaling the fonts is done separately and is up to you. Important:
+// This operation is lossy because we round all sizes to integer. If you need to change your scale
+// multiples, call this over a freshly initialized ImGuiStyle structure rather than scaling multiple
+// times.
+void ImGuiStyle::ScaleAllSizes(float scale_factor)
+{
+    WindowPadding          = ImFloor(WindowPadding * scale_factor);
+    WindowRounding         = ImFloor(WindowRounding * scale_factor);
+    WindowMinSize          = ImFloor(WindowMinSize * scale_factor);
+    ChildRounding          = ImFloor(ChildRounding * scale_factor);
+    PopupRounding          = ImFloor(PopupRounding * scale_factor);
+    FramePadding           = ImFloor(FramePadding * scale_factor);
+    FrameRounding          = ImFloor(FrameRounding * scale_factor);
+    ItemSpacing            = ImFloor(ItemSpacing * scale_factor);
+    ItemInnerSpacing       = ImFloor(ItemInnerSpacing * scale_factor);
+    TouchExtraPadding      = ImFloor(TouchExtraPadding * scale_factor);
+    IndentSpacing          = ImFloor(IndentSpacing * scale_factor);
+    ColumnsMinSpacing      = ImFloor(ColumnsMinSpacing * scale_factor);
+    ScrollbarSize          = ImFloor(ScrollbarSize * scale_factor);
+    ScrollbarRounding      = ImFloor(ScrollbarRounding * scale_factor);
+    GrabMinSize            = ImFloor(GrabMinSize * scale_factor);
+    GrabRounding           = ImFloor(GrabRounding * scale_factor);
+    TabRounding            = ImFloor(TabRounding * scale_factor);
+    DisplayWindowPadding   = ImFloor(DisplayWindowPadding * scale_factor);
+    DisplaySafeAreaPadding = ImFloor(DisplaySafeAreaPadding * scale_factor);
+    MouseCursorScale       = ImFloor(MouseCursorScale * scale_factor);
+}
+
+ImGuiIO::ImGuiIO()
+{
+    // Most fields are initialized with zero
+    memset(this, 0, sizeof(*this));
+
+    // Settings
+    ConfigFlags             = ImGuiConfigFlags_None;
+    BackendFlags            = ImGuiBackendFlags_None;
+    DisplaySize             = ImVec2(-1.0f, -1.0f);
+    DeltaTime               = 1.0f / 60.0f;
+    IniSavingRate           = 5.0f;
+    IniFilename             = "imgui.ini";
+    LogFilename             = "imgui_log.txt";
+    MouseDoubleClickTime    = 0.30f;
+    MouseDoubleClickMaxDist = 6.0f;
+    for (int i = 0; i < ImGuiKey_COUNT; i++)
+        KeyMap[i] = -1;
+    KeyRepeatDelay = 0.250f;
+    KeyRepeatRate  = 0.050f;
+    UserData       = NULL;
+
+    Fonts                   = NULL;
+    FontGlobalScale         = 1.0f;
+    FontDefault             = NULL;
+    FontAllowUserScaling    = false;
+    DisplayFramebufferScale = ImVec2(1.0f, 1.0f);
+
+    // Miscellaneous options
+    MouseDrawCursor = false;
+#ifdef __APPLE__
+    ConfigMacOSXBehaviors =
+        true;  // Set Mac OS X style defaults based on __APPLE__ compile time flag
+#else
+    ConfigMacOSXBehaviors = false;
+#endif
+    ConfigInputTextCursorBlink        = true;
+    ConfigWindowsResizeFromEdges      = true;
+    ConfigWindowsMoveFromTitleBarOnly = false;
+
+    // Platform Functions
+    BackendPlatformName = BackendRendererName = NULL;
+    BackendPlatformUserData = BackendRendererUserData = BackendLanguageUserData = NULL;
+    GetClipboardTextFn =
+        GetClipboardTextFn_DefaultImpl;  // Platform dependent default implementations
+    SetClipboardTextFn     = SetClipboardTextFn_DefaultImpl;
+    ClipboardUserData      = NULL;
+    ImeSetInputScreenPosFn = ImeSetInputScreenPosFn_DefaultImpl;
+    ImeWindowHandle        = NULL;
+
+#ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+    RenderDrawListsFn = NULL;
+#endif
+
+    // Input (NB: we already have memset zero the entire structure!)
+    MousePos           = ImVec2(-FLT_MAX, -FLT_MAX);
+    MousePosPrev       = ImVec2(-FLT_MAX, -FLT_MAX);
+    MouseDragThreshold = 6.0f;
+    for (int i = 0; i < IM_ARRAYSIZE(MouseDownDuration); i++)
+        MouseDownDuration[i] = MouseDownDurationPrev[i] = -1.0f;
+    for (int i = 0; i < IM_ARRAYSIZE(KeysDownDuration); i++)
+        KeysDownDuration[i] = KeysDownDurationPrev[i] = -1.0f;
+    for (int i = 0; i < IM_ARRAYSIZE(NavInputsDownDuration); i++)
+        NavInputsDownDuration[i] = -1.0f;
+}
+
+// Pass in translated ASCII characters for text input.
+// - with glfw you can get those from the callback set in glfwSetCharCallback()
+// - on Windows you can get those using ToAscii+keyboard state, or via the WM_CHAR message
+void ImGuiIO::AddInputCharacter(unsigned int c)
+{
+    if (c > 0 && c < 0x10000)
+        InputQueueCharacters.push_back((ImWchar)c);
+}
+
+void ImGuiIO::AddInputCharactersUTF8(const char *utf8_chars)
+{
+    while (*utf8_chars != 0)
+    {
+        unsigned int c = 0;
+        utf8_chars += ImTextCharFromUtf8(&c, utf8_chars, NULL);
+        if (c > 0 && c < 0x10000)
+            InputQueueCharacters.push_back((ImWchar)c);
+    }
+}
+
+void ImGuiIO::ClearInputCharacters()
+{
+    InputQueueCharacters.resize(0);
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] MISC HELPERS/UTILITIES (Maths, String, Format, Hash, File functions)
+//-----------------------------------------------------------------------------
+
+ImVec2 ImLineClosestPoint(const ImVec2 &a, const ImVec2 &b, const ImVec2 &p)
+{
+    ImVec2 ap     = p - a;
+    ImVec2 ab_dir = b - a;
+    float dot     = ap.x * ab_dir.x + ap.y * ab_dir.y;
+    if (dot < 0.0f)
+        return a;
+    float ab_len_sqr = ab_dir.x * ab_dir.x + ab_dir.y * ab_dir.y;
+    if (dot > ab_len_sqr)
+        return b;
+    return a + ab_dir * dot / ab_len_sqr;
+}
+
+bool ImTriangleContainsPoint(const ImVec2 &a, const ImVec2 &b, const ImVec2 &c, const ImVec2 &p)
+{
+    bool b1 = ((p.x - b.x) * (a.y - b.y) - (p.y - b.y) * (a.x - b.x)) < 0.0f;
+    bool b2 = ((p.x - c.x) * (b.y - c.y) - (p.y - c.y) * (b.x - c.x)) < 0.0f;
+    bool b3 = ((p.x - a.x) * (c.y - a.y) - (p.y - a.y) * (c.x - a.x)) < 0.0f;
+    return ((b1 == b2) && (b2 == b3));
+}
+
+void ImTriangleBarycentricCoords(const ImVec2 &a,
+                                 const ImVec2 &b,
+                                 const ImVec2 &c,
+                                 const ImVec2 &p,
+                                 float &out_u,
+                                 float &out_v,
+                                 float &out_w)
+{
+    ImVec2 v0         = b - a;
+    ImVec2 v1         = c - a;
+    ImVec2 v2         = p - a;
+    const float denom = v0.x * v1.y - v1.x * v0.y;
+    out_v             = (v2.x * v1.y - v1.x * v2.y) / denom;
+    out_w             = (v0.x * v2.y - v2.x * v0.y) / denom;
+    out_u             = 1.0f - out_v - out_w;
+}
+
+ImVec2 ImTriangleClosestPoint(const ImVec2 &a, const ImVec2 &b, const ImVec2 &c, const ImVec2 &p)
+{
+    ImVec2 proj_ab = ImLineClosestPoint(a, b, p);
+    ImVec2 proj_bc = ImLineClosestPoint(b, c, p);
+    ImVec2 proj_ca = ImLineClosestPoint(c, a, p);
+    float dist2_ab = ImLengthSqr(p - proj_ab);
+    float dist2_bc = ImLengthSqr(p - proj_bc);
+    float dist2_ca = ImLengthSqr(p - proj_ca);
+    float m        = ImMin(dist2_ab, ImMin(dist2_bc, dist2_ca));
+    if (m == dist2_ab)
+        return proj_ab;
+    if (m == dist2_bc)
+        return proj_bc;
+    return proj_ca;
+}
+
+// Consider using _stricmp/_strnicmp under Windows or strcasecmp/strncasecmp. We don't actually use
+// either ImStricmp/ImStrnicmp in the codebase any more.
+int ImStricmp(const char *str1, const char *str2)
+{
+    int d;
+    while ((d = toupper(*str2) - toupper(*str1)) == 0 && *str1)
+    {
+        str1++;
+        str2++;
+    }
+    return d;
+}
+
+int ImStrnicmp(const char *str1, const char *str2, size_t count)
+{
+    int d = 0;
+    while (count > 0 && (d = toupper(*str2) - toupper(*str1)) == 0 && *str1)
+    {
+        str1++;
+        str2++;
+        count--;
+    }
+    return d;
+}
+
+void ImStrncpy(char *dst, const char *src, size_t count)
+{
+    if (count < 1)
+        return;
+    if (count > 1)
+        strncpy(dst, src, count - 1);
+    dst[count - 1] = 0;
+}
+
+char *ImStrdup(const char *str)
+{
+    size_t len = strlen(str);
+    void *buf  = IM_ALLOC(len + 1);
+    return (char *)memcpy(buf, (const void *)str, len + 1);
+}
+
+char *ImStrdupcpy(char *dst, size_t *p_dst_size, const char *src)
+{
+    size_t dst_buf_size = p_dst_size ? *p_dst_size : strlen(dst) + 1;
+    size_t src_size     = strlen(src) + 1;
+    if (dst_buf_size < src_size)
+    {
+        IM_FREE(dst);
+        dst = (char *)IM_ALLOC(src_size);
+        if (p_dst_size)
+            *p_dst_size = src_size;
+    }
+    return (char *)memcpy(dst, (const void *)src, src_size);
+}
+
+const char *ImStrchrRange(const char *str, const char *str_end, char c)
+{
+    const char *p = (const char *)memchr(str, (int)c, str_end - str);
+    return p;
+}
+
+int ImStrlenW(const ImWchar *str)
+{
+    // return (int)wcslen((const wchar_t*)str);  // FIXME-OPT: Could use this when wchar_t are
+    // 16-bits
+    int n = 0;
+    while (*str++)
+        n++;
+    return n;
+}
+
+// Find end-of-line. Return pointer will point to either first \n, either str_end.
+const char *ImStreolRange(const char *str, const char *str_end)
+{
+    const char *p = (const char *)memchr(str, '\n', str_end - str);
+    return p ? p : str_end;
+}
+
+const ImWchar *ImStrbolW(const ImWchar *buf_mid_line,
+                         const ImWchar *buf_begin)  // find beginning-of-line
+{
+    while (buf_mid_line > buf_begin && buf_mid_line[-1] != '\n')
+        buf_mid_line--;
+    return buf_mid_line;
+}
+
+const char *ImStristr(const char *haystack,
+                      const char *haystack_end,
+                      const char *needle,
+                      const char *needle_end)
+{
+    if (!needle_end)
+        needle_end = needle + strlen(needle);
+
+    const char un0 = (char)toupper(*needle);
+    while ((!haystack_end && *haystack) || (haystack_end && haystack < haystack_end))
+    {
+        if (toupper(*haystack) == un0)
+        {
+            const char *b = needle + 1;
+            for (const char *a = haystack + 1; b < needle_end; a++, b++)
+                if (toupper(*a) != toupper(*b))
+                    break;
+            if (b == needle_end)
+                return haystack;
+        }
+        haystack++;
+    }
+    return NULL;
+}
+
+// Trim str by offsetting contents when there's leading data + writing a \0 at the trailing
+// position. We use this in situation where the cost is negligible.
+void ImStrTrimBlanks(char *buf)
+{
+    char *p = buf;
+    while (p[0] == ' ' || p[0] == '\t')  // Leading blanks
+        p++;
+    char *p_start = p;
+    while (*p != 0)  // Find end of string
+        p++;
+    while (p > p_start && (p[-1] == ' ' || p[-1] == '\t'))  // Trailing blanks
+        p--;
+    if (p_start != buf)  // Copy memory if we had leading blanks
+        memmove(buf, p_start, p - p_start);
+    buf[p - p_start] = 0;  // Zero terminate
+}
+
+// A) MSVC version appears to return -1 on overflow, whereas glibc appears to return total count
+// (which may be >= buf_size). Ideally we would test for only one of those limits at runtime
+// depending on the behavior the vsnprintf(), but trying to deduct it at compile time sounds like a
+// pandora can of worm. B) When buf==NULL vsnprintf() will return the output size.
+#ifndef IMGUI_DISABLE_FORMAT_STRING_FUNCTIONS
+
+//#define IMGUI_USE_STB_SPRINTF
+#ifdef IMGUI_USE_STB_SPRINTF
+#define STB_SPRINTF_IMPLEMENTATION
+#include "imstb_sprintf.h"
+#endif
+
+#if defined(_MSC_VER) && !defined(vsnprintf)
+#define vsnprintf _vsnprintf
+#endif
+
+int ImFormatString(char *buf, size_t buf_size, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+#ifdef IMGUI_USE_STB_SPRINTF
+    int w = stbsp_vsnprintf(buf, (int)buf_size, fmt, args);
+#else
+    int w = vsnprintf(buf, buf_size, fmt, args);
+#endif
+    va_end(args);
+    if (buf == NULL)
+        return w;
+    if (w == -1 || w >= (int)buf_size)
+        w = (int)buf_size - 1;
+    buf[w] = 0;
+    return w;
+}
+
+int ImFormatStringV(char *buf, size_t buf_size, const char *fmt, va_list args)
+{
+#ifdef IMGUI_USE_STB_SPRINTF
+    int w = stbsp_vsnprintf(buf, (int)buf_size, fmt, args);
+#else
+    int w = vsnprintf(buf, buf_size, fmt, args);
+#endif
+    if (buf == NULL)
+        return w;
+    if (w == -1 || w >= (int)buf_size)
+        w = (int)buf_size - 1;
+    buf[w] = 0;
+    return w;
+}
+#endif  // #ifdef IMGUI_DISABLE_FORMAT_STRING_FUNCTIONS
+
+// CRC32 needs a 1KB lookup table (not cache friendly)
+// Although the code to generate the table is simple and shorter than the table itself, using a
+// const table allows us to easily:
+// - avoid an unnecessary branch/memory tap, - keep the ImHashXXX functions usable by static
+// constructors, - make it thread-safe.
+static const ImU32 GCrc32LookupTable[256] = {
+    0x00000000, 0x77073096, 0xEE0E612C, 0x990951BA, 0x076DC419, 0x706AF48F, 0xE963A535, 0x9E6495A3,
+    0x0EDB8832, 0x79DCB8A4, 0xE0D5E91E, 0x97D2D988, 0x09B64C2B, 0x7EB17CBD, 0xE7B82D07, 0x90BF1D91,
+    0x1DB71064, 0x6AB020F2, 0xF3B97148, 0x84BE41DE, 0x1ADAD47D, 0x6DDDE4EB, 0xF4D4B551, 0x83D385C7,
+    0x136C9856, 0x646BA8C0, 0xFD62F97A, 0x8A65C9EC, 0x14015C4F, 0x63066CD9, 0xFA0F3D63, 0x8D080DF5,
+    0x3B6E20C8, 0x4C69105E, 0xD56041E4, 0xA2677172, 0x3C03E4D1, 0x4B04D447, 0xD20D85FD, 0xA50AB56B,
+    0x35B5A8FA, 0x42B2986C, 0xDBBBC9D6, 0xACBCF940, 0x32D86CE3, 0x45DF5C75, 0xDCD60DCF, 0xABD13D59,
+    0x26D930AC, 0x51DE003A, 0xC8D75180, 0xBFD06116, 0x21B4F4B5, 0x56B3C423, 0xCFBA9599, 0xB8BDA50F,
+    0x2802B89E, 0x5F058808, 0xC60CD9B2, 0xB10BE924, 0x2F6F7C87, 0x58684C11, 0xC1611DAB, 0xB6662D3D,
+    0x76DC4190, 0x01DB7106, 0x98D220BC, 0xEFD5102A, 0x71B18589, 0x06B6B51F, 0x9FBFE4A5, 0xE8B8D433,
+    0x7807C9A2, 0x0F00F934, 0x9609A88E, 0xE10E9818, 0x7F6A0DBB, 0x086D3D2D, 0x91646C97, 0xE6635C01,
+    0x6B6B51F4, 0x1C6C6162, 0x856530D8, 0xF262004E, 0x6C0695ED, 0x1B01A57B, 0x8208F4C1, 0xF50FC457,
+    0x65B0D9C6, 0x12B7E950, 0x8BBEB8EA, 0xFCB9887C, 0x62DD1DDF, 0x15DA2D49, 0x8CD37CF3, 0xFBD44C65,
+    0x4DB26158, 0x3AB551CE, 0xA3BC0074, 0xD4BB30E2, 0x4ADFA541, 0x3DD895D7, 0xA4D1C46D, 0xD3D6F4FB,
+    0x4369E96A, 0x346ED9FC, 0xAD678846, 0xDA60B8D0, 0x44042D73, 0x33031DE5, 0xAA0A4C5F, 0xDD0D7CC9,
+    0x5005713C, 0x270241AA, 0xBE0B1010, 0xC90C2086, 0x5768B525, 0x206F85B3, 0xB966D409, 0xCE61E49F,
+    0x5EDEF90E, 0x29D9C998, 0xB0D09822, 0xC7D7A8B4, 0x59B33D17, 0x2EB40D81, 0xB7BD5C3B, 0xC0BA6CAD,
+    0xEDB88320, 0x9ABFB3B6, 0x03B6E20C, 0x74B1D29A, 0xEAD54739, 0x9DD277AF, 0x04DB2615, 0x73DC1683,
+    0xE3630B12, 0x94643B84, 0x0D6D6A3E, 0x7A6A5AA8, 0xE40ECF0B, 0x9309FF9D, 0x0A00AE27, 0x7D079EB1,
+    0xF00F9344, 0x8708A3D2, 0x1E01F268, 0x6906C2FE, 0xF762575D, 0x806567CB, 0x196C3671, 0x6E6B06E7,
+    0xFED41B76, 0x89D32BE0, 0x10DA7A5A, 0x67DD4ACC, 0xF9B9DF6F, 0x8EBEEFF9, 0x17B7BE43, 0x60B08ED5,
+    0xD6D6A3E8, 0xA1D1937E, 0x38D8C2C4, 0x4FDFF252, 0xD1BB67F1, 0xA6BC5767, 0x3FB506DD, 0x48B2364B,
+    0xD80D2BDA, 0xAF0A1B4C, 0x36034AF6, 0x41047A60, 0xDF60EFC3, 0xA867DF55, 0x316E8EEF, 0x4669BE79,
+    0xCB61B38C, 0xBC66831A, 0x256FD2A0, 0x5268E236, 0xCC0C7795, 0xBB0B4703, 0x220216B9, 0x5505262F,
+    0xC5BA3BBE, 0xB2BD0B28, 0x2BB45A92, 0x5CB36A04, 0xC2D7FFA7, 0xB5D0CF31, 0x2CD99E8B, 0x5BDEAE1D,
+    0x9B64C2B0, 0xEC63F226, 0x756AA39C, 0x026D930A, 0x9C0906A9, 0xEB0E363F, 0x72076785, 0x05005713,
+    0x95BF4A82, 0xE2B87A14, 0x7BB12BAE, 0x0CB61B38, 0x92D28E9B, 0xE5D5BE0D, 0x7CDCEFB7, 0x0BDBDF21,
+    0x86D3D2D4, 0xF1D4E242, 0x68DDB3F8, 0x1FDA836E, 0x81BE16CD, 0xF6B9265B, 0x6FB077E1, 0x18B74777,
+    0x88085AE6, 0xFF0F6A70, 0x66063BCA, 0x11010B5C, 0x8F659EFF, 0xF862AE69, 0x616BFFD3, 0x166CCF45,
+    0xA00AE278, 0xD70DD2EE, 0x4E048354, 0x3903B3C2, 0xA7672661, 0xD06016F7, 0x4969474D, 0x3E6E77DB,
+    0xAED16A4A, 0xD9D65ADC, 0x40DF0B66, 0x37D83BF0, 0xA9BCAE53, 0xDEBB9EC5, 0x47B2CF7F, 0x30B5FFE9,
+    0xBDBDF21C, 0xCABAC28A, 0x53B39330, 0x24B4A3A6, 0xBAD03605, 0xCDD70693, 0x54DE5729, 0x23D967BF,
+    0xB3667A2E, 0xC4614AB8, 0x5D681B02, 0x2A6F2B94, 0xB40BBE37, 0xC30C8EA1, 0x5A05DF1B, 0x2D02EF8D,
+};
+
+// Known size hash
+// It is ok to call ImHashData on a string with known length but the ### operator won't be
+// supported.
+// FIXME-OPT: Replace with e.g. FNV1a hash? CRC32 pretty much randomly access 1KB. Need to do proper
+// measurements.
+ImU32 ImHashData(const void *data_p, size_t data_size, ImU32 seed)
+{
+    ImU32 crc                 = ~seed;
+    const unsigned char *data = (const unsigned char *)data_p;
+    const ImU32 *crc32_lut    = GCrc32LookupTable;
+    while (data_size-- != 0)
+        crc = (crc >> 8) ^ crc32_lut[(crc & 0xFF) ^ *data++];
+    return ~crc;
+}
+
+// Zero-terminated string hash, with support for ### to reset back to seed value
+// We support a syntax of "label###id" where only "###id" is included in the hash, and only "label"
+// gets displayed. Because this syntax is rarely used we are optimizing for the common case.
+// - If we reach ### in the string we discard the hash so far and reset to the seed.
+// - We don't do 'current += 2; continue;' after handling ### to keep the code smaller/faster
+// (measured ~10% diff in Debug build)
+// FIXME-OPT: Replace with e.g. FNV1a hash? CRC32 pretty much randomly access 1KB. Need to do proper
+// measurements.
+ImU32 ImHashStr(const char *data_p, size_t data_size, ImU32 seed)
+{
+    seed                      = ~seed;
+    ImU32 crc                 = seed;
+    const unsigned char *data = (const unsigned char *)data_p;
+    const ImU32 *crc32_lut    = GCrc32LookupTable;
+    if (data_size != 0)
+    {
+        while (data_size-- != 0)
+        {
+            unsigned char c = *data++;
+            if (c == '#' && data_size >= 2 && data[0] == '#' && data[1] == '#')
+                crc = seed;
+            crc = (crc >> 8) ^ crc32_lut[(crc & 0xFF) ^ c];
+        }
+    }
+    else
+    {
+        while (unsigned char c = *data++)
+        {
+            if (c == '#' && data[0] == '#' && data[1] == '#')
+                crc = seed;
+            crc = (crc >> 8) ^ crc32_lut[(crc & 0xFF) ^ c];
+        }
+    }
+    return ~crc;
+}
+
+FILE *ImFileOpen(const char *filename, const char *mode)
+{
+#if defined(_WIN32) && !defined(__CYGWIN__) && !defined(__GNUC__)
+    // We need a fopen() wrapper because MSVC/Windows fopen doesn't handle UTF-8 filenames.
+    // Converting both strings from UTF-8 to wchar format (using a single allocation, because we
+    // can)
+    const int filename_wsize = ImTextCountCharsFromUtf8(filename, NULL) + 1;
+    const int mode_wsize     = ImTextCountCharsFromUtf8(mode, NULL) + 1;
+    ImVector<ImWchar> buf;
+    buf.resize(filename_wsize + mode_wsize);
+    ImTextStrFromUtf8(&buf[0], filename_wsize, filename, NULL);
+    ImTextStrFromUtf8(&buf[filename_wsize], mode_wsize, mode, NULL);
+    return _wfopen((wchar_t *)&buf[0], (wchar_t *)&buf[filename_wsize]);
+#else
+    return fopen(filename, mode);
+#endif
+}
+
+// Load file content into memory
+// Memory allocated with IM_ALLOC(), must be freed by user using IM_FREE() == ImGui::MemFree()
+void *ImFileLoadToMemory(const char *filename,
+                         const char *file_open_mode,
+                         size_t *out_file_size,
+                         int padding_bytes)
+{
+    IM_ASSERT(filename && file_open_mode);
+    if (out_file_size)
+        *out_file_size = 0;
+
+    FILE *f;
+    if ((f = ImFileOpen(filename, file_open_mode)) == NULL)
+        return NULL;
+
+    long file_size_signed;
+    if (fseek(f, 0, SEEK_END) || (file_size_signed = ftell(f)) == -1 || fseek(f, 0, SEEK_SET))
+    {
+        fclose(f);
+        return NULL;
+    }
+
+    size_t file_size = (size_t)file_size_signed;
+    void *file_data  = IM_ALLOC(file_size + padding_bytes);
+    if (file_data == NULL)
+    {
+        fclose(f);
+        return NULL;
+    }
+    if (fread(file_data, 1, file_size, f) != file_size)
+    {
+        fclose(f);
+        IM_FREE(file_data);
+        return NULL;
+    }
+    if (padding_bytes > 0)
+        memset((void *)(((char *)file_data) + file_size), 0, (size_t)padding_bytes);
+
+    fclose(f);
+    if (out_file_size)
+        *out_file_size = file_size;
+
+    return file_data;
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] MISC HELPERS/UTILITIES (ImText* functions)
+//-----------------------------------------------------------------------------
+
+// Convert UTF-8 to 32-bits character, process single character input.
+// Based on stb_from_utf8() from github.com/nothings/stb/
+// We handle UTF-8 decoding error by skipping forward.
+int ImTextCharFromUtf8(unsigned int *out_char, const char *in_text, const char *in_text_end)
+{
+    unsigned int c           = (unsigned int)-1;
+    const unsigned char *str = (const unsigned char *)in_text;
+    if (!(*str & 0x80))
+    {
+        c         = (unsigned int)(*str++);
+        *out_char = c;
+        return 1;
+    }
+    if ((*str & 0xe0) == 0xc0)
+    {
+        *out_char = 0xFFFD;  // will be invalid but not end of string
+        if (in_text_end && in_text_end - (const char *)str < 2)
+            return 1;
+        if (*str < 0xc2)
+            return 2;
+        c = (unsigned int)((*str++ & 0x1f) << 6);
+        if ((*str & 0xc0) != 0x80)
+            return 2;
+        c += (*str++ & 0x3f);
+        *out_char = c;
+        return 2;
+    }
+    if ((*str & 0xf0) == 0xe0)
+    {
+        *out_char = 0xFFFD;  // will be invalid but not end of string
+        if (in_text_end && in_text_end - (const char *)str < 3)
+            return 1;
+        if (*str == 0xe0 && (str[1] < 0xa0 || str[1] > 0xbf))
+            return 3;
+        if (*str == 0xed && str[1] > 0x9f)
+            return 3;  // str[1] < 0x80 is checked below
+        c = (unsigned int)((*str++ & 0x0f) << 12);
+        if ((*str & 0xc0) != 0x80)
+            return 3;
+        c += (unsigned int)((*str++ & 0x3f) << 6);
+        if ((*str & 0xc0) != 0x80)
+            return 3;
+        c += (*str++ & 0x3f);
+        *out_char = c;
+        return 3;
+    }
+    if ((*str & 0xf8) == 0xf0)
+    {
+        *out_char = 0xFFFD;  // will be invalid but not end of string
+        if (in_text_end && in_text_end - (const char *)str < 4)
+            return 1;
+        if (*str > 0xf4)
+            return 4;
+        if (*str == 0xf0 && (str[1] < 0x90 || str[1] > 0xbf))
+            return 4;
+        if (*str == 0xf4 && str[1] > 0x8f)
+            return 4;  // str[1] < 0x80 is checked below
+        c = (unsigned int)((*str++ & 0x07) << 18);
+        if ((*str & 0xc0) != 0x80)
+            return 4;
+        c += (unsigned int)((*str++ & 0x3f) << 12);
+        if ((*str & 0xc0) != 0x80)
+            return 4;
+        c += (unsigned int)((*str++ & 0x3f) << 6);
+        if ((*str & 0xc0) != 0x80)
+            return 4;
+        c += (*str++ & 0x3f);
+        // utf-8 encodings of values used in surrogate pairs are invalid
+        if ((c & 0xFFFFF800) == 0xD800)
+            return 4;
+        *out_char = c;
+        return 4;
+    }
+    *out_char = 0;
+    return 0;
+}
+
+int ImTextStrFromUtf8(ImWchar *buf,
+                      int buf_size,
+                      const char *in_text,
+                      const char *in_text_end,
+                      const char **in_text_remaining)
+{
+    ImWchar *buf_out = buf;
+    ImWchar *buf_end = buf + buf_size;
+    while (buf_out < buf_end - 1 && (!in_text_end || in_text < in_text_end) && *in_text)
+    {
+        unsigned int c;
+        in_text += ImTextCharFromUtf8(&c, in_text, in_text_end);
+        if (c == 0)
+            break;
+        if (c < 0x10000)  // FIXME: Losing characters that don't fit in 2 bytes
+            *buf_out++ = (ImWchar)c;
+    }
+    *buf_out = 0;
+    if (in_text_remaining)
+        *in_text_remaining = in_text;
+    return (int)(buf_out - buf);
+}
+
+int ImTextCountCharsFromUtf8(const char *in_text, const char *in_text_end)
+{
+    int char_count = 0;
+    while ((!in_text_end || in_text < in_text_end) && *in_text)
+    {
+        unsigned int c;
+        in_text += ImTextCharFromUtf8(&c, in_text, in_text_end);
+        if (c == 0)
+            break;
+        if (c < 0x10000)
+            char_count++;
+    }
+    return char_count;
+}
+
+// Based on stb_to_utf8() from github.com/nothings/stb/
+static inline int ImTextCharToUtf8(char *buf, int buf_size, unsigned int c)
+{
+    if (c < 0x80)
+    {
+        buf[0] = (char)c;
+        return 1;
+    }
+    if (c < 0x800)
+    {
+        if (buf_size < 2)
+            return 0;
+        buf[0] = (char)(0xc0 + (c >> 6));
+        buf[1] = (char)(0x80 + (c & 0x3f));
+        return 2;
+    }
+    if (c >= 0xdc00 && c < 0xe000)
+    {
+        return 0;
+    }
+    if (c >= 0xd800 && c < 0xdc00)
+    {
+        if (buf_size < 4)
+            return 0;
+        buf[0] = (char)(0xf0 + (c >> 18));
+        buf[1] = (char)(0x80 + ((c >> 12) & 0x3f));
+        buf[2] = (char)(0x80 + ((c >> 6) & 0x3f));
+        buf[3] = (char)(0x80 + ((c)&0x3f));
+        return 4;
+    }
+    // else if (c < 0x10000)
+    {
+        if (buf_size < 3)
+            return 0;
+        buf[0] = (char)(0xe0 + (c >> 12));
+        buf[1] = (char)(0x80 + ((c >> 6) & 0x3f));
+        buf[2] = (char)(0x80 + ((c)&0x3f));
+        return 3;
+    }
+}
+
+// Not optimal but we very rarely use this function.
+int ImTextCountUtf8BytesFromChar(const char *in_text, const char *in_text_end)
+{
+    unsigned int dummy = 0;
+    return ImTextCharFromUtf8(&dummy, in_text, in_text_end);
+}
+
+static inline int ImTextCountUtf8BytesFromChar(unsigned int c)
+{
+    if (c < 0x80)
+        return 1;
+    if (c < 0x800)
+        return 2;
+    if (c >= 0xdc00 && c < 0xe000)
+        return 0;
+    if (c >= 0xd800 && c < 0xdc00)
+        return 4;
+    return 3;
+}
+
+int ImTextStrToUtf8(char *buf, int buf_size, const ImWchar *in_text, const ImWchar *in_text_end)
+{
+    char *buf_out       = buf;
+    const char *buf_end = buf + buf_size;
+    while (buf_out < buf_end - 1 && (!in_text_end || in_text < in_text_end) && *in_text)
+    {
+        unsigned int c = (unsigned int)(*in_text++);
+        if (c < 0x80)
+            *buf_out++ = (char)c;
+        else
+            buf_out += ImTextCharToUtf8(buf_out, (int)(buf_end - buf_out - 1), c);
+    }
+    *buf_out = 0;
+    return (int)(buf_out - buf);
+}
+
+int ImTextCountUtf8BytesFromStr(const ImWchar *in_text, const ImWchar *in_text_end)
+{
+    int bytes_count = 0;
+    while ((!in_text_end || in_text < in_text_end) && *in_text)
+    {
+        unsigned int c = (unsigned int)(*in_text++);
+        if (c < 0x80)
+            bytes_count++;
+        else
+            bytes_count += ImTextCountUtf8BytesFromChar(c);
+    }
+    return bytes_count;
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] MISC HELPERS/UTILTIES (Color functions)
+// Note: The Convert functions are early design which are not consistent with other API.
+//-----------------------------------------------------------------------------
+
+ImVec4 ImGui::ColorConvertU32ToFloat4(ImU32 in)
+{
+    float s = 1.0f / 255.0f;
+    return ImVec4(((in >> IM_COL32_R_SHIFT) & 0xFF) * s, ((in >> IM_COL32_G_SHIFT) & 0xFF) * s,
+                  ((in >> IM_COL32_B_SHIFT) & 0xFF) * s, ((in >> IM_COL32_A_SHIFT) & 0xFF) * s);
+}
+
+ImU32 ImGui::ColorConvertFloat4ToU32(const ImVec4 &in)
+{
+    ImU32 out;
+    out = ((ImU32)IM_F32_TO_INT8_SAT(in.x)) << IM_COL32_R_SHIFT;
+    out |= ((ImU32)IM_F32_TO_INT8_SAT(in.y)) << IM_COL32_G_SHIFT;
+    out |= ((ImU32)IM_F32_TO_INT8_SAT(in.z)) << IM_COL32_B_SHIFT;
+    out |= ((ImU32)IM_F32_TO_INT8_SAT(in.w)) << IM_COL32_A_SHIFT;
+    return out;
+}
+
+// Convert rgb floats ([0-1],[0-1],[0-1]) to hsv floats ([0-1],[0-1],[0-1]), from Foley & van Dam
+// p592 Optimized http://lolengine.net/blog/2013/01/13/fast-rgb-to-hsv
+void ImGui::ColorConvertRGBtoHSV(float r,
+                                 float g,
+                                 float b,
+                                 float &out_h,
+                                 float &out_s,
+                                 float &out_v)
+{
+    float K = 0.f;
+    if (g < b)
+    {
+        ImSwap(g, b);
+        K = -1.f;
+    }
+    if (r < g)
+    {
+        ImSwap(r, g);
+        K = -2.f / 6.f - K;
+    }
+
+    const float chroma = r - (g < b ? g : b);
+    out_h              = ImFabs(K + (g - b) / (6.f * chroma + 1e-20f));
+    out_s              = chroma / (r + 1e-20f);
+    out_v              = r;
+}
+
+// Convert hsv floats ([0-1],[0-1],[0-1]) to rgb floats ([0-1],[0-1],[0-1]), from Foley & van Dam
+// p593 also http://en.wikipedia.org/wiki/HSL_and_HSV
+void ImGui::ColorConvertHSVtoRGB(float h,
+                                 float s,
+                                 float v,
+                                 float &out_r,
+                                 float &out_g,
+                                 float &out_b)
+{
+    if (s == 0.0f)
+    {
+        // gray
+        out_r = out_g = out_b = v;
+        return;
+    }
+
+    h       = ImFmod(h, 1.0f) / (60.0f / 360.0f);
+    int i   = (int)h;
+    float f = h - (float)i;
+    float p = v * (1.0f - s);
+    float q = v * (1.0f - s * f);
+    float t = v * (1.0f - s * (1.0f - f));
+
+    switch (i)
+    {
+        case 0:
+            out_r = v;
+            out_g = t;
+            out_b = p;
+            break;
+        case 1:
+            out_r = q;
+            out_g = v;
+            out_b = p;
+            break;
+        case 2:
+            out_r = p;
+            out_g = v;
+            out_b = t;
+            break;
+        case 3:
+            out_r = p;
+            out_g = q;
+            out_b = v;
+            break;
+        case 4:
+            out_r = t;
+            out_g = p;
+            out_b = v;
+            break;
+        case 5:
+        default:
+            out_r = v;
+            out_g = p;
+            out_b = q;
+            break;
+    }
+}
+
+ImU32 ImGui::GetColorU32(ImGuiCol idx, float alpha_mul)
+{
+    ImGuiStyle &style = GImGui->Style;
+    ImVec4 c          = style.Colors[idx];
+    c.w *= style.Alpha * alpha_mul;
+    return ColorConvertFloat4ToU32(c);
+}
+
+ImU32 ImGui::GetColorU32(const ImVec4 &col)
+{
+    ImGuiStyle &style = GImGui->Style;
+    ImVec4 c          = col;
+    c.w *= style.Alpha;
+    return ColorConvertFloat4ToU32(c);
+}
+
+const ImVec4 &ImGui::GetStyleColorVec4(ImGuiCol idx)
+{
+    ImGuiStyle &style = GImGui->Style;
+    return style.Colors[idx];
+}
+
+ImU32 ImGui::GetColorU32(ImU32 col)
+{
+    float style_alpha = GImGui->Style.Alpha;
+    if (style_alpha >= 1.0f)
+        return col;
+    ImU32 a = (col & IM_COL32_A_MASK) >> IM_COL32_A_SHIFT;
+    a       = (ImU32)(
+        a * style_alpha);  // We don't need to clamp 0..255 because Style.Alpha is in 0..1 range.
+    return (col & ~IM_COL32_A_MASK) | (a << IM_COL32_A_SHIFT);
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] ImGuiStorage
+// Helper: Key->value storage
+//-----------------------------------------------------------------------------
+
+// std::lower_bound but without the bullshit
+static ImGuiStorage::Pair *LowerBound(ImVector<ImGuiStorage::Pair> &data, ImGuiID key)
+{
+    ImGuiStorage::Pair *first = data.Data;
+    ImGuiStorage::Pair *last  = data.Data + data.Size;
+    size_t count              = (size_t)(last - first);
+    while (count > 0)
+    {
+        size_t count2           = count >> 1;
+        ImGuiStorage::Pair *mid = first + count2;
+        if (mid->key < key)
+        {
+            first = ++mid;
+            count -= count2 + 1;
+        }
+        else
+        {
+            count = count2;
+        }
+    }
+    return first;
+}
+
+// For quicker full rebuild of a storage (instead of an incremental one), you may add all your
+// contents and then sort once.
+void ImGuiStorage::BuildSortByKey()
+{
+    struct StaticFunc
+    {
+        static int IMGUI_CDECL PairCompareByID(const void *lhs, const void *rhs)
+        {
+            // We can't just do a subtraction because qsort uses signed integers and subtracting our
+            // ID doesn't play well with that.
+            if (((const Pair *)lhs)->key > ((const Pair *)rhs)->key)
+                return +1;
+            if (((const Pair *)lhs)->key < ((const Pair *)rhs)->key)
+                return -1;
+            return 0;
+        }
+    };
+    if (Data.Size > 1)
+        ImQsort(Data.Data, (size_t)Data.Size, sizeof(Pair), StaticFunc::PairCompareByID);
+}
+
+int ImGuiStorage::GetInt(ImGuiID key, int default_val) const
+{
+    ImGuiStorage::Pair *it = LowerBound(const_cast<ImVector<ImGuiStorage::Pair> &>(Data), key);
+    if (it == Data.end() || it->key != key)
+        return default_val;
+    return it->val_i;
+}
+
+bool ImGuiStorage::GetBool(ImGuiID key, bool default_val) const
+{
+    return GetInt(key, default_val ? 1 : 0) != 0;
+}
+
+float ImGuiStorage::GetFloat(ImGuiID key, float default_val) const
+{
+    ImGuiStorage::Pair *it = LowerBound(const_cast<ImVector<ImGuiStorage::Pair> &>(Data), key);
+    if (it == Data.end() || it->key != key)
+        return default_val;
+    return it->val_f;
+}
+
+void *ImGuiStorage::GetVoidPtr(ImGuiID key) const
+{
+    ImGuiStorage::Pair *it = LowerBound(const_cast<ImVector<ImGuiStorage::Pair> &>(Data), key);
+    if (it == Data.end() || it->key != key)
+        return NULL;
+    return it->val_p;
+}
+
+// References are only valid until a new value is added to the storage. Calling a Set***() function
+// or a Get***Ref() function invalidates the pointer.
+int *ImGuiStorage::GetIntRef(ImGuiID key, int default_val)
+{
+    ImGuiStorage::Pair *it = LowerBound(Data, key);
+    if (it == Data.end() || it->key != key)
+        it = Data.insert(it, Pair(key, default_val));
+    return &it->val_i;
+}
+
+bool *ImGuiStorage::GetBoolRef(ImGuiID key, bool default_val)
+{
+    return (bool *)GetIntRef(key, default_val ? 1 : 0);
+}
+
+float *ImGuiStorage::GetFloatRef(ImGuiID key, float default_val)
+{
+    ImGuiStorage::Pair *it = LowerBound(Data, key);
+    if (it == Data.end() || it->key != key)
+        it = Data.insert(it, Pair(key, default_val));
+    return &it->val_f;
+}
+
+void **ImGuiStorage::GetVoidPtrRef(ImGuiID key, void *default_val)
+{
+    ImGuiStorage::Pair *it = LowerBound(Data, key);
+    if (it == Data.end() || it->key != key)
+        it = Data.insert(it, Pair(key, default_val));
+    return &it->val_p;
+}
+
+// FIXME-OPT: Need a way to reuse the result of lower_bound when doing GetInt()/SetInt() - not too
+// bad because it only happens on explicit interaction (maximum one a frame)
+void ImGuiStorage::SetInt(ImGuiID key, int val)
+{
+    ImGuiStorage::Pair *it = LowerBound(Data, key);
+    if (it == Data.end() || it->key != key)
+    {
+        Data.insert(it, Pair(key, val));
+        return;
+    }
+    it->val_i = val;
+}
+
+void ImGuiStorage::SetBool(ImGuiID key, bool val)
+{
+    SetInt(key, val ? 1 : 0);
+}
+
+void ImGuiStorage::SetFloat(ImGuiID key, float val)
+{
+    ImGuiStorage::Pair *it = LowerBound(Data, key);
+    if (it == Data.end() || it->key != key)
+    {
+        Data.insert(it, Pair(key, val));
+        return;
+    }
+    it->val_f = val;
+}
+
+void ImGuiStorage::SetVoidPtr(ImGuiID key, void *val)
+{
+    ImGuiStorage::Pair *it = LowerBound(Data, key);
+    if (it == Data.end() || it->key != key)
+    {
+        Data.insert(it, Pair(key, val));
+        return;
+    }
+    it->val_p = val;
+}
+
+void ImGuiStorage::SetAllInt(int v)
+{
+    for (int i = 0; i < Data.Size; i++)
+        Data[i].val_i = v;
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] ImGuiTextFilter
+//-----------------------------------------------------------------------------
+
+// Helper: Parse and apply text filters. In format "aaaaa[,bbbb][,ccccc]"
+ImGuiTextFilter::ImGuiTextFilter(const char *default_filter)
+{
+    if (default_filter)
+    {
+        ImStrncpy(InputBuf, default_filter, IM_ARRAYSIZE(InputBuf));
+        Build();
+    }
+    else
+    {
+        InputBuf[0] = 0;
+        CountGrep   = 0;
+    }
+}
+
+bool ImGuiTextFilter::Draw(const char *label, float width)
+{
+    if (width != 0.0f)
+        ImGui::SetNextItemWidth(width);
+    bool value_changed = ImGui::InputText(label, InputBuf, IM_ARRAYSIZE(InputBuf));
+    if (value_changed)
+        Build();
+    return value_changed;
+}
+
+void ImGuiTextFilter::TextRange::split(char separator, ImVector<TextRange> *out) const
+{
+    out->resize(0);
+    const char *wb = b;
+    const char *we = wb;
+    while (we < e)
+    {
+        if (*we == separator)
+        {
+            out->push_back(TextRange(wb, we));
+            wb = we + 1;
+        }
+        we++;
+    }
+    if (wb != we)
+        out->push_back(TextRange(wb, we));
+}
+
+void ImGuiTextFilter::Build()
+{
+    Filters.resize(0);
+    TextRange input_range(InputBuf, InputBuf + strlen(InputBuf));
+    input_range.split(',', &Filters);
+
+    CountGrep = 0;
+    for (int i = 0; i != Filters.Size; i++)
+    {
+        TextRange &f = Filters[i];
+        while (f.b < f.e && ImCharIsBlankA(f.b[0]))
+            f.b++;
+        while (f.e > f.b && ImCharIsBlankA(f.e[-1]))
+            f.e--;
+        if (f.empty())
+            continue;
+        if (Filters[i].b[0] != '-')
+            CountGrep += 1;
+    }
+}
+
+bool ImGuiTextFilter::PassFilter(const char *text, const char *text_end) const
+{
+    if (Filters.empty())
+        return true;
+
+    if (text == NULL)
+        text = "";
+
+    for (int i = 0; i != Filters.Size; i++)
+    {
+        const TextRange &f = Filters[i];
+        if (f.empty())
+            continue;
+        if (f.b[0] == '-')
+        {
+            // Subtract
+            if (ImStristr(text, text_end, f.begin() + 1, f.end()) != NULL)
+                return false;
+        }
+        else
+        {
+            // Grep
+            if (ImStristr(text, text_end, f.begin(), f.end()) != NULL)
+                return true;
+        }
+    }
+
+    // Implicit * grep
+    if (CountGrep == 0)
+        return true;
+
+    return false;
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] ImGuiTextBuffer
+//-----------------------------------------------------------------------------
+
+// On some platform vsnprintf() takes va_list by reference and modifies it.
+// va_copy is the 'correct' way to copy a va_list but Visual Studio prior to 2013 doesn't have it.
+#ifndef va_copy
+#if defined(__GNUC__) || defined(__clang__)
+#define va_copy(dest, src) __builtin_va_copy(dest, src)
+#else
+#define va_copy(dest, src) (dest = src)
+#endif
+#endif
+
+char ImGuiTextBuffer::EmptyString[1] = {0};
+
+void ImGuiTextBuffer::append(const char *str, const char *str_end)
+{
+    int len = str_end ? (int)(str_end - str) : (int)strlen(str);
+
+    // Add zero-terminator the first time
+    const int write_off = (Buf.Size != 0) ? Buf.Size : 1;
+    const int needed_sz = write_off + len;
+    if (write_off + len >= Buf.Capacity)
+    {
+        int new_capacity = Buf.Capacity * 2;
+        Buf.reserve(needed_sz > new_capacity ? needed_sz : new_capacity);
+    }
+
+    Buf.resize(needed_sz);
+    memcpy(&Buf[write_off - 1], str, (size_t)len);
+    Buf[write_off - 1 + len] = 0;
+}
+
+void ImGuiTextBuffer::appendf(const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    appendfv(fmt, args);
+    va_end(args);
+}
+
+// Helper: Text buffer for logging/accumulating text
+void ImGuiTextBuffer::appendfv(const char *fmt, va_list args)
+{
+    va_list args_copy;
+    va_copy(args_copy, args);
+
+    int len = ImFormatStringV(
+        NULL, 0, fmt,
+        args);  // FIXME-OPT: could do a first pass write attempt, likely successful on first pass.
+    if (len <= 0)
+    {
+        va_end(args_copy);
+        return;
+    }
+
+    // Add zero-terminator the first time
+    const int write_off = (Buf.Size != 0) ? Buf.Size : 1;
+    const int needed_sz = write_off + len;
+    if (write_off + len >= Buf.Capacity)
+    {
+        int new_capacity = Buf.Capacity * 2;
+        Buf.reserve(needed_sz > new_capacity ? needed_sz : new_capacity);
+    }
+
+    Buf.resize(needed_sz);
+    ImFormatStringV(&Buf[write_off - 1], (size_t)len + 1, fmt, args_copy);
+    va_end(args_copy);
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] ImGuiListClipper
+// This is currently not as flexible/powerful as it should be and really confusing/spaghetti, mostly
+// because we changed the API mid-way through development and support two ways to using the clipper,
+// needs some rework (see TODO)
+//-----------------------------------------------------------------------------
+
+// Helper to calculate coarse clipping of large list of evenly sized items.
+// NB: Prefer using the ImGuiListClipper higher-level helper if you can! Read comments and
+// instructions there on how those use this sort of pattern. NB: 'items_count' is only used to clamp
+// the result, if you don't know your count you can use INT_MAX
+void ImGui::CalcListClipping(int items_count,
+                             float items_height,
+                             int *out_items_display_start,
+                             int *out_items_display_end)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+    if (g.LogEnabled)
+    {
+        // If logging is active, do not perform any clipping
+        *out_items_display_start = 0;
+        *out_items_display_end   = items_count;
+        return;
+    }
+    if (window->SkipItems)
+    {
+        *out_items_display_start = *out_items_display_end = 0;
+        return;
+    }
+
+    // We create the union of the ClipRect and the NavScoringRect which at worst should be 1 page
+    // away from ClipRect
+    ImRect unclipped_rect = window->ClipRect;
+    if (g.NavMoveRequest)
+        unclipped_rect.Add(g.NavScoringRectScreen);
+
+    const ImVec2 pos = window->DC.CursorPos;
+    int start        = (int)((unclipped_rect.Min.y - pos.y) / items_height);
+    int end          = (int)((unclipped_rect.Max.y - pos.y) / items_height);
+
+    // When performing a navigation request, ensure we have one item extra in the direction we are
+    // moving to
+    if (g.NavMoveRequest && g.NavMoveClipDir == ImGuiDir_Up)
+        start--;
+    if (g.NavMoveRequest && g.NavMoveClipDir == ImGuiDir_Down)
+        end++;
+
+    start                    = ImClamp(start, 0, items_count);
+    end                      = ImClamp(end + 1, start, items_count);
+    *out_items_display_start = start;
+    *out_items_display_end   = end;
+}
+
+static void SetCursorPosYAndSetupDummyPrevLine(float pos_y, float line_height)
+{
+    // Set cursor position and a few other things so that SetScrollHereY() and Columns() can work
+    // when seeking cursor.
+    // FIXME: It is problematic that we have to do that here, because custom/equivalent end-user
+    // code would stumble on the same issue. The clipper should probably have a 4th step to display
+    // the last item in a regular manner.
+    ImGuiContext &g           = *GImGui;
+    ImGuiWindow *window       = g.CurrentWindow;
+    window->DC.CursorPos.y    = pos_y;
+    window->DC.CursorMaxPos.y = ImMax(window->DC.CursorMaxPos.y, pos_y);
+    window->DC.CursorPosPrevLine.y =
+        window->DC.CursorPos.y -
+        line_height;  // Setting those fields so that SetScrollHereY() can properly function after
+                      // the end of our clipper usage.
+    window->DC.PrevLineSize.y =
+        (line_height -
+         g.Style.ItemSpacing.y);  // If we end up needing more accurate data (to e.g. use SameLine)
+                                  // we may as well make the clipper have a fourth step to let user
+                                  // process and display the last item in their list.
+    if (ImGuiColumns *columns = window->DC.CurrentColumns)
+        columns->LineMinY =
+            window->DC.CursorPos.y;  // Setting this so that cell Y position are set properly
+}
+
+// Use case A: Begin() called from constructor with items_height<0, then called again from Sync() in
+// StepNo 1 Use case B: Begin() called from constructor with items_height>0
+// FIXME-LEGACY: Ideally we should remove the Begin/End functions but they are part of the legacy
+// API we still support. This is why some of the code in Step() calling Begin() and reassign some
+// fields, spaghetti style.
+void ImGuiListClipper::Begin(int count, float items_height)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+
+    StartPosY   = window->DC.CursorPos.y;
+    ItemsHeight = items_height;
+    ItemsCount  = count;
+    StepNo      = 0;
+    DisplayEnd = DisplayStart = -1;
+    if (ItemsHeight > 0.0f)
+    {
+        ImGui::CalcListClipping(ItemsCount, ItemsHeight, &DisplayStart,
+                                &DisplayEnd);  // calculate how many to clip/display
+        if (DisplayStart > 0)
+            SetCursorPosYAndSetupDummyPrevLine(StartPosY + DisplayStart * ItemsHeight,
+                                               ItemsHeight);  // advance cursor
+        StepNo = 2;
+    }
+}
+
+void ImGuiListClipper::End()
+{
+    if (ItemsCount < 0)
+        return;
+    // In theory here we should assert that ImGui::GetCursorPosY() == StartPosY + DisplayEnd *
+    // ItemsHeight, but it feels saner to just seek at the end and not assert/crash the user.
+    if (ItemsCount < INT_MAX)
+        SetCursorPosYAndSetupDummyPrevLine(StartPosY + ItemsCount * ItemsHeight,
+                                           ItemsHeight);  // advance cursor
+    ItemsCount = -1;
+    StepNo     = 3;
+}
+
+bool ImGuiListClipper::Step()
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+
+    if (ItemsCount == 0 || window->SkipItems)
+    {
+        ItemsCount = -1;
+        return false;
+    }
+    if (StepNo == 0)  // Step 0: the clipper let you process the first element, regardless of it
+                      // being visible or not, so we can measure the element height.
+    {
+        DisplayStart = 0;
+        DisplayEnd   = 1;
+        StartPosY    = window->DC.CursorPos.y;
+        StepNo       = 1;
+        return true;
+    }
+    if (StepNo ==
+        1)  // Step 1: the clipper infer height from first element, calculate the actual range of
+            // elements to display, and position the cursor before the first element.
+    {
+        if (ItemsCount == 1)
+        {
+            ItemsCount = -1;
+            return false;
+        }
+        float items_height = window->DC.CursorPos.y - StartPosY;
+        IM_ASSERT(items_height >
+                  0.0f);  // If this triggers, it means Item 0 hasn't moved the cursor vertically
+        Begin(ItemsCount - 1, items_height);
+        DisplayStart++;
+        DisplayEnd++;
+        StepNo = 3;
+        return true;
+    }
+    if (StepNo ==
+        2)  // Step 2: dummy step only required if an explicit items_height was passed to
+            // constructor or Begin() and user still call Step(). Does nothing and switch to Step 3.
+    {
+        IM_ASSERT(DisplayStart >= 0 && DisplayEnd >= 0);
+        StepNo = 3;
+        return true;
+    }
+    if (StepNo == 3)  // Step 3: the clipper validate that we have reached the expected Y position
+                      // (corresponding to element DisplayEnd), advance the cursor to the end of the
+                      // list and then returns 'false' to end the loop.
+        End();
+    return false;
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] RENDER HELPERS
+// Those (internal) functions are currently quite a legacy mess - their signature and behavior will
+// change. Also see imgui_draw.cpp for some more which have been reworked to not rely on ImGui::
+// state.
+//-----------------------------------------------------------------------------
+
+const char *ImGui::FindRenderedTextEnd(const char *text, const char *text_end)
+{
+    const char *text_display_end = text;
+    if (!text_end)
+        text_end = (const char *)-1;
+
+    while (text_display_end < text_end && *text_display_end != '\0' &&
+           (text_display_end[0] != '#' || text_display_end[1] != '#'))
+        text_display_end++;
+    return text_display_end;
+}
+
+// Internal ImGui functions to render text
+// RenderText***() functions calls ImDrawList::AddText() calls ImBitmapFont::RenderText()
+void ImGui::RenderText(ImVec2 pos,
+                       const char *text,
+                       const char *text_end,
+                       bool hide_text_after_hash)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+
+    // Hide anything after a '##' string
+    const char *text_display_end;
+    if (hide_text_after_hash)
+    {
+        text_display_end = FindRenderedTextEnd(text, text_end);
+    }
+    else
+    {
+        if (!text_end)
+            text_end = text + strlen(text);  // FIXME-OPT
+        text_display_end = text_end;
+    }
+
+    if (text != text_display_end)
+    {
+        window->DrawList->AddText(g.Font, g.FontSize, pos, GetColorU32(ImGuiCol_Text), text,
+                                  text_display_end);
+        if (g.LogEnabled)
+            LogRenderedText(&pos, text, text_display_end);
+    }
+}
+
+void ImGui::RenderTextWrapped(ImVec2 pos, const char *text, const char *text_end, float wrap_width)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+
+    if (!text_end)
+        text_end = text + strlen(text);  // FIXME-OPT
+
+    if (text != text_end)
+    {
+        window->DrawList->AddText(g.Font, g.FontSize, pos, GetColorU32(ImGuiCol_Text), text,
+                                  text_end, wrap_width);
+        if (g.LogEnabled)
+            LogRenderedText(&pos, text, text_end);
+    }
+}
+
+// Default clip_rect uses (pos_min,pos_max)
+// Handle clipping on CPU immediately (vs typically let the GPU clip the triangles that are
+// overlapping the clipping rectangle edges)
+void ImGui::RenderTextClippedEx(ImDrawList *draw_list,
+                                const ImVec2 &pos_min,
+                                const ImVec2 &pos_max,
+                                const char *text,
+                                const char *text_display_end,
+                                const ImVec2 *text_size_if_known,
+                                const ImVec2 &align,
+                                const ImRect *clip_rect)
+{
+    // Perform CPU side clipping for single clipped element to avoid using scissor state
+    ImVec2 pos             = pos_min;
+    const ImVec2 text_size = text_size_if_known ? *text_size_if_known
+                                                : CalcTextSize(text, text_display_end, false, 0.0f);
+
+    const ImVec2 *clip_min = clip_rect ? &clip_rect->Min : &pos_min;
+    const ImVec2 *clip_max = clip_rect ? &clip_rect->Max : &pos_max;
+    bool need_clipping =
+        (pos.x + text_size.x >= clip_max->x) || (pos.y + text_size.y >= clip_max->y);
+    if (clip_rect)  // If we had no explicit clipping rectangle then pos==clip_min
+        need_clipping |= (pos.x < clip_min->x) || (pos.y < clip_min->y);
+
+    // Align whole block. We should defer that to the better rendering function when we'll have
+    // support for individual line alignment.
+    if (align.x > 0.0f)
+        pos.x = ImMax(pos.x, pos.x + (pos_max.x - pos.x - text_size.x) * align.x);
+    if (align.y > 0.0f)
+        pos.y = ImMax(pos.y, pos.y + (pos_max.y - pos.y - text_size.y) * align.y);
+
+    // Render
+    if (need_clipping)
+    {
+        ImVec4 fine_clip_rect(clip_min->x, clip_min->y, clip_max->x, clip_max->y);
+        draw_list->AddText(NULL, 0.0f, pos, GetColorU32(ImGuiCol_Text), text, text_display_end,
+                           0.0f, &fine_clip_rect);
+    }
+    else
+    {
+        draw_list->AddText(NULL, 0.0f, pos, GetColorU32(ImGuiCol_Text), text, text_display_end,
+                           0.0f, NULL);
+    }
+}
+
+void ImGui::RenderTextClipped(const ImVec2 &pos_min,
+                              const ImVec2 &pos_max,
+                              const char *text,
+                              const char *text_end,
+                              const ImVec2 *text_size_if_known,
+                              const ImVec2 &align,
+                              const ImRect *clip_rect)
+{
+    // Hide anything after a '##' string
+    const char *text_display_end = FindRenderedTextEnd(text, text_end);
+    const int text_len           = (int)(text_display_end - text);
+    if (text_len == 0)
+        return;
+
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+    RenderTextClippedEx(window->DrawList, pos_min, pos_max, text, text_display_end,
+                        text_size_if_known, align, clip_rect);
+    if (g.LogEnabled)
+        LogRenderedText(&pos_min, text, text_display_end);
+}
+
+// Another overly complex function until we reorganize everything into a nice all-in-one helper.
+// This is made more complex because we have dissociated the layout rectangle (pos_min..pos_max)
+// which define _where_ the ellipsis is, from actual clipping of text and limit of the ellipsis
+// display. This is because in the context of tabs we selectively hide part of the text when the
+// Close Button appears, but we don't want the ellipsis to move.
+void ImGui::RenderTextEllipsis(ImDrawList *draw_list,
+                               const ImVec2 &pos_min,
+                               const ImVec2 &pos_max,
+                               float clip_max_x,
+                               float ellipsis_max_x,
+                               const char *text,
+                               const char *text_end_full,
+                               const ImVec2 *text_size_if_known)
+{
+    ImGuiContext &g = *GImGui;
+    if (text_end_full == NULL)
+        text_end_full = FindRenderedTextEnd(text);
+    const ImVec2 text_size =
+        text_size_if_known ? *text_size_if_known : CalcTextSize(text, text_end_full, false, 0.0f);
+
+    if (text_size.x > pos_max.x - pos_min.x)
+    {
+        // Hello wo...
+        // |       |   |
+        // min   max   ellipsis_max
+        //          <-> this is generally some padding value
+
+        // FIXME-STYLE: RenderPixelEllipsis() style should use actual font data.
+        const ImFont *font            = draw_list->_Data->Font;
+        const float font_size         = draw_list->_Data->FontSize;
+        const int ellipsis_dot_count  = 3;
+        const float ellipsis_width    = (1.0f + 1.0f) * ellipsis_dot_count - 1.0f;
+        const char *text_end_ellipsis = NULL;
+
+        float text_width          = ImMax((pos_max.x - ellipsis_width) - pos_min.x, 1.0f);
+        float text_size_clipped_x = font->CalcTextSizeA(font_size, text_width, 0.0f, text,
+                                                        text_end_full, &text_end_ellipsis)
+                                        .x;
+        if (text == text_end_ellipsis && text_end_ellipsis < text_end_full)
+        {
+            // Always display at least 1 character if there's no room for character + ellipsis
+            text_end_ellipsis = text + ImTextCountUtf8BytesFromChar(text, text_end_full);
+            text_size_clipped_x =
+                font->CalcTextSizeA(font_size, FLT_MAX, 0.0f, text, text_end_ellipsis).x;
+        }
+        while (text_end_ellipsis > text && ImCharIsBlankA(text_end_ellipsis[-1]))
+        {
+            // Trim trailing space before ellipsis
+            text_end_ellipsis--;
+            text_size_clipped_x -= font->CalcTextSizeA(font_size, FLT_MAX, 0.0f, text_end_ellipsis,
+                                                       text_end_ellipsis + 1)
+                                       .x;  // Ascii blanks are always 1 byte
+        }
+        RenderTextClippedEx(draw_list, pos_min, ImVec2(clip_max_x, pos_max.y), text,
+                            text_end_ellipsis, &text_size, ImVec2(0.0f, 0.0f));
+
+        const float ellipsis_x = pos_min.x + text_size_clipped_x + 1.0f;
+        if (ellipsis_x + ellipsis_width - 1.0f <= ellipsis_max_x)
+            RenderPixelEllipsis(draw_list, ImVec2(ellipsis_x, pos_min.y),
+                                GetColorU32(ImGuiCol_Text), ellipsis_dot_count);
+    }
+    else
+    {
+        RenderTextClippedEx(draw_list, pos_min, ImVec2(clip_max_x, pos_max.y), text, text_end_full,
+                            &text_size, ImVec2(0.0f, 0.0f));
+    }
+
+    if (g.LogEnabled)
+        LogRenderedText(&pos_min, text, text_end_full);
+}
+
+// Render a rectangle shaped with optional rounding and borders
+void ImGui::RenderFrame(ImVec2 p_min, ImVec2 p_max, ImU32 fill_col, bool border, float rounding)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+    window->DrawList->AddRectFilled(p_min, p_max, fill_col, rounding);
+    const float border_size = g.Style.FrameBorderSize;
+    if (border && border_size > 0.0f)
+    {
+        window->DrawList->AddRect(p_min + ImVec2(1, 1), p_max + ImVec2(1, 1),
+                                  GetColorU32(ImGuiCol_BorderShadow), rounding,
+                                  ImDrawCornerFlags_All, border_size);
+        window->DrawList->AddRect(p_min, p_max, GetColorU32(ImGuiCol_Border), rounding,
+                                  ImDrawCornerFlags_All, border_size);
+    }
+}
+
+void ImGui::RenderFrameBorder(ImVec2 p_min, ImVec2 p_max, float rounding)
+{
+    ImGuiContext &g         = *GImGui;
+    ImGuiWindow *window     = g.CurrentWindow;
+    const float border_size = g.Style.FrameBorderSize;
+    if (border_size > 0.0f)
+    {
+        window->DrawList->AddRect(p_min + ImVec2(1, 1), p_max + ImVec2(1, 1),
+                                  GetColorU32(ImGuiCol_BorderShadow), rounding,
+                                  ImDrawCornerFlags_All, border_size);
+        window->DrawList->AddRect(p_min, p_max, GetColorU32(ImGuiCol_Border), rounding,
+                                  ImDrawCornerFlags_All, border_size);
+    }
+}
+
+// Render an arrow aimed to be aligned with text (p_min is a position in the same space text would
+// be positioned). To e.g. denote expanded/collapsed state
+void ImGui::RenderArrow(ImDrawList *draw_list, ImVec2 pos, ImU32 col, ImGuiDir dir, float scale)
+{
+    const float h = draw_list->_Data->FontSize * 1.00f;
+    float r       = h * 0.40f * scale;
+    ImVec2 center = pos + ImVec2(h * 0.50f, h * 0.50f * scale);
+
+    ImVec2 a, b, c;
+    switch (dir)
+    {
+        case ImGuiDir_Up:
+        case ImGuiDir_Down:
+            if (dir == ImGuiDir_Up)
+                r = -r;
+            a = ImVec2(+0.000f, +0.750f) * r;
+            b = ImVec2(-0.866f, -0.750f) * r;
+            c = ImVec2(+0.866f, -0.750f) * r;
+            break;
+        case ImGuiDir_Left:
+        case ImGuiDir_Right:
+            if (dir == ImGuiDir_Left)
+                r = -r;
+            a = ImVec2(+0.750f, +0.000f) * r;
+            b = ImVec2(-0.750f, +0.866f) * r;
+            c = ImVec2(-0.750f, -0.866f) * r;
+            break;
+        case ImGuiDir_None:
+        case ImGuiDir_COUNT:
+            IM_ASSERT(0);
+            break;
+    }
+    draw_list->AddTriangleFilled(center + a, center + b, center + c, col);
+}
+
+void ImGui::RenderBullet(ImDrawList *draw_list, ImVec2 pos, ImU32 col)
+{
+    draw_list->AddCircleFilled(pos, draw_list->_Data->FontSize * 0.20f, col, 8);
+}
+
+void ImGui::RenderCheckMark(ImVec2 pos, ImU32 col, float sz)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+
+    float thickness = ImMax(sz / 5.0f, 1.0f);
+    sz -= thickness * 0.5f;
+    pos += ImVec2(thickness * 0.25f, thickness * 0.25f);
+
+    float third = sz / 3.0f;
+    float bx    = pos.x + third;
+    float by    = pos.y + sz - third * 0.5f;
+    window->DrawList->PathLineTo(ImVec2(bx - third, by - third));
+    window->DrawList->PathLineTo(ImVec2(bx, by));
+    window->DrawList->PathLineTo(ImVec2(bx + third * 2, by - third * 2));
+    window->DrawList->PathStroke(col, false, thickness);
+}
+
+void ImGui::RenderNavHighlight(const ImRect &bb, ImGuiID id, ImGuiNavHighlightFlags flags)
+{
+    ImGuiContext &g = *GImGui;
+    if (id != g.NavId)
+        return;
+    if (g.NavDisableHighlight && !(flags & ImGuiNavHighlightFlags_AlwaysDraw))
+        return;
+    ImGuiWindow *window = g.CurrentWindow;
+    if (window->DC.NavHideHighlightOneFrame)
+        return;
+
+    float rounding = (flags & ImGuiNavHighlightFlags_NoRounding) ? 0.0f : g.Style.FrameRounding;
+    ImRect display_rect = bb;
+    display_rect.ClipWith(window->ClipRect);
+    if (flags & ImGuiNavHighlightFlags_TypeDefault)
+    {
+        const float THICKNESS = 2.0f;
+        const float DISTANCE  = 3.0f + THICKNESS * 0.5f;
+        display_rect.Expand(ImVec2(DISTANCE, DISTANCE));
+        bool fully_visible = window->ClipRect.Contains(display_rect);
+        if (!fully_visible)
+            window->DrawList->PushClipRect(display_rect.Min, display_rect.Max);
+        window->DrawList->AddRect(display_rect.Min + ImVec2(THICKNESS * 0.5f, THICKNESS * 0.5f),
+                                  display_rect.Max - ImVec2(THICKNESS * 0.5f, THICKNESS * 0.5f),
+                                  GetColorU32(ImGuiCol_NavHighlight), rounding,
+                                  ImDrawCornerFlags_All, THICKNESS);
+        if (!fully_visible)
+            window->DrawList->PopClipRect();
+    }
+    if (flags & ImGuiNavHighlightFlags_TypeThin)
+    {
+        window->DrawList->AddRect(display_rect.Min, display_rect.Max,
+                                  GetColorU32(ImGuiCol_NavHighlight), rounding, ~0, 1.0f);
+    }
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] MAIN CODE (most of the code! lots of stuff, needs tidying up!)
+//-----------------------------------------------------------------------------
+
+// ImGuiWindow is mostly a dumb struct. It merely has a constructor and a few helper methods
+ImGuiWindow::ImGuiWindow(ImGuiContext *context, const char *name)
+    : DrawListInst(&context->DrawListSharedData)
+{
+    Name = ImStrdup(name);
+    ID   = ImHashStr(name);
+    IDStack.push_back(ID);
+    Flags = ImGuiWindowFlags_None;
+    Pos   = ImVec2(0.0f, 0.0f);
+    Size = SizeFull = ImVec2(0.0f, 0.0f);
+    ContentSize = ContentSizeExplicit = ImVec2(0.0f, 0.0f);
+    WindowPadding                     = ImVec2(0.0f, 0.0f);
+    WindowRounding                    = 0.0f;
+    WindowBorderSize                  = 0.0f;
+    NameBufLen                        = (int)strlen(name) + 1;
+    MoveId                            = GetID("#MOVE");
+    ChildId                           = 0;
+    Scroll                            = ImVec2(0.0f, 0.0f);
+    ScrollTarget                      = ImVec2(FLT_MAX, FLT_MAX);
+    ScrollTargetCenterRatio           = ImVec2(0.5f, 0.5f);
+    ScrollbarSizes                    = ImVec2(0.0f, 0.0f);
+    ScrollbarX = ScrollbarY = false;
+    Active = WasActive      = false;
+    WriteAccessed           = false;
+    Collapsed               = false;
+    WantCollapseToggle      = false;
+    SkipItems               = false;
+    Appearing               = false;
+    Hidden                  = false;
+    HasCloseButton          = false;
+    ResizeBorderHeld        = -1;
+    BeginCount              = 0;
+    BeginOrderWithinParent  = -1;
+    BeginOrderWithinContext = -1;
+    PopupId                 = 0;
+    AutoFitFramesX = AutoFitFramesY = -1;
+    AutoFitOnlyGrows                = false;
+    AutoFitChildAxises              = 0x00;
+    AutoPosLastDirection            = ImGuiDir_None;
+    HiddenFramesCanSkipItems = HiddenFramesCannotSkipItems = 0;
+    SetWindowPosAllowFlags = SetWindowSizeAllowFlags = SetWindowCollapsedAllowFlags =
+        ImGuiCond_Always | ImGuiCond_Once | ImGuiCond_FirstUseEver | ImGuiCond_Appearing;
+    SetWindowPosVal = SetWindowPosPivot = ImVec2(FLT_MAX, FLT_MAX);
+
+    LastFrameActive  = -1;
+    ItemWidthDefault = 0.0f;
+    FontWindowScale  = 1.0f;
+    SettingsIdx      = -1;
+
+    DrawList                       = &DrawListInst;
+    DrawList->_OwnerName           = Name;
+    ParentWindow                   = NULL;
+    RootWindow                     = NULL;
+    RootWindowForTitleBarHighlight = NULL;
+    RootWindowForNav               = NULL;
+
+    NavLastIds[0] = NavLastIds[1] = 0;
+    NavRectRel[0] = NavRectRel[1] = ImRect();
+    NavLastChildNavWindow         = NULL;
+}
+
+ImGuiWindow::~ImGuiWindow()
+{
+    IM_ASSERT(DrawList == &DrawListInst);
+    IM_DELETE(Name);
+    for (int i = 0; i != ColumnsStorage.Size; i++)
+        ColumnsStorage[i].~ImGuiColumns();
+}
+
+ImGuiID ImGuiWindow::GetID(const char *str, const char *str_end)
+{
+    ImGuiID seed = IDStack.back();
+    ImGuiID id   = ImHashStr(str, str_end ? (str_end - str) : 0, seed);
+    ImGui::KeepAliveID(id);
+    return id;
+}
+
+ImGuiID ImGuiWindow::GetID(const void *ptr)
+{
+    ImGuiID seed = IDStack.back();
+    ImGuiID id   = ImHashData(&ptr, sizeof(void *), seed);
+    ImGui::KeepAliveID(id);
+    return id;
+}
+
+ImGuiID ImGuiWindow::GetID(int n)
+{
+    ImGuiID seed = IDStack.back();
+    ImGuiID id   = ImHashData(&n, sizeof(n), seed);
+    ImGui::KeepAliveID(id);
+    return id;
+}
+
+ImGuiID ImGuiWindow::GetIDNoKeepAlive(const char *str, const char *str_end)
+{
+    ImGuiID seed = IDStack.back();
+    return ImHashStr(str, str_end ? (str_end - str) : 0, seed);
+}
+
+ImGuiID ImGuiWindow::GetIDNoKeepAlive(const void *ptr)
+{
+    ImGuiID seed = IDStack.back();
+    return ImHashData(&ptr, sizeof(void *), seed);
+}
+
+ImGuiID ImGuiWindow::GetIDNoKeepAlive(int n)
+{
+    ImGuiID seed = IDStack.back();
+    return ImHashData(&n, sizeof(n), seed);
+}
+
+// This is only used in rare/specific situations to manufacture an ID out of nowhere.
+ImGuiID ImGuiWindow::GetIDFromRectangle(const ImRect &r_abs)
+{
+    ImGuiID seed       = IDStack.back();
+    const int r_rel[4] = {(int)(r_abs.Min.x - Pos.x), (int)(r_abs.Min.y - Pos.y),
+                          (int)(r_abs.Max.x - Pos.x), (int)(r_abs.Max.y - Pos.y)};
+    ImGuiID id         = ImHashData(&r_rel, sizeof(r_rel), seed);
+    ImGui::KeepAliveID(id);
+    return id;
+}
+
+static void SetCurrentWindow(ImGuiWindow *window)
+{
+    ImGuiContext &g = *GImGui;
+    g.CurrentWindow = window;
+    if (window)
+        g.FontSize = g.DrawListSharedData.FontSize = window->CalcFontSize();
+}
+
+void ImGui::SetNavID(ImGuiID id, int nav_layer)
+{
+    ImGuiContext &g = *GImGui;
+    IM_ASSERT(g.NavWindow);
+    IM_ASSERT(nav_layer == 0 || nav_layer == 1);
+    g.NavId                            = id;
+    g.NavWindow->NavLastIds[nav_layer] = id;
+}
+
+void ImGui::SetNavIDWithRectRel(ImGuiID id, int nav_layer, const ImRect &rect_rel)
+{
+    ImGuiContext &g = *GImGui;
+    SetNavID(id, nav_layer);
+    g.NavWindow->NavRectRel[nav_layer] = rect_rel;
+    g.NavMousePosDirty                 = true;
+    g.NavDisableHighlight              = false;
+    g.NavDisableMouseHover             = true;
+}
+
+void ImGui::SetActiveID(ImGuiID id, ImGuiWindow *window)
+{
+    ImGuiContext &g           = *GImGui;
+    g.ActiveIdIsJustActivated = (g.ActiveId != id);
+    if (g.ActiveIdIsJustActivated)
+    {
+        g.ActiveIdTimer                = 0.0f;
+        g.ActiveIdHasBeenPressedBefore = false;
+        g.ActiveIdHasBeenEditedBefore  = false;
+        if (id != 0)
+        {
+            g.LastActiveId      = id;
+            g.LastActiveIdTimer = 0.0f;
+        }
+    }
+    g.ActiveId                       = id;
+    g.ActiveIdAllowNavDirFlags       = 0;
+    g.ActiveIdBlockNavInputFlags     = 0;
+    g.ActiveIdAllowOverlap           = false;
+    g.ActiveIdWindow                 = window;
+    g.ActiveIdHasBeenEditedThisFrame = false;
+    if (id)
+    {
+        g.ActiveIdIsAlive = id;
+        g.ActiveIdSource  = (g.NavActivateId == id || g.NavInputId == id ||
+                            g.NavJustTabbedId == id || g.NavJustMovedToId == id)
+                               ? ImGuiInputSource_Nav
+                               : ImGuiInputSource_Mouse;
+    }
+}
+
+// FIXME-NAV: The existence of SetNavID/SetNavIDWithRectRel/SetFocusID is incredibly messy and
+// confusing and needs some explanation or refactoring.
+void ImGui::SetFocusID(ImGuiID id, ImGuiWindow *window)
+{
+    ImGuiContext &g = *GImGui;
+    IM_ASSERT(id != 0);
+
+    // Assume that SetFocusID() is called in the context where its NavLayer is the current layer,
+    // which is the case everywhere we call it.
+    const ImGuiNavLayer nav_layer = window->DC.NavLayerCurrent;
+    if (g.NavWindow != window)
+        g.NavInitRequest = false;
+    g.NavId                       = id;
+    g.NavWindow                   = window;
+    g.NavLayer                    = nav_layer;
+    window->NavLastIds[nav_layer] = id;
+    if (window->DC.LastItemId == id)
+        window->NavRectRel[nav_layer] = ImRect(window->DC.LastItemRect.Min - window->Pos,
+                                               window->DC.LastItemRect.Max - window->Pos);
+
+    if (g.ActiveIdSource == ImGuiInputSource_Nav)
+        g.NavDisableMouseHover = true;
+    else
+        g.NavDisableHighlight = true;
+}
+
+void ImGui::ClearActiveID()
+{
+    SetActiveID(0, NULL);
+}
+
+void ImGui::SetHoveredID(ImGuiID id)
+{
+    ImGuiContext &g         = *GImGui;
+    g.HoveredId             = id;
+    g.HoveredIdAllowOverlap = false;
+    if (id != 0 && g.HoveredIdPreviousFrame != id)
+        g.HoveredIdTimer = g.HoveredIdNotActiveTimer = 0.0f;
+}
+
+ImGuiID ImGui::GetHoveredID()
+{
+    ImGuiContext &g = *GImGui;
+    return g.HoveredId ? g.HoveredId : g.HoveredIdPreviousFrame;
+}
+
+void ImGui::KeepAliveID(ImGuiID id)
+{
+    ImGuiContext &g = *GImGui;
+    if (g.ActiveId == id)
+        g.ActiveIdIsAlive = id;
+    if (g.ActiveIdPreviousFrame == id)
+        g.ActiveIdPreviousFrameIsAlive = true;
+}
+
+void ImGui::MarkItemEdited(ImGuiID id)
+{
+    // This marking is solely to be able to provide info for IsItemDeactivatedAfterEdit().
+    // ActiveId might have been released by the time we call this (as in the typical press/release
+    // button behavior) but still need need to fill the data.
+    ImGuiContext &g = *GImGui;
+    IM_ASSERT(g.ActiveId == id || g.ActiveId == 0 || g.DragDropActive);
+    IM_UNUSED(id);  // Avoid unused variable warnings when asserts are compiled out.
+    // IM_ASSERT(g.CurrentWindow->DC.LastItemId == id);
+    g.ActiveIdHasBeenEditedThisFrame = true;
+    g.ActiveIdHasBeenEditedBefore    = true;
+    g.CurrentWindow->DC.LastItemStatusFlags |= ImGuiItemStatusFlags_Edited;
+}
+
+static inline bool IsWindowContentHoverable(ImGuiWindow *window, ImGuiHoveredFlags flags)
+{
+    // An active popup disable hovering on other windows (apart from its own children)
+    // FIXME-OPT: This could be cached/stored within the window.
+    ImGuiContext &g = *GImGui;
+    if (g.NavWindow)
+        if (ImGuiWindow *focused_root_window = g.NavWindow->RootWindow)
+            if (focused_root_window->WasActive && focused_root_window != window->RootWindow)
+            {
+                // For the purpose of those flags we differentiate "standard popup" from "modal
+                // popup" NB: The order of those two tests is important because Modal windows are
+                // also Popups.
+                if (focused_root_window->Flags & ImGuiWindowFlags_Modal)
+                    return false;
+                if ((focused_root_window->Flags & ImGuiWindowFlags_Popup) &&
+                    !(flags & ImGuiHoveredFlags_AllowWhenBlockedByPopup))
+                    return false;
+            }
+
+    return true;
+}
+
+// Advance cursor given item size for layout.
+void ImGui::ItemSize(const ImVec2 &size, float text_offset_y)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+    if (window->SkipItems)
+        return;
+
+    // Always align ourselves on pixel boundaries
+    const float line_height      = ImMax(window->DC.CurrLineSize.y, size.y);
+    const float text_base_offset = ImMax(window->DC.CurrLineTextBaseOffset, text_offset_y);
+    // if (g.IO.KeyAlt) window->DrawList->AddRect(window->DC.CursorPos, window->DC.CursorPos +
+    // ImVec2(size.x, line_height), IM_COL32(255,0,0,200)); // [DEBUG]
+    window->DC.CursorPosPrevLine.x = window->DC.CursorPos.x + size.x;
+    window->DC.CursorPosPrevLine.y = window->DC.CursorPos.y;
+    window->DC.CursorPos.x =
+        (float)(int)(window->Pos.x + window->DC.Indent.x + window->DC.ColumnsOffset.x);
+    window->DC.CursorPos.y =
+        (float)(int)(window->DC.CursorPos.y + line_height + g.Style.ItemSpacing.y);
+    window->DC.CursorMaxPos.x = ImMax(window->DC.CursorMaxPos.x, window->DC.CursorPosPrevLine.x);
+    window->DC.CursorMaxPos.y =
+        ImMax(window->DC.CursorMaxPos.y, window->DC.CursorPos.y - g.Style.ItemSpacing.y);
+    // if (g.IO.KeyAlt) window->DrawList->AddCircle(window->DC.CursorMaxPos, 3.0f,
+    // IM_COL32(255,0,0,255), 4); // [DEBUG]
+
+    window->DC.PrevLineSize.y         = line_height;
+    window->DC.PrevLineTextBaseOffset = text_base_offset;
+    window->DC.CurrLineSize.y = window->DC.CurrLineTextBaseOffset = 0.0f;
+
+    // Horizontal layout mode
+    if (window->DC.LayoutType == ImGuiLayoutType_Horizontal)
+        SameLine();
+}
+
+void ImGui::ItemSize(const ImRect &bb, float text_offset_y)
+{
+    ItemSize(bb.GetSize(), text_offset_y);
+}
+
+// Declare item bounding box for clipping and interaction.
+// Note that the size can be different than the one provided to ItemSize(). Typically, widgets that
+// spread over available surface declare their minimum size requirement to ItemSize() and then use a
+// larger region for drawing/interaction, which is passed to ItemAdd().
+bool ImGui::ItemAdd(const ImRect &bb, ImGuiID id, const ImRect *nav_bb_arg)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+
+    if (id != 0)
+    {
+        // Navigation processing runs prior to clipping early-out
+        //  (a) So that NavInitRequest can be honored, for newly opened windows to select a default
+        //  widget (b) So that we can scroll up/down past clipped items. This adds a small O(N) cost
+        //  to regular navigation requests
+        //      unfortunately, but it is still limited to one window. It may not scale very well for
+        //      windows with ten of thousands of item, but at least NavMoveRequest is only set on
+        //      user interaction, aka maximum once a frame. We could early out with "if (is_clipped
+        //      && !g.NavInitRequest) return false;" but when we wouldn't be able to reach unclipped
+        //      widgets. This would work if user had explicit scrolling control (e.g. mapped on a
+        //      stick).
+        // We intentionally don't check if g.NavWindow != NULL because g.NavAnyRequest should only
+        // be set when it is non null. If we crash on a NULL g.NavWindow we need to fix the bug
+        // elsewhere.
+        window->DC.NavLayerActiveMaskNext |= window->DC.NavLayerCurrentMask;
+        if (g.NavId == id || g.NavAnyRequest)
+            if (g.NavWindow->RootWindowForNav == window->RootWindowForNav)
+                if (window == g.NavWindow ||
+                    ((window->Flags | g.NavWindow->Flags) & ImGuiWindowFlags_NavFlattened))
+                    NavProcessItem(window, nav_bb_arg ? *nav_bb_arg : bb, id);
+    }
+
+    window->DC.LastItemId          = id;
+    window->DC.LastItemRect        = bb;
+    window->DC.LastItemStatusFlags = ImGuiItemStatusFlags_None;
+    g.NextItemData.Flags           = ImGuiNextItemDataFlags_None;
+
+#ifdef IMGUI_ENABLE_TEST_ENGINE
+    if (id != 0)
+        IMGUI_TEST_ENGINE_ITEM_ADD(nav_bb_arg ? *nav_bb_arg : bb, id);
+#endif
+
+    // Clipping test
+    const bool is_clipped = IsClippedEx(bb, id, false);
+    if (is_clipped)
+        return false;
+    // if (g.IO.KeyAlt) window->DrawList->AddRect(bb.Min, bb.Max, IM_COL32(255,255,0,120)); //
+    // [DEBUG]
+
+    // We need to calculate this now to take account of the current clipping rectangle (as items
+    // like Selectable may change them)
+    if (IsMouseHoveringRect(bb.Min, bb.Max))
+        window->DC.LastItemStatusFlags |= ImGuiItemStatusFlags_HoveredRect;
+    return true;
+}
+
+// This is roughly matching the behavior of internal-facing ItemHoverable()
+// - we allow hovering to be true when ActiveId==window->MoveID, so that clicking on non-interactive
+// items such as a Text() item still returns true with IsItemHovered()
+// - this should work even for non-interactive items that have no ID, so we cannot use LastItemId
+bool ImGui::IsItemHovered(ImGuiHoveredFlags flags)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+    if (g.NavDisableMouseHover && !g.NavDisableHighlight)
+        return IsItemFocused();
+
+    // Test for bounding box overlap, as updated as ItemAdd()
+    if (!(window->DC.LastItemStatusFlags & ImGuiItemStatusFlags_HoveredRect))
+        return false;
+    IM_ASSERT((flags & (ImGuiHoveredFlags_RootWindow | ImGuiHoveredFlags_ChildWindows)) ==
+              0);  // Flags not supported by this function
+
+    // Test if we are hovering the right window (our window could be behind another window)
+    // [2017/10/16] Reverted commit 344d48be3 and testing RootWindow instead. I believe it is
+    // correct to NOT test for RootWindow but this leaves us unable to use IsItemHovered() after
+    // EndChild() itself. Until a solution is found I believe reverting to the test from 2017/09/27
+    // is safe since this was the test that has been running for a long while.
+    // if (g.HoveredWindow != window)
+    //    return false;
+    if (g.HoveredRootWindow != window->RootWindow &&
+        !(flags & ImGuiHoveredFlags_AllowWhenOverlapped))
+        return false;
+
+    // Test if another item is active (e.g. being dragged)
+    if (!(flags & ImGuiHoveredFlags_AllowWhenBlockedByActiveItem))
+        if (g.ActiveId != 0 && g.ActiveId != window->DC.LastItemId && !g.ActiveIdAllowOverlap &&
+            g.ActiveId != window->MoveId)
+            return false;
+
+    // Test if interactions on this window are blocked by an active popup or modal.
+    // The ImGuiHoveredFlags_AllowWhenBlockedByPopup flag will be tested here.
+    if (!IsWindowContentHoverable(window, flags))
+        return false;
+
+    // Test if the item is disabled
+    if ((window->DC.ItemFlags & ImGuiItemFlags_Disabled) &&
+        !(flags & ImGuiHoveredFlags_AllowWhenDisabled))
+        return false;
+
+    // Special handling for the dummy item after Begin() which represent the title bar or tab.
+    // When the window is collapsed (SkipItems==true) that last item will never be overwritten so we
+    // need to detect the case.
+    if (window->DC.LastItemId == window->MoveId && window->WriteAccessed)
+        return false;
+    return true;
+}
+
+// Internal facing ItemHoverable() used when submitting widgets. Differs slightly from
+// IsItemHovered().
+bool ImGui::ItemHoverable(const ImRect &bb, ImGuiID id)
+{
+    ImGuiContext &g = *GImGui;
+    if (g.HoveredId != 0 && g.HoveredId != id && !g.HoveredIdAllowOverlap)
+        return false;
+
+    ImGuiWindow *window = g.CurrentWindow;
+    if (g.HoveredWindow != window)
+        return false;
+    if (g.ActiveId != 0 && g.ActiveId != id && !g.ActiveIdAllowOverlap)
+        return false;
+    if (!IsMouseHoveringRect(bb.Min, bb.Max))
+        return false;
+    if (g.NavDisableMouseHover || !IsWindowContentHoverable(window, ImGuiHoveredFlags_None))
+        return false;
+    if (window->DC.ItemFlags & ImGuiItemFlags_Disabled)
+        return false;
+
+    SetHoveredID(id);
+    return true;
+}
+
+bool ImGui::IsClippedEx(const ImRect &bb, ImGuiID id, bool clip_even_when_logged)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+    if (!bb.Overlaps(window->ClipRect))
+        if (id == 0 || id != g.ActiveId)
+            if (clip_even_when_logged || !g.LogEnabled)
+                return true;
+    return false;
+}
+
+// Process TAB/Shift+TAB. Be mindful that this function may _clear_ the ActiveID when tabbing out.
+bool ImGui::FocusableItemRegister(ImGuiWindow *window, ImGuiID id)
+{
+    ImGuiContext &g = *GImGui;
+
+    // Increment counters
+    const bool is_tab_stop =
+        (window->DC.ItemFlags & (ImGuiItemFlags_NoTabStop | ImGuiItemFlags_Disabled)) == 0;
+    window->DC.FocusCounterAll++;
+    if (is_tab_stop)
+        window->DC.FocusCounterTab++;
+
+    // Process TAB/Shift-TAB to tab *OUT* of the currently focused item.
+    // (Note that we can always TAB out of a widget that doesn't allow tabbing in)
+    if (g.ActiveId == id && g.FocusTabPressed &&
+        !(g.ActiveIdBlockNavInputFlags & (1 << ImGuiNavInput_KeyTab_)) &&
+        g.FocusRequestNextWindow == NULL)
+    {
+        g.FocusRequestNextWindow = window;
+        g.FocusRequestNextCounterTab =
+            window->DC.FocusCounterTab +
+            (g.IO.KeyShift ? (is_tab_stop ? -1 : 0)
+                           : +1);  // Modulo on index will be applied at the end of frame once we've
+                                   // got the total counter of items.
+    }
+
+    // Handle focus requests
+    if (g.FocusRequestCurrWindow == window)
+    {
+        if (window->DC.FocusCounterAll == g.FocusRequestCurrCounterAll)
+            return true;
+        if (is_tab_stop && window->DC.FocusCounterTab == g.FocusRequestCurrCounterTab)
+        {
+            g.NavJustTabbedId = id;
+            return true;
+        }
+
+        // If another item is about to be focused, we clear our own active id
+        if (g.ActiveId == id)
+            ClearActiveID();
+    }
+
+    return false;
+}
+
+void ImGui::FocusableItemUnregister(ImGuiWindow *window)
+{
+    window->DC.FocusCounterAll--;
+    window->DC.FocusCounterTab--;
+}
+
+float ImGui::CalcWrapWidthForPos(const ImVec2 &pos, float wrap_pos_x)
+{
+    if (wrap_pos_x < 0.0f)
+        return 0.0f;
+
+    ImGuiWindow *window = GImGui->CurrentWindow;
+    if (wrap_pos_x == 0.0f)
+        wrap_pos_x = window->WorkRect.Max.x;
+    else if (wrap_pos_x > 0.0f)
+        wrap_pos_x +=
+            window->Pos.x - window->Scroll.x;  // wrap_pos_x is provided is window local space
+
+    return ImMax(wrap_pos_x - pos.x, 1.0f);
+}
+
+// IM_ALLOC() == ImGui::MemAlloc()
+void *ImGui::MemAlloc(size_t size)
+{
+    if (ImGuiContext *ctx = GImGui)
+        ctx->IO.MetricsActiveAllocations++;
+    return GImAllocatorAllocFunc(size, GImAllocatorUserData);
+}
+
+// IM_FREE() == ImGui::MemFree()
+void ImGui::MemFree(void *ptr)
+{
+    if (ptr)
+        if (ImGuiContext *ctx = GImGui)
+            ctx->IO.MetricsActiveAllocations--;
+    return GImAllocatorFreeFunc(ptr, GImAllocatorUserData);
+}
+
+const char *ImGui::GetClipboardText()
+{
+    return GImGui->IO.GetClipboardTextFn
+               ? GImGui->IO.GetClipboardTextFn(GImGui->IO.ClipboardUserData)
+               : "";
+}
+
+void ImGui::SetClipboardText(const char *text)
+{
+    if (GImGui->IO.SetClipboardTextFn)
+        GImGui->IO.SetClipboardTextFn(GImGui->IO.ClipboardUserData, text);
+}
+
+const char *ImGui::GetVersion()
+{
+    return IMGUI_VERSION;
+}
+
+// Internal state access - if you want to share Dear ImGui state between modules (e.g. DLL) or
+// allocate it yourself Note that we still point to some static data and members (such as
+// GFontAtlas), so the state instance you end up using will point to the static data within its
+// module
+ImGuiContext *ImGui::GetCurrentContext()
+{
+    return GImGui;
+}
+
+void ImGui::SetCurrentContext(ImGuiContext *ctx)
+{
+#ifdef IMGUI_SET_CURRENT_CONTEXT_FUNC
+    IMGUI_SET_CURRENT_CONTEXT_FUNC(
+        ctx);  // For custom thread-based hackery you may want to have control over this.
+#else
+    GImGui = ctx;
+#endif
+}
+
+// Helper function to verify ABI compatibility between caller code and compiled version of Dear
+// ImGui. Verify that the type sizes are matching between the calling file's compilation unit and
+// imgui.cpp's compilation unit If the user has inconsistent compilation settings, imgui
+// configuration #define, packing pragma, etc. your user code may see different structures than what
+// imgui.cpp sees, which is problematic. We usually require settings to be in imconfig.h to make
+// sure that they are accessible to all compilation units involved with Dear ImGui.
+bool ImGui::DebugCheckVersionAndDataLayout(const char *version,
+                                           size_t sz_io,
+                                           size_t sz_style,
+                                           size_t sz_vec2,
+                                           size_t sz_vec4,
+                                           size_t sz_vert,
+                                           size_t sz_idx)
+{
+    bool error = false;
+    if (strcmp(version, IMGUI_VERSION) != 0)
+    {
+        error = true;
+        IM_ASSERT(strcmp(version, IMGUI_VERSION) == 0 && "Mismatched version string!");
+    }
+    if (sz_io != sizeof(ImGuiIO))
+    {
+        error = true;
+        IM_ASSERT(sz_io == sizeof(ImGuiIO) && "Mismatched struct layout!");
+    }
+    if (sz_style != sizeof(ImGuiStyle))
+    {
+        error = true;
+        IM_ASSERT(sz_style == sizeof(ImGuiStyle) && "Mismatched struct layout!");
+    }
+    if (sz_vec2 != sizeof(ImVec2))
+    {
+        error = true;
+        IM_ASSERT(sz_vec2 == sizeof(ImVec2) && "Mismatched struct layout!");
+    }
+    if (sz_vec4 != sizeof(ImVec4))
+    {
+        error = true;
+        IM_ASSERT(sz_vec4 == sizeof(ImVec4) && "Mismatched struct layout!");
+    }
+    if (sz_vert != sizeof(ImDrawVert))
+    {
+        error = true;
+        IM_ASSERT(sz_vert == sizeof(ImDrawVert) && "Mismatched struct layout!");
+    }
+    if (sz_idx != sizeof(ImDrawIdx))
+    {
+        error = true;
+        IM_ASSERT(sz_idx == sizeof(ImDrawIdx) && "Mismatched struct layout!");
+    }
+    return !error;
+}
+
+void ImGui::SetAllocatorFunctions(void *(*alloc_func)(size_t sz, void *user_data),
+                                  void (*free_func)(void *ptr, void *user_data),
+                                  void *user_data)
+{
+    GImAllocatorAllocFunc = alloc_func;
+    GImAllocatorFreeFunc  = free_func;
+    GImAllocatorUserData  = user_data;
+}
+
+ImGuiContext *ImGui::CreateContext(ImFontAtlas *shared_font_atlas)
+{
+    ImGuiContext *ctx = IM_NEW(ImGuiContext)(shared_font_atlas);
+    if (GImGui == NULL)
+        SetCurrentContext(ctx);
+    Initialize(ctx);
+    return ctx;
+}
+
+void ImGui::DestroyContext(ImGuiContext *ctx)
+{
+    if (ctx == NULL)
+        ctx = GImGui;
+    Shutdown(ctx);
+    if (GImGui == ctx)
+        SetCurrentContext(NULL);
+    IM_DELETE(ctx);
+}
+
+ImGuiIO &ImGui::GetIO()
+{
+    IM_ASSERT(
+        GImGui != NULL &&
+        "No current context. Did you call ImGui::CreateContext() and ImGui::SetCurrentContext() ?");
+    return GImGui->IO;
+}
+
+ImGuiStyle &ImGui::GetStyle()
+{
+    IM_ASSERT(
+        GImGui != NULL &&
+        "No current context. Did you call ImGui::CreateContext() and ImGui::SetCurrentContext() ?");
+    return GImGui->Style;
+}
+
+// Same value as passed to the old io.RenderDrawListsFn function. Valid after Render() and until the
+// next call to NewFrame()
+ImDrawData *ImGui::GetDrawData()
+{
+    ImGuiContext &g = *GImGui;
+    return g.DrawData.Valid ? &g.DrawData : NULL;
+}
+
+double ImGui::GetTime()
+{
+    return GImGui->Time;
+}
+
+int ImGui::GetFrameCount()
+{
+    return GImGui->FrameCount;
+}
+
+ImDrawList *ImGui::GetBackgroundDrawList()
+{
+    return &GImGui->BackgroundDrawList;
+}
+
+static ImDrawList *GetForegroundDrawList(ImGuiWindow *)
+{
+    // This seemingly unnecessary wrapper simplifies compatibility between the 'master' and
+    // 'docking' branches.
+    return &GImGui->ForegroundDrawList;
+}
+
+ImDrawList *ImGui::GetForegroundDrawList()
+{
+    return &GImGui->ForegroundDrawList;
+}
+
+ImDrawListSharedData *ImGui::GetDrawListSharedData()
+{
+    return &GImGui->DrawListSharedData;
+}
+
+void ImGui::StartMouseMovingWindow(ImGuiWindow *window)
+{
+    // Set ActiveId even if the _NoMove flag is set. Without it, dragging away from a window with
+    // _NoMove would activate hover on other windows. We _also_ call this when clicking in a window
+    // empty space when io.ConfigWindowsMoveFromTitleBarOnly is set, but clear g.MovingWindow
+    // afterward. This is because we want ActiveId to be set even when the window is not permitted
+    // to move.
+    ImGuiContext &g = *GImGui;
+    FocusWindow(window);
+    SetActiveID(window->MoveId, window);
+    g.NavDisableHighlight = true;
+    g.ActiveIdClickOffset = g.IO.MousePos - window->RootWindow->Pos;
+
+    bool can_move_window = true;
+    if ((window->Flags & ImGuiWindowFlags_NoMove) ||
+        (window->RootWindow->Flags & ImGuiWindowFlags_NoMove))
+        can_move_window = false;
+    if (can_move_window)
+        g.MovingWindow = window;
+}
+
+// Handle mouse moving window
+// Note: moving window with the navigation keys (Square + d-pad / CTRL+TAB + Arrows) are processed
+// in NavUpdateWindowing()
+void ImGui::UpdateMouseMovingWindowNewFrame()
+{
+    ImGuiContext &g = *GImGui;
+    if (g.MovingWindow != NULL)
+    {
+        // We actually want to move the root window. g.MovingWindow == window we clicked on (could
+        // be a child window). We track it to preserve Focus and so that generally ActiveIdWindow ==
+        // MovingWindow and ActiveId == MovingWindow->MoveId for consistency.
+        KeepAliveID(g.ActiveId);
+        IM_ASSERT(g.MovingWindow && g.MovingWindow->RootWindow);
+        ImGuiWindow *moving_window = g.MovingWindow->RootWindow;
+        if (g.IO.MouseDown[0] && IsMousePosValid(&g.IO.MousePos))
+        {
+            ImVec2 pos = g.IO.MousePos - g.ActiveIdClickOffset;
+            if (moving_window->Pos.x != pos.x || moving_window->Pos.y != pos.y)
+            {
+                MarkIniSettingsDirty(moving_window);
+                SetWindowPos(moving_window, pos, ImGuiCond_Always);
+            }
+            FocusWindow(g.MovingWindow);
+        }
+        else
+        {
+            ClearActiveID();
+            g.MovingWindow = NULL;
+        }
+    }
+    else
+    {
+        // When clicking/dragging from a window that has the _NoMove flag, we still set the ActiveId
+        // in order to prevent hovering others.
+        if (g.ActiveIdWindow && g.ActiveIdWindow->MoveId == g.ActiveId)
+        {
+            KeepAliveID(g.ActiveId);
+            if (!g.IO.MouseDown[0])
+                ClearActiveID();
+        }
+    }
+}
+
+// Initiate moving window, handle left-click and right-click focus
+void ImGui::UpdateMouseMovingWindowEndFrame()
+{
+    // Initiate moving window
+    ImGuiContext &g = *GImGui;
+    if (g.ActiveId != 0 || g.HoveredId != 0)
+        return;
+
+    // Unless we just made a window/popup appear
+    if (g.NavWindow && g.NavWindow->Appearing)
+        return;
+
+    // Click to focus window and start moving (after we're done with all our widgets)
+    if (g.IO.MouseClicked[0])
+    {
+        if (g.HoveredRootWindow != NULL)
+        {
+            StartMouseMovingWindow(g.HoveredWindow);
+            if (g.IO.ConfigWindowsMoveFromTitleBarOnly &&
+                !(g.HoveredRootWindow->Flags & ImGuiWindowFlags_NoTitleBar))
+                if (!g.HoveredRootWindow->TitleBarRect().Contains(g.IO.MouseClickedPos[0]))
+                    g.MovingWindow = NULL;
+        }
+        else if (g.NavWindow != NULL && GetTopMostPopupModal() == NULL)
+        {
+            // Clicking on void disable focus
+            FocusWindow(NULL);
+        }
+    }
+
+    // With right mouse button we close popups without changing focus based on where the mouse is
+    // aimed Instead, focus will be restored to the window under the bottom-most closed popup. (The
+    // left mouse button path calls FocusWindow on the hovered window, which will lead
+    // NewFrame->ClosePopupsOverWindow to trigger)
+    if (g.IO.MouseClicked[1])
+    {
+        // Find the top-most window between HoveredWindow and the top-most Modal Window.
+        // This is where we can trim the popup stack.
+        ImGuiWindow *modal              = GetTopMostPopupModal();
+        bool hovered_window_above_modal = false;
+        if (modal == NULL)
+            hovered_window_above_modal = true;
+        for (int i = g.Windows.Size - 1; i >= 0 && hovered_window_above_modal == false; i--)
+        {
+            ImGuiWindow *window = g.Windows[i];
+            if (window == modal)
+                break;
+            if (window == g.HoveredWindow)
+                hovered_window_above_modal = true;
+        }
+        ClosePopupsOverWindow(hovered_window_above_modal ? g.HoveredWindow : modal, true);
+    }
+}
+
+static bool IsWindowActiveAndVisible(ImGuiWindow *window)
+{
+    return (window->Active) && (!window->Hidden);
+}
+
+static void ImGui::UpdateMouseInputs()
+{
+    ImGuiContext &g = *GImGui;
+
+    // Round mouse position to avoid spreading non-rounded position (e.g. UpdateManualResize doesn't
+    // support them well)
+    if (IsMousePosValid(&g.IO.MousePos))
+        g.IO.MousePos = g.LastValidMousePos = ImFloor(g.IO.MousePos);
+
+    // If mouse just appeared or disappeared (usually denoted by -FLT_MAX components) we cancel out
+    // movement in MouseDelta
+    if (IsMousePosValid(&g.IO.MousePos) && IsMousePosValid(&g.IO.MousePosPrev))
+        g.IO.MouseDelta = g.IO.MousePos - g.IO.MousePosPrev;
+    else
+        g.IO.MouseDelta = ImVec2(0.0f, 0.0f);
+    if (g.IO.MouseDelta.x != 0.0f || g.IO.MouseDelta.y != 0.0f)
+        g.NavDisableMouseHover = false;
+
+    g.IO.MousePosPrev = g.IO.MousePos;
+    for (int i = 0; i < IM_ARRAYSIZE(g.IO.MouseDown); i++)
+    {
+        g.IO.MouseClicked[i]          = g.IO.MouseDown[i] && g.IO.MouseDownDuration[i] < 0.0f;
+        g.IO.MouseReleased[i]         = !g.IO.MouseDown[i] && g.IO.MouseDownDuration[i] >= 0.0f;
+        g.IO.MouseDownDurationPrev[i] = g.IO.MouseDownDuration[i];
+        g.IO.MouseDownDuration[i] =
+            g.IO.MouseDown[i]
+                ? (g.IO.MouseDownDuration[i] < 0.0f ? 0.0f
+                                                    : g.IO.MouseDownDuration[i] + g.IO.DeltaTime)
+                : -1.0f;
+        g.IO.MouseDoubleClicked[i] = false;
+        if (g.IO.MouseClicked[i])
+        {
+            if ((float)(g.Time - g.IO.MouseClickedTime[i]) < g.IO.MouseDoubleClickTime)
+            {
+                ImVec2 delta_from_click_pos = IsMousePosValid(&g.IO.MousePos)
+                                                  ? (g.IO.MousePos - g.IO.MouseClickedPos[i])
+                                                  : ImVec2(0.0f, 0.0f);
+                if (ImLengthSqr(delta_from_click_pos) <
+                    g.IO.MouseDoubleClickMaxDist * g.IO.MouseDoubleClickMaxDist)
+                    g.IO.MouseDoubleClicked[i] = true;
+                g.IO.MouseClickedTime[i] =
+                    -FLT_MAX;  // so the third click isn't turned into a double-click
+            }
+            else
+            {
+                g.IO.MouseClickedTime[i] = g.Time;
+            }
+            g.IO.MouseClickedPos[i]         = g.IO.MousePos;
+            g.IO.MouseDownWasDoubleClick[i] = g.IO.MouseDoubleClicked[i];
+            g.IO.MouseDragMaxDistanceAbs[i] = ImVec2(0.0f, 0.0f);
+            g.IO.MouseDragMaxDistanceSqr[i] = 0.0f;
+        }
+        else if (g.IO.MouseDown[i])
+        {
+            // Maintain the maximum distance we reaching from the initial click position, which is
+            // used with dragging threshold
+            ImVec2 delta_from_click_pos = IsMousePosValid(&g.IO.MousePos)
+                                              ? (g.IO.MousePos - g.IO.MouseClickedPos[i])
+                                              : ImVec2(0.0f, 0.0f);
+            g.IO.MouseDragMaxDistanceSqr[i] =
+                ImMax(g.IO.MouseDragMaxDistanceSqr[i], ImLengthSqr(delta_from_click_pos));
+            g.IO.MouseDragMaxDistanceAbs[i].x = ImMax(
+                g.IO.MouseDragMaxDistanceAbs[i].x,
+                delta_from_click_pos.x < 0.0f ? -delta_from_click_pos.x : delta_from_click_pos.x);
+            g.IO.MouseDragMaxDistanceAbs[i].y = ImMax(
+                g.IO.MouseDragMaxDistanceAbs[i].y,
+                delta_from_click_pos.y < 0.0f ? -delta_from_click_pos.y : delta_from_click_pos.y);
+        }
+        if (!g.IO.MouseDown[i] && !g.IO.MouseReleased[i])
+            g.IO.MouseDownWasDoubleClick[i] = false;
+        if (g.IO.MouseClicked[i])  // Clicking any mouse button reactivate mouse hovering which may
+                                   // have been deactivated by gamepad/keyboard navigation
+            g.NavDisableMouseHover = false;
+    }
+}
+
+void ImGui::UpdateMouseWheel()
+{
+    ImGuiContext &g = *GImGui;
+    if (!g.HoveredWindow || g.HoveredWindow->Collapsed)
+        return;
+    if (g.IO.MouseWheel == 0.0f && g.IO.MouseWheelH == 0.0f)
+        return;
+    ImGuiWindow *window = g.HoveredWindow;
+
+    // Zoom / Scale window
+    // FIXME-OBSOLETE: This is an old feature, it still works but pretty much nobody is using it and
+    // may be best redesigned.
+    if (g.IO.MouseWheel != 0.0f && g.IO.KeyCtrl && g.IO.FontAllowUserScaling && !window->Collapsed)
+    {
+        const float new_font_scale =
+            ImClamp(window->FontWindowScale + g.IO.MouseWheel * 0.10f, 0.50f, 2.50f);
+        const float scale       = new_font_scale / window->FontWindowScale;
+        window->FontWindowScale = new_font_scale;
+        if (!(window->Flags & ImGuiWindowFlags_ChildWindow))
+        {
+            const ImVec2 offset =
+                window->Size * (1.0f - scale) * (g.IO.MousePos - window->Pos) / window->Size;
+            SetWindowPos(window, window->Pos + offset, 0);
+            window->Size     = ImFloor(window->Size * scale);
+            window->SizeFull = ImFloor(window->SizeFull * scale);
+        }
+        return;
+    }
+
+    // Mouse wheel scrolling
+    // If a child window has the ImGuiWindowFlags_NoScrollWithMouse flag, we give a chance to scroll
+    // its parent (unless either ImGuiWindowFlags_NoInputs or ImGuiWindowFlags_NoScrollbar are also
+    // set).
+    while ((window->Flags & ImGuiWindowFlags_ChildWindow) &&
+           (window->Flags & ImGuiWindowFlags_NoScrollWithMouse) &&
+           !(window->Flags & ImGuiWindowFlags_NoScrollbar) &&
+           !(window->Flags & ImGuiWindowFlags_NoMouseInputs) && window->ParentWindow)
+        window = window->ParentWindow;
+    const bool scroll_allowed = !(window->Flags & ImGuiWindowFlags_NoScrollWithMouse) &&
+                                !(window->Flags & ImGuiWindowFlags_NoMouseInputs);
+    if (scroll_allowed && (g.IO.MouseWheel != 0.0f || g.IO.MouseWheelH != 0.0f) && !g.IO.KeyCtrl)
+    {
+        ImVec2 max_step = window->InnerRect.GetSize() * 0.67f;
+
+        // Vertical Mouse Wheel Scrolling (hold Shift to scroll horizontally)
+        if (g.IO.MouseWheel != 0.0f && !g.IO.KeyShift)
+        {
+            float scroll_step = ImFloor(ImMin(5 * window->CalcFontSize(), max_step.y));
+            SetWindowScrollY(window, window->Scroll.y - g.IO.MouseWheel * scroll_step);
+        }
+        else if (g.IO.MouseWheel != 0.0f && g.IO.KeyShift)
+        {
+            float scroll_step = ImFloor(ImMin(2 * window->CalcFontSize(), max_step.x));
+            SetWindowScrollX(window, window->Scroll.x - g.IO.MouseWheel * scroll_step);
+        }
+
+        // Horizontal Mouse Wheel Scrolling (for hardware that supports it)
+        if (g.IO.MouseWheelH != 0.0f && !g.IO.KeyShift)
+        {
+            float scroll_step = ImFloor(ImMin(2 * window->CalcFontSize(), max_step.x));
+            SetWindowScrollX(window, window->Scroll.x - g.IO.MouseWheelH * scroll_step);
+        }
+    }
+}
+
+// The reason this is exposed in imgui_internal.h is: on touch-based system that don't have
+// hovering, we want to dispatch inputs to the right target (imgui vs imgui+app)
+void ImGui::UpdateHoveredWindowAndCaptureFlags()
+{
+    ImGuiContext &g = *GImGui;
+
+    // Find the window hovered by mouse:
+    // - Child windows can extend beyond the limit of their parent so we need to derive
+    // HoveredRootWindow from HoveredWindow.
+    // - When moving a window we can skip the search, which also conveniently bypasses the fact that
+    // window->WindowRectClipped is lagging as this point of the frame.
+    // - We also support the moved window toggling the NoInputs flag after moving has started in
+    // order to be able to detect windows below it, which is useful for e.g. docking mechanisms.
+    FindHoveredWindow();
+
+    // Modal windows prevents cursor from hovering behind them.
+    ImGuiWindow *modal_window = GetTopMostPopupModal();
+    if (modal_window)
+        if (g.HoveredRootWindow && !IsWindowChildOf(g.HoveredRootWindow, modal_window))
+            g.HoveredRootWindow = g.HoveredWindow = NULL;
+
+    // Disabled mouse?
+    if (g.IO.ConfigFlags & ImGuiConfigFlags_NoMouse)
+        g.HoveredWindow = g.HoveredRootWindow = NULL;
+
+    // We track click ownership. When clicked outside of a window the click is owned by the
+    // application and won't report hovering nor request capture even while dragging over our
+    // windows afterward.
+    int mouse_earliest_button_down = -1;
+    bool mouse_any_down            = false;
+    for (int i = 0; i < IM_ARRAYSIZE(g.IO.MouseDown); i++)
+    {
+        if (g.IO.MouseClicked[i])
+            g.IO.MouseDownOwned[i] = (g.HoveredWindow != NULL) || (!g.OpenPopupStack.empty());
+        mouse_any_down |= g.IO.MouseDown[i];
+        if (g.IO.MouseDown[i])
+            if (mouse_earliest_button_down == -1 ||
+                g.IO.MouseClickedTime[i] < g.IO.MouseClickedTime[mouse_earliest_button_down])
+                mouse_earliest_button_down = i;
+    }
+    const bool mouse_avail_to_imgui =
+        (mouse_earliest_button_down == -1) || g.IO.MouseDownOwned[mouse_earliest_button_down];
+
+    // If mouse was first clicked outside of ImGui bounds we also cancel out hovering.
+    // FIXME: For patterns of drag and drop across OS windows, we may need to rework/remove this
+    // test (first committed 311c0ca9 on 2015/02)
+    const bool mouse_dragging_extern_payload =
+        g.DragDropActive && (g.DragDropSourceFlags & ImGuiDragDropFlags_SourceExtern) != 0;
+    if (!mouse_avail_to_imgui && !mouse_dragging_extern_payload)
+        g.HoveredWindow = g.HoveredRootWindow = NULL;
+
+    // Update io.WantCaptureMouse for the user application (true = dispatch mouse info to imgui,
+    // false = dispatch mouse info to Dear ImGui + app)
+    if (g.WantCaptureMouseNextFrame != -1)
+        g.IO.WantCaptureMouse = (g.WantCaptureMouseNextFrame != 0);
+    else
+        g.IO.WantCaptureMouse =
+            (mouse_avail_to_imgui && (g.HoveredWindow != NULL || mouse_any_down)) ||
+            (!g.OpenPopupStack.empty());
+
+    // Update io.WantCaptureKeyboard for the user application (true = dispatch keyboard info to
+    // imgui, false = dispatch keyboard info to Dear ImGui + app)
+    if (g.WantCaptureKeyboardNextFrame != -1)
+        g.IO.WantCaptureKeyboard = (g.WantCaptureKeyboardNextFrame != 0);
+    else
+        g.IO.WantCaptureKeyboard = (g.ActiveId != 0) || (modal_window != NULL);
+    if (g.IO.NavActive && (g.IO.ConfigFlags & ImGuiConfigFlags_NavEnableKeyboard) &&
+        !(g.IO.ConfigFlags & ImGuiConfigFlags_NavNoCaptureKeyboard))
+        g.IO.WantCaptureKeyboard = true;
+
+    // Update io.WantTextInput flag, this is to allow systems without a keyboard (e.g. mobile,
+    // hand-held) to show a software keyboard if possible
+    g.IO.WantTextInput = (g.WantTextInputNextFrame != -1) ? (g.WantTextInputNextFrame != 0) : false;
+}
+
+void ImGui::NewFrame()
+{
+    IM_ASSERT(
+        GImGui != NULL &&
+        "No current context. Did you call ImGui::CreateContext() and ImGui::SetCurrentContext() ?");
+    ImGuiContext &g = *GImGui;
+
+#ifdef IMGUI_ENABLE_TEST_ENGINE
+    ImGuiTestEngineHook_PreNewFrame(&g);
+#endif
+
+    // Check user data
+    // (We pass an error message in the assert expression to make it visible to programmers who are
+    // not using a debugger, as most assert handlers display their argument)
+    IM_ASSERT(g.Initialized);
+    IM_ASSERT((g.IO.DeltaTime > 0.0f || g.FrameCount == 0) && "Need a positive DeltaTime!");
+    IM_ASSERT((g.FrameCount == 0 || g.FrameCountEnded == g.FrameCount) &&
+              "Forgot to call Render() or EndFrame() at the end of the previous frame?");
+    IM_ASSERT(g.IO.DisplaySize.x >= 0.0f && g.IO.DisplaySize.y >= 0.0f &&
+              "Invalid DisplaySize value!");
+    IM_ASSERT(g.IO.Fonts->Fonts.Size > 0 &&
+              "Font Atlas not built. Did you call io.Fonts->GetTexDataAsRGBA32() / "
+              "GetTexDataAsAlpha8() ?");
+    IM_ASSERT(g.IO.Fonts->Fonts[0]->IsLoaded() &&
+              "Font Atlas not built. Did you call io.Fonts->GetTexDataAsRGBA32() / "
+              "GetTexDataAsAlpha8() ?");
+    IM_ASSERT(g.Style.CurveTessellationTol > 0.0f && "Invalid style setting!");
+    IM_ASSERT(g.Style.Alpha >= 0.0f && g.Style.Alpha <= 1.0f &&
+              "Invalid style setting. Alpha cannot be negative (allows us to avoid a few clamps in "
+              "color computations)!");
+    IM_ASSERT(g.Style.WindowMinSize.x >= 1.0f && g.Style.WindowMinSize.y >= 1.0f &&
+              "Invalid style setting.");
+    IM_ASSERT(g.Style.WindowMenuButtonPosition == ImGuiDir_Left ||
+              g.Style.WindowMenuButtonPosition == ImGuiDir_Right);
+
+    for (int n = 0; n < ImGuiKey_COUNT; n++)
+        IM_ASSERT(g.IO.KeyMap[n] >= -1 && g.IO.KeyMap[n] < IM_ARRAYSIZE(g.IO.KeysDown) &&
+                  "io.KeyMap[] contains an out of bound value (need to be 0..512, or -1 for "
+                  "unmapped key)");
+
+    // Perform simple check: required key mapping (we intentionally do NOT check all keys to not
+    // pressure user into setting up everything, but Space is required and was only recently added
+    // in 1.60 WIP)
+    if (g.IO.ConfigFlags & ImGuiConfigFlags_NavEnableKeyboard)
+        IM_ASSERT(g.IO.KeyMap[ImGuiKey_Space] != -1 &&
+                  "ImGuiKey_Space is not mapped, required for keyboard navigation.");
+
+    // Perform simple check: the beta io.ConfigWindowsResizeFromEdges option requires back-end to
+    // honor mouse cursor changes and set the ImGuiBackendFlags_HasMouseCursors flag accordingly.
+    if (g.IO.ConfigWindowsResizeFromEdges &&
+        !(g.IO.BackendFlags & ImGuiBackendFlags_HasMouseCursors))
+        g.IO.ConfigWindowsResizeFromEdges = false;
+
+    // Load settings on first frame (if not explicitly loaded manually before)
+    if (!g.SettingsLoaded)
+    {
+        IM_ASSERT(g.SettingsWindows.empty());
+        if (g.IO.IniFilename)
+            LoadIniSettingsFromDisk(g.IO.IniFilename);
+        g.SettingsLoaded = true;
+    }
+
+    // Save settings (with a delay after the last modification, so we don't spam disk too much)
+    if (g.SettingsDirtyTimer > 0.0f)
+    {
+        g.SettingsDirtyTimer -= g.IO.DeltaTime;
+        if (g.SettingsDirtyTimer <= 0.0f)
+        {
+            if (g.IO.IniFilename != NULL)
+                SaveIniSettingsToDisk(g.IO.IniFilename);
+            else
+                g.IO.WantSaveIniSettings =
+                    true;  // Let user know they can call SaveIniSettingsToMemory(). user will need
+                           // to clear io.WantSaveIniSettings themselves.
+            g.SettingsDirtyTimer = 0.0f;
+        }
+    }
+
+    g.Time += g.IO.DeltaTime;
+    g.FrameScopeActive = true;
+    g.FrameCount += 1;
+    g.TooltipOverrideCount = 0;
+    g.WindowsActiveCount   = 0;
+
+    // Setup current font and draw list shared data
+    g.IO.Fonts->Locked = true;
+    SetCurrentFont(GetDefaultFont());
+    IM_ASSERT(g.Font->IsLoaded());
+    g.DrawListSharedData.ClipRectFullscreen =
+        ImVec4(0.0f, 0.0f, g.IO.DisplaySize.x, g.IO.DisplaySize.y);
+    g.DrawListSharedData.CurveTessellationTol = g.Style.CurveTessellationTol;
+    g.DrawListSharedData.InitialFlags         = ImDrawListFlags_None;
+    if (g.Style.AntiAliasedLines)
+        g.DrawListSharedData.InitialFlags |= ImDrawListFlags_AntiAliasedLines;
+    if (g.Style.AntiAliasedFill)
+        g.DrawListSharedData.InitialFlags |= ImDrawListFlags_AntiAliasedFill;
+    if (g.IO.BackendFlags & ImGuiBackendFlags_RendererHasVtxOffset)
+        g.DrawListSharedData.InitialFlags |= ImDrawListFlags_AllowVtxOffset;
+
+    g.BackgroundDrawList.Clear();
+    g.BackgroundDrawList.PushTextureID(g.IO.Fonts->TexID);
+    g.BackgroundDrawList.PushClipRectFullScreen();
+
+    g.ForegroundDrawList.Clear();
+    g.ForegroundDrawList.PushTextureID(g.IO.Fonts->TexID);
+    g.ForegroundDrawList.PushClipRectFullScreen();
+
+    // Mark rendering data as invalid to prevent user who may have a handle on it to use it.
+    g.DrawData.Clear();
+
+    // Drag and drop keep the source ID alive so even if the source disappear our state is
+    // consistent
+    if (g.DragDropActive && g.DragDropPayload.SourceId == g.ActiveId)
+        KeepAliveID(g.DragDropPayload.SourceId);
+
+    // Clear reference to active widget if the widget isn't alive anymore
+    if (!g.HoveredIdPreviousFrame)
+        g.HoveredIdTimer = 0.0f;
+    if (!g.HoveredIdPreviousFrame || (g.HoveredId && g.ActiveId == g.HoveredId))
+        g.HoveredIdNotActiveTimer = 0.0f;
+    if (g.HoveredId)
+        g.HoveredIdTimer += g.IO.DeltaTime;
+    if (g.HoveredId && g.ActiveId != g.HoveredId)
+        g.HoveredIdNotActiveTimer += g.IO.DeltaTime;
+    g.HoveredIdPreviousFrame = g.HoveredId;
+    g.HoveredId              = 0;
+    g.HoveredIdAllowOverlap  = false;
+    if (g.ActiveIdIsAlive != g.ActiveId && g.ActiveIdPreviousFrame == g.ActiveId && g.ActiveId != 0)
+        ClearActiveID();
+    if (g.ActiveId)
+        g.ActiveIdTimer += g.IO.DeltaTime;
+    g.LastActiveIdTimer += g.IO.DeltaTime;
+    g.ActiveIdPreviousFrame                    = g.ActiveId;
+    g.ActiveIdPreviousFrameWindow              = g.ActiveIdWindow;
+    g.ActiveIdPreviousFrameHasBeenEditedBefore = g.ActiveIdHasBeenEditedBefore;
+    g.ActiveIdIsAlive                          = 0;
+    g.ActiveIdHasBeenEditedThisFrame           = false;
+    g.ActiveIdPreviousFrameIsAlive             = false;
+    g.ActiveIdIsJustActivated                  = false;
+    if (g.TempInputTextId != 0 && g.ActiveId != g.TempInputTextId)
+        g.TempInputTextId = 0;
+
+    // Drag and drop
+    g.DragDropAcceptIdPrev            = g.DragDropAcceptIdCurr;
+    g.DragDropAcceptIdCurr            = 0;
+    g.DragDropAcceptIdCurrRectSurface = FLT_MAX;
+    g.DragDropWithinSourceOrTarget    = false;
+
+    // Update keyboard input state
+    memcpy(g.IO.KeysDownDurationPrev, g.IO.KeysDownDuration, sizeof(g.IO.KeysDownDuration));
+    for (int i = 0; i < IM_ARRAYSIZE(g.IO.KeysDown); i++)
+        g.IO.KeysDownDuration[i] =
+            g.IO.KeysDown[i]
+                ? (g.IO.KeysDownDuration[i] < 0.0f ? 0.0f
+                                                   : g.IO.KeysDownDuration[i] + g.IO.DeltaTime)
+                : -1.0f;
+
+    // Update gamepad/keyboard directional navigation
+    NavUpdate();
+
+    // Update mouse input state
+    UpdateMouseInputs();
+
+    // Calculate frame-rate for the user, as a purely luxurious feature
+    g.FramerateSecPerFrameAccum +=
+        g.IO.DeltaTime - g.FramerateSecPerFrame[g.FramerateSecPerFrameIdx];
+    g.FramerateSecPerFrame[g.FramerateSecPerFrameIdx] = g.IO.DeltaTime;
+    g.FramerateSecPerFrameIdx =
+        (g.FramerateSecPerFrameIdx + 1) % IM_ARRAYSIZE(g.FramerateSecPerFrame);
+    g.IO.Framerate =
+        (g.FramerateSecPerFrameAccum > 0.0f)
+            ? (1.0f / (g.FramerateSecPerFrameAccum / (float)IM_ARRAYSIZE(g.FramerateSecPerFrame)))
+            : FLT_MAX;
+
+    // Find hovered window
+    // (needs to be before UpdateMouseMovingWindowNewFrame so we fill
+    // g.HoveredWindowUnderMovingWindow on the mouse release frame)
+    UpdateHoveredWindowAndCaptureFlags();
+
+    // Handle user moving window with mouse (at the beginning of the frame to avoid input lag or
+    // sheering)
+    UpdateMouseMovingWindowNewFrame();
+
+    // Background darkening/whitening
+    if (GetTopMostPopupModal() != NULL ||
+        (g.NavWindowingTarget != NULL && g.NavWindowingHighlightAlpha > 0.0f))
+        g.DimBgRatio = ImMin(g.DimBgRatio + g.IO.DeltaTime * 6.0f, 1.0f);
+    else
+        g.DimBgRatio = ImMax(g.DimBgRatio - g.IO.DeltaTime * 10.0f, 0.0f);
+
+    g.MouseCursor               = ImGuiMouseCursor_Arrow;
+    g.WantCaptureMouseNextFrame = g.WantCaptureKeyboardNextFrame = g.WantTextInputNextFrame = -1;
+    g.PlatformImePos =
+        ImVec2(1.0f, 1.0f);  // OS Input Method Editor showing on top-left of our window by default
+
+    // Mouse wheel scrolling, scale
+    UpdateMouseWheel();
+
+    // Pressing TAB activate widget focus
+    g.FocusTabPressed = (g.NavWindow && g.NavWindow->Active &&
+                         !(g.NavWindow->Flags & ImGuiWindowFlags_NoNavInputs) && !g.IO.KeyCtrl &&
+                         IsKeyPressedMap(ImGuiKey_Tab));
+    if (g.ActiveId == 0 && g.FocusTabPressed)
+    {
+        // Note that SetKeyboardFocusHere() sets the Next fields mid-frame. To be consistent we also
+        // manipulate the Next fields even, even though they will be turned into Curr fields by the
+        // code below.
+        g.FocusRequestNextWindow     = g.NavWindow;
+        g.FocusRequestNextCounterAll = INT_MAX;
+        if (g.NavId != 0 && g.NavIdTabCounter != INT_MAX)
+            g.FocusRequestNextCounterTab = g.NavIdTabCounter + 1 + (g.IO.KeyShift ? -1 : 1);
+        else
+            g.FocusRequestNextCounterTab = g.IO.KeyShift ? -1 : 0;
+    }
+
+    // Turn queued focus request into current one
+    g.FocusRequestCurrWindow     = NULL;
+    g.FocusRequestCurrCounterAll = g.FocusRequestCurrCounterTab = INT_MAX;
+    if (g.FocusRequestNextWindow != NULL)
+    {
+        ImGuiWindow *window      = g.FocusRequestNextWindow;
+        g.FocusRequestCurrWindow = window;
+        if (g.FocusRequestNextCounterAll != INT_MAX && window->DC.FocusCounterAll != -1)
+            g.FocusRequestCurrCounterAll =
+                ImModPositive(g.FocusRequestNextCounterAll, window->DC.FocusCounterAll + 1);
+        if (g.FocusRequestNextCounterTab != INT_MAX && window->DC.FocusCounterTab != -1)
+            g.FocusRequestCurrCounterTab =
+                ImModPositive(g.FocusRequestNextCounterTab, window->DC.FocusCounterTab + 1);
+        g.FocusRequestNextWindow     = NULL;
+        g.FocusRequestNextCounterAll = g.FocusRequestNextCounterTab = INT_MAX;
+    }
+
+    g.NavIdTabCounter = INT_MAX;
+
+    // Mark all windows as not visible
+    IM_ASSERT(g.WindowsFocusOrder.Size == g.Windows.Size);
+    for (int i = 0; i != g.Windows.Size; i++)
+    {
+        ImGuiWindow *window   = g.Windows[i];
+        window->WasActive     = window->Active;
+        window->BeginCount    = 0;
+        window->Active        = false;
+        window->WriteAccessed = false;
+    }
+
+    // Closing the focused window restore focus to the first active root window in descending
+    // z-order
+    if (g.NavWindow && !g.NavWindow->WasActive)
+        FocusTopMostWindowUnderOne(NULL, NULL);
+
+    // No window should be open at the beginning of the frame.
+    // But in order to allow the user to call NewFrame() multiple times without calling Render(), we
+    // are doing an explicit clear.
+    g.CurrentWindowStack.resize(0);
+    g.BeginPopupStack.resize(0);
+    ClosePopupsOverWindow(g.NavWindow, false);
+
+    // Create implicit/fallback window - which we will only render it if the user has added
+    // something to it. We don't use "Debug" to avoid colliding with user trying to create a "Debug"
+    // window with custom flags. This fallback is particularly important as it avoid ImGui:: calls
+    // from crashing.
+    SetNextWindowSize(ImVec2(400, 400), ImGuiCond_FirstUseEver);
+    Begin("Debug##Default");
+    g.FrameScopePushedImplicitWindow = true;
+
+#ifdef IMGUI_ENABLE_TEST_ENGINE
+    ImGuiTestEngineHook_PostNewFrame(&g);
+#endif
+}
+
+void ImGui::Initialize(ImGuiContext *context)
+{
+    ImGuiContext &g = *context;
+    IM_ASSERT(!g.Initialized && !g.SettingsLoaded);
+
+    // Add .ini handle for ImGuiWindow type
+    ImGuiSettingsHandler ini_handler;
+    ini_handler.TypeName   = "Window";
+    ini_handler.TypeHash   = ImHashStr("Window");
+    ini_handler.ReadOpenFn = SettingsHandlerWindow_ReadOpen;
+    ini_handler.ReadLineFn = SettingsHandlerWindow_ReadLine;
+    ini_handler.WriteAllFn = SettingsHandlerWindow_WriteAll;
+    g.SettingsHandlers.push_back(ini_handler);
+
+    g.Initialized = true;
+}
+
+// This function is merely here to free heap allocations.
+void ImGui::Shutdown(ImGuiContext *context)
+{
+    // The fonts atlas can be used prior to calling NewFrame(), so we clear it even if g.Initialized
+    // is FALSE (which would happen if we never called NewFrame)
+    ImGuiContext &g = *context;
+    if (g.IO.Fonts && g.FontAtlasOwnedByContext)
+    {
+        g.IO.Fonts->Locked = false;
+        IM_DELETE(g.IO.Fonts);
+    }
+    g.IO.Fonts = NULL;
+
+    // Cleanup of other data are conditional on actually having initialized Dear ImGui.
+    if (!g.Initialized)
+        return;
+
+    // Save settings (unless we haven't attempted to load them: CreateContext/DestroyContext without
+    // a call to NewFrame shouldn't save an empty file)
+    if (g.SettingsLoaded && g.IO.IniFilename != NULL)
+    {
+        ImGuiContext *backup_context = GImGui;
+        SetCurrentContext(context);
+        SaveIniSettingsToDisk(g.IO.IniFilename);
+        SetCurrentContext(backup_context);
+    }
+
+    // Clear everything else
+    for (int i = 0; i < g.Windows.Size; i++)
+        IM_DELETE(g.Windows[i]);
+    g.Windows.clear();
+    g.WindowsFocusOrder.clear();
+    g.WindowsSortBuffer.clear();
+    g.CurrentWindow = NULL;
+    g.CurrentWindowStack.clear();
+    g.WindowsById.Clear();
+    g.NavWindow     = NULL;
+    g.HoveredWindow = g.HoveredRootWindow = NULL;
+    g.ActiveIdWindow = g.ActiveIdPreviousFrameWindow = NULL;
+    g.MovingWindow                                   = NULL;
+    g.ColorModifiers.clear();
+    g.StyleModifiers.clear();
+    g.FontStack.clear();
+    g.OpenPopupStack.clear();
+    g.BeginPopupStack.clear();
+    g.DrawDataBuilder.ClearFreeMemory();
+    g.BackgroundDrawList.ClearFreeMemory();
+    g.ForegroundDrawList.ClearFreeMemory();
+    g.PrivateClipboard.clear();
+    g.InputTextState.ClearFreeMemory();
+
+    for (int i = 0; i < g.SettingsWindows.Size; i++)
+        IM_DELETE(g.SettingsWindows[i].Name);
+    g.SettingsWindows.clear();
+    g.SettingsHandlers.clear();
+
+    if (g.LogFile && g.LogFile != stdout)
+    {
+        fclose(g.LogFile);
+        g.LogFile = NULL;
+    }
+    g.LogBuffer.clear();
+
+    g.Initialized = false;
+}
+
+// FIXME: Add a more explicit sort order in the window structure.
+static int IMGUI_CDECL ChildWindowComparer(const void *lhs, const void *rhs)
+{
+    const ImGuiWindow *const a = *(const ImGuiWindow *const *)lhs;
+    const ImGuiWindow *const b = *(const ImGuiWindow *const *)rhs;
+    if (int d = (a->Flags & ImGuiWindowFlags_Popup) - (b->Flags & ImGuiWindowFlags_Popup))
+        return d;
+    if (int d = (a->Flags & ImGuiWindowFlags_Tooltip) - (b->Flags & ImGuiWindowFlags_Tooltip))
+        return d;
+    return (a->BeginOrderWithinParent - b->BeginOrderWithinParent);
+}
+
+static void AddWindowToSortBuffer(ImVector<ImGuiWindow *> *out_sorted_windows, ImGuiWindow *window)
+{
+    out_sorted_windows->push_back(window);
+    if (window->Active)
+    {
+        int count = window->DC.ChildWindows.Size;
+        if (count > 1)
+            ImQsort(window->DC.ChildWindows.Data, (size_t)count, sizeof(ImGuiWindow *),
+                    ChildWindowComparer);
+        for (int i = 0; i < count; i++)
+        {
+            ImGuiWindow *child = window->DC.ChildWindows[i];
+            if (child->Active)
+                AddWindowToSortBuffer(out_sorted_windows, child);
+        }
+    }
+}
+
+static void AddDrawListToDrawData(ImVector<ImDrawList *> *out_list, ImDrawList *draw_list)
+{
+    if (draw_list->CmdBuffer.empty())
+        return;
+
+    // Remove trailing command if unused
+    ImDrawCmd &last_cmd = draw_list->CmdBuffer.back();
+    if (last_cmd.ElemCount == 0 && last_cmd.UserCallback == NULL)
+    {
+        draw_list->CmdBuffer.pop_back();
+        if (draw_list->CmdBuffer.empty())
+            return;
+    }
+
+    // Draw list sanity check. Detect mismatch between PrimReserve() calls and incrementing
+    // _VtxCurrentIdx, _VtxWritePtr etc. May trigger for you if you are using PrimXXX functions
+    // incorrectly.
+    IM_ASSERT(draw_list->VtxBuffer.Size == 0 ||
+              draw_list->_VtxWritePtr == draw_list->VtxBuffer.Data + draw_list->VtxBuffer.Size);
+    IM_ASSERT(draw_list->IdxBuffer.Size == 0 ||
+              draw_list->_IdxWritePtr == draw_list->IdxBuffer.Data + draw_list->IdxBuffer.Size);
+    if (!(draw_list->Flags & ImDrawListFlags_AllowVtxOffset))
+        IM_ASSERT((int)draw_list->_VtxCurrentIdx == draw_list->VtxBuffer.Size);
+
+    // Check that draw_list doesn't use more vertices than indexable (default ImDrawIdx = unsigned
+    // short = 2 bytes = 64K vertices per ImDrawList = per window) If this assert triggers because
+    // you are drawing lots of stuff manually:
+    // - First, make sure you are coarse clipping yourself and not trying to draw many things
+    // outside visible bounds.
+    //   Be mindful that the ImDrawList API doesn't filter vertices. Use the Metrics window to
+    //   inspect draw list contents.
+    // - If you want large meshes with more than 64K vertices, you can either:
+    //   (A) Handle the ImDrawCmd::VtxOffset value in your renderer back-end, and set
+    //   'io.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset'.
+    //       Most example back-ends already support this from 1.71. Pre-1.71 back-ends won't.
+    //       Some graphics API such as GL ES 1/2 don't have a way to offset the starting vertex so
+    //       it is not supported for them.
+    //   (B) Or handle 32-bits indices in your renderer back-end, and uncomment '#define ImDrawIdx
+    //   unsigned int' line in imconfig.h.
+    //       Most example back-ends already support this. For example, the OpenGL example code
+    //       detect index size at compile-time:
+    //         glDrawElements(GL_TRIANGLES, (GLsizei)pcmd->ElemCount, sizeof(ImDrawIdx) == 2 ?
+    //         GL_UNSIGNED_SHORT : GL_UNSIGNED_INT, idx_buffer_offset);
+    //       Your own engine or render API may use different parameters or function calls to specify
+    //       index sizes. 2 and 4 bytes indices are generally supported by most graphics API.
+    // - If for some reason neither of those solutions works for you, a workaround is to call
+    // BeginChild()/EndChild() before reaching
+    //   the 64K limit to split your draw commands in multiple draw lists.
+    if (sizeof(ImDrawIdx) == 2)
+        IM_ASSERT(draw_list->_VtxCurrentIdx < (1 << 16) &&
+                  "Too many vertices in ImDrawList using 16-bit indices. Read comment above");
+
+    out_list->push_back(draw_list);
+}
+
+static void AddWindowToDrawData(ImVector<ImDrawList *> *out_render_list, ImGuiWindow *window)
+{
+    ImGuiContext &g = *GImGui;
+    g.IO.MetricsRenderWindows++;
+    AddDrawListToDrawData(out_render_list, window->DrawList);
+    for (int i = 0; i < window->DC.ChildWindows.Size; i++)
+    {
+        ImGuiWindow *child = window->DC.ChildWindows[i];
+        if (IsWindowActiveAndVisible(child))  // clipped children may have been marked not active
+            AddWindowToDrawData(out_render_list, child);
+    }
+}
+
+// Layer is locked for the root window, however child windows may use a different viewport (e.g.
+// extruding menu)
+static void AddRootWindowToDrawData(ImGuiWindow *window)
+{
+    ImGuiContext &g = *GImGui;
+    if (window->Flags & ImGuiWindowFlags_Tooltip)
+        AddWindowToDrawData(&g.DrawDataBuilder.Layers[1], window);
+    else
+        AddWindowToDrawData(&g.DrawDataBuilder.Layers[0], window);
+}
+
+void ImDrawDataBuilder::FlattenIntoSingleLayer()
+{
+    int n    = Layers[0].Size;
+    int size = n;
+    for (int i = 1; i < IM_ARRAYSIZE(Layers); i++)
+        size += Layers[i].Size;
+    Layers[0].resize(size);
+    for (int layer_n = 1; layer_n < IM_ARRAYSIZE(Layers); layer_n++)
+    {
+        ImVector<ImDrawList *> &layer = Layers[layer_n];
+        if (layer.empty())
+            continue;
+        memcpy(&Layers[0][n], &layer[0], layer.Size * sizeof(ImDrawList *));
+        n += layer.Size;
+        layer.resize(0);
+    }
+}
+
+static void SetupDrawData(ImVector<ImDrawList *> *draw_lists, ImDrawData *draw_data)
+{
+    ImGuiIO &io              = ImGui::GetIO();
+    draw_data->Valid         = true;
+    draw_data->CmdLists      = (draw_lists->Size > 0) ? draw_lists->Data : NULL;
+    draw_data->CmdListsCount = draw_lists->Size;
+    draw_data->TotalVtxCount = draw_data->TotalIdxCount = 0;
+    draw_data->DisplayPos                               = ImVec2(0.0f, 0.0f);
+    draw_data->DisplaySize                              = io.DisplaySize;
+    draw_data->FramebufferScale                         = io.DisplayFramebufferScale;
+    for (int n = 0; n < draw_lists->Size; n++)
+    {
+        draw_data->TotalVtxCount += draw_lists->Data[n]->VtxBuffer.Size;
+        draw_data->TotalIdxCount += draw_lists->Data[n]->IdxBuffer.Size;
+    }
+}
+
+// When using this function it is sane to ensure that float are perfectly rounded to integer values,
+// to that e.g. (int)(max.x-min.x) in user's render produce correct result.
+void ImGui::PushClipRect(const ImVec2 &clip_rect_min,
+                         const ImVec2 &clip_rect_max,
+                         bool intersect_with_current_clip_rect)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    window->DrawList->PushClipRect(clip_rect_min, clip_rect_max, intersect_with_current_clip_rect);
+    window->ClipRect = window->DrawList->_ClipRectStack.back();
+}
+
+void ImGui::PopClipRect()
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    window->DrawList->PopClipRect();
+    window->ClipRect = window->DrawList->_ClipRectStack.back();
+}
+
+// This is normally called by Render(). You may want to call it directly if you want to avoid
+// calling Render() but the gain will be very minimal.
+void ImGui::EndFrame()
+{
+    ImGuiContext &g = *GImGui;
+    IM_ASSERT(g.Initialized);
+    if (g.FrameCountEnded == g.FrameCount)  // Don't process EndFrame() multiple times.
+        return;
+    IM_ASSERT(g.FrameScopeActive && "Forgot to call ImGui::NewFrame()?");
+
+    // Notify OS when our Input Method Editor cursor has moved (e.g. CJK inputs using Microsoft IME)
+    if (g.IO.ImeSetInputScreenPosFn &&
+        (g.PlatformImeLastPos.x == FLT_MAX ||
+         ImLengthSqr(g.PlatformImeLastPos - g.PlatformImePos) > 0.0001f))
+    {
+        g.IO.ImeSetInputScreenPosFn((int)g.PlatformImePos.x, (int)g.PlatformImePos.y);
+        g.PlatformImeLastPos = g.PlatformImePos;
+    }
+
+    // Report when there is a mismatch of Begin/BeginChild vs End/EndChild calls. Important:
+    // Remember that the Begin/BeginChild API requires you to always call End/EndChild even if
+    // Begin/BeginChild returns false! (this is unfortunately inconsistent with most other Begin*
+    // API).
+    if (g.CurrentWindowStack.Size != 1)
+    {
+        if (g.CurrentWindowStack.Size > 1)
+        {
+            IM_ASSERT(g.CurrentWindowStack.Size == 1 &&
+                      "Mismatched Begin/BeginChild vs End/EndChild calls: did you forget to call "
+                      "End/EndChild?");
+            while (g.CurrentWindowStack.Size > 1)  // FIXME-ERRORHANDLING
+                End();
+        }
+        else
+        {
+            IM_ASSERT(g.CurrentWindowStack.Size == 1 &&
+                      "Mismatched Begin/BeginChild vs End/EndChild calls: did you call "
+                      "End/EndChild too much?");
+        }
+    }
+
+    // Hide implicit/fallback "Debug" window if it hasn't been used
+    g.FrameScopePushedImplicitWindow = false;
+    if (g.CurrentWindow && !g.CurrentWindow->WriteAccessed)
+        g.CurrentWindow->Active = false;
+    End();
+
+    // Show CTRL+TAB list window
+    if (g.NavWindowingTarget)
+        NavUpdateWindowingList();
+
+    // Drag and Drop: Elapse payload (if delivered, or if source stops being submitted)
+    if (g.DragDropActive)
+    {
+        bool is_delivered = g.DragDropPayload.Delivery;
+        bool is_elapsed   = (g.DragDropPayload.DataFrameCount + 1 < g.FrameCount) &&
+                          ((g.DragDropSourceFlags & ImGuiDragDropFlags_SourceAutoExpirePayload) ||
+                           !IsMouseDown(g.DragDropMouseButton));
+        if (is_delivered || is_elapsed)
+            ClearDragDrop();
+    }
+
+    // Drag and Drop: Fallback for source tooltip. This is not ideal but better than nothing.
+    if (g.DragDropActive && g.DragDropSourceFrameCount < g.FrameCount)
+    {
+        g.DragDropWithinSourceOrTarget = true;
+        SetTooltip("...");
+        g.DragDropWithinSourceOrTarget = false;
+    }
+
+    // End frame
+    g.FrameScopeActive = false;
+    g.FrameCountEnded  = g.FrameCount;
+
+    // Initiate moving window + handle left-click and right-click focus
+    UpdateMouseMovingWindowEndFrame();
+
+    // Sort the window list so that all child windows are after their parent
+    // We cannot do that on FocusWindow() because childs may not exist yet
+    g.WindowsSortBuffer.resize(0);
+    g.WindowsSortBuffer.reserve(g.Windows.Size);
+    for (int i = 0; i != g.Windows.Size; i++)
+    {
+        ImGuiWindow *window = g.Windows[i];
+        if (window->Active &&
+            (window->Flags &
+             ImGuiWindowFlags_ChildWindow))  // if a child is active its parent will add it
+            continue;
+        AddWindowToSortBuffer(&g.WindowsSortBuffer, window);
+    }
+
+    // This usually assert if there is a mismatch between the ImGuiWindowFlags_ChildWindow /
+    // ParentWindow values and DC.ChildWindows[] in parents, aka we've done something wrong.
+    IM_ASSERT(g.Windows.Size == g.WindowsSortBuffer.Size);
+    g.Windows.swap(g.WindowsSortBuffer);
+    g.IO.MetricsActiveWindows = g.WindowsActiveCount;
+
+    // Unlock font atlas
+    g.IO.Fonts->Locked = false;
+
+    // Clear Input data for next frame
+    g.IO.MouseWheel = g.IO.MouseWheelH = 0.0f;
+    g.IO.InputQueueCharacters.resize(0);
+    memset(g.IO.NavInputs, 0, sizeof(g.IO.NavInputs));
+}
+
+void ImGui::Render()
+{
+    ImGuiContext &g = *GImGui;
+    IM_ASSERT(g.Initialized);
+
+    if (g.FrameCountEnded != g.FrameCount)
+        EndFrame();
+    g.FrameCountRendered = g.FrameCount;
+
+    // Gather ImDrawList to render (for each active window)
+    g.IO.MetricsRenderVertices = g.IO.MetricsRenderIndices = g.IO.MetricsRenderWindows = 0;
+    g.DrawDataBuilder.Clear();
+    if (!g.BackgroundDrawList.VtxBuffer.empty())
+        AddDrawListToDrawData(&g.DrawDataBuilder.Layers[0], &g.BackgroundDrawList);
+
+    ImGuiWindow *windows_to_render_top_most[2];
+    windows_to_render_top_most[0] =
+        (g.NavWindowingTarget &&
+         !(g.NavWindowingTarget->Flags & ImGuiWindowFlags_NoBringToFrontOnFocus))
+            ? g.NavWindowingTarget->RootWindow
+            : NULL;
+    windows_to_render_top_most[1] = g.NavWindowingTarget ? g.NavWindowingList : NULL;
+    for (int n = 0; n != g.Windows.Size; n++)
+    {
+        ImGuiWindow *window = g.Windows[n];
+        if (IsWindowActiveAndVisible(window) &&
+            (window->Flags & ImGuiWindowFlags_ChildWindow) == 0 &&
+            window != windows_to_render_top_most[0] && window != windows_to_render_top_most[1])
+            AddRootWindowToDrawData(window);
+    }
+    for (int n = 0; n < IM_ARRAYSIZE(windows_to_render_top_most); n++)
+        if (windows_to_render_top_most[n] &&
+            IsWindowActiveAndVisible(
+                windows_to_render_top_most[n]))  // NavWindowingTarget is always temporarily
+                                                 // displayed as the top-most window
+            AddRootWindowToDrawData(windows_to_render_top_most[n]);
+    g.DrawDataBuilder.FlattenIntoSingleLayer();
+
+    // Draw software mouse cursor if requested
+    if (g.IO.MouseDrawCursor)
+        RenderMouseCursor(&g.ForegroundDrawList, g.IO.MousePos, g.Style.MouseCursorScale,
+                          g.MouseCursor);
+
+    if (!g.ForegroundDrawList.VtxBuffer.empty())
+        AddDrawListToDrawData(&g.DrawDataBuilder.Layers[0], &g.ForegroundDrawList);
+
+    // Setup ImDrawData structure for end-user
+    SetupDrawData(&g.DrawDataBuilder.Layers[0], &g.DrawData);
+    g.IO.MetricsRenderVertices = g.DrawData.TotalVtxCount;
+    g.IO.MetricsRenderIndices  = g.DrawData.TotalIdxCount;
+
+    // (Legacy) Call the Render callback function. The current prefer way is to let the user
+    // retrieve GetDrawData() and call the render function themselves.
+#ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+    if (g.DrawData.CmdListsCount > 0 && g.IO.RenderDrawListsFn != NULL)
+        g.IO.RenderDrawListsFn(&g.DrawData);
+#endif
+}
+
+// Calculate text size. Text can be multi-line. Optionally ignore text after a ## marker.
+// CalcTextSize("") should return ImVec2(0.0f, GImGui->FontSize)
+ImVec2 ImGui::CalcTextSize(const char *text,
+                           const char *text_end,
+                           bool hide_text_after_double_hash,
+                           float wrap_width)
+{
+    ImGuiContext &g = *GImGui;
+
+    const char *text_display_end;
+    if (hide_text_after_double_hash)
+        text_display_end =
+            FindRenderedTextEnd(text, text_end);  // Hide anything after a '##' string
+    else
+        text_display_end = text_end;
+
+    ImFont *font          = g.Font;
+    const float font_size = g.FontSize;
+    if (text == text_display_end)
+        return ImVec2(0.0f, font_size);
+    ImVec2 text_size =
+        font->CalcTextSizeA(font_size, FLT_MAX, wrap_width, text, text_display_end, NULL);
+
+    // Round
+    text_size.x = (float)(int)(text_size.x + 0.95f);
+
+    return text_size;
+}
+
+// Find window given position, search front-to-back
+// FIXME: Note that we have an inconsequential lag here: OuterRectClipped is updated in Begin(), so
+// windows moved programatically with SetWindowPos() and not SetNextWindowPos() will have that
+// rectangle lagging by a frame at the time FindHoveredWindow() is called, aka before the next
+// Begin(). Moving window isn't affected.
+static void FindHoveredWindow()
+{
+    ImGuiContext &g = *GImGui;
+
+    ImGuiWindow *hovered_window = NULL;
+    if (g.MovingWindow && !(g.MovingWindow->Flags & ImGuiWindowFlags_NoMouseInputs))
+        hovered_window = g.MovingWindow;
+
+    ImVec2 padding_regular = g.Style.TouchExtraPadding;
+    ImVec2 padding_for_resize_from_edges =
+        g.IO.ConfigWindowsResizeFromEdges
+            ? ImMax(g.Style.TouchExtraPadding, ImVec2(WINDOWS_RESIZE_FROM_EDGES_HALF_THICKNESS,
+                                                      WINDOWS_RESIZE_FROM_EDGES_HALF_THICKNESS))
+            : padding_regular;
+    for (int i = g.Windows.Size - 1; i >= 0; i--)
+    {
+        ImGuiWindow *window = g.Windows[i];
+        if (!window->Active || window->Hidden)
+            continue;
+        if (window->Flags & ImGuiWindowFlags_NoMouseInputs)
+            continue;
+
+        // Using the clipped AABB, a child window will typically be clipped by its parent (not
+        // always)
+        ImRect bb(window->OuterRectClipped);
+        if (window->Flags & (ImGuiWindowFlags_ChildWindow | ImGuiWindowFlags_NoResize |
+                             ImGuiWindowFlags_AlwaysAutoResize))
+            bb.Expand(padding_regular);
+        else
+            bb.Expand(padding_for_resize_from_edges);
+        if (!bb.Contains(g.IO.MousePos))
+            continue;
+
+        // Those seemingly unnecessary extra tests are because the code here is a little different
+        // in viewport/docking branches.
+        if (hovered_window == NULL)
+            hovered_window = window;
+        if (hovered_window)
+            break;
+    }
+
+    g.HoveredWindow     = hovered_window;
+    g.HoveredRootWindow = g.HoveredWindow ? g.HoveredWindow->RootWindow : NULL;
+}
+
+// Test if mouse cursor is hovering given rectangle
+// NB- Rectangle is clipped by our current clip setting
+// NB- Expand the rectangle to be generous on imprecise inputs systems (g.Style.TouchExtraPadding)
+bool ImGui::IsMouseHoveringRect(const ImVec2 &r_min, const ImVec2 &r_max, bool clip)
+{
+    ImGuiContext &g = *GImGui;
+
+    // Clip
+    ImRect rect_clipped(r_min, r_max);
+    if (clip)
+        rect_clipped.ClipWith(g.CurrentWindow->ClipRect);
+
+    // Expand for touch input
+    const ImRect rect_for_touch(rect_clipped.Min - g.Style.TouchExtraPadding,
+                                rect_clipped.Max + g.Style.TouchExtraPadding);
+    if (!rect_for_touch.Contains(g.IO.MousePos))
+        return false;
+    return true;
+}
+
+int ImGui::GetKeyIndex(ImGuiKey imgui_key)
+{
+    IM_ASSERT(imgui_key >= 0 && imgui_key < ImGuiKey_COUNT);
+    return GImGui->IO.KeyMap[imgui_key];
+}
+
+// Note that imgui doesn't know the semantic of each entry of io.KeysDown[]. Use your own
+// indices/enums according to how your back-end/engine stored them into io.KeysDown[]!
+bool ImGui::IsKeyDown(int user_key_index)
+{
+    if (user_key_index < 0)
+        return false;
+    IM_ASSERT(user_key_index >= 0 && user_key_index < IM_ARRAYSIZE(GImGui->IO.KeysDown));
+    return GImGui->IO.KeysDown[user_key_index];
+}
+
+int ImGui::CalcTypematicPressedRepeatAmount(float t,
+                                            float t_prev,
+                                            float repeat_delay,
+                                            float repeat_rate)
+{
+    if (t == 0.0f)
+        return 1;
+    if (t <= repeat_delay || repeat_rate <= 0.0f)
+        return 0;
+    const int count =
+        (int)((t - repeat_delay) / repeat_rate) - (int)((t_prev - repeat_delay) / repeat_rate);
+    return (count > 0) ? count : 0;
+}
+
+int ImGui::GetKeyPressedAmount(int key_index, float repeat_delay, float repeat_rate)
+{
+    ImGuiContext &g = *GImGui;
+    if (key_index < 0)
+        return 0;
+    IM_ASSERT(key_index >= 0 && key_index < IM_ARRAYSIZE(g.IO.KeysDown));
+    const float t = g.IO.KeysDownDuration[key_index];
+    return CalcTypematicPressedRepeatAmount(t, t - g.IO.DeltaTime, repeat_delay, repeat_rate);
+}
+
+bool ImGui::IsKeyPressed(int user_key_index, bool repeat)
+{
+    ImGuiContext &g = *GImGui;
+    if (user_key_index < 0)
+        return false;
+    IM_ASSERT(user_key_index >= 0 && user_key_index < IM_ARRAYSIZE(g.IO.KeysDown));
+    const float t = g.IO.KeysDownDuration[user_key_index];
+    if (t == 0.0f)
+        return true;
+    if (repeat && t > g.IO.KeyRepeatDelay)
+        return GetKeyPressedAmount(user_key_index, g.IO.KeyRepeatDelay, g.IO.KeyRepeatRate) > 0;
+    return false;
+}
+
+bool ImGui::IsKeyReleased(int user_key_index)
+{
+    ImGuiContext &g = *GImGui;
+    if (user_key_index < 0)
+        return false;
+    IM_ASSERT(user_key_index >= 0 && user_key_index < IM_ARRAYSIZE(g.IO.KeysDown));
+    return g.IO.KeysDownDurationPrev[user_key_index] >= 0.0f && !g.IO.KeysDown[user_key_index];
+}
+
+bool ImGui::IsMouseDown(int button)
+{
+    ImGuiContext &g = *GImGui;
+    IM_ASSERT(button >= 0 && button < IM_ARRAYSIZE(g.IO.MouseDown));
+    return g.IO.MouseDown[button];
+}
+
+bool ImGui::IsAnyMouseDown()
+{
+    ImGuiContext &g = *GImGui;
+    for (int n = 0; n < IM_ARRAYSIZE(g.IO.MouseDown); n++)
+        if (g.IO.MouseDown[n])
+            return true;
+    return false;
+}
+
+bool ImGui::IsMouseClicked(int button, bool repeat)
+{
+    ImGuiContext &g = *GImGui;
+    IM_ASSERT(button >= 0 && button < IM_ARRAYSIZE(g.IO.MouseDown));
+    const float t = g.IO.MouseDownDuration[button];
+    if (t == 0.0f)
+        return true;
+
+    if (repeat && t > g.IO.KeyRepeatDelay)
+    {
+        // FIXME: 2019/05/03: Our old repeat code was wrong here and led to doubling the repeat
+        // rate, which made it an ok rate for repeat on mouse hold.
+        int amount = CalcTypematicPressedRepeatAmount(t, t - g.IO.DeltaTime, g.IO.KeyRepeatDelay,
+                                                      g.IO.KeyRepeatRate * 0.5f);
+        if (amount > 0)
+            return true;
+    }
+
+    return false;
+}
+
+bool ImGui::IsMouseReleased(int button)
+{
+    ImGuiContext &g = *GImGui;
+    IM_ASSERT(button >= 0 && button < IM_ARRAYSIZE(g.IO.MouseDown));
+    return g.IO.MouseReleased[button];
+}
+
+bool ImGui::IsMouseDoubleClicked(int button)
+{
+    ImGuiContext &g = *GImGui;
+    IM_ASSERT(button >= 0 && button < IM_ARRAYSIZE(g.IO.MouseDown));
+    return g.IO.MouseDoubleClicked[button];
+}
+
+bool ImGui::IsMouseDragging(int button, float lock_threshold)
+{
+    ImGuiContext &g = *GImGui;
+    IM_ASSERT(button >= 0 && button < IM_ARRAYSIZE(g.IO.MouseDown));
+    if (!g.IO.MouseDown[button])
+        return false;
+    if (lock_threshold < 0.0f)
+        lock_threshold = g.IO.MouseDragThreshold;
+    return g.IO.MouseDragMaxDistanceSqr[button] >= lock_threshold * lock_threshold;
+}
+
+ImVec2 ImGui::GetMousePos()
+{
+    return GImGui->IO.MousePos;
+}
+
+// NB: prefer to call right after BeginPopup(). At the time Selectable/MenuItem is activated, the
+// popup is already closed!
+ImVec2 ImGui::GetMousePosOnOpeningCurrentPopup()
+{
+    ImGuiContext &g = *GImGui;
+    if (g.BeginPopupStack.Size > 0)
+        return g.OpenPopupStack[g.BeginPopupStack.Size - 1].OpenMousePos;
+    return g.IO.MousePos;
+}
+
+// We typically use ImVec2(-FLT_MAX,-FLT_MAX) to denote an invalid mouse position.
+bool ImGui::IsMousePosValid(const ImVec2 *mouse_pos)
+{
+    // The assert is only to silence a false-positive in XCode Static Analysis.
+    // Because GImGui is not dereferenced in every code path, the static analyzer assume that it may
+    // be NULL (which it doesn't for other functions).
+    IM_ASSERT(GImGui != NULL);
+    const float MOUSE_INVALID = -256000.0f;
+    ImVec2 p                  = mouse_pos ? *mouse_pos : GImGui->IO.MousePos;
+    return p.x >= MOUSE_INVALID && p.y >= MOUSE_INVALID;
+}
+
+// Return the delta from the initial clicking position while the mouse button is clicked or was just
+// released. This is locked and return 0.0f until the mouse moves past a distance threshold at least
+// once. NB: This is only valid if IsMousePosValid(). Back-ends in theory should always keep mouse
+// position valid when dragging even outside the client window.
+ImVec2 ImGui::GetMouseDragDelta(int button, float lock_threshold)
+{
+    ImGuiContext &g = *GImGui;
+    IM_ASSERT(button >= 0 && button < IM_ARRAYSIZE(g.IO.MouseDown));
+    if (lock_threshold < 0.0f)
+        lock_threshold = g.IO.MouseDragThreshold;
+    if (g.IO.MouseDown[button] || g.IO.MouseReleased[button])
+        if (g.IO.MouseDragMaxDistanceSqr[button] >= lock_threshold * lock_threshold)
+            if (IsMousePosValid(&g.IO.MousePos) && IsMousePosValid(&g.IO.MouseClickedPos[button]))
+                return g.IO.MousePos - g.IO.MouseClickedPos[button];
+    return ImVec2(0.0f, 0.0f);
+}
+
+void ImGui::ResetMouseDragDelta(int button)
+{
+    ImGuiContext &g = *GImGui;
+    IM_ASSERT(button >= 0 && button < IM_ARRAYSIZE(g.IO.MouseDown));
+    // NB: We don't need to reset g.IO.MouseDragMaxDistanceSqr
+    g.IO.MouseClickedPos[button] = g.IO.MousePos;
+}
+
+ImGuiMouseCursor ImGui::GetMouseCursor()
+{
+    return GImGui->MouseCursor;
+}
+
+void ImGui::SetMouseCursor(ImGuiMouseCursor cursor_type)
+{
+    GImGui->MouseCursor = cursor_type;
+}
+
+void ImGui::CaptureKeyboardFromApp(bool capture)
+{
+    GImGui->WantCaptureKeyboardNextFrame = capture ? 1 : 0;
+}
+
+void ImGui::CaptureMouseFromApp(bool capture)
+{
+    GImGui->WantCaptureMouseNextFrame = capture ? 1 : 0;
+}
+
+bool ImGui::IsItemActive()
+{
+    ImGuiContext &g = *GImGui;
+    if (g.ActiveId)
+    {
+        ImGuiWindow *window = g.CurrentWindow;
+        return g.ActiveId == window->DC.LastItemId;
+    }
+    return false;
+}
+
+bool ImGui::IsItemActivated()
+{
+    ImGuiContext &g = *GImGui;
+    if (g.ActiveId)
+    {
+        ImGuiWindow *window = g.CurrentWindow;
+        if (g.ActiveId == window->DC.LastItemId && g.ActiveIdPreviousFrame != window->DC.LastItemId)
+            return true;
+    }
+    return false;
+}
+
+bool ImGui::IsItemDeactivated()
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+    if (window->DC.LastItemStatusFlags & ImGuiItemStatusFlags_HasDeactivated)
+        return (window->DC.LastItemStatusFlags & ImGuiItemStatusFlags_Deactivated) != 0;
+    return (g.ActiveIdPreviousFrame == window->DC.LastItemId && g.ActiveIdPreviousFrame != 0 &&
+            g.ActiveId != window->DC.LastItemId);
+}
+
+bool ImGui::IsItemDeactivatedAfterEdit()
+{
+    ImGuiContext &g = *GImGui;
+    return IsItemDeactivated() && (g.ActiveIdPreviousFrameHasBeenEditedBefore ||
+                                   (g.ActiveId == 0 && g.ActiveIdHasBeenEditedBefore));
+}
+
+bool ImGui::IsItemFocused()
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+
+    if (g.NavId == 0 || g.NavDisableHighlight || g.NavId != window->DC.LastItemId)
+        return false;
+    return true;
+}
+
+bool ImGui::IsItemClicked(int mouse_button)
+{
+    return IsMouseClicked(mouse_button) && IsItemHovered(ImGuiHoveredFlags_None);
+}
+
+bool ImGui::IsItemToggledSelection()
+{
+    ImGuiContext &g = *GImGui;
+    return (g.CurrentWindow->DC.LastItemStatusFlags & ImGuiItemStatusFlags_ToggledSelection)
+               ? true
+               : false;
+}
+
+bool ImGui::IsAnyItemHovered()
+{
+    ImGuiContext &g = *GImGui;
+    return g.HoveredId != 0 || g.HoveredIdPreviousFrame != 0;
+}
+
+bool ImGui::IsAnyItemActive()
+{
+    ImGuiContext &g = *GImGui;
+    return g.ActiveId != 0;
+}
+
+bool ImGui::IsAnyItemFocused()
+{
+    ImGuiContext &g = *GImGui;
+    return g.NavId != 0 && !g.NavDisableHighlight;
+}
+
+bool ImGui::IsItemVisible()
+{
+    ImGuiWindow *window = GetCurrentWindowRead();
+    return window->ClipRect.Overlaps(window->DC.LastItemRect);
+}
+
+bool ImGui::IsItemEdited()
+{
+    ImGuiWindow *window = GetCurrentWindowRead();
+    return (window->DC.LastItemStatusFlags & ImGuiItemStatusFlags_Edited) != 0;
+}
+
+// Allow last item to be overlapped by a subsequent item. Both may be activated during the same
+// frame before the later one takes priority.
+void ImGui::SetItemAllowOverlap()
+{
+    ImGuiContext &g = *GImGui;
+    if (g.HoveredId == g.CurrentWindow->DC.LastItemId)
+        g.HoveredIdAllowOverlap = true;
+    if (g.ActiveId == g.CurrentWindow->DC.LastItemId)
+        g.ActiveIdAllowOverlap = true;
+}
+
+ImVec2 ImGui::GetItemRectMin()
+{
+    ImGuiWindow *window = GetCurrentWindowRead();
+    return window->DC.LastItemRect.Min;
+}
+
+ImVec2 ImGui::GetItemRectMax()
+{
+    ImGuiWindow *window = GetCurrentWindowRead();
+    return window->DC.LastItemRect.Max;
+}
+
+ImVec2 ImGui::GetItemRectSize()
+{
+    ImGuiWindow *window = GetCurrentWindowRead();
+    return window->DC.LastItemRect.GetSize();
+}
+
+static ImRect GetViewportRect()
+{
+    ImGuiContext &g = *GImGui;
+    return ImRect(0.0f, 0.0f, g.IO.DisplaySize.x, g.IO.DisplaySize.y);
+}
+
+static bool ImGui::BeginChildEx(const char *name,
+                                ImGuiID id,
+                                const ImVec2 &size_arg,
+                                bool border,
+                                ImGuiWindowFlags flags)
+{
+    ImGuiContext &g            = *GImGui;
+    ImGuiWindow *parent_window = g.CurrentWindow;
+
+    flags |= ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize |
+             ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_ChildWindow;
+    flags |= (parent_window->Flags & ImGuiWindowFlags_NoMove);  // Inherit the NoMove flag
+
+    // Size
+    const ImVec2 content_avail = GetContentRegionAvail();
+    ImVec2 size                = ImFloor(size_arg);
+    const int auto_fit_axises  = ((size.x == 0.0f) ? (1 << ImGuiAxis_X) : 0x00) |
+                                ((size.y == 0.0f) ? (1 << ImGuiAxis_Y) : 0x00);
+    if (size.x <= 0.0f)
+        size.x = ImMax(content_avail.x + size.x,
+                       4.0f);  // Arbitrary minimum child size (0.0f causing too much issues)
+    if (size.y <= 0.0f)
+        size.y = ImMax(content_avail.y + size.y, 4.0f);
+    SetNextWindowSize(size);
+
+    // Build up name. If you need to append to a same child from multiple location in the ID stack,
+    // use BeginChild(ImGuiID id) with a stable value.
+    char title[256];
+    if (name)
+        ImFormatString(title, IM_ARRAYSIZE(title), "%s/%s_%08X", parent_window->Name, name, id);
+    else
+        ImFormatString(title, IM_ARRAYSIZE(title), "%s/%08X", parent_window->Name, id);
+
+    const float backup_border_size = g.Style.ChildBorderSize;
+    if (!border)
+        g.Style.ChildBorderSize = 0.0f;
+    bool ret                = Begin(title, NULL, flags);
+    g.Style.ChildBorderSize = backup_border_size;
+
+    ImGuiWindow *child_window        = g.CurrentWindow;
+    child_window->ChildId            = id;
+    child_window->AutoFitChildAxises = auto_fit_axises;
+
+    // Set the cursor to handle case where the user called SetNextWindowPos()+BeginChild() manually.
+    // While this is not really documented/defined, it seems that the expected thing to do.
+    if (child_window->BeginCount == 1)
+        parent_window->DC.CursorPos = child_window->Pos;
+
+    // Process navigation-in immediately so NavInit can run on first frame
+    if (g.NavActivateId == id && !(flags & ImGuiWindowFlags_NavFlattened) &&
+        (child_window->DC.NavLayerActiveMask != 0 || child_window->DC.NavHasScroll))
+    {
+        FocusWindow(child_window);
+        NavInitWindow(child_window, false);
+        SetActiveID(id + 1, child_window);  // Steal ActiveId with a dummy id so that key-press
+                                            // won't activate child item
+        g.ActiveIdSource = ImGuiInputSource_Nav;
+    }
+    return ret;
+}
+
+bool ImGui::BeginChild(const char *str_id,
+                       const ImVec2 &size_arg,
+                       bool border,
+                       ImGuiWindowFlags extra_flags)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    return BeginChildEx(str_id, window->GetID(str_id), size_arg, border, extra_flags);
+}
+
+bool ImGui::BeginChild(ImGuiID id,
+                       const ImVec2 &size_arg,
+                       bool border,
+                       ImGuiWindowFlags extra_flags)
+{
+    IM_ASSERT(id != 0);
+    return BeginChildEx(NULL, id, size_arg, border, extra_flags);
+}
+
+void ImGui::EndChild()
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+
+    IM_ASSERT(window->Flags &
+              ImGuiWindowFlags_ChildWindow);  // Mismatched BeginChild()/EndChild() callss
+    if (window->BeginCount > 1)
+    {
+        End();
+    }
+    else
+    {
+        ImVec2 sz = window->Size;
+        if (window->AutoFitChildAxises &
+            (1 << ImGuiAxis_X))  // Arbitrary minimum zero-ish child size of 4.0f causes less
+                                 // trouble than a 0.0f
+            sz.x = ImMax(4.0f, sz.x);
+        if (window->AutoFitChildAxises & (1 << ImGuiAxis_Y))
+            sz.y = ImMax(4.0f, sz.y);
+        End();
+
+        ImGuiWindow *parent_window = g.CurrentWindow;
+        ImRect bb(parent_window->DC.CursorPos, parent_window->DC.CursorPos + sz);
+        ItemSize(sz);
+        if ((window->DC.NavLayerActiveMask != 0 || window->DC.NavHasScroll) &&
+            !(window->Flags & ImGuiWindowFlags_NavFlattened))
+        {
+            ItemAdd(bb, window->ChildId);
+            RenderNavHighlight(bb, window->ChildId);
+
+            // When browsing a window that has no activable items (scroll only) we keep a highlight
+            // on the child
+            if (window->DC.NavLayerActiveMask == 0 && window == g.NavWindow)
+                RenderNavHighlight(ImRect(bb.Min - ImVec2(2, 2), bb.Max + ImVec2(2, 2)), g.NavId,
+                                   ImGuiNavHighlightFlags_TypeThin);
+        }
+        else
+        {
+            // Not navigable into
+            ItemAdd(bb, 0);
+        }
+    }
+}
+
+// Helper to create a child window / scrolling region that looks like a normal widget frame.
+bool ImGui::BeginChildFrame(ImGuiID id, const ImVec2 &size, ImGuiWindowFlags extra_flags)
+{
+    ImGuiContext &g         = *GImGui;
+    const ImGuiStyle &style = g.Style;
+    PushStyleColor(ImGuiCol_ChildBg, style.Colors[ImGuiCol_FrameBg]);
+    PushStyleVar(ImGuiStyleVar_ChildRounding, style.FrameRounding);
+    PushStyleVar(ImGuiStyleVar_ChildBorderSize, style.FrameBorderSize);
+    PushStyleVar(ImGuiStyleVar_WindowPadding, style.FramePadding);
+    bool ret =
+        BeginChild(id, size, true,
+                   ImGuiWindowFlags_NoMove | ImGuiWindowFlags_AlwaysUseWindowPadding | extra_flags);
+    PopStyleVar(3);
+    PopStyleColor();
+    return ret;
+}
+
+void ImGui::EndChildFrame()
+{
+    EndChild();
+}
+
+// Save and compare stack sizes on Begin()/End() to detect usage errors
+static void CheckStacksSize(ImGuiWindow *window, bool write)
+{
+    // NOT checking: DC.ItemWidth, DC.AllowKeyboardFocus, DC.ButtonRepeat, DC.TextWrapPos (per
+    // window) to allow user to conveniently push once and not pop (they are cleared on Begin)
+    ImGuiContext &g = *GImGui;
+    short *p_backup = &window->DC.StackSizesBackup[0];
+    {
+        int current = window->IDStack.Size;
+        if (write)
+            *p_backup = (short)current;
+        else
+            IM_ASSERT(*p_backup == current && "PushID/PopID or TreeNode/TreePop Mismatch!");
+        p_backup++;
+    }  // Too few or too many PopID()/TreePop()
+    {
+        int current = window->DC.GroupStack.Size;
+        if (write)
+            *p_backup = (short)current;
+        else
+            IM_ASSERT(*p_backup == current && "BeginGroup/EndGroup Mismatch!");
+        p_backup++;
+    }  // Too few or too many EndGroup()
+    {
+        int current = g.BeginPopupStack.Size;
+        if (write)
+            *p_backup = (short)current;
+        else
+            IM_ASSERT(*p_backup == current && "BeginMenu/EndMenu or BeginPopup/EndPopup Mismatch");
+        p_backup++;
+    }  // Too few or too many EndMenu()/EndPopup()
+    // For color, style and font stacks there is an incentive to use Push/Begin/Pop/.../End
+    // patterns, so we relax our checks a little to allow them.
+    {
+        int current = g.ColorModifiers.Size;
+        if (write)
+            *p_backup = (short)current;
+        else
+            IM_ASSERT(*p_backup >= current && "PushStyleColor/PopStyleColor Mismatch!");
+        p_backup++;
+    }  // Too few or too many PopStyleColor()
+    {
+        int current = g.StyleModifiers.Size;
+        if (write)
+            *p_backup = (short)current;
+        else
+            IM_ASSERT(*p_backup >= current && "PushStyleVar/PopStyleVar Mismatch!");
+        p_backup++;
+    }  // Too few or too many PopStyleVar()
+    {
+        int current = g.FontStack.Size;
+        if (write)
+            *p_backup = (short)current;
+        else
+            IM_ASSERT(*p_backup >= current && "PushFont/PopFont Mismatch!");
+        p_backup++;
+    }  // Too few or too many PopFont()
+    IM_ASSERT(p_backup == window->DC.StackSizesBackup + IM_ARRAYSIZE(window->DC.StackSizesBackup));
+}
+
+static void SetWindowConditionAllowFlags(ImGuiWindow *window, ImGuiCond flags, bool enabled)
+{
+    window->SetWindowPosAllowFlags = enabled ? (window->SetWindowPosAllowFlags | flags)
+                                             : (window->SetWindowPosAllowFlags & ~flags);
+    window->SetWindowSizeAllowFlags = enabled ? (window->SetWindowSizeAllowFlags | flags)
+                                              : (window->SetWindowSizeAllowFlags & ~flags);
+    window->SetWindowCollapsedAllowFlags = enabled
+                                               ? (window->SetWindowCollapsedAllowFlags | flags)
+                                               : (window->SetWindowCollapsedAllowFlags & ~flags);
+}
+
+ImGuiWindow *ImGui::FindWindowByID(ImGuiID id)
+{
+    ImGuiContext &g = *GImGui;
+    return (ImGuiWindow *)g.WindowsById.GetVoidPtr(id);
+}
+
+ImGuiWindow *ImGui::FindWindowByName(const char *name)
+{
+    ImGuiID id = ImHashStr(name);
+    return FindWindowByID(id);
+}
+
+static ImGuiWindow *CreateNewWindow(const char *name, ImVec2 size, ImGuiWindowFlags flags)
+{
+    ImGuiContext &g = *GImGui;
+
+    // Create window the first time
+    ImGuiWindow *window = IM_NEW(ImGuiWindow)(&g, name);
+    window->Flags       = flags;
+    g.WindowsById.SetVoidPtr(window->ID, window);
+
+    // Default/arbitrary window position. Use SetNextWindowPos() with the appropriate condition flag
+    // to change the initial position of a window.
+    window->Pos = ImVec2(60, 60);
+
+    // User can disable loading and saving of settings. Tooltip and child windows also don't store
+    // settings.
+    if (!(flags & ImGuiWindowFlags_NoSavedSettings))
+        if (ImGuiWindowSettings *settings = ImGui::FindWindowSettings(window->ID))
+        {
+            // Retrieve settings from .ini file
+            window->SettingsIdx = g.SettingsWindows.index_from_ptr(settings);
+            SetWindowConditionAllowFlags(window, ImGuiCond_FirstUseEver, false);
+            window->Pos       = ImFloor(settings->Pos);
+            window->Collapsed = settings->Collapsed;
+            if (ImLengthSqr(settings->Size) > 0.00001f)
+                size = ImFloor(settings->Size);
+        }
+    window->Size = window->SizeFull = ImFloor(size);
+    window->DC.CursorStartPos       = window->DC.CursorMaxPos =
+        window->Pos;  // So first call to CalcContentSize() doesn't return crazy values
+
+    if ((flags & ImGuiWindowFlags_AlwaysAutoResize) != 0)
+    {
+        window->AutoFitFramesX = window->AutoFitFramesY = 2;
+        window->AutoFitOnlyGrows                        = false;
+    }
+    else
+    {
+        if (window->Size.x <= 0.0f)
+            window->AutoFitFramesX = 2;
+        if (window->Size.y <= 0.0f)
+            window->AutoFitFramesY = 2;
+        window->AutoFitOnlyGrows = (window->AutoFitFramesX > 0) || (window->AutoFitFramesY > 0);
+    }
+
+    g.WindowsFocusOrder.push_back(window);
+    if (flags & ImGuiWindowFlags_NoBringToFrontOnFocus)
+        g.Windows.push_front(window);  // Quite slow but rare and only once
+    else
+        g.Windows.push_back(window);
+    return window;
+}
+
+static ImVec2 CalcSizeAfterConstraint(ImGuiWindow *window, ImVec2 new_size)
+{
+    ImGuiContext &g = *GImGui;
+    if (g.NextWindowData.Flags & ImGuiNextWindowDataFlags_HasSizeConstraint)
+    {
+        // Using -1,-1 on either X/Y axis to preserve the current size.
+        ImRect cr  = g.NextWindowData.SizeConstraintRect;
+        new_size.x = (cr.Min.x >= 0 && cr.Max.x >= 0) ? ImClamp(new_size.x, cr.Min.x, cr.Max.x)
+                                                      : window->SizeFull.x;
+        new_size.y = (cr.Min.y >= 0 && cr.Max.y >= 0) ? ImClamp(new_size.y, cr.Min.y, cr.Max.y)
+                                                      : window->SizeFull.y;
+        if (g.NextWindowData.SizeCallback)
+        {
+            ImGuiSizeCallbackData data;
+            data.UserData    = g.NextWindowData.SizeCallbackUserData;
+            data.Pos         = window->Pos;
+            data.CurrentSize = window->SizeFull;
+            data.DesiredSize = new_size;
+            g.NextWindowData.SizeCallback(&data);
+            new_size = data.DesiredSize;
+        }
+        new_size.x = ImFloor(new_size.x);
+        new_size.y = ImFloor(new_size.y);
+    }
+
+    // Minimum size
+    if (!(window->Flags & (ImGuiWindowFlags_ChildWindow | ImGuiWindowFlags_AlwaysAutoResize)))
+    {
+        new_size   = ImMax(new_size, g.Style.WindowMinSize);
+        new_size.y = ImMax(new_size.y,
+                           window->TitleBarHeight() + window->MenuBarHeight() +
+                               ImMax(0.0f, g.Style.WindowRounding -
+                                               1.0f));  // Reduce artifacts with very small windows
+    }
+    return new_size;
+}
+
+static ImVec2 CalcContentSize(ImGuiWindow *window)
+{
+    if (window->Collapsed)
+        if (window->AutoFitFramesX <= 0 && window->AutoFitFramesY <= 0)
+            return window->ContentSize;
+    if (window->Hidden && window->HiddenFramesCannotSkipItems == 0 &&
+        window->HiddenFramesCanSkipItems > 0)
+        return window->ContentSize;
+
+    ImVec2 sz;
+    sz.x = (float)(int)((window->ContentSizeExplicit.x != 0.0f)
+                            ? window->ContentSizeExplicit.x
+                            : window->DC.CursorMaxPos.x - window->DC.CursorStartPos.x);
+    sz.y = (float)(int)((window->ContentSizeExplicit.y != 0.0f)
+                            ? window->ContentSizeExplicit.y
+                            : window->DC.CursorMaxPos.y - window->DC.CursorStartPos.y);
+    return sz;
+}
+
+static ImVec2 CalcSizeAutoFit(ImGuiWindow *window, const ImVec2 &size_contents)
+{
+    ImGuiContext &g         = *GImGui;
+    ImGuiStyle &style       = g.Style;
+    ImVec2 size_decorations = ImVec2(0.0f, window->TitleBarHeight() + window->MenuBarHeight());
+    ImVec2 size_pad         = window->WindowPadding * 2.0f;
+    ImVec2 size_desired     = size_contents + size_pad + size_decorations;
+    if (window->Flags & ImGuiWindowFlags_Tooltip)
+    {
+        // Tooltip always resize
+        return size_desired;
+    }
+    else
+    {
+        // Maximum window size is determined by the viewport size or monitor size
+        const bool is_popup = (window->Flags & ImGuiWindowFlags_Popup) != 0;
+        const bool is_menu  = (window->Flags & ImGuiWindowFlags_ChildMenu) != 0;
+        ImVec2 size_min     = style.WindowMinSize;
+        if (is_popup || is_menu)  // Popups and menus bypass style.WindowMinSize by default, but we
+                                  // give then a non-zero minimum size to facilitate understanding
+                                  // problematic cases (e.g. empty popups)
+            size_min = ImMin(size_min, ImVec2(4.0f, 4.0f));
+        ImVec2 size_auto_fit =
+            ImClamp(size_desired, size_min,
+                    ImMax(size_min, g.IO.DisplaySize - style.DisplaySafeAreaPadding * 2.0f));
+
+        // When the window cannot fit all contents (either because of constraints, either because
+        // screen is too small), we are growing the size on the other axis to compensate for
+        // expected scrollbar. FIXME: Might turn bigger than ViewportSize-WindowPadding.
+        ImVec2 size_auto_fit_after_constraint = CalcSizeAfterConstraint(window, size_auto_fit);
+        bool will_have_scrollbar_x =
+            (size_auto_fit_after_constraint.x - size_pad.x - size_decorations.x < size_contents.x &&
+             !(window->Flags & ImGuiWindowFlags_NoScrollbar) &&
+             (window->Flags & ImGuiWindowFlags_HorizontalScrollbar)) ||
+            (window->Flags & ImGuiWindowFlags_AlwaysHorizontalScrollbar);
+        bool will_have_scrollbar_y =
+            (size_auto_fit_after_constraint.y - size_pad.y - size_decorations.y < size_contents.y &&
+             !(window->Flags & ImGuiWindowFlags_NoScrollbar)) ||
+            (window->Flags & ImGuiWindowFlags_AlwaysVerticalScrollbar);
+        if (will_have_scrollbar_x)
+            size_auto_fit.y += style.ScrollbarSize;
+        if (will_have_scrollbar_y)
+            size_auto_fit.x += style.ScrollbarSize;
+        return size_auto_fit;
+    }
+}
+
+ImVec2 ImGui::CalcWindowExpectedSize(ImGuiWindow *window)
+{
+    ImVec2 size_contents = CalcContentSize(window);
+    return CalcSizeAfterConstraint(window, CalcSizeAutoFit(window, size_contents));
+}
+
+static ImVec2 CalcNextScrollFromScrollTargetAndClamp(ImGuiWindow *window, bool snap_on_edges)
+{
+    ImGuiContext &g = *GImGui;
+    ImVec2 scroll   = window->Scroll;
+    if (window->ScrollTarget.x < FLT_MAX)
+    {
+        float cr_x     = window->ScrollTargetCenterRatio.x;
+        float target_x = window->ScrollTarget.x;
+        if (snap_on_edges && cr_x <= 0.0f && target_x <= window->WindowPadding.x)
+            target_x = 0.0f;
+        else if (snap_on_edges && cr_x >= 1.0f &&
+                 target_x >=
+                     window->ContentSize.x + window->WindowPadding.x + GImGui->Style.ItemSpacing.x)
+            target_x = window->ContentSize.x + window->WindowPadding.x * 2.0f;
+        scroll.x = target_x - cr_x * window->InnerRect.GetWidth();
+    }
+    if (window->ScrollTarget.y < FLT_MAX)
+    {
+        // 'snap_on_edges' allows for a discontinuity at the edge of scrolling limits to take
+        // account of WindowPadding so that scrolling to make the last item visible scroll far
+        // enough to see the padding.
+        float cr_y     = window->ScrollTargetCenterRatio.y;
+        float target_y = window->ScrollTarget.y;
+        if (snap_on_edges && cr_y <= 0.0f && target_y <= window->WindowPadding.y)
+            target_y = 0.0f;
+        if (snap_on_edges && cr_y >= 1.0f &&
+            target_y >= window->ContentSize.y + window->WindowPadding.y + g.Style.ItemSpacing.y)
+            target_y = window->ContentSize.y + window->WindowPadding.y * 2.0f;
+        scroll.y = target_y - cr_y * window->InnerRect.GetHeight();
+    }
+    scroll = ImMax(scroll, ImVec2(0.0f, 0.0f));
+    if (!window->Collapsed && !window->SkipItems)
+    {
+        scroll.x = ImMin(scroll.x, window->ScrollMax.x);
+        scroll.y = ImMin(scroll.y, window->ScrollMax.y);
+    }
+    return scroll;
+}
+
+static ImGuiCol GetWindowBgColorIdxFromFlags(ImGuiWindowFlags flags)
+{
+    if (flags & (ImGuiWindowFlags_Tooltip | ImGuiWindowFlags_Popup))
+        return ImGuiCol_PopupBg;
+    if (flags & ImGuiWindowFlags_ChildWindow)
+        return ImGuiCol_ChildBg;
+    return ImGuiCol_WindowBg;
+}
+
+static void CalcResizePosSizeFromAnyCorner(ImGuiWindow *window,
+                                           const ImVec2 &corner_target,
+                                           const ImVec2 &corner_norm,
+                                           ImVec2 *out_pos,
+                                           ImVec2 *out_size)
+{
+    ImVec2 pos_min = ImLerp(corner_target, window->Pos, corner_norm);  // Expected window upper-left
+    ImVec2 pos_max = ImLerp(window->Pos + window->Size, corner_target,
+                            corner_norm);  // Expected window lower-right
+    ImVec2 size_expected    = pos_max - pos_min;
+    ImVec2 size_constrained = CalcSizeAfterConstraint(window, size_expected);
+    *out_pos                = pos_min;
+    if (corner_norm.x == 0.0f)
+        out_pos->x -= (size_constrained.x - size_expected.x);
+    if (corner_norm.y == 0.0f)
+        out_pos->y -= (size_constrained.y - size_expected.y);
+    *out_size = size_constrained;
+}
+
+struct ImGuiResizeGripDef
+{
+    ImVec2 CornerPosN;
+    ImVec2 InnerDir;
+    int AngleMin12, AngleMax12;
+};
+
+static const ImGuiResizeGripDef resize_grip_def[4] = {
+    {ImVec2(1, 1), ImVec2(-1, -1), 0, 3},   // Lower right
+    {ImVec2(0, 1), ImVec2(+1, -1), 3, 6},   // Lower left
+    {ImVec2(0, 0), ImVec2(+1, +1), 6, 9},   // Upper left
+    {ImVec2(1, 0), ImVec2(-1, +1), 9, 12},  // Upper right
+};
+
+static ImRect GetResizeBorderRect(ImGuiWindow *window,
+                                  int border_n,
+                                  float perp_padding,
+                                  float thickness)
+{
+    ImRect rect = window->Rect();
+    if (thickness == 0.0f)
+        rect.Max -= ImVec2(1, 1);
+    if (border_n == 0)
+        return ImRect(rect.Min.x + perp_padding, rect.Min.y - thickness, rect.Max.x - perp_padding,
+                      rect.Min.y + thickness);  // Top
+    if (border_n == 1)
+        return ImRect(rect.Max.x - thickness, rect.Min.y + perp_padding, rect.Max.x + thickness,
+                      rect.Max.y - perp_padding);  // Right
+    if (border_n == 2)
+        return ImRect(rect.Min.x + perp_padding, rect.Max.y - thickness, rect.Max.x - perp_padding,
+                      rect.Max.y + thickness);  // Bottom
+    if (border_n == 3)
+        return ImRect(rect.Min.x - thickness, rect.Min.y + perp_padding, rect.Min.x + thickness,
+                      rect.Max.y - perp_padding);  // Left
+    IM_ASSERT(0);
+    return ImRect();
+}
+
+// Handle resize for: Resize Grips, Borders, Gamepad
+// Return true when using auto-fit (double click on resize grip)
+static bool ImGui::UpdateManualResize(ImGuiWindow *window,
+                                      const ImVec2 &size_auto_fit,
+                                      int *border_held,
+                                      int resize_grip_count,
+                                      ImU32 resize_grip_col[4])
+{
+    ImGuiContext &g        = *GImGui;
+    ImGuiWindowFlags flags = window->Flags;
+
+    if ((flags & ImGuiWindowFlags_NoResize) || (flags & ImGuiWindowFlags_AlwaysAutoResize) ||
+        window->AutoFitFramesX > 0 || window->AutoFitFramesY > 0)
+        return false;
+    if (window->WasActive == false)  // Early out to avoid running this code for e.g. an hidden
+                                     // implicit/fallback Debug window.
+        return false;
+
+    bool ret_auto_fit             = false;
+    const int resize_border_count = g.IO.ConfigWindowsResizeFromEdges ? 4 : 0;
+    const float grip_draw_size =
+        (float)(int)ImMax(g.FontSize * 1.35f, window->WindowRounding + 1.0f + g.FontSize * 0.2f);
+    const float grip_hover_inner_size = (float)(int)(grip_draw_size * 0.75f);
+    const float grip_hover_outer_size =
+        g.IO.ConfigWindowsResizeFromEdges ? WINDOWS_RESIZE_FROM_EDGES_HALF_THICKNESS : 0.0f;
+
+    ImVec2 pos_target(FLT_MAX, FLT_MAX);
+    ImVec2 size_target(FLT_MAX, FLT_MAX);
+
+    // Resize grips and borders are on layer 1
+    window->DC.NavLayerCurrent     = ImGuiNavLayer_Menu;
+    window->DC.NavLayerCurrentMask = (1 << ImGuiNavLayer_Menu);
+
+    // Manual resize grips
+    PushID("#RESIZE");
+    for (int resize_grip_n = 0; resize_grip_n < resize_grip_count; resize_grip_n++)
+    {
+        const ImGuiResizeGripDef &grip = resize_grip_def[resize_grip_n];
+        const ImVec2 corner = ImLerp(window->Pos, window->Pos + window->Size, grip.CornerPosN);
+
+        // Using the FlattenChilds button flag we make the resize button accessible even if we are
+        // hovering over a child window
+        ImRect resize_rect(corner - grip.InnerDir * grip_hover_outer_size,
+                           corner + grip.InnerDir * grip_hover_inner_size);
+        if (resize_rect.Min.x > resize_rect.Max.x)
+            ImSwap(resize_rect.Min.x, resize_rect.Max.x);
+        if (resize_rect.Min.y > resize_rect.Max.y)
+            ImSwap(resize_rect.Min.y, resize_rect.Max.y);
+        bool hovered, held;
+        ButtonBehavior(resize_rect, window->GetID((void *)(intptr_t)resize_grip_n), &hovered, &held,
+                       ImGuiButtonFlags_FlattenChildren | ImGuiButtonFlags_NoNavFocus);
+        // GetForegroundDrawList(window)->AddRect(resize_rect.Min, resize_rect.Max, IM_COL32(255,
+        // 255, 0, 255));
+        if (hovered || held)
+            g.MouseCursor =
+                (resize_grip_n & 1) ? ImGuiMouseCursor_ResizeNESW : ImGuiMouseCursor_ResizeNWSE;
+
+        if (held && g.IO.MouseDoubleClicked[0] && resize_grip_n == 0)
+        {
+            // Manual auto-fit when double-clicking
+            size_target  = CalcSizeAfterConstraint(window, size_auto_fit);
+            ret_auto_fit = true;
+            ClearActiveID();
+        }
+        else if (held)
+        {
+            // Resize from any of the four corners
+            // We don't use an incremental MouseDelta but rather compute an absolute target size
+            // based on mouse position
+            ImVec2 corner_target =
+                g.IO.MousePos - g.ActiveIdClickOffset +
+                ImLerp(grip.InnerDir * grip_hover_outer_size,
+                       grip.InnerDir * -grip_hover_inner_size,
+                       grip.CornerPosN);  // Corner of the window corresponding to our corner grip
+            CalcResizePosSizeFromAnyCorner(window, corner_target, grip.CornerPosN, &pos_target,
+                                           &size_target);
+        }
+        if (resize_grip_n == 0 || held || hovered)
+            resize_grip_col[resize_grip_n] =
+                GetColorU32(held ? ImGuiCol_ResizeGripActive
+                                 : hovered ? ImGuiCol_ResizeGripHovered : ImGuiCol_ResizeGrip);
+    }
+    for (int border_n = 0; border_n < resize_border_count; border_n++)
+    {
+        bool hovered, held;
+        ImRect border_rect = GetResizeBorderRect(window, border_n, grip_hover_inner_size,
+                                                 WINDOWS_RESIZE_FROM_EDGES_HALF_THICKNESS);
+        ButtonBehavior(border_rect, window->GetID((void *)(intptr_t)(border_n + 4)), &hovered,
+                       &held, ImGuiButtonFlags_FlattenChildren);
+        // GetForegroundDrawLists(window)->AddRect(border_rect.Min, border_rect.Max, IM_COL32(255,
+        // 255, 0, 255));
+        if ((hovered && g.HoveredIdTimer > WINDOWS_RESIZE_FROM_EDGES_FEEDBACK_TIMER) || held)
+        {
+            g.MouseCursor = (border_n & 1) ? ImGuiMouseCursor_ResizeEW : ImGuiMouseCursor_ResizeNS;
+            if (held)
+                *border_held = border_n;
+        }
+        if (held)
+        {
+            ImVec2 border_target = window->Pos;
+            ImVec2 border_posn;
+            if (border_n == 0)
+            {
+                border_posn     = ImVec2(0, 0);
+                border_target.y = (g.IO.MousePos.y - g.ActiveIdClickOffset.y +
+                                   WINDOWS_RESIZE_FROM_EDGES_HALF_THICKNESS);
+            }  // Top
+            if (border_n == 1)
+            {
+                border_posn     = ImVec2(1, 0);
+                border_target.x = (g.IO.MousePos.x - g.ActiveIdClickOffset.x +
+                                   WINDOWS_RESIZE_FROM_EDGES_HALF_THICKNESS);
+            }  // Right
+            if (border_n == 2)
+            {
+                border_posn     = ImVec2(0, 1);
+                border_target.y = (g.IO.MousePos.y - g.ActiveIdClickOffset.y +
+                                   WINDOWS_RESIZE_FROM_EDGES_HALF_THICKNESS);
+            }  // Bottom
+            if (border_n == 3)
+            {
+                border_posn     = ImVec2(0, 0);
+                border_target.x = (g.IO.MousePos.x - g.ActiveIdClickOffset.x +
+                                   WINDOWS_RESIZE_FROM_EDGES_HALF_THICKNESS);
+            }  // Left
+            CalcResizePosSizeFromAnyCorner(window, border_target, border_posn, &pos_target,
+                                           &size_target);
+        }
+    }
+    PopID();
+
+    // Navigation resize (keyboard/gamepad)
+    if (g.NavWindowingTarget && g.NavWindowingTarget->RootWindow == window)
+    {
+        ImVec2 nav_resize_delta;
+        if (g.NavInputSource == ImGuiInputSource_NavKeyboard && g.IO.KeyShift)
+            nav_resize_delta =
+                GetNavInputAmount2d(ImGuiNavDirSourceFlags_Keyboard, ImGuiInputReadMode_Down);
+        if (g.NavInputSource == ImGuiInputSource_NavGamepad)
+            nav_resize_delta =
+                GetNavInputAmount2d(ImGuiNavDirSourceFlags_PadDPad, ImGuiInputReadMode_Down);
+        if (nav_resize_delta.x != 0.0f || nav_resize_delta.y != 0.0f)
+        {
+            const float NAV_RESIZE_SPEED = 600.0f;
+            nav_resize_delta *=
+                ImFloor(NAV_RESIZE_SPEED * g.IO.DeltaTime *
+                        ImMin(g.IO.DisplayFramebufferScale.x, g.IO.DisplayFramebufferScale.y));
+            g.NavWindowingToggleLayer = false;
+            g.NavDisableMouseHover    = true;
+            resize_grip_col[0]        = GetColorU32(ImGuiCol_ResizeGripActive);
+            // FIXME-NAV: Should store and accumulate into a separate size buffer to handle sizing
+            // constraints properly, right now a constraint will make us stuck.
+            size_target = CalcSizeAfterConstraint(window, window->SizeFull + nav_resize_delta);
+        }
+    }
+
+    // Apply back modified position/size to window
+    if (size_target.x != FLT_MAX)
+    {
+        window->SizeFull = size_target;
+        MarkIniSettingsDirty(window);
+    }
+    if (pos_target.x != FLT_MAX)
+    {
+        window->Pos = ImFloor(pos_target);
+        MarkIniSettingsDirty(window);
+    }
+
+    // Resize nav layer
+    window->DC.NavLayerCurrent     = ImGuiNavLayer_Main;
+    window->DC.NavLayerCurrentMask = (1 << ImGuiNavLayer_Main);
+
+    window->Size = window->SizeFull;
+    return ret_auto_fit;
+}
+
+static inline void ClampWindowRect(ImGuiWindow *window, const ImRect &rect, const ImVec2 &padding)
+{
+    ImGuiContext &g = *GImGui;
+    ImVec2 size_for_clamping =
+        (g.IO.ConfigWindowsMoveFromTitleBarOnly && !(window->Flags & ImGuiWindowFlags_NoTitleBar))
+            ? ImVec2(window->Size.x, window->TitleBarHeight())
+            : window->Size;
+    window->Pos =
+        ImMin(rect.Max - padding,
+              ImMax(window->Pos + size_for_clamping, rect.Min + padding) - size_for_clamping);
+}
+
+static void ImGui::RenderWindowOuterBorders(ImGuiWindow *window)
+{
+    ImGuiContext &g   = *GImGui;
+    float rounding    = window->WindowRounding;
+    float border_size = window->WindowBorderSize;
+    if (border_size > 0.0f && !(window->Flags & ImGuiWindowFlags_NoBackground))
+        window->DrawList->AddRect(window->Pos, window->Pos + window->Size,
+                                  GetColorU32(ImGuiCol_Border), rounding, ImDrawCornerFlags_All,
+                                  border_size);
+
+    int border_held = window->ResizeBorderHeld;
+    if (border_held != -1)
+    {
+        struct ImGuiResizeBorderDef
+        {
+            ImVec2 InnerDir;
+            ImVec2 CornerPosN1, CornerPosN2;
+            float OuterAngle;
+        };
+        static const ImGuiResizeBorderDef resize_border_def[4] = {
+            {ImVec2(0, +1), ImVec2(0, 0), ImVec2(1, 0), IM_PI * 1.50f},  // Top
+            {ImVec2(-1, 0), ImVec2(1, 0), ImVec2(1, 1), IM_PI * 0.00f},  // Right
+            {ImVec2(0, -1), ImVec2(1, 1), ImVec2(0, 1), IM_PI * 0.50f},  // Bottom
+            {ImVec2(+1, 0), ImVec2(0, 1), ImVec2(0, 0), IM_PI * 1.00f}   // Left
+        };
+        const ImGuiResizeBorderDef &def = resize_border_def[border_held];
+        ImRect border_r                 = GetResizeBorderRect(window, border_held, rounding, 0.0f);
+        window->DrawList->PathArcTo(ImLerp(border_r.Min, border_r.Max, def.CornerPosN1) +
+                                        ImVec2(0.5f, 0.5f) + def.InnerDir * rounding,
+                                    rounding, def.OuterAngle - IM_PI * 0.25f, def.OuterAngle);
+        window->DrawList->PathArcTo(ImLerp(border_r.Min, border_r.Max, def.CornerPosN2) +
+                                        ImVec2(0.5f, 0.5f) + def.InnerDir * rounding,
+                                    rounding, def.OuterAngle, def.OuterAngle + IM_PI * 0.25f);
+        window->DrawList->PathStroke(GetColorU32(ImGuiCol_SeparatorActive), false,
+                                     ImMax(2.0f, border_size));  // Thicker than usual
+    }
+    if (g.Style.FrameBorderSize > 0 && !(window->Flags & ImGuiWindowFlags_NoTitleBar))
+    {
+        float y = window->Pos.y + window->TitleBarHeight() - 1;
+        window->DrawList->AddLine(ImVec2(window->Pos.x + border_size, y),
+                                  ImVec2(window->Pos.x + window->Size.x - border_size, y),
+                                  GetColorU32(ImGuiCol_Border), g.Style.FrameBorderSize);
+    }
+}
+
+void ImGui::RenderWindowDecorations(ImGuiWindow *window,
+                                    const ImRect &title_bar_rect,
+                                    bool title_bar_is_highlight,
+                                    int resize_grip_count,
+                                    const ImU32 resize_grip_col[4],
+                                    float resize_grip_draw_size)
+{
+    ImGuiContext &g        = *GImGui;
+    ImGuiStyle &style      = g.Style;
+    ImGuiWindowFlags flags = window->Flags;
+
+    // Draw window + handle manual resize
+    // As we highlight the title bar when want_focus is set, multiple reappearing windows will have
+    // have their title bar highlighted on their reappearing frame.
+    const float window_rounding    = window->WindowRounding;
+    const float window_border_size = window->WindowBorderSize;
+    if (window->Collapsed)
+    {
+        // Title bar only
+        float backup_border_size = style.FrameBorderSize;
+        g.Style.FrameBorderSize  = window->WindowBorderSize;
+        ImU32 title_bar_col      = GetColorU32((title_bar_is_highlight && !g.NavDisableHighlight)
+                                              ? ImGuiCol_TitleBgActive
+                                              : ImGuiCol_TitleBgCollapsed);
+        RenderFrame(title_bar_rect.Min, title_bar_rect.Max, title_bar_col, true, window_rounding);
+        g.Style.FrameBorderSize = backup_border_size;
+    }
+    else
+    {
+        // Window background
+        if (!(flags & ImGuiWindowFlags_NoBackground))
+        {
+            ImU32 bg_col = GetColorU32(GetWindowBgColorIdxFromFlags(flags));
+            float alpha  = 1.0f;
+            if (g.NextWindowData.Flags & ImGuiNextWindowDataFlags_HasBgAlpha)
+                alpha = g.NextWindowData.BgAlphaVal;
+            if (alpha != 1.0f)
+                bg_col =
+                    (bg_col & ~IM_COL32_A_MASK) | (IM_F32_TO_INT8_SAT(alpha) << IM_COL32_A_SHIFT);
+            window->DrawList->AddRectFilled(window->Pos + ImVec2(0, window->TitleBarHeight()),
+                                            window->Pos + window->Size, bg_col, window_rounding,
+                                            (flags & ImGuiWindowFlags_NoTitleBar)
+                                                ? ImDrawCornerFlags_All
+                                                : ImDrawCornerFlags_Bot);
+        }
+
+        // Title bar
+        if (!(flags & ImGuiWindowFlags_NoTitleBar))
+        {
+            ImU32 title_bar_col =
+                GetColorU32(title_bar_is_highlight ? ImGuiCol_TitleBgActive : ImGuiCol_TitleBg);
+            window->DrawList->AddRectFilled(title_bar_rect.Min, title_bar_rect.Max, title_bar_col,
+                                            window_rounding, ImDrawCornerFlags_Top);
+        }
+
+        // Menu bar
+        if (flags & ImGuiWindowFlags_MenuBar)
+        {
+            ImRect menu_bar_rect = window->MenuBarRect();
+            menu_bar_rect.ClipWith(
+                window->Rect());  // Soft clipping, in particular child window don't have minimum
+                                  // size covering the menu bar so this is useful for them.
+            window->DrawList->AddRectFilled(
+                menu_bar_rect.Min + ImVec2(window_border_size, 0),
+                menu_bar_rect.Max - ImVec2(window_border_size, 0), GetColorU32(ImGuiCol_MenuBarBg),
+                (flags & ImGuiWindowFlags_NoTitleBar) ? window_rounding : 0.0f,
+                ImDrawCornerFlags_Top);
+            if (style.FrameBorderSize > 0.0f &&
+                menu_bar_rect.Max.y < window->Pos.y + window->Size.y)
+                window->DrawList->AddLine(menu_bar_rect.GetBL(), menu_bar_rect.GetBR(),
+                                          GetColorU32(ImGuiCol_Border), style.FrameBorderSize);
+        }
+
+        // Scrollbars
+        if (window->ScrollbarX)
+            Scrollbar(ImGuiAxis_X);
+        if (window->ScrollbarY)
+            Scrollbar(ImGuiAxis_Y);
+
+        // Render resize grips (after their input handling so we don't have a frame of latency)
+        if (!(flags & ImGuiWindowFlags_NoResize))
+        {
+            for (int resize_grip_n = 0; resize_grip_n < resize_grip_count; resize_grip_n++)
+            {
+                const ImGuiResizeGripDef &grip = resize_grip_def[resize_grip_n];
+                const ImVec2 corner =
+                    ImLerp(window->Pos, window->Pos + window->Size, grip.CornerPosN);
+                window->DrawList->PathLineTo(
+                    corner +
+                    grip.InnerDir * ((resize_grip_n & 1)
+                                         ? ImVec2(window_border_size, resize_grip_draw_size)
+                                         : ImVec2(resize_grip_draw_size, window_border_size)));
+                window->DrawList->PathLineTo(
+                    corner +
+                    grip.InnerDir * ((resize_grip_n & 1)
+                                         ? ImVec2(resize_grip_draw_size, window_border_size)
+                                         : ImVec2(window_border_size, resize_grip_draw_size)));
+                window->DrawList->PathArcToFast(
+                    ImVec2(corner.x + grip.InnerDir.x * (window_rounding + window_border_size),
+                           corner.y + grip.InnerDir.y * (window_rounding + window_border_size)),
+                    window_rounding, grip.AngleMin12, grip.AngleMax12);
+                window->DrawList->PathFillConvex(resize_grip_col[resize_grip_n]);
+            }
+        }
+
+        // Borders
+        RenderWindowOuterBorders(window);
+    }
+}
+
+// Render title text, collapse button, close button
+void ImGui::RenderWindowTitleBarContents(ImGuiWindow *window,
+                                         const ImRect &title_bar_rect,
+                                         const char *name,
+                                         bool *p_open)
+{
+    ImGuiContext &g        = *GImGui;
+    ImGuiStyle &style      = g.Style;
+    ImGuiWindowFlags flags = window->Flags;
+
+    const bool has_close_button    = (p_open != NULL);
+    const bool has_collapse_button = !(flags & ImGuiWindowFlags_NoCollapse);
+
+    // Close & Collapse button are on the Menu NavLayer and don't default focus (unless there's
+    // nothing else on that layer)
+    const ImGuiItemFlags item_flags_backup = window->DC.ItemFlags;
+    window->DC.ItemFlags |= ImGuiItemFlags_NoNavDefaultFocus;
+    window->DC.NavLayerCurrent     = ImGuiNavLayer_Menu;
+    window->DC.NavLayerCurrentMask = (1 << ImGuiNavLayer_Menu);
+
+    // Layout buttons
+    // FIXME: Would be nice to generalize the subtleties expressed here into reusable code.
+    float pad_l     = style.FramePadding.x;
+    float pad_r     = style.FramePadding.x;
+    float button_sz = g.FontSize;
+    ImVec2 close_button_pos;
+    ImVec2 collapse_button_pos;
+    if (has_close_button)
+    {
+        pad_r += button_sz;
+        close_button_pos =
+            ImVec2(title_bar_rect.Max.x - pad_r - style.FramePadding.x, title_bar_rect.Min.y);
+    }
+    if (has_collapse_button && style.WindowMenuButtonPosition == ImGuiDir_Right)
+    {
+        pad_r += button_sz;
+        collapse_button_pos =
+            ImVec2(title_bar_rect.Max.x - pad_r - style.FramePadding.x, title_bar_rect.Min.y);
+    }
+    if (has_collapse_button && style.WindowMenuButtonPosition == ImGuiDir_Left)
+    {
+        collapse_button_pos =
+            ImVec2(title_bar_rect.Min.x + pad_l - style.FramePadding.x, title_bar_rect.Min.y);
+        pad_l += button_sz;
+    }
+
+    // Collapse button (submitting first so it gets priority when choosing a navigation init
+    // fallback)
+    if (has_collapse_button)
+        if (CollapseButton(window->GetID("#COLLAPSE"), collapse_button_pos))
+            window->WantCollapseToggle = true;  // Defer actual collapsing to next frame as we are
+                                                // too far in the Begin() function
+
+    // Close button
+    if (has_close_button)
+        if (CloseButton(window->GetID("#CLOSE"), close_button_pos))
+            *p_open = false;
+
+    window->DC.NavLayerCurrent     = ImGuiNavLayer_Main;
+    window->DC.NavLayerCurrentMask = (1 << ImGuiNavLayer_Main);
+    window->DC.ItemFlags           = item_flags_backup;
+
+    // Title bar text (with: horizontal alignment, avoiding collapse/close button, optional "unsaved
+    // document" marker)
+    // FIXME: Refactor text alignment facilities along with RenderText helpers, this is WAY too much
+    // messy code..
+    const char *UNSAVED_DOCUMENT_MARKER = "*";
+    const float marker_size_x           = (flags & ImGuiWindowFlags_UnsavedDocument)
+                                    ? CalcTextSize(UNSAVED_DOCUMENT_MARKER, NULL, false).x
+                                    : 0.0f;
+    const ImVec2 text_size = CalcTextSize(name, NULL, true) + ImVec2(marker_size_x, 0.0f);
+
+    // As a nice touch we try to ensure that centered title text doesn't get affected by visibility
+    // of Close/Collapse button, while uncentered title text will still reach edges correct.
+    if (pad_l > style.FramePadding.x)
+        pad_l += g.Style.ItemInnerSpacing.x;
+    if (pad_r > style.FramePadding.x)
+        pad_r += g.Style.ItemInnerSpacing.x;
+    if (style.WindowTitleAlign.x > 0.0f && style.WindowTitleAlign.x < 1.0f)
+    {
+        float centerness = ImSaturate(1.0f - ImFabs(style.WindowTitleAlign.x - 0.5f) *
+                                                 2.0f);  // 0.0f on either edges, 1.0f on center
+        float pad_extend =
+            ImMin(ImMax(pad_l, pad_r), title_bar_rect.GetWidth() - pad_l - pad_r - text_size.x);
+        pad_l = ImMax(pad_l, pad_extend * centerness);
+        pad_r = ImMax(pad_r, pad_extend * centerness);
+    }
+
+    ImRect layout_r(title_bar_rect.Min.x + pad_l, title_bar_rect.Min.y,
+                    title_bar_rect.Max.x - pad_r, title_bar_rect.Max.y);
+    ImRect clip_r(layout_r.Min.x, layout_r.Min.y, layout_r.Max.x + g.Style.ItemInnerSpacing.x,
+                  layout_r.Max.y);
+    // if (g.IO.KeyCtrl) window->DrawList->AddRect(layout_r.Min, layout_r.Max, IM_COL32(255, 128, 0,
+    // 255)); // [DEBUG]
+    RenderTextClipped(layout_r.Min, layout_r.Max, name, NULL, &text_size, style.WindowTitleAlign,
+                      &clip_r);
+    if (flags & ImGuiWindowFlags_UnsavedDocument)
+    {
+        ImVec2 marker_pos =
+            ImVec2(ImMax(layout_r.Min.x, layout_r.Min.x + (layout_r.GetWidth() - text_size.x) *
+                                                              style.WindowTitleAlign.x) +
+                       text_size.x,
+                   layout_r.Min.y) +
+            ImVec2(2 - marker_size_x, 0.0f);
+        ImVec2 off = ImVec2(0.0f, (float)(int)(-g.FontSize * 0.25f));
+        RenderTextClipped(marker_pos + off, layout_r.Max + off, UNSAVED_DOCUMENT_MARKER, NULL, NULL,
+                          ImVec2(0, style.WindowTitleAlign.y), &clip_r);
+    }
+}
+
+void ImGui::UpdateWindowParentAndRootLinks(ImGuiWindow *window,
+                                           ImGuiWindowFlags flags,
+                                           ImGuiWindow *parent_window)
+{
+    window->ParentWindow = parent_window;
+    window->RootWindow = window->RootWindowForTitleBarHighlight = window->RootWindowForNav = window;
+    if (parent_window && (flags & ImGuiWindowFlags_ChildWindow) &&
+        !(flags & ImGuiWindowFlags_Tooltip))
+        window->RootWindow = parent_window->RootWindow;
+    if (parent_window && !(flags & ImGuiWindowFlags_Modal) &&
+        (flags & (ImGuiWindowFlags_ChildWindow | ImGuiWindowFlags_Popup)))
+        window->RootWindowForTitleBarHighlight = parent_window->RootWindowForTitleBarHighlight;
+    while (window->RootWindowForNav->Flags & ImGuiWindowFlags_NavFlattened)
+    {
+        IM_ASSERT(window->RootWindowForNav->ParentWindow != NULL);
+        window->RootWindowForNav = window->RootWindowForNav->ParentWindow;
+    }
+}
+
+// Push a new Dear ImGui window to add widgets to.
+// - A default window called "Debug" is automatically stacked at the beginning of every frame so you
+// can use widgets without explicitly calling a Begin/End pair.
+// - Begin/End can be called multiple times during the frame with the same window name to append
+// content.
+// - The window name is used as a unique identifier to preserve window information across frames
+// (and save rudimentary information to the .ini file).
+//   You can use the "##" or "###" markers to use the same label with different id, or same id with
+//   different label. See documentation at the top of this file.
+// - Return false when window is collapsed, so you can early out in your code. You always need to
+// call ImGui::End() even if false is returned.
+// - Passing 'bool* p_open' displays a Close button on the upper-right corner of the window, the
+// pointed value will be set to false when the button is pressed.
+bool ImGui::Begin(const char *name, bool *p_open, ImGuiWindowFlags flags)
+{
+    ImGuiContext &g         = *GImGui;
+    const ImGuiStyle &style = g.Style;
+    IM_ASSERT(name != NULL && name[0] != '\0');    // Window name required
+    IM_ASSERT(g.FrameScopeActive);                 // Forgot to call ImGui::NewFrame()
+    IM_ASSERT(g.FrameCountEnded != g.FrameCount);  // Called ImGui::Render() or ImGui::EndFrame()
+                                                   // and haven't called ImGui::NewFrame() again yet
+
+    // Find or create
+    ImGuiWindow *window            = FindWindowByName(name);
+    const bool window_just_created = (window == NULL);
+    if (window_just_created)
+    {
+        ImVec2 size_on_first_use =
+            (g.NextWindowData.Flags & ImGuiNextWindowDataFlags_HasSize)
+                ? g.NextWindowData.SizeVal
+                : ImVec2(
+                      0.0f,
+                      0.0f);  // Any condition flag will do since we are creating a new window here.
+        window = CreateNewWindow(name, size_on_first_use, flags);
+    }
+
+    // Automatically disable manual moving/resizing when NoInputs is set
+    if ((flags & ImGuiWindowFlags_NoInputs) == ImGuiWindowFlags_NoInputs)
+        flags |= ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize;
+
+    if (flags & ImGuiWindowFlags_NavFlattened)
+        IM_ASSERT(flags & ImGuiWindowFlags_ChildWindow);
+
+    const int current_frame             = g.FrameCount;
+    const bool first_begin_of_the_frame = (window->LastFrameActive != current_frame);
+
+    // Update the Appearing flag
+    bool window_just_activated_by_user =
+        (window->LastFrameActive <
+         current_frame - 1);  // Not using !WasActive because the implicit "Debug" window would
+                              // always toggle off->on
+    const bool window_just_appearing_after_hidden_for_resize =
+        (window->HiddenFramesCannotSkipItems > 0);
+    if (flags & ImGuiWindowFlags_Popup)
+    {
+        ImGuiPopupData &popup_ref = g.OpenPopupStack[g.BeginPopupStack.Size];
+        window_just_activated_by_user |=
+            (window->PopupId !=
+             popup_ref
+                 .PopupId);  // We recycle popups so treat window as activated if popup id changed
+        window_just_activated_by_user |= (window != popup_ref.Window);
+    }
+    window->Appearing =
+        (window_just_activated_by_user || window_just_appearing_after_hidden_for_resize);
+    if (window->Appearing)
+        SetWindowConditionAllowFlags(window, ImGuiCond_Appearing, true);
+
+    // Update Flags, LastFrameActive, BeginOrderXXX fields
+    if (first_begin_of_the_frame)
+    {
+        window->Flags                   = (ImGuiWindowFlags)flags;
+        window->LastFrameActive         = current_frame;
+        window->BeginOrderWithinParent  = 0;
+        window->BeginOrderWithinContext = (short)(g.WindowsActiveCount++);
+    }
+    else
+    {
+        flags = window->Flags;
+    }
+
+    // Parent window is latched only on the first call to Begin() of the frame, so further
+    // append-calls can be done from a different window stack
+    ImGuiWindow *parent_window_in_stack =
+        g.CurrentWindowStack.empty() ? NULL : g.CurrentWindowStack.back();
+    ImGuiWindow *parent_window =
+        first_begin_of_the_frame
+            ? ((flags & (ImGuiWindowFlags_ChildWindow | ImGuiWindowFlags_Popup))
+                   ? parent_window_in_stack
+                   : NULL)
+            : window->ParentWindow;
+    IM_ASSERT(parent_window != NULL || !(flags & ImGuiWindowFlags_ChildWindow));
+
+    // Add to stack
+    // We intentionally set g.CurrentWindow to NULL to prevent usage until when the viewport is set,
+    // then will call SetCurrentWindow()
+    g.CurrentWindowStack.push_back(window);
+    g.CurrentWindow = NULL;
+    CheckStacksSize(window, true);
+    if (flags & ImGuiWindowFlags_Popup)
+    {
+        ImGuiPopupData &popup_ref = g.OpenPopupStack[g.BeginPopupStack.Size];
+        popup_ref.Window          = window;
+        g.BeginPopupStack.push_back(popup_ref);
+        window->PopupId = popup_ref.PopupId;
+    }
+
+    if (window_just_appearing_after_hidden_for_resize && !(flags & ImGuiWindowFlags_ChildWindow))
+        window->NavLastIds[0] = 0;
+
+    // Process SetNextWindow***() calls
+    bool window_pos_set_by_api    = false;
+    bool window_size_x_set_by_api = false, window_size_y_set_by_api = false;
+    if (g.NextWindowData.Flags & ImGuiNextWindowDataFlags_HasPos)
+    {
+        window_pos_set_by_api = (window->SetWindowPosAllowFlags & g.NextWindowData.PosCond) != 0;
+        if (window_pos_set_by_api && ImLengthSqr(g.NextWindowData.PosPivotVal) > 0.00001f)
+        {
+            // May be processed on the next frame if this is our first frame and we are measuring
+            // size
+            // FIXME: Look into removing the branch so everything can go through this same code path
+            // for consistency.
+            window->SetWindowPosVal   = g.NextWindowData.PosVal;
+            window->SetWindowPosPivot = g.NextWindowData.PosPivotVal;
+            window->SetWindowPosAllowFlags &=
+                ~(ImGuiCond_Once | ImGuiCond_FirstUseEver | ImGuiCond_Appearing);
+        }
+        else
+        {
+            SetWindowPos(window, g.NextWindowData.PosVal, g.NextWindowData.PosCond);
+        }
+    }
+    if (g.NextWindowData.Flags & ImGuiNextWindowDataFlags_HasSize)
+    {
+        window_size_x_set_by_api =
+            (window->SetWindowSizeAllowFlags & g.NextWindowData.SizeCond) != 0 &&
+            (g.NextWindowData.SizeVal.x > 0.0f);
+        window_size_y_set_by_api =
+            (window->SetWindowSizeAllowFlags & g.NextWindowData.SizeCond) != 0 &&
+            (g.NextWindowData.SizeVal.y > 0.0f);
+        SetWindowSize(window, g.NextWindowData.SizeVal, g.NextWindowData.SizeCond);
+    }
+    if (g.NextWindowData.Flags & ImGuiNextWindowDataFlags_HasContentSize)
+        window->ContentSizeExplicit = g.NextWindowData.ContentSizeVal;
+    else if (first_begin_of_the_frame)
+        window->ContentSizeExplicit = ImVec2(0.0f, 0.0f);
+    if (g.NextWindowData.Flags & ImGuiNextWindowDataFlags_HasCollapsed)
+        SetWindowCollapsed(window, g.NextWindowData.CollapsedVal, g.NextWindowData.CollapsedCond);
+    if (g.NextWindowData.Flags & ImGuiNextWindowDataFlags_HasFocus)
+        FocusWindow(window);
+    if (window->Appearing)
+        SetWindowConditionAllowFlags(window, ImGuiCond_Appearing, false);
+
+    // When reusing window again multiple times a frame, just append content (don't need to setup
+    // again)
+    if (first_begin_of_the_frame)
+    {
+        // Initialize
+        const bool window_is_child_tooltip =
+            (flags & ImGuiWindowFlags_ChildWindow) &&
+            (flags & ImGuiWindowFlags_Tooltip);  // FIXME-WIP: Undocumented behavior of
+                                                 // Child+Tooltip for pinned tooltip (#1345)
+        UpdateWindowParentAndRootLinks(window, flags, parent_window);
+
+        window->Active         = true;
+        window->HasCloseButton = (p_open != NULL);
+        window->ClipRect       = ImVec4(-FLT_MAX, -FLT_MAX, +FLT_MAX, +FLT_MAX);
+        window->IDStack.resize(1);
+
+        // Update stored window name when it changes (which can _only_ happen with the "###"
+        // operator, so the ID would stay unchanged). The title bar always display the 'name'
+        // parameter, so we only update the string storage if it needs to be visible to the end-user
+        // elsewhere.
+        bool window_title_visible_elsewhere = false;
+        if (g.NavWindowingList != NULL && (window->Flags & ImGuiWindowFlags_NoNavFocus) ==
+                                              0)  // Window titles visible when using CTRL+TAB
+            window_title_visible_elsewhere = true;
+        if (window_title_visible_elsewhere && !window_just_created &&
+            strcmp(name, window->Name) != 0)
+        {
+            size_t buf_len     = (size_t)window->NameBufLen;
+            window->Name       = ImStrdupcpy(window->Name, &buf_len, name);
+            window->NameBufLen = (int)buf_len;
+        }
+
+        // UPDATE CONTENTS SIZE, UPDATE HIDDEN STATUS
+
+        // Update contents size from last frame for auto-fitting (or use explicit size)
+        window->ContentSize = CalcContentSize(window);
+        if (window->HiddenFramesCanSkipItems > 0)
+            window->HiddenFramesCanSkipItems--;
+        if (window->HiddenFramesCannotSkipItems > 0)
+            window->HiddenFramesCannotSkipItems--;
+
+        // Hide new windows for one frame until they calculate their size
+        if (window_just_created && (!window_size_x_set_by_api || !window_size_y_set_by_api))
+            window->HiddenFramesCannotSkipItems = 1;
+
+        // Hide popup/tooltip window when re-opening while we measure size (because we recycle the
+        // windows) We reset Size/ContentSize for reappearing popups/tooltips early in this
+        // function, so further code won't be tempted to use the old size.
+        if (window_just_activated_by_user &&
+            (flags & (ImGuiWindowFlags_Popup | ImGuiWindowFlags_Tooltip)) != 0)
+        {
+            window->HiddenFramesCannotSkipItems = 1;
+            if (flags & ImGuiWindowFlags_AlwaysAutoResize)
+            {
+                if (!window_size_x_set_by_api)
+                    window->Size.x = window->SizeFull.x = 0.f;
+                if (!window_size_y_set_by_api)
+                    window->Size.y = window->SizeFull.y = 0.f;
+                window->ContentSize = ImVec2(0.f, 0.f);
+            }
+        }
+
+        // FIXME-VIEWPORT: In the docking/viewport branch, this is the point where we select the
+        // current viewport (which may affect the style)
+        SetCurrentWindow(window);
+
+        // LOCK BORDER SIZE AND PADDING FOR THE FRAME (so that altering them doesn't cause
+        // inconsistencies)
+
+        if (flags & ImGuiWindowFlags_ChildWindow)
+            window->WindowBorderSize = style.ChildBorderSize;
+        else
+            window->WindowBorderSize =
+                ((flags & (ImGuiWindowFlags_Popup | ImGuiWindowFlags_Tooltip)) &&
+                 !(flags & ImGuiWindowFlags_Modal))
+                    ? style.PopupBorderSize
+                    : style.WindowBorderSize;
+        window->WindowPadding = style.WindowPadding;
+        if ((flags & ImGuiWindowFlags_ChildWindow) &&
+            !(flags & (ImGuiWindowFlags_AlwaysUseWindowPadding | ImGuiWindowFlags_Popup)) &&
+            window->WindowBorderSize == 0.0f)
+            window->WindowPadding =
+                ImVec2(0.0f, (flags & ImGuiWindowFlags_MenuBar) ? style.WindowPadding.y : 0.0f);
+        window->DC.MenuBarOffset.x = ImMax(ImMax(window->WindowPadding.x, style.ItemSpacing.x),
+                                           g.NextWindowData.MenuBarOffsetMinVal.x);
+        window->DC.MenuBarOffset.y = g.NextWindowData.MenuBarOffsetMinVal.y;
+
+        // Collapse window by double-clicking on title bar
+        // At this point we don't have a clipping rectangle setup yet, so we can use the title bar
+        // area for hit detection and drawing
+        if (!(flags & ImGuiWindowFlags_NoTitleBar) && !(flags & ImGuiWindowFlags_NoCollapse))
+        {
+            // We don't use a regular button+id to test for double-click on title bar (mostly due to
+            // legacy reason, could be fixed), so verify that we don't have items over the title
+            // bar.
+            ImRect title_bar_rect = window->TitleBarRect();
+            if (g.HoveredWindow == window && g.HoveredId == 0 && g.HoveredIdPreviousFrame == 0 &&
+                IsMouseHoveringRect(title_bar_rect.Min, title_bar_rect.Max) &&
+                g.IO.MouseDoubleClicked[0])
+                window->WantCollapseToggle = true;
+            if (window->WantCollapseToggle)
+            {
+                window->Collapsed = !window->Collapsed;
+                MarkIniSettingsDirty(window);
+                FocusWindow(window);
+            }
+        }
+        else
+        {
+            window->Collapsed = false;
+        }
+        window->WantCollapseToggle = false;
+
+        // SIZE
+
+        // Calculate auto-fit size, handle automatic resize
+        const ImVec2 size_auto_fit            = CalcSizeAutoFit(window, window->ContentSize);
+        bool use_current_size_for_scrollbar_x = window_just_created;
+        bool use_current_size_for_scrollbar_y = window_just_created;
+        if ((flags & ImGuiWindowFlags_AlwaysAutoResize) && !window->Collapsed)
+        {
+            // Using SetNextWindowSize() overrides ImGuiWindowFlags_AlwaysAutoResize, so it can be
+            // used on tooltips/popups, etc.
+            if (!window_size_x_set_by_api)
+            {
+                window->SizeFull.x               = size_auto_fit.x;
+                use_current_size_for_scrollbar_x = true;
+            }
+            if (!window_size_y_set_by_api)
+            {
+                window->SizeFull.y               = size_auto_fit.y;
+                use_current_size_for_scrollbar_y = true;
+            }
+        }
+        else if (window->AutoFitFramesX > 0 || window->AutoFitFramesY > 0)
+        {
+            // Auto-fit may only grow window during the first few frames
+            // We still process initial auto-fit on collapsed windows to get a window width, but
+            // otherwise don't honor ImGuiWindowFlags_AlwaysAutoResize when collapsed.
+            if (!window_size_x_set_by_api && window->AutoFitFramesX > 0)
+            {
+                window->SizeFull.x = window->AutoFitOnlyGrows
+                                         ? ImMax(window->SizeFull.x, size_auto_fit.x)
+                                         : size_auto_fit.x;
+                use_current_size_for_scrollbar_x = true;
+            }
+            if (!window_size_y_set_by_api && window->AutoFitFramesY > 0)
+            {
+                window->SizeFull.y = window->AutoFitOnlyGrows
+                                         ? ImMax(window->SizeFull.y, size_auto_fit.y)
+                                         : size_auto_fit.y;
+                use_current_size_for_scrollbar_y = true;
+            }
+            if (!window->Collapsed)
+                MarkIniSettingsDirty(window);
+        }
+
+        // Apply minimum/maximum window size constraints and final size
+        window->SizeFull = CalcSizeAfterConstraint(window, window->SizeFull);
+        window->Size     = window->Collapsed && !(flags & ImGuiWindowFlags_ChildWindow)
+                           ? window->TitleBarRect().GetSize()
+                           : window->SizeFull;
+
+        // Decoration size
+        const float decoration_up_height = window->TitleBarHeight() + window->MenuBarHeight();
+
+        // POSITION
+
+        // Popup latch its initial position, will position itself when it appears next frame
+        if (window_just_activated_by_user)
+        {
+            window->AutoPosLastDirection = ImGuiDir_None;
+            if ((flags & ImGuiWindowFlags_Popup) != 0 && !window_pos_set_by_api)
+                window->Pos = g.BeginPopupStack.back().OpenPopupPos;
+        }
+
+        // Position child window
+        if (flags & ImGuiWindowFlags_ChildWindow)
+        {
+            IM_ASSERT(parent_window && parent_window->Active);
+            window->BeginOrderWithinParent = (short)parent_window->DC.ChildWindows.Size;
+            parent_window->DC.ChildWindows.push_back(window);
+            if (!(flags & ImGuiWindowFlags_Popup) && !window_pos_set_by_api &&
+                !window_is_child_tooltip)
+                window->Pos = parent_window->DC.CursorPos;
+        }
+
+        const bool window_pos_with_pivot =
+            (window->SetWindowPosVal.x != FLT_MAX && window->HiddenFramesCannotSkipItems == 0);
+        if (window_pos_with_pivot)
+            SetWindowPos(
+                window,
+                ImMax(style.DisplaySafeAreaPadding,
+                      window->SetWindowPosVal - window->SizeFull * window->SetWindowPosPivot),
+                0);  // Position given a pivot (e.g. for centering)
+        else if ((flags & ImGuiWindowFlags_ChildMenu) != 0)
+            window->Pos = FindBestWindowPosForPopup(window);
+        else if ((flags & ImGuiWindowFlags_Popup) != 0 && !window_pos_set_by_api &&
+                 window_just_appearing_after_hidden_for_resize)
+            window->Pos = FindBestWindowPosForPopup(window);
+        else if ((flags & ImGuiWindowFlags_Tooltip) != 0 && !window_pos_set_by_api &&
+                 !window_is_child_tooltip)
+            window->Pos = FindBestWindowPosForPopup(window);
+
+        // Clamp position/size so window stays visible within its viewport or monitor
+
+        // Ignore zero-sized display explicitly to avoid losing positions if a window manager
+        // reports zero-sized window when initializing or minimizing.
+        ImRect viewport_rect(GetViewportRect());
+        if (!window_pos_set_by_api && !(flags & ImGuiWindowFlags_ChildWindow) &&
+            window->AutoFitFramesX <= 0 && window->AutoFitFramesY <= 0)
+        {
+            if (g.IO.DisplaySize.x > 0.0f &&
+                g.IO.DisplaySize.y > 0.0f)  // Ignore zero-sized display explicitly to avoid losing
+                                            // positions if a window manager reports zero-sized
+                                            // window when initializing or minimizing.
+            {
+                ImVec2 clamp_padding =
+                    ImMax(style.DisplayWindowPadding, style.DisplaySafeAreaPadding);
+                ClampWindowRect(window, viewport_rect, clamp_padding);
+            }
+        }
+        window->Pos = ImFloor(window->Pos);
+
+        // Lock window rounding for the frame (so that altering them doesn't cause inconsistencies)
+        window->WindowRounding =
+            (flags & ImGuiWindowFlags_ChildWindow)
+                ? style.ChildRounding
+                : ((flags & ImGuiWindowFlags_Popup) && !(flags & ImGuiWindowFlags_Modal))
+                      ? style.PopupRounding
+                      : style.WindowRounding;
+
+        // Apply window focus (new and reactivated windows are moved to front)
+        bool want_focus = false;
+        if (window_just_activated_by_user && !(flags & ImGuiWindowFlags_NoFocusOnAppearing))
+        {
+            if (flags & ImGuiWindowFlags_Popup)
+                want_focus = true;
+            else if ((flags & (ImGuiWindowFlags_ChildWindow | ImGuiWindowFlags_Tooltip)) == 0)
+                want_focus = true;
+        }
+
+        // Handle manual resize: Resize Grips, Borders, Gamepad
+        int border_held                   = -1;
+        ImU32 resize_grip_col[4]          = {0};
+        const int resize_grip_count       = g.IO.ConfigWindowsResizeFromEdges ? 2 : 1;  // 4
+        const float resize_grip_draw_size = (float)(int)ImMax(
+            g.FontSize * 1.35f, window->WindowRounding + 1.0f + g.FontSize * 0.2f);
+        if (!window->Collapsed)
+            if (UpdateManualResize(window, size_auto_fit, &border_held, resize_grip_count,
+                                   &resize_grip_col[0]))
+                use_current_size_for_scrollbar_x = use_current_size_for_scrollbar_y = true;
+        window->ResizeBorderHeld = (signed char)border_held;
+
+        // SCROLLBAR VISIBILITY
+
+        // Update scrollbar visibility (based on the Size that was effective during last frame or
+        // the auto-resized Size).
+        if (!window->Collapsed)
+        {
+            // When reading the current size we need to read it after size constraints have been
+            // applied. When we use InnerRect here we are intentionally reading last frame size,
+            // same for ScrollbarSizes values before we set them again.
+            ImVec2 avail_size_from_current_frame =
+                ImVec2(window->SizeFull.x, window->SizeFull.y - decoration_up_height);
+            ImVec2 avail_size_from_last_frame =
+                window->InnerRect.GetSize() + window->ScrollbarSizes;
+            ImVec2 needed_size_from_last_frame =
+                window_just_created ? ImVec2(0, 0)
+                                    : window->ContentSize + window->WindowPadding * 2.0f;
+            float size_x_for_scrollbars = use_current_size_for_scrollbar_x
+                                              ? avail_size_from_current_frame.x
+                                              : avail_size_from_last_frame.x;
+            float size_y_for_scrollbars = use_current_size_for_scrollbar_y
+                                              ? avail_size_from_current_frame.y
+                                              : avail_size_from_last_frame.y;
+            // bool scrollbar_y_from_last_frame = window->ScrollbarY; // FIXME: May want to use that
+            // in the ScrollbarX expression? How many pros vs cons?
+            window->ScrollbarY = (flags & ImGuiWindowFlags_AlwaysVerticalScrollbar) ||
+                                 ((needed_size_from_last_frame.y > size_y_for_scrollbars) &&
+                                  !(flags & ImGuiWindowFlags_NoScrollbar));
+            window->ScrollbarX =
+                (flags & ImGuiWindowFlags_AlwaysHorizontalScrollbar) ||
+                ((needed_size_from_last_frame.x >
+                  size_x_for_scrollbars - (window->ScrollbarY ? style.ScrollbarSize : 0.0f)) &&
+                 !(flags & ImGuiWindowFlags_NoScrollbar) &&
+                 (flags & ImGuiWindowFlags_HorizontalScrollbar));
+            if (window->ScrollbarX && !window->ScrollbarY)
+                window->ScrollbarY = (needed_size_from_last_frame.y > size_y_for_scrollbars) &&
+                                     !(flags & ImGuiWindowFlags_NoScrollbar);
+            window->ScrollbarSizes = ImVec2(window->ScrollbarY ? style.ScrollbarSize : 0.0f,
+                                            window->ScrollbarX ? style.ScrollbarSize : 0.0f);
+        }
+
+        // UPDATE RECTANGLES (1- THOSE NOT AFFECTED BY SCROLLING)
+        // Update various regions. Variables they depends on should be set above in this function.
+        // We set this up after processing the resize grip so that our rectangles doesn't lag by a
+        // frame.
+
+        // Outer rectangle
+        // Not affected by window border size. Used by:
+        // - FindHoveredWindow() (w/ extra padding when border resize is enabled)
+        // - Begin() initial clipping rect for drawing window background and borders.
+        // - Begin() clipping whole child
+        const ImRect host_rect = ((flags & ImGuiWindowFlags_ChildWindow) &&
+                                  !(flags & ImGuiWindowFlags_Popup) && !window_is_child_tooltip)
+                                     ? parent_window->ClipRect
+                                     : viewport_rect;
+        const ImRect outer_rect     = window->Rect();
+        const ImRect title_bar_rect = window->TitleBarRect();
+        window->OuterRectClipped    = outer_rect;
+        window->OuterRectClipped.ClipWith(host_rect);
+
+        // Inner rectangle
+        // Not affected by window border size. Used by:
+        // - InnerClipRect
+        // - NavScrollToBringItemIntoView()
+        // - NavUpdatePageUpPageDown()
+        // - Scrollbar()
+        window->InnerRect.Min.x = window->Pos.x;
+        window->InnerRect.Min.y = window->Pos.y + decoration_up_height;
+        window->InnerRect.Max.x = window->Pos.x + window->Size.x - window->ScrollbarSizes.x;
+        window->InnerRect.Max.y = window->Pos.y + window->Size.y - window->ScrollbarSizes.y;
+
+        // Inner clipping rectangle.
+        // Will extend a little bit outside the normal work region.
+        // This is to allow e.g. Selectable or CollapsingHeader or some separators to cover that
+        // space. Force round operator last to ensure that e.g. (int)(max.x-min.x) in user's render
+        // code produce correct result. Note that if our window is collapsed we will end up with an
+        // inverted (~null) clipping rectangle which is the correct behavior. Affected by
+        // window/frame border size. Used by:
+        // - Begin() initial clip rect
+        float top_border_size =
+            (((flags & ImGuiWindowFlags_MenuBar) || !(flags & ImGuiWindowFlags_NoTitleBar))
+                 ? style.FrameBorderSize
+                 : window->WindowBorderSize);
+        window->InnerClipRect.Min.x =
+            ImFloor(0.5f + window->InnerRect.Min.x +
+                    ImMax(ImFloor(window->WindowPadding.x * 0.5f), window->WindowBorderSize));
+        window->InnerClipRect.Min.y = ImFloor(0.5f + window->InnerRect.Min.y + top_border_size);
+        window->InnerClipRect.Max.x =
+            ImFloor(0.5f + window->InnerRect.Max.x -
+                    ImMax(ImFloor(window->WindowPadding.x * 0.5f), window->WindowBorderSize));
+        window->InnerClipRect.Max.y =
+            ImFloor(0.5f + window->InnerRect.Max.y - window->WindowBorderSize);
+        window->InnerClipRect.ClipWithFull(host_rect);
+
+        // Default item width. Make it proportional to window size if window manually resizes
+        if (window->Size.x > 0.0f && !(flags & ImGuiWindowFlags_Tooltip) &&
+            !(flags & ImGuiWindowFlags_AlwaysAutoResize))
+            window->ItemWidthDefault = (float)(int)(window->Size.x * 0.65f);
+        else
+            window->ItemWidthDefault = (float)(int)(g.FontSize * 16.0f);
+
+        // SCROLLING
+
+        // Lock down maximum scrolling
+        // The value of ScrollMax are ahead from ScrollbarX/ScrollbarY which is intentionally using
+        // InnerRect from previous rect in order to accommodate for right/bottom aligned items
+        // without creating a scrollbar.
+        window->ScrollMax.x = ImMax(0.0f, window->ContentSize.x + window->WindowPadding.x * 2.0f -
+                                              window->InnerRect.GetWidth());
+        window->ScrollMax.y = ImMax(0.0f, window->ContentSize.y + window->WindowPadding.y * 2.0f -
+                                              window->InnerRect.GetHeight());
+
+        // Apply scrolling
+        window->Scroll       = CalcNextScrollFromScrollTargetAndClamp(window, true);
+        window->ScrollTarget = ImVec2(FLT_MAX, FLT_MAX);
+
+        // DRAWING
+
+        // Setup draw list and outer clipping rectangle
+        window->DrawList->Clear();
+        window->DrawList->PushTextureID(g.Font->ContainerAtlas->TexID);
+        PushClipRect(host_rect.Min, host_rect.Max, false);
+
+        // Draw modal window background (darkens what is behind them, all viewports)
+        const bool dim_bg_for_modal = (flags & ImGuiWindowFlags_Modal) &&
+                                      window == GetTopMostPopupModal() &&
+                                      window->HiddenFramesCannotSkipItems <= 0;
+        const bool dim_bg_for_window_list =
+            g.NavWindowingTargetAnim && (window == g.NavWindowingTargetAnim->RootWindow);
+        if (dim_bg_for_modal || dim_bg_for_window_list)
+        {
+            const ImU32 dim_bg_col = GetColorU32(
+                dim_bg_for_modal ? ImGuiCol_ModalWindowDimBg : ImGuiCol_NavWindowingDimBg,
+                g.DimBgRatio);
+            window->DrawList->AddRectFilled(viewport_rect.Min, viewport_rect.Max, dim_bg_col);
+        }
+
+        // Draw navigation selection/windowing rectangle background
+        if (dim_bg_for_window_list && window == g.NavWindowingTargetAnim)
+        {
+            ImRect bb = window->Rect();
+            bb.Expand(g.FontSize);
+            if (!bb.Contains(
+                    viewport_rect))  // Avoid drawing if the window covers all the viewport anyway
+                window->DrawList->AddRectFilled(bb.Min, bb.Max,
+                                                GetColorU32(ImGuiCol_NavWindowingHighlight,
+                                                            g.NavWindowingHighlightAlpha * 0.25f),
+                                                g.Style.WindowRounding);
+        }
+
+        // Since 1.71, child window can render their decoration (bg color, border, scrollbars, etc.)
+        // within their parent to save a draw call. When using overlapping child windows, this will
+        // break the assumption that child z-order is mapped to submission order. We disable this
+        // when the parent window has zero vertices, which is a common pattern leading to laying out
+        // multiple overlapping child. We also disabled this when we have dimming overlay behind
+        // this specific one child.
+        // FIXME: More code may rely on explicit sorting of overlapping child window and would need
+        // to disable this somehow. Please get in contact if you are affected.
+        bool render_decorations_in_parent = false;
+        if ((flags & ImGuiWindowFlags_ChildWindow) && !(flags & ImGuiWindowFlags_Popup) &&
+            !window_is_child_tooltip)
+            if (window->DrawList->CmdBuffer.back().ElemCount == 0 &&
+                parent_window->DrawList->VtxBuffer.Size > 0)
+                render_decorations_in_parent = true;
+        if (render_decorations_in_parent)
+            window->DrawList = parent_window->DrawList;
+
+        const ImGuiWindow *window_to_highlight =
+            g.NavWindowingTarget ? g.NavWindowingTarget : g.NavWindow;
+        const bool title_bar_is_highlight =
+            want_focus ||
+            (window_to_highlight && window->RootWindowForTitleBarHighlight ==
+                                        window_to_highlight->RootWindowForTitleBarHighlight);
+        RenderWindowDecorations(window, title_bar_rect, title_bar_is_highlight, resize_grip_count,
+                                resize_grip_col, resize_grip_draw_size);
+
+        if (render_decorations_in_parent)
+            window->DrawList = &window->DrawListInst;
+
+        // Draw navigation selection/windowing rectangle border
+        if (g.NavWindowingTargetAnim == window)
+        {
+            float rounding = ImMax(window->WindowRounding, g.Style.WindowRounding);
+            ImRect bb      = window->Rect();
+            bb.Expand(g.FontSize);
+            if (bb.Contains(viewport_rect))  // If a window fits the entire viewport, adjust its
+                                             // highlight inward
+            {
+                bb.Expand(-g.FontSize - 1.0f);
+                rounding = window->WindowRounding;
+            }
+            window->DrawList->AddRect(
+                bb.Min, bb.Max,
+                GetColorU32(ImGuiCol_NavWindowingHighlight, g.NavWindowingHighlightAlpha), rounding,
+                ~0, 3.0f);
+        }
+
+        // UPDATE RECTANGLES (2- THOSE AFFECTED BY SCROLLING)
+
+        // Work rectangle.
+        // Affected by window padding and border size. Used by:
+        // - Columns() for right-most edge
+        // - TreeNode(), CollapsingHeader() for right-most edge
+        // - BeginTabBar() for right-most edge
+        const bool allow_scrollbar_x = !(flags & ImGuiWindowFlags_NoScrollbar) &&
+                                       (flags & ImGuiWindowFlags_HorizontalScrollbar);
+        const bool allow_scrollbar_y = !(flags & ImGuiWindowFlags_NoScrollbar);
+        const float work_rect_size_x =
+            (window->ContentSizeExplicit.x != 0.0f
+                 ? window->ContentSizeExplicit.x
+                 : ImMax(
+                       allow_scrollbar_x ? window->ContentSize.x : 0.0f,
+                       window->Size.x - window->WindowPadding.x * 2.0f - window->ScrollbarSizes.x));
+        const float work_rect_size_y =
+            (window->ContentSizeExplicit.y != 0.0f
+                 ? window->ContentSizeExplicit.y
+                 : ImMax(allow_scrollbar_y ? window->ContentSize.y : 0.0f,
+                         window->Size.y - window->WindowPadding.y * 2.0f - decoration_up_height -
+                             window->ScrollbarSizes.y));
+        window->WorkRect.Min.x = ImFloor(window->InnerRect.Min.x - window->Scroll.x +
+                                         ImMax(window->WindowPadding.x, window->WindowBorderSize));
+        window->WorkRect.Min.y = ImFloor(window->InnerRect.Min.y - window->Scroll.y +
+                                         ImMax(window->WindowPadding.y, window->WindowBorderSize));
+        window->WorkRect.Max.x = window->WorkRect.Min.x + work_rect_size_x;
+        window->WorkRect.Max.y = window->WorkRect.Min.y + work_rect_size_y;
+
+        // [LEGACY] Contents Region
+        // FIXME-OBSOLETE: window->ContentsRegionRect.Max is currently very misleading / partly
+        // faulty, but some BeginChild() patterns relies on it. Used by:
+        // - Mouse wheel scrolling + many other things
+        window->ContentsRegionRect.Min.x =
+            window->Pos.x - window->Scroll.x + window->WindowPadding.x;
+        window->ContentsRegionRect.Min.y =
+            window->Pos.y - window->Scroll.y + window->WindowPadding.y + decoration_up_height;
+        window->ContentsRegionRect.Max.x =
+            window->ContentsRegionRect.Min.x +
+            (window->ContentSizeExplicit.x != 0.0f
+                 ? window->ContentSizeExplicit.x
+                 : (window->Size.x - window->WindowPadding.x * 2.0f - window->ScrollbarSizes.x));
+        window->ContentsRegionRect.Max.y =
+            window->ContentsRegionRect.Min.y +
+            (window->ContentSizeExplicit.y != 0.0f
+                 ? window->ContentSizeExplicit.y
+                 : (window->Size.y - window->WindowPadding.y * 2.0f - decoration_up_height -
+                    window->ScrollbarSizes.y));
+
+        // Setup drawing context
+        // (NB: That term "drawing context / DC" lost its meaning a long time ago. Initially was
+        // meant to hold transient data only. Nowadays difference between window-> and window->DC->
+        // is dubious.)
+        window->DC.Indent.x        = 0.0f + window->WindowPadding.x - window->Scroll.x;
+        window->DC.GroupOffset.x   = 0.0f;
+        window->DC.ColumnsOffset.x = 0.0f;
+        window->DC.CursorStartPos =
+            window->Pos + ImVec2(window->DC.Indent.x + window->DC.ColumnsOffset.x,
+                                 decoration_up_height + window->WindowPadding.y - window->Scroll.y);
+        window->DC.CursorPos         = window->DC.CursorStartPos;
+        window->DC.CursorPosPrevLine = window->DC.CursorPos;
+        window->DC.CursorMaxPos      = window->DC.CursorStartPos;
+        window->DC.CurrLineSize = window->DC.PrevLineSize = ImVec2(0.0f, 0.0f);
+        window->DC.CurrLineTextBaseOffset = window->DC.PrevLineTextBaseOffset = 0.0f;
+        window->DC.NavHideHighlightOneFrame                                   = false;
+        window->DC.NavHasScroll           = (window->ScrollMax.y > 0.0f);
+        window->DC.NavLayerActiveMask     = window->DC.NavLayerActiveMaskNext;
+        window->DC.NavLayerActiveMaskNext = 0x00;
+        window->DC.MenuBarAppending       = false;
+        window->DC.ChildWindows.resize(0);
+        window->DC.LayoutType = ImGuiLayoutType_Vertical;
+        window->DC.ParentLayoutType =
+            parent_window ? parent_window->DC.LayoutType : ImGuiLayoutType_Vertical;
+        window->DC.FocusCounterAll = window->DC.FocusCounterTab = -1;
+        window->DC.ItemFlags =
+            parent_window ? parent_window->DC.ItemFlags : ImGuiItemFlags_Default_;
+        window->DC.ItemWidth   = window->ItemWidthDefault;
+        window->DC.TextWrapPos = -1.0f;  // disabled
+        window->DC.ItemFlagsStack.resize(0);
+        window->DC.ItemWidthStack.resize(0);
+        window->DC.TextWrapPosStack.resize(0);
+        window->DC.CurrentColumns                = NULL;
+        window->DC.TreeDepth                     = 0;
+        window->DC.TreeStoreMayJumpToParentOnPop = 0x00;
+        window->DC.StateStorage                  = &window->StateStorage;
+        window->DC.GroupStack.resize(0);
+        window->MenuColumns.Update(3, style.ItemSpacing.x, window_just_activated_by_user);
+
+        if ((flags & ImGuiWindowFlags_ChildWindow) &&
+            (window->DC.ItemFlags != parent_window->DC.ItemFlags))
+        {
+            window->DC.ItemFlags = parent_window->DC.ItemFlags;
+            window->DC.ItemFlagsStack.push_back(window->DC.ItemFlags);
+        }
+
+        if (window->AutoFitFramesX > 0)
+            window->AutoFitFramesX--;
+        if (window->AutoFitFramesY > 0)
+            window->AutoFitFramesY--;
+
+        // Apply focus (we need to call FocusWindow() AFTER setting DC.CursorStartPos so our initial
+        // navigation reference rectangle can start around there)
+        if (want_focus)
+        {
+            FocusWindow(window);
+            NavInitWindow(window, false);
+        }
+
+        // Title bar
+        if (!(flags & ImGuiWindowFlags_NoTitleBar))
+            RenderWindowTitleBarContents(window, title_bar_rect, name, p_open);
+
+        // Pressing CTRL+C while holding on a window copy its content to the clipboard
+        // This works but 1. doesn't handle multiple Begin/End pairs, 2. recursing into another
+        // Begin/End pair - so we need to work that out and add better logging scope. Maybe we can
+        // support CTRL+C on every element?
+        /*
+        if (g.ActiveId == move_id)
+            if (g.IO.KeyCtrl && IsKeyPressedMap(ImGuiKey_C))
+                LogToClipboard();
+        */
+
+        // We fill last item data based on Title Bar/Tab, in order for IsItemHovered() and
+        // IsItemActive() to be usable after Begin(). This is useful to allow creating context menus
+        // on title bar only, etc.
+        window->DC.LastItemId = window->MoveId;
+        window->DC.LastItemStatusFlags =
+            IsMouseHoveringRect(title_bar_rect.Min, title_bar_rect.Max, false)
+                ? ImGuiItemStatusFlags_HoveredRect
+                : 0;
+        window->DC.LastItemRect = title_bar_rect;
+#ifdef IMGUI_ENABLE_TEST_ENGINE
+        if (!(window->Flags & ImGuiWindowFlags_NoTitleBar))
+            IMGUI_TEST_ENGINE_ITEM_ADD(window->DC.LastItemRect, window->DC.LastItemId);
+#endif
+    }
+    else
+    {
+        // Append
+        SetCurrentWindow(window);
+    }
+
+    PushClipRect(window->InnerClipRect.Min, window->InnerClipRect.Max, true);
+
+    // Clear 'accessed' flag last thing (After PushClipRect which will set the flag. We want the
+    // flag to stay false when the default "Debug" window is unused)
+    if (first_begin_of_the_frame)
+        window->WriteAccessed = false;
+
+    window->BeginCount++;
+    g.NextWindowData.ClearFlags();
+
+    if (flags & ImGuiWindowFlags_ChildWindow)
+    {
+        // Child window can be out of sight and have "negative" clip windows.
+        // Mark them as collapsed so commands are skipped earlier (we can't manually collapse them
+        // because they have no title bar).
+        IM_ASSERT((flags & ImGuiWindowFlags_NoTitleBar) != 0);
+        if (!(flags & ImGuiWindowFlags_AlwaysAutoResize) && window->AutoFitFramesX <= 0 &&
+            window->AutoFitFramesY <= 0)
+            if (window->OuterRectClipped.Min.x >= window->OuterRectClipped.Max.x ||
+                window->OuterRectClipped.Min.y >= window->OuterRectClipped.Max.y)
+                window->HiddenFramesCanSkipItems = 1;
+
+        // Hide along with parent or if parent is collapsed
+        if (parent_window &&
+            (parent_window->Collapsed || parent_window->HiddenFramesCanSkipItems > 0))
+            window->HiddenFramesCanSkipItems = 1;
+        if (parent_window &&
+            (parent_window->Collapsed || parent_window->HiddenFramesCannotSkipItems > 0))
+            window->HiddenFramesCannotSkipItems = 1;
+    }
+
+    // Don't render if style alpha is 0.0 at the time of Begin(). This is arbitrary and inconsistent
+    // but has been there for a long while (may remove at some point)
+    if (style.Alpha <= 0.0f)
+        window->HiddenFramesCanSkipItems = 1;
+
+    // Update the Hidden flag
+    window->Hidden =
+        (window->HiddenFramesCanSkipItems > 0) || (window->HiddenFramesCannotSkipItems > 0);
+
+    // Update the SkipItems flag, used to early out of all items functions (no layout required)
+    bool skip_items = false;
+    if (window->Collapsed || !window->Active || window->Hidden)
+        if (window->AutoFitFramesX <= 0 && window->AutoFitFramesY <= 0 &&
+            window->HiddenFramesCannotSkipItems <= 0)
+            skip_items = true;
+    window->SkipItems = skip_items;
+
+    return !skip_items;
+}
+
+// Old Begin() API with 5 parameters, avoid calling this version directly! Use
+// SetNextWindowSize()/SetNextWindowBgAlpha() + Begin() instead.
+#ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+bool ImGui::Begin(const char *name,
+                  bool *p_open,
+                  const ImVec2 &size_first_use,
+                  float bg_alpha_override,
+                  ImGuiWindowFlags flags)
+{
+    // Old API feature: we could pass the initial window size as a parameter. This was misleading
+    // because it only had an effect if the window didn't have data in the .ini file.
+    if (size_first_use.x != 0.0f || size_first_use.y != 0.0f)
+        SetNextWindowSize(size_first_use, ImGuiCond_FirstUseEver);
+
+    // Old API feature: override the window background alpha with a parameter.
+    if (bg_alpha_override >= 0.0f)
+        SetNextWindowBgAlpha(bg_alpha_override);
+
+    return Begin(name, p_open, flags);
+}
+#endif  // IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+
+void ImGui::End()
+{
+    ImGuiContext &g = *GImGui;
+
+    if (g.CurrentWindowStack.Size <= 1 && g.FrameScopePushedImplicitWindow)
+    {
+        IM_ASSERT(g.CurrentWindowStack.Size > 1 && "Calling End() too many times!");
+        return;  // FIXME-ERRORHANDLING
+    }
+    IM_ASSERT(g.CurrentWindowStack.Size > 0);
+
+    ImGuiWindow *window = g.CurrentWindow;
+
+    if (window->DC.CurrentColumns)
+        EndColumns();
+    PopClipRect();  // Inner window clip rectangle
+
+    // Stop logging
+    if (!(window->Flags &
+          ImGuiWindowFlags_ChildWindow))  // FIXME: add more options for scope of logging
+        LogFinish();
+
+    // Pop from window stack
+    g.CurrentWindowStack.pop_back();
+    if (window->Flags & ImGuiWindowFlags_Popup)
+        g.BeginPopupStack.pop_back();
+    CheckStacksSize(window, false);
+    SetCurrentWindow(g.CurrentWindowStack.empty() ? NULL : g.CurrentWindowStack.back());
+}
+
+void ImGui::BringWindowToFocusFront(ImGuiWindow *window)
+{
+    ImGuiContext &g = *GImGui;
+    if (g.WindowsFocusOrder.back() == window)
+        return;
+    for (int i = g.WindowsFocusOrder.Size - 2; i >= 0; i--)  // We can ignore the top-most window
+        if (g.WindowsFocusOrder[i] == window)
+        {
+            memmove(&g.WindowsFocusOrder[i], &g.WindowsFocusOrder[i + 1],
+                    (size_t)(g.WindowsFocusOrder.Size - i - 1) * sizeof(ImGuiWindow *));
+            g.WindowsFocusOrder[g.WindowsFocusOrder.Size - 1] = window;
+            break;
+        }
+}
+
+void ImGui::BringWindowToDisplayFront(ImGuiWindow *window)
+{
+    ImGuiContext &g                   = *GImGui;
+    ImGuiWindow *current_front_window = g.Windows.back();
+    if (current_front_window == window || current_front_window->RootWindow == window)
+        return;
+    for (int i = g.Windows.Size - 2; i >= 0; i--)  // We can ignore the top-most window
+        if (g.Windows[i] == window)
+        {
+            memmove(&g.Windows[i], &g.Windows[i + 1],
+                    (size_t)(g.Windows.Size - i - 1) * sizeof(ImGuiWindow *));
+            g.Windows[g.Windows.Size - 1] = window;
+            break;
+        }
+}
+
+void ImGui::BringWindowToDisplayBack(ImGuiWindow *window)
+{
+    ImGuiContext &g = *GImGui;
+    if (g.Windows[0] == window)
+        return;
+    for (int i = 0; i < g.Windows.Size; i++)
+        if (g.Windows[i] == window)
+        {
+            memmove(&g.Windows[1], &g.Windows[0], (size_t)i * sizeof(ImGuiWindow *));
+            g.Windows[0] = window;
+            break;
+        }
+}
+
+// Moving window to front of display and set focus (which happens to be back of our sorted list)
+void ImGui::FocusWindow(ImGuiWindow *window)
+{
+    ImGuiContext &g = *GImGui;
+
+    if (g.NavWindow != window)
+    {
+        g.NavWindow = window;
+        if (window && g.NavDisableMouseHover)
+            g.NavMousePosDirty = true;
+        g.NavInitRequest = false;
+        g.NavId          = window ? window->NavLastIds[0] : 0;  // Restore NavId
+        g.NavIdIsAlive   = false;
+        g.NavLayer       = ImGuiNavLayer_Main;
+        // IMGUI_DEBUG_LOG("FocusWindow(\"%s\")\n", window ? window->Name : NULL);
+    }
+
+    // Close popups if any
+    ClosePopupsOverWindow(window, false);
+
+    // Passing NULL allow to disable keyboard focus
+    if (!window)
+        return;
+
+    // Move the root window to the top of the pile
+    if (window->RootWindow)
+        window = window->RootWindow;
+
+    // Steal focus on active widgets
+    if (window->Flags & ImGuiWindowFlags_Popup)  // FIXME: This statement should be unnecessary.
+                                                 // Need further testing before removing it..
+        if (g.ActiveId != 0 && g.ActiveIdWindow && g.ActiveIdWindow->RootWindow != window)
+            ClearActiveID();
+
+    // Bring to front
+    BringWindowToFocusFront(window);
+    if (!(window->Flags & ImGuiWindowFlags_NoBringToFrontOnFocus))
+        BringWindowToDisplayFront(window);
+}
+
+void ImGui::FocusTopMostWindowUnderOne(ImGuiWindow *under_this_window, ImGuiWindow *ignore_window)
+{
+    ImGuiContext &g = *GImGui;
+
+    int start_idx = g.WindowsFocusOrder.Size - 1;
+    if (under_this_window != NULL)
+    {
+        int under_this_window_idx = FindWindowFocusIndex(under_this_window);
+        if (under_this_window_idx != -1)
+            start_idx = under_this_window_idx - 1;
+    }
+    for (int i = start_idx; i >= 0; i--)
+    {
+        // We may later decide to test for different NoXXXInputs based on the active navigation
+        // input (mouse vs nav) but that may feel more confusing to the user.
+        ImGuiWindow *window = g.WindowsFocusOrder[i];
+        if (window != ignore_window && window->WasActive &&
+            !(window->Flags & ImGuiWindowFlags_ChildWindow))
+            if ((window->Flags & (ImGuiWindowFlags_NoMouseInputs | ImGuiWindowFlags_NoNavInputs)) !=
+                (ImGuiWindowFlags_NoMouseInputs | ImGuiWindowFlags_NoNavInputs))
+            {
+                ImGuiWindow *focus_window = NavRestoreLastChildNavWindow(window);
+                FocusWindow(focus_window);
+                return;
+            }
+    }
+    FocusWindow(NULL);
+}
+
+void ImGui::SetNextItemWidth(float item_width)
+{
+    ImGuiContext &g = *GImGui;
+    g.NextItemData.Flags |= ImGuiNextItemDataFlags_HasWidth;
+    g.NextItemData.Width = item_width;
+}
+
+void ImGui::PushItemWidth(float item_width)
+{
+    ImGuiContext &g      = *GImGui;
+    ImGuiWindow *window  = g.CurrentWindow;
+    window->DC.ItemWidth = (item_width == 0.0f ? window->ItemWidthDefault : item_width);
+    window->DC.ItemWidthStack.push_back(window->DC.ItemWidth);
+    g.NextItemData.Flags &= ~ImGuiNextItemDataFlags_HasWidth;
+}
+
+void ImGui::PushMultiItemsWidths(int components, float w_full)
+{
+    ImGuiContext &g         = *GImGui;
+    ImGuiWindow *window     = g.CurrentWindow;
+    const ImGuiStyle &style = GImGui->Style;
+    const float w_item_one  = ImMax(
+        1.0f,
+        (float)(int)((w_full - (style.ItemInnerSpacing.x) * (components - 1)) / (float)components));
+    const float w_item_last = ImMax(
+        1.0f, (float)(int)(w_full - (w_item_one + style.ItemInnerSpacing.x) * (components - 1)));
+    window->DC.ItemWidthStack.push_back(w_item_last);
+    for (int i = 0; i < components - 1; i++)
+        window->DC.ItemWidthStack.push_back(w_item_one);
+    window->DC.ItemWidth = window->DC.ItemWidthStack.back();
+    g.NextItemData.Flags &= ~ImGuiNextItemDataFlags_HasWidth;
+}
+
+void ImGui::PopItemWidth()
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    window->DC.ItemWidthStack.pop_back();
+    window->DC.ItemWidth = window->DC.ItemWidthStack.empty() ? window->ItemWidthDefault
+                                                             : window->DC.ItemWidthStack.back();
+}
+
+// Calculate default item width given value passed to PushItemWidth() or SetNextItemWidth().
+// The SetNextItemWidth() data is generally cleared/consumed by ItemAdd() or
+// NextItemData.ClearFlags()
+float ImGui::CalcItemWidth()
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+    float w;
+    if (g.NextItemData.Flags & ImGuiNextItemDataFlags_HasWidth)
+        w = g.NextItemData.Width;
+    else
+        w = window->DC.ItemWidth;
+    if (w < 0.0f)
+    {
+        float region_max_x = GetContentRegionMaxAbs().x;
+        w                  = ImMax(1.0f, region_max_x - window->DC.CursorPos.x + w);
+    }
+    w = (float)(int)w;
+    return w;
+}
+
+// [Internal] Calculate full item size given user provided 'size' parameter and default
+// width/height. Default width is often == CalcItemWidth(). Those two functions CalcItemWidth vs
+// CalcItemSize are awkwardly named because they are not fully symmetrical. Note that only
+// CalcItemWidth() is publicly exposed. The 4.0f here may be changed to match CalcItemWidth() and/or
+// BeginChild() (right now we have a mismatch which is harmless but undesirable)
+ImVec2 ImGui::CalcItemSize(ImVec2 size, float default_w, float default_h)
+{
+    ImGuiWindow *window = GImGui->CurrentWindow;
+
+    ImVec2 region_max;
+    if (size.x < 0.0f || size.y < 0.0f)
+        region_max = GetContentRegionMaxAbs();
+
+    if (size.x == 0.0f)
+        size.x = default_w;
+    else if (size.x < 0.0f)
+        size.x = ImMax(4.0f, region_max.x - window->DC.CursorPos.x + size.x);
+
+    if (size.y == 0.0f)
+        size.y = default_h;
+    else if (size.y < 0.0f)
+        size.y = ImMax(4.0f, region_max.y - window->DC.CursorPos.y + size.y);
+
+    return size;
+}
+
+void ImGui::SetCurrentFont(ImFont *font)
+{
+    ImGuiContext &g = *GImGui;
+    IM_ASSERT(font && font->IsLoaded());  // Font Atlas not created. Did you call
+                                          // io.Fonts->GetTexDataAsRGBA32 / GetTexDataAsAlpha8 ?
+    IM_ASSERT(font->Scale > 0.0f);
+    g.Font         = font;
+    g.FontBaseSize = ImMax(1.0f, g.IO.FontGlobalScale * g.Font->FontSize * g.Font->Scale);
+    g.FontSize     = g.CurrentWindow ? g.CurrentWindow->CalcFontSize() : 0.0f;
+
+    ImFontAtlas *atlas                   = g.Font->ContainerAtlas;
+    g.DrawListSharedData.TexUvWhitePixel = atlas->TexUvWhitePixel;
+    g.DrawListSharedData.Font            = g.Font;
+    g.DrawListSharedData.FontSize        = g.FontSize;
+}
+
+void ImGui::PushFont(ImFont *font)
+{
+    ImGuiContext &g = *GImGui;
+    if (!font)
+        font = GetDefaultFont();
+    SetCurrentFont(font);
+    g.FontStack.push_back(font);
+    g.CurrentWindow->DrawList->PushTextureID(font->ContainerAtlas->TexID);
+}
+
+void ImGui::PopFont()
+{
+    ImGuiContext &g = *GImGui;
+    g.CurrentWindow->DrawList->PopTextureID();
+    g.FontStack.pop_back();
+    SetCurrentFont(g.FontStack.empty() ? GetDefaultFont() : g.FontStack.back());
+}
+
+void ImGui::PushItemFlag(ImGuiItemFlags option, bool enabled)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (enabled)
+        window->DC.ItemFlags |= option;
+    else
+        window->DC.ItemFlags &= ~option;
+    window->DC.ItemFlagsStack.push_back(window->DC.ItemFlags);
+}
+
+void ImGui::PopItemFlag()
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    window->DC.ItemFlagsStack.pop_back();
+    window->DC.ItemFlags = window->DC.ItemFlagsStack.empty() ? ImGuiItemFlags_Default_
+                                                             : window->DC.ItemFlagsStack.back();
+}
+
+// FIXME: Look into renaming this once we have settled the new Focus/Activation/TabStop system.
+void ImGui::PushAllowKeyboardFocus(bool allow_keyboard_focus)
+{
+    PushItemFlag(ImGuiItemFlags_NoTabStop, !allow_keyboard_focus);
+}
+
+void ImGui::PopAllowKeyboardFocus()
+{
+    PopItemFlag();
+}
+
+void ImGui::PushButtonRepeat(bool repeat)
+{
+    PushItemFlag(ImGuiItemFlags_ButtonRepeat, repeat);
+}
+
+void ImGui::PopButtonRepeat()
+{
+    PopItemFlag();
+}
+
+void ImGui::PushTextWrapPos(float wrap_pos_x)
+{
+    ImGuiWindow *window    = GetCurrentWindow();
+    window->DC.TextWrapPos = wrap_pos_x;
+    window->DC.TextWrapPosStack.push_back(wrap_pos_x);
+}
+
+void ImGui::PopTextWrapPos()
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    window->DC.TextWrapPosStack.pop_back();
+    window->DC.TextWrapPos =
+        window->DC.TextWrapPosStack.empty() ? -1.0f : window->DC.TextWrapPosStack.back();
+}
+
+// FIXME: This may incur a round-trip (if the end user got their data from a float4) but eventually
+// we aim to store the in-flight colors as ImU32
+void ImGui::PushStyleColor(ImGuiCol idx, ImU32 col)
+{
+    ImGuiContext &g = *GImGui;
+    ImGuiColorMod backup;
+    backup.Col         = idx;
+    backup.BackupValue = g.Style.Colors[idx];
+    g.ColorModifiers.push_back(backup);
+    g.Style.Colors[idx] = ColorConvertU32ToFloat4(col);
+}
+
+void ImGui::PushStyleColor(ImGuiCol idx, const ImVec4 &col)
+{
+    ImGuiContext &g = *GImGui;
+    ImGuiColorMod backup;
+    backup.Col         = idx;
+    backup.BackupValue = g.Style.Colors[idx];
+    g.ColorModifiers.push_back(backup);
+    g.Style.Colors[idx] = col;
+}
+
+void ImGui::PopStyleColor(int count)
+{
+    ImGuiContext &g = *GImGui;
+    while (count > 0)
+    {
+        ImGuiColorMod &backup      = g.ColorModifiers.back();
+        g.Style.Colors[backup.Col] = backup.BackupValue;
+        g.ColorModifiers.pop_back();
+        count--;
+    }
+}
+
+struct ImGuiStyleVarInfo
+{
+    ImGuiDataType Type;
+    ImU32 Count;
+    ImU32 Offset;
+    void *GetVarPtr(ImGuiStyle *style) const { return (void *)((unsigned char *)style + Offset); }
+};
+
+static const ImGuiStyleVarInfo GStyleVarInfo[] = {
+    {ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImGuiStyle, Alpha)},  // ImGuiStyleVar_Alpha
+    {ImGuiDataType_Float, 2,
+     (ImU32)IM_OFFSETOF(ImGuiStyle, WindowPadding)},  // ImGuiStyleVar_WindowPadding
+    {ImGuiDataType_Float, 1,
+     (ImU32)IM_OFFSETOF(ImGuiStyle, WindowRounding)},  // ImGuiStyleVar_WindowRounding
+    {ImGuiDataType_Float, 1,
+     (ImU32)IM_OFFSETOF(ImGuiStyle, WindowBorderSize)},  // ImGuiStyleVar_WindowBorderSize
+    {ImGuiDataType_Float, 2,
+     (ImU32)IM_OFFSETOF(ImGuiStyle, WindowMinSize)},  // ImGuiStyleVar_WindowMinSize
+    {ImGuiDataType_Float, 2,
+     (ImU32)IM_OFFSETOF(ImGuiStyle, WindowTitleAlign)},  // ImGuiStyleVar_WindowTitleAlign
+    {ImGuiDataType_Float, 1,
+     (ImU32)IM_OFFSETOF(ImGuiStyle, ChildRounding)},  // ImGuiStyleVar_ChildRounding
+    {ImGuiDataType_Float, 1,
+     (ImU32)IM_OFFSETOF(ImGuiStyle, ChildBorderSize)},  // ImGuiStyleVar_ChildBorderSize
+    {ImGuiDataType_Float, 1,
+     (ImU32)IM_OFFSETOF(ImGuiStyle, PopupRounding)},  // ImGuiStyleVar_PopupRounding
+    {ImGuiDataType_Float, 1,
+     (ImU32)IM_OFFSETOF(ImGuiStyle, PopupBorderSize)},  // ImGuiStyleVar_PopupBorderSize
+    {ImGuiDataType_Float, 2,
+     (ImU32)IM_OFFSETOF(ImGuiStyle, FramePadding)},  // ImGuiStyleVar_FramePadding
+    {ImGuiDataType_Float, 1,
+     (ImU32)IM_OFFSETOF(ImGuiStyle, FrameRounding)},  // ImGuiStyleVar_FrameRounding
+    {ImGuiDataType_Float, 1,
+     (ImU32)IM_OFFSETOF(ImGuiStyle, FrameBorderSize)},  // ImGuiStyleVar_FrameBorderSize
+    {ImGuiDataType_Float, 2,
+     (ImU32)IM_OFFSETOF(ImGuiStyle, ItemSpacing)},  // ImGuiStyleVar_ItemSpacing
+    {ImGuiDataType_Float, 2,
+     (ImU32)IM_OFFSETOF(ImGuiStyle, ItemInnerSpacing)},  // ImGuiStyleVar_ItemInnerSpacing
+    {ImGuiDataType_Float, 1,
+     (ImU32)IM_OFFSETOF(ImGuiStyle, IndentSpacing)},  // ImGuiStyleVar_IndentSpacing
+    {ImGuiDataType_Float, 1,
+     (ImU32)IM_OFFSETOF(ImGuiStyle, ScrollbarSize)},  // ImGuiStyleVar_ScrollbarSize
+    {ImGuiDataType_Float, 1,
+     (ImU32)IM_OFFSETOF(ImGuiStyle, ScrollbarRounding)},  // ImGuiStyleVar_ScrollbarRounding
+    {ImGuiDataType_Float, 1,
+     (ImU32)IM_OFFSETOF(ImGuiStyle, GrabMinSize)},  // ImGuiStyleVar_GrabMinSize
+    {ImGuiDataType_Float, 1,
+     (ImU32)IM_OFFSETOF(ImGuiStyle, GrabRounding)},  // ImGuiStyleVar_GrabRounding
+    {ImGuiDataType_Float, 1,
+     (ImU32)IM_OFFSETOF(ImGuiStyle, TabRounding)},  // ImGuiStyleVar_TabRounding
+    {ImGuiDataType_Float, 2,
+     (ImU32)IM_OFFSETOF(ImGuiStyle, ButtonTextAlign)},  // ImGuiStyleVar_ButtonTextAlign
+    {ImGuiDataType_Float, 2,
+     (ImU32)IM_OFFSETOF(ImGuiStyle, SelectableTextAlign)},  // ImGuiStyleVar_SelectableTextAlign
+};
+
+static const ImGuiStyleVarInfo *GetStyleVarInfo(ImGuiStyleVar idx)
+{
+    IM_ASSERT(idx >= 0 && idx < ImGuiStyleVar_COUNT);
+    IM_ASSERT(IM_ARRAYSIZE(GStyleVarInfo) == ImGuiStyleVar_COUNT);
+    return &GStyleVarInfo[idx];
+}
+
+void ImGui::PushStyleVar(ImGuiStyleVar idx, float val)
+{
+    const ImGuiStyleVarInfo *var_info = GetStyleVarInfo(idx);
+    if (var_info->Type == ImGuiDataType_Float && var_info->Count == 1)
+    {
+        ImGuiContext &g = *GImGui;
+        float *pvar     = (float *)var_info->GetVarPtr(&g.Style);
+        g.StyleModifiers.push_back(ImGuiStyleMod(idx, *pvar));
+        *pvar = val;
+        return;
+    }
+    IM_ASSERT(0 && "Called PushStyleVar() float variant but variable is not a float!");
+}
+
+void ImGui::PushStyleVar(ImGuiStyleVar idx, const ImVec2 &val)
+{
+    const ImGuiStyleVarInfo *var_info = GetStyleVarInfo(idx);
+    if (var_info->Type == ImGuiDataType_Float && var_info->Count == 2)
+    {
+        ImGuiContext &g = *GImGui;
+        ImVec2 *pvar    = (ImVec2 *)var_info->GetVarPtr(&g.Style);
+        g.StyleModifiers.push_back(ImGuiStyleMod(idx, *pvar));
+        *pvar = val;
+        return;
+    }
+    IM_ASSERT(0 && "Called PushStyleVar() ImVec2 variant but variable is not a ImVec2!");
+}
+
+void ImGui::PopStyleVar(int count)
+{
+    ImGuiContext &g = *GImGui;
+    while (count > 0)
+    {
+        // We avoid a generic memcpy(data, &backup.Backup.., GDataTypeSize[info->Type] *
+        // info->Count), the overhead in Debug is not worth it.
+        ImGuiStyleMod &backup         = g.StyleModifiers.back();
+        const ImGuiStyleVarInfo *info = GetStyleVarInfo(backup.VarIdx);
+        void *data                    = info->GetVarPtr(&g.Style);
+        if (info->Type == ImGuiDataType_Float && info->Count == 1)
+        {
+            ((float *)data)[0] = backup.BackupFloat[0];
+        }
+        else if (info->Type == ImGuiDataType_Float && info->Count == 2)
+        {
+            ((float *)data)[0] = backup.BackupFloat[0];
+            ((float *)data)[1] = backup.BackupFloat[1];
+        }
+        g.StyleModifiers.pop_back();
+        count--;
+    }
+}
+
+const char *ImGui::GetStyleColorName(ImGuiCol idx)
+{
+    // Create switch-case from enum with regexp: ImGuiCol_{.*}, --> case ImGuiCol_\1: return "\1";
+    switch (idx)
+    {
+        case ImGuiCol_Text:
+            return "Text";
+        case ImGuiCol_TextDisabled:
+            return "TextDisabled";
+        case ImGuiCol_WindowBg:
+            return "WindowBg";
+        case ImGuiCol_ChildBg:
+            return "ChildBg";
+        case ImGuiCol_PopupBg:
+            return "PopupBg";
+        case ImGuiCol_Border:
+            return "Border";
+        case ImGuiCol_BorderShadow:
+            return "BorderShadow";
+        case ImGuiCol_FrameBg:
+            return "FrameBg";
+        case ImGuiCol_FrameBgHovered:
+            return "FrameBgHovered";
+        case ImGuiCol_FrameBgActive:
+            return "FrameBgActive";
+        case ImGuiCol_TitleBg:
+            return "TitleBg";
+        case ImGuiCol_TitleBgActive:
+            return "TitleBgActive";
+        case ImGuiCol_TitleBgCollapsed:
+            return "TitleBgCollapsed";
+        case ImGuiCol_MenuBarBg:
+            return "MenuBarBg";
+        case ImGuiCol_ScrollbarBg:
+            return "ScrollbarBg";
+        case ImGuiCol_ScrollbarGrab:
+            return "ScrollbarGrab";
+        case ImGuiCol_ScrollbarGrabHovered:
+            return "ScrollbarGrabHovered";
+        case ImGuiCol_ScrollbarGrabActive:
+            return "ScrollbarGrabActive";
+        case ImGuiCol_CheckMark:
+            return "CheckMark";
+        case ImGuiCol_SliderGrab:
+            return "SliderGrab";
+        case ImGuiCol_SliderGrabActive:
+            return "SliderGrabActive";
+        case ImGuiCol_Button:
+            return "Button";
+        case ImGuiCol_ButtonHovered:
+            return "ButtonHovered";
+        case ImGuiCol_ButtonActive:
+            return "ButtonActive";
+        case ImGuiCol_Header:
+            return "Header";
+        case ImGuiCol_HeaderHovered:
+            return "HeaderHovered";
+        case ImGuiCol_HeaderActive:
+            return "HeaderActive";
+        case ImGuiCol_Separator:
+            return "Separator";
+        case ImGuiCol_SeparatorHovered:
+            return "SeparatorHovered";
+        case ImGuiCol_SeparatorActive:
+            return "SeparatorActive";
+        case ImGuiCol_ResizeGrip:
+            return "ResizeGrip";
+        case ImGuiCol_ResizeGripHovered:
+            return "ResizeGripHovered";
+        case ImGuiCol_ResizeGripActive:
+            return "ResizeGripActive";
+        case ImGuiCol_Tab:
+            return "Tab";
+        case ImGuiCol_TabHovered:
+            return "TabHovered";
+        case ImGuiCol_TabActive:
+            return "TabActive";
+        case ImGuiCol_TabUnfocused:
+            return "TabUnfocused";
+        case ImGuiCol_TabUnfocusedActive:
+            return "TabUnfocusedActive";
+        case ImGuiCol_PlotLines:
+            return "PlotLines";
+        case ImGuiCol_PlotLinesHovered:
+            return "PlotLinesHovered";
+        case ImGuiCol_PlotHistogram:
+            return "PlotHistogram";
+        case ImGuiCol_PlotHistogramHovered:
+            return "PlotHistogramHovered";
+        case ImGuiCol_TextSelectedBg:
+            return "TextSelectedBg";
+        case ImGuiCol_DragDropTarget:
+            return "DragDropTarget";
+        case ImGuiCol_NavHighlight:
+            return "NavHighlight";
+        case ImGuiCol_NavWindowingHighlight:
+            return "NavWindowingHighlight";
+        case ImGuiCol_NavWindowingDimBg:
+            return "NavWindowingDimBg";
+        case ImGuiCol_ModalWindowDimBg:
+            return "ModalWindowDimBg";
+    }
+    IM_ASSERT(0);
+    return "Unknown";
+}
+
+bool ImGui::IsWindowChildOf(ImGuiWindow *window, ImGuiWindow *potential_parent)
+{
+    if (window->RootWindow == potential_parent)
+        return true;
+    while (window != NULL)
+    {
+        if (window == potential_parent)
+            return true;
+        window = window->ParentWindow;
+    }
+    return false;
+}
+
+bool ImGui::IsWindowHovered(ImGuiHoveredFlags flags)
+{
+    IM_ASSERT((flags & ImGuiHoveredFlags_AllowWhenOverlapped) ==
+              0);  // Flags not supported by this function
+    ImGuiContext &g = *GImGui;
+
+    if (flags & ImGuiHoveredFlags_AnyWindow)
+    {
+        if (g.HoveredWindow == NULL)
+            return false;
+    }
+    else
+    {
+        switch (flags & (ImGuiHoveredFlags_RootWindow | ImGuiHoveredFlags_ChildWindows))
+        {
+            case ImGuiHoveredFlags_RootWindow | ImGuiHoveredFlags_ChildWindows:
+                if (g.HoveredRootWindow != g.CurrentWindow->RootWindow)
+                    return false;
+                break;
+            case ImGuiHoveredFlags_RootWindow:
+                if (g.HoveredWindow != g.CurrentWindow->RootWindow)
+                    return false;
+                break;
+            case ImGuiHoveredFlags_ChildWindows:
+                if (g.HoveredWindow == NULL || !IsWindowChildOf(g.HoveredWindow, g.CurrentWindow))
+                    return false;
+                break;
+            default:
+                if (g.HoveredWindow != g.CurrentWindow)
+                    return false;
+                break;
+        }
+    }
+
+    if (!IsWindowContentHoverable(g.HoveredWindow, flags))
+        return false;
+    if (!(flags & ImGuiHoveredFlags_AllowWhenBlockedByActiveItem))
+        if (g.ActiveId != 0 && !g.ActiveIdAllowOverlap && g.ActiveId != g.HoveredWindow->MoveId)
+            return false;
+    return true;
+}
+
+bool ImGui::IsWindowFocused(ImGuiFocusedFlags flags)
+{
+    ImGuiContext &g = *GImGui;
+
+    if (flags & ImGuiFocusedFlags_AnyWindow)
+        return g.NavWindow != NULL;
+
+    IM_ASSERT(g.CurrentWindow);  // Not inside a Begin()/End()
+    switch (flags & (ImGuiFocusedFlags_RootWindow | ImGuiFocusedFlags_ChildWindows))
+    {
+        case ImGuiFocusedFlags_RootWindow | ImGuiFocusedFlags_ChildWindows:
+            return g.NavWindow && g.NavWindow->RootWindow == g.CurrentWindow->RootWindow;
+        case ImGuiFocusedFlags_RootWindow:
+            return g.NavWindow == g.CurrentWindow->RootWindow;
+        case ImGuiFocusedFlags_ChildWindows:
+            return g.NavWindow && IsWindowChildOf(g.NavWindow, g.CurrentWindow);
+        default:
+            return g.NavWindow == g.CurrentWindow;
+    }
+}
+
+// Can we focus this window with CTRL+TAB (or PadMenu + PadFocusPrev/PadFocusNext)
+// Note that NoNavFocus makes the window not reachable with CTRL+TAB but it can still be focused
+// with mouse or programmaticaly. If you want a window to never be focused, you may use the e.g.
+// NoInputs flag.
+bool ImGui::IsWindowNavFocusable(ImGuiWindow *window)
+{
+    return window->Active && window == window->RootWindow &&
+           !(window->Flags & ImGuiWindowFlags_NoNavFocus);
+}
+
+float ImGui::GetWindowWidth()
+{
+    ImGuiWindow *window = GImGui->CurrentWindow;
+    return window->Size.x;
+}
+
+float ImGui::GetWindowHeight()
+{
+    ImGuiWindow *window = GImGui->CurrentWindow;
+    return window->Size.y;
+}
+
+ImVec2 ImGui::GetWindowPos()
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+    return window->Pos;
+}
+
+void ImGui::SetWindowScrollX(ImGuiWindow *window, float new_scroll_x)
+{
+    window->Scroll.x = new_scroll_x;
+}
+
+void ImGui::SetWindowScrollY(ImGuiWindow *window, float new_scroll_y)
+{
+    window->Scroll.y = new_scroll_y;
+}
+
+void ImGui::SetWindowPos(ImGuiWindow *window, const ImVec2 &pos, ImGuiCond cond)
+{
+    // Test condition (NB: bit 0 is always true) and clear flags for next time
+    if (cond && (window->SetWindowPosAllowFlags & cond) == 0)
+        return;
+
+    IM_ASSERT(
+        cond == 0 ||
+        ImIsPowerOfTwo(
+            cond));  // Make sure the user doesn't attempt to combine multiple condition flags.
+    window->SetWindowPosAllowFlags &=
+        ~(ImGuiCond_Once | ImGuiCond_FirstUseEver | ImGuiCond_Appearing);
+    window->SetWindowPosVal = ImVec2(FLT_MAX, FLT_MAX);
+
+    // Set
+    const ImVec2 old_pos = window->Pos;
+    window->Pos          = ImFloor(pos);
+    ImVec2 offset        = window->Pos - old_pos;
+    window->DC.CursorPos +=
+        offset;  // As we happen to move the window while it is being appended to (which is a bad
+                 // idea - will smear) let's at least offset the cursor
+    window->DC.CursorMaxPos +=
+        offset;  // And more importantly we need to offset CursorMaxPos/CursorStartPos this so
+                 // ContentSize calculation doesn't get affected.
+    window->DC.CursorStartPos += offset;
+}
+
+void ImGui::SetWindowPos(const ImVec2 &pos, ImGuiCond cond)
+{
+    ImGuiWindow *window = GetCurrentWindowRead();
+    SetWindowPos(window, pos, cond);
+}
+
+void ImGui::SetWindowPos(const char *name, const ImVec2 &pos, ImGuiCond cond)
+{
+    if (ImGuiWindow *window = FindWindowByName(name))
+        SetWindowPos(window, pos, cond);
+}
+
+ImVec2 ImGui::GetWindowSize()
+{
+    ImGuiWindow *window = GetCurrentWindowRead();
+    return window->Size;
+}
+
+void ImGui::SetWindowSize(ImGuiWindow *window, const ImVec2 &size, ImGuiCond cond)
+{
+    // Test condition (NB: bit 0 is always true) and clear flags for next time
+    if (cond && (window->SetWindowSizeAllowFlags & cond) == 0)
+        return;
+
+    IM_ASSERT(
+        cond == 0 ||
+        ImIsPowerOfTwo(
+            cond));  // Make sure the user doesn't attempt to combine multiple condition flags.
+    window->SetWindowSizeAllowFlags &=
+        ~(ImGuiCond_Once | ImGuiCond_FirstUseEver | ImGuiCond_Appearing);
+
+    // Set
+    if (size.x > 0.0f)
+    {
+        window->AutoFitFramesX = 0;
+        window->SizeFull.x     = ImFloor(size.x);
+    }
+    else
+    {
+        window->AutoFitFramesX   = 2;
+        window->AutoFitOnlyGrows = false;
+    }
+    if (size.y > 0.0f)
+    {
+        window->AutoFitFramesY = 0;
+        window->SizeFull.y     = ImFloor(size.y);
+    }
+    else
+    {
+        window->AutoFitFramesY   = 2;
+        window->AutoFitOnlyGrows = false;
+    }
+}
+
+void ImGui::SetWindowSize(const ImVec2 &size, ImGuiCond cond)
+{
+    SetWindowSize(GImGui->CurrentWindow, size, cond);
+}
+
+void ImGui::SetWindowSize(const char *name, const ImVec2 &size, ImGuiCond cond)
+{
+    if (ImGuiWindow *window = FindWindowByName(name))
+        SetWindowSize(window, size, cond);
+}
+
+void ImGui::SetWindowCollapsed(ImGuiWindow *window, bool collapsed, ImGuiCond cond)
+{
+    // Test condition (NB: bit 0 is always true) and clear flags for next time
+    if (cond && (window->SetWindowCollapsedAllowFlags & cond) == 0)
+        return;
+    window->SetWindowCollapsedAllowFlags &=
+        ~(ImGuiCond_Once | ImGuiCond_FirstUseEver | ImGuiCond_Appearing);
+
+    // Set
+    window->Collapsed = collapsed;
+}
+
+void ImGui::SetWindowCollapsed(bool collapsed, ImGuiCond cond)
+{
+    SetWindowCollapsed(GImGui->CurrentWindow, collapsed, cond);
+}
+
+bool ImGui::IsWindowCollapsed()
+{
+    ImGuiWindow *window = GetCurrentWindowRead();
+    return window->Collapsed;
+}
+
+bool ImGui::IsWindowAppearing()
+{
+    ImGuiWindow *window = GetCurrentWindowRead();
+    return window->Appearing;
+}
+
+void ImGui::SetWindowCollapsed(const char *name, bool collapsed, ImGuiCond cond)
+{
+    if (ImGuiWindow *window = FindWindowByName(name))
+        SetWindowCollapsed(window, collapsed, cond);
+}
+
+void ImGui::SetWindowFocus()
+{
+    FocusWindow(GImGui->CurrentWindow);
+}
+
+void ImGui::SetWindowFocus(const char *name)
+{
+    if (name)
+    {
+        if (ImGuiWindow *window = FindWindowByName(name))
+            FocusWindow(window);
+    }
+    else
+    {
+        FocusWindow(NULL);
+    }
+}
+
+void ImGui::SetNextWindowPos(const ImVec2 &pos, ImGuiCond cond, const ImVec2 &pivot)
+{
+    ImGuiContext &g = *GImGui;
+    IM_ASSERT(
+        cond == 0 ||
+        ImIsPowerOfTwo(
+            cond));  // Make sure the user doesn't attempt to combine multiple condition flags.
+    g.NextWindowData.Flags |= ImGuiNextWindowDataFlags_HasPos;
+    g.NextWindowData.PosVal      = pos;
+    g.NextWindowData.PosPivotVal = pivot;
+    g.NextWindowData.PosCond     = cond ? cond : ImGuiCond_Always;
+}
+
+void ImGui::SetNextWindowSize(const ImVec2 &size, ImGuiCond cond)
+{
+    ImGuiContext &g = *GImGui;
+    IM_ASSERT(
+        cond == 0 ||
+        ImIsPowerOfTwo(
+            cond));  // Make sure the user doesn't attempt to combine multiple condition flags.
+    g.NextWindowData.Flags |= ImGuiNextWindowDataFlags_HasSize;
+    g.NextWindowData.SizeVal  = size;
+    g.NextWindowData.SizeCond = cond ? cond : ImGuiCond_Always;
+}
+
+void ImGui::SetNextWindowSizeConstraints(const ImVec2 &size_min,
+                                         const ImVec2 &size_max,
+                                         ImGuiSizeCallback custom_callback,
+                                         void *custom_callback_user_data)
+{
+    ImGuiContext &g = *GImGui;
+    g.NextWindowData.Flags |= ImGuiNextWindowDataFlags_HasSizeConstraint;
+    g.NextWindowData.SizeConstraintRect   = ImRect(size_min, size_max);
+    g.NextWindowData.SizeCallback         = custom_callback;
+    g.NextWindowData.SizeCallbackUserData = custom_callback_user_data;
+}
+
+// Content size = inner scrollable rectangle, padded with WindowPadding.
+// SetNextWindowContentSize(ImVec2(100,100) + ImGuiWindowFlags_AlwaysAutoResize will always allow
+// submitting a 100x100 item.
+void ImGui::SetNextWindowContentSize(const ImVec2 &size)
+{
+    ImGuiContext &g = *GImGui;
+    g.NextWindowData.Flags |= ImGuiNextWindowDataFlags_HasContentSize;
+    g.NextWindowData.ContentSizeVal = size;
+}
+
+void ImGui::SetNextWindowCollapsed(bool collapsed, ImGuiCond cond)
+{
+    ImGuiContext &g = *GImGui;
+    IM_ASSERT(
+        cond == 0 ||
+        ImIsPowerOfTwo(
+            cond));  // Make sure the user doesn't attempt to combine multiple condition flags.
+    g.NextWindowData.Flags |= ImGuiNextWindowDataFlags_HasCollapsed;
+    g.NextWindowData.CollapsedVal  = collapsed;
+    g.NextWindowData.CollapsedCond = cond ? cond : ImGuiCond_Always;
+}
+
+void ImGui::SetNextWindowFocus()
+{
+    ImGuiContext &g = *GImGui;
+    g.NextWindowData.Flags |= ImGuiNextWindowDataFlags_HasFocus;
+}
+
+void ImGui::SetNextWindowBgAlpha(float alpha)
+{
+    ImGuiContext &g = *GImGui;
+    g.NextWindowData.Flags |= ImGuiNextWindowDataFlags_HasBgAlpha;
+    g.NextWindowData.BgAlphaVal = alpha;
+}
+
+// FIXME: This is in window space (not screen space!). We should try to obsolete all those
+// functions.
+ImVec2 ImGui::GetContentRegionMax()
+{
+    ImGuiWindow *window = GImGui->CurrentWindow;
+    ImVec2 mx           = window->ContentsRegionRect.Max - window->Pos;
+    if (window->DC.CurrentColumns)
+        mx.x = window->WorkRect.Max.x - window->Pos.x;
+    return mx;
+}
+
+// [Internal] Absolute coordinate. Saner. This is not exposed until we finishing refactoring work
+// rect features.
+ImVec2 ImGui::GetContentRegionMaxAbs()
+{
+    ImGuiWindow *window = GImGui->CurrentWindow;
+    ImVec2 mx           = window->ContentsRegionRect.Max;
+    if (window->DC.CurrentColumns)
+        mx.x = window->WorkRect.Max.x;
+    return mx;
+}
+
+ImVec2 ImGui::GetContentRegionAvail()
+{
+    ImGuiWindow *window = GImGui->CurrentWindow;
+    return GetContentRegionMaxAbs() - window->DC.CursorPos;
+}
+
+// In window space (not screen space!)
+ImVec2 ImGui::GetWindowContentRegionMin()
+{
+    ImGuiWindow *window = GImGui->CurrentWindow;
+    return window->ContentsRegionRect.Min - window->Pos;
+}
+
+ImVec2 ImGui::GetWindowContentRegionMax()
+{
+    ImGuiWindow *window = GImGui->CurrentWindow;
+    return window->ContentsRegionRect.Max - window->Pos;
+}
+
+float ImGui::GetWindowContentRegionWidth()
+{
+    ImGuiWindow *window = GImGui->CurrentWindow;
+    return window->ContentsRegionRect.GetWidth();
+}
+
+float ImGui::GetTextLineHeight()
+{
+    ImGuiContext &g = *GImGui;
+    return g.FontSize;
+}
+
+float ImGui::GetTextLineHeightWithSpacing()
+{
+    ImGuiContext &g = *GImGui;
+    return g.FontSize + g.Style.ItemSpacing.y;
+}
+
+float ImGui::GetFrameHeight()
+{
+    ImGuiContext &g = *GImGui;
+    return g.FontSize + g.Style.FramePadding.y * 2.0f;
+}
+
+float ImGui::GetFrameHeightWithSpacing()
+{
+    ImGuiContext &g = *GImGui;
+    return g.FontSize + g.Style.FramePadding.y * 2.0f + g.Style.ItemSpacing.y;
+}
+
+ImDrawList *ImGui::GetWindowDrawList()
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    return window->DrawList;
+}
+
+ImFont *ImGui::GetFont()
+{
+    return GImGui->Font;
+}
+
+float ImGui::GetFontSize()
+{
+    return GImGui->FontSize;
+}
+
+ImVec2 ImGui::GetFontTexUvWhitePixel()
+{
+    return GImGui->DrawListSharedData.TexUvWhitePixel;
+}
+
+void ImGui::SetWindowFontScale(float scale)
+{
+    ImGuiContext &g         = *GImGui;
+    ImGuiWindow *window     = GetCurrentWindow();
+    window->FontWindowScale = scale;
+    g.FontSize = g.DrawListSharedData.FontSize = window->CalcFontSize();
+}
+
+// User generally sees positions in window coordinates. Internally we store CursorPos in absolute
+// screen coordinates because it is more convenient. Conversion happens as we pass the value to
+// user, but it makes our naming convention confusing because GetCursorPos() == (DC.CursorPos -
+// window.Pos). May want to rename 'DC.CursorPos'.
+ImVec2 ImGui::GetCursorPos()
+{
+    ImGuiWindow *window = GetCurrentWindowRead();
+    return window->DC.CursorPos - window->Pos + window->Scroll;
+}
+
+float ImGui::GetCursorPosX()
+{
+    ImGuiWindow *window = GetCurrentWindowRead();
+    return window->DC.CursorPos.x - window->Pos.x + window->Scroll.x;
+}
+
+float ImGui::GetCursorPosY()
+{
+    ImGuiWindow *window = GetCurrentWindowRead();
+    return window->DC.CursorPos.y - window->Pos.y + window->Scroll.y;
+}
+
+void ImGui::SetCursorPos(const ImVec2 &local_pos)
+{
+    ImGuiWindow *window     = GetCurrentWindow();
+    window->DC.CursorPos    = window->Pos - window->Scroll + local_pos;
+    window->DC.CursorMaxPos = ImMax(window->DC.CursorMaxPos, window->DC.CursorPos);
+}
+
+void ImGui::SetCursorPosX(float x)
+{
+    ImGuiWindow *window       = GetCurrentWindow();
+    window->DC.CursorPos.x    = window->Pos.x - window->Scroll.x + x;
+    window->DC.CursorMaxPos.x = ImMax(window->DC.CursorMaxPos.x, window->DC.CursorPos.x);
+}
+
+void ImGui::SetCursorPosY(float y)
+{
+    ImGuiWindow *window       = GetCurrentWindow();
+    window->DC.CursorPos.y    = window->Pos.y - window->Scroll.y + y;
+    window->DC.CursorMaxPos.y = ImMax(window->DC.CursorMaxPos.y, window->DC.CursorPos.y);
+}
+
+ImVec2 ImGui::GetCursorStartPos()
+{
+    ImGuiWindow *window = GetCurrentWindowRead();
+    return window->DC.CursorStartPos - window->Pos;
+}
+
+ImVec2 ImGui::GetCursorScreenPos()
+{
+    ImGuiWindow *window = GetCurrentWindowRead();
+    return window->DC.CursorPos;
+}
+
+void ImGui::SetCursorScreenPos(const ImVec2 &pos)
+{
+    ImGuiWindow *window     = GetCurrentWindow();
+    window->DC.CursorPos    = pos;
+    window->DC.CursorMaxPos = ImMax(window->DC.CursorMaxPos, window->DC.CursorPos);
+}
+
+float ImGui::GetScrollX()
+{
+    ImGuiWindow *window = GImGui->CurrentWindow;
+    return window->Scroll.x;
+}
+
+float ImGui::GetScrollY()
+{
+    ImGuiWindow *window = GImGui->CurrentWindow;
+    return window->Scroll.y;
+}
+
+float ImGui::GetScrollMaxX()
+{
+    ImGuiWindow *window = GImGui->CurrentWindow;
+    return window->ScrollMax.x;
+}
+
+float ImGui::GetScrollMaxY()
+{
+    ImGuiWindow *window = GImGui->CurrentWindow;
+    return window->ScrollMax.y;
+}
+
+void ImGui::SetScrollX(float scroll_x)
+{
+    ImGuiWindow *window               = GetCurrentWindow();
+    window->ScrollTarget.x            = scroll_x;
+    window->ScrollTargetCenterRatio.x = 0.0f;
+}
+
+void ImGui::SetScrollY(float scroll_y)
+{
+    ImGuiWindow *window               = GetCurrentWindow();
+    window->ScrollTarget.y            = scroll_y;
+    window->ScrollTargetCenterRatio.y = 0.0f;
+}
+
+void ImGui::SetScrollFromPosX(float local_x, float center_x_ratio)
+{
+    // We store a target position so centering can occur on the next frame when we are guaranteed to
+    // have a known window size
+    ImGuiWindow *window = GetCurrentWindow();
+    IM_ASSERT(center_x_ratio >= 0.0f && center_x_ratio <= 1.0f);
+    window->ScrollTarget.x            = (float)(int)(local_x + window->Scroll.x);
+    window->ScrollTargetCenterRatio.x = center_x_ratio;
+}
+
+void ImGui::SetScrollFromPosY(float local_y, float center_y_ratio)
+{
+    // We store a target position so centering can occur on the next frame when we are guaranteed to
+    // have a known window size
+    ImGuiWindow *window = GetCurrentWindow();
+    IM_ASSERT(center_y_ratio >= 0.0f && center_y_ratio <= 1.0f);
+    window->ScrollTarget.y            = (float)(int)(local_y + window->Scroll.y);
+    window->ScrollTargetCenterRatio.y = center_y_ratio;
+}
+
+// center_x_ratio: 0.0f left of last item, 0.5f horizontal center of last item, 1.0f right of last
+// item.
+void ImGui::SetScrollHereX(float center_x_ratio)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    float target_x =
+        window->DC.LastItemRect.Min.x - window->Pos.x;  // Left of last item, in window space
+    float last_item_width = window->DC.LastItemRect.GetWidth();
+    target_x += (last_item_width * center_x_ratio) +
+                (GImGui->Style.ItemSpacing.x * (center_x_ratio - 0.5f) *
+                 2.0f);  // Precisely aim before, in the middle or after the last item.
+    SetScrollFromPosX(target_x, center_x_ratio);
+}
+
+// center_y_ratio: 0.0f top of last item, 0.5f vertical center of last item, 1.0f bottom of last
+// item.
+void ImGui::SetScrollHereY(float center_y_ratio)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    float target_y =
+        window->DC.CursorPosPrevLine.y - window->Pos.y;  // Top of last item, in window space
+    target_y += (window->DC.PrevLineSize.y * center_y_ratio) +
+                (GImGui->Style.ItemSpacing.y * (center_y_ratio - 0.5f) *
+                 2.0f);  // Precisely aim above, in the middle or below the last line.
+    SetScrollFromPosY(target_y, center_y_ratio);
+}
+
+void ImGui::ActivateItem(ImGuiID id)
+{
+    ImGuiContext &g     = *GImGui;
+    g.NavNextActivateId = id;
+}
+
+void ImGui::SetKeyboardFocusHere(int offset)
+{
+    IM_ASSERT(offset >= -1);  // -1 is allowed but not below
+    ImGuiContext &g              = *GImGui;
+    ImGuiWindow *window          = g.CurrentWindow;
+    g.FocusRequestNextWindow     = window;
+    g.FocusRequestNextCounterAll = window->DC.FocusCounterAll + 1 + offset;
+    g.FocusRequestNextCounterTab = INT_MAX;
+}
+
+void ImGui::SetItemDefaultFocus()
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+    if (!window->Appearing)
+        return;
+    if (g.NavWindow == window->RootWindowForNav && (g.NavInitRequest || g.NavInitResultId != 0) &&
+        g.NavLayer == g.NavWindow->DC.NavLayerCurrent)
+    {
+        g.NavInitRequest       = false;
+        g.NavInitResultId      = g.NavWindow->DC.LastItemId;
+        g.NavInitResultRectRel = ImRect(g.NavWindow->DC.LastItemRect.Min - g.NavWindow->Pos,
+                                        g.NavWindow->DC.LastItemRect.Max - g.NavWindow->Pos);
+        NavUpdateAnyRequestFlag();
+        if (!IsItemVisible())
+            SetScrollHereY();
+    }
+}
+
+void ImGui::SetStateStorage(ImGuiStorage *tree)
+{
+    ImGuiWindow *window     = GImGui->CurrentWindow;
+    window->DC.StateStorage = tree ? tree : &window->StateStorage;
+}
+
+ImGuiStorage *ImGui::GetStateStorage()
+{
+    ImGuiWindow *window = GImGui->CurrentWindow;
+    return window->DC.StateStorage;
+}
+
+void ImGui::PushID(const char *str_id)
+{
+    ImGuiWindow *window = GImGui->CurrentWindow;
+    window->IDStack.push_back(window->GetIDNoKeepAlive(str_id));
+}
+
+void ImGui::PushID(const char *str_id_begin, const char *str_id_end)
+{
+    ImGuiWindow *window = GImGui->CurrentWindow;
+    window->IDStack.push_back(window->GetIDNoKeepAlive(str_id_begin, str_id_end));
+}
+
+void ImGui::PushID(const void *ptr_id)
+{
+    ImGuiWindow *window = GImGui->CurrentWindow;
+    window->IDStack.push_back(window->GetIDNoKeepAlive(ptr_id));
+}
+
+void ImGui::PushID(int int_id)
+{
+    ImGuiWindow *window = GImGui->CurrentWindow;
+    window->IDStack.push_back(window->GetIDNoKeepAlive(int_id));
+}
+
+// Push a given id value ignoring the ID stack as a seed.
+void ImGui::PushOverrideID(ImGuiID id)
+{
+    ImGuiWindow *window = GImGui->CurrentWindow;
+    window->IDStack.push_back(id);
+}
+
+void ImGui::PopID()
+{
+    ImGuiWindow *window = GImGui->CurrentWindow;
+    window->IDStack.pop_back();
+}
+
+ImGuiID ImGui::GetID(const char *str_id)
+{
+    ImGuiWindow *window = GImGui->CurrentWindow;
+    return window->GetID(str_id);
+}
+
+ImGuiID ImGui::GetID(const char *str_id_begin, const char *str_id_end)
+{
+    ImGuiWindow *window = GImGui->CurrentWindow;
+    return window->GetID(str_id_begin, str_id_end);
+}
+
+ImGuiID ImGui::GetID(const void *ptr_id)
+{
+    ImGuiWindow *window = GImGui->CurrentWindow;
+    return window->GetID(ptr_id);
+}
+
+bool ImGui::IsRectVisible(const ImVec2 &size)
+{
+    ImGuiWindow *window = GImGui->CurrentWindow;
+    return window->ClipRect.Overlaps(ImRect(window->DC.CursorPos, window->DC.CursorPos + size));
+}
+
+bool ImGui::IsRectVisible(const ImVec2 &rect_min, const ImVec2 &rect_max)
+{
+    ImGuiWindow *window = GImGui->CurrentWindow;
+    return window->ClipRect.Overlaps(ImRect(rect_min, rect_max));
+}
+
+// Lock horizontal starting position + capture group bounding box into one "item" (so you can use
+// IsItemHovered() or layout primitives such as SameLine() on whole group, etc.)
+void ImGui::BeginGroup()
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = GetCurrentWindow();
+
+    window->DC.GroupStack.resize(window->DC.GroupStack.Size + 1);
+    ImGuiGroupData &group_data                    = window->DC.GroupStack.back();
+    group_data.BackupCursorPos                    = window->DC.CursorPos;
+    group_data.BackupCursorMaxPos                 = window->DC.CursorMaxPos;
+    group_data.BackupIndent                       = window->DC.Indent;
+    group_data.BackupGroupOffset                  = window->DC.GroupOffset;
+    group_data.BackupCurrLineSize                 = window->DC.CurrLineSize;
+    group_data.BackupCurrLineTextBaseOffset       = window->DC.CurrLineTextBaseOffset;
+    group_data.BackupActiveIdIsAlive              = g.ActiveIdIsAlive;
+    group_data.BackupActiveIdPreviousFrameIsAlive = g.ActiveIdPreviousFrameIsAlive;
+    group_data.EmitItem                           = true;
+
+    window->DC.GroupOffset.x = window->DC.CursorPos.x - window->Pos.x - window->DC.ColumnsOffset.x;
+    window->DC.Indent        = window->DC.GroupOffset;
+    window->DC.CursorMaxPos  = window->DC.CursorPos;
+    window->DC.CurrLineSize  = ImVec2(0.0f, 0.0f);
+    if (g.LogEnabled)
+        g.LogLinePosY = -FLT_MAX;  // To enforce Log carriage return
+}
+
+void ImGui::EndGroup()
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = GetCurrentWindow();
+    IM_ASSERT(!window->DC.GroupStack.empty());  // Mismatched BeginGroup()/EndGroup() calls
+
+    ImGuiGroupData &group_data = window->DC.GroupStack.back();
+
+    ImRect group_bb(group_data.BackupCursorPos,
+                    ImMax(window->DC.CursorMaxPos, group_data.BackupCursorPos));
+
+    window->DC.CursorPos    = group_data.BackupCursorPos;
+    window->DC.CursorMaxPos = ImMax(group_data.BackupCursorMaxPos, window->DC.CursorMaxPos);
+    window->DC.Indent       = group_data.BackupIndent;
+    window->DC.GroupOffset  = group_data.BackupGroupOffset;
+    window->DC.CurrLineSize = group_data.BackupCurrLineSize;
+    window->DC.CurrLineTextBaseOffset = group_data.BackupCurrLineTextBaseOffset;
+    if (g.LogEnabled)
+        g.LogLinePosY = -FLT_MAX;  // To enforce Log carriage return
+
+    if (!group_data.EmitItem)
+    {
+        window->DC.GroupStack.pop_back();
+        return;
+    }
+
+    window->DC.CurrLineTextBaseOffset =
+        ImMax(window->DC.PrevLineTextBaseOffset,
+              group_data.BackupCurrLineTextBaseOffset);  // FIXME: Incorrect, we should grab the
+                                                         // base offset from the *first line* of the
+                                                         // group but it is hard to obtain now.
+    ItemSize(group_bb.GetSize(), 0.0f);
+    ItemAdd(group_bb, 0);
+
+    // If the current ActiveId was declared within the boundary of our group, we copy it to
+    // LastItemId so IsItemActive(), IsItemDeactivated() etc. will be functional on the entire
+    // group. It would be be neater if we replaced window.DC.LastItemId by e.g. 'bool
+    // LastItemIsActive', but would put a little more burden on individual widgets. Also if you grep
+    // for LastItemId you'll notice it is only used in that context. (The tests not symmetrical
+    // because ActiveIdIsAlive is an ID itself, in order to be able to handle ActiveId being
+    // overwritten during the frame.)
+    const bool group_contains_curr_active_id = (group_data.BackupActiveIdIsAlive != g.ActiveId) &&
+                                               (g.ActiveIdIsAlive == g.ActiveId) && g.ActiveId;
+    const bool group_contains_prev_active_id =
+        !group_data.BackupActiveIdPreviousFrameIsAlive && g.ActiveIdPreviousFrameIsAlive;
+    if (group_contains_curr_active_id)
+        window->DC.LastItemId = g.ActiveId;
+    else if (group_contains_prev_active_id)
+        window->DC.LastItemId = g.ActiveIdPreviousFrame;
+    window->DC.LastItemRect = group_bb;
+
+    // Forward Edited flag
+    if (group_contains_curr_active_id && g.ActiveIdHasBeenEditedThisFrame)
+        window->DC.LastItemStatusFlags |= ImGuiItemStatusFlags_Edited;
+
+    // Forward Deactivated flag
+    window->DC.LastItemStatusFlags |= ImGuiItemStatusFlags_HasDeactivated;
+    if (group_contains_prev_active_id && g.ActiveId != g.ActiveIdPreviousFrame)
+        window->DC.LastItemStatusFlags |= ImGuiItemStatusFlags_Deactivated;
+
+    window->DC.GroupStack.pop_back();
+    // window->DrawList->AddRect(group_bb.Min, group_bb.Max, IM_COL32(255,0,255,255));   // [Debug]
+}
+
+// Gets back to previous line and continue with horizontal layout
+//      offset_from_start_x == 0 : follow right after previous item
+//      offset_from_start_x != 0 : align to specified x position (relative to window/group left)
+//      spacing_w < 0            : use default spacing if pos_x == 0, no spacing if pos_x != 0
+//      spacing_w >= 0           : enforce spacing amount
+void ImGui::SameLine(float offset_from_start_x, float spacing_w)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return;
+
+    ImGuiContext &g = *GImGui;
+    if (offset_from_start_x != 0.0f)
+    {
+        if (spacing_w < 0.0f)
+            spacing_w = 0.0f;
+        window->DC.CursorPos.x = window->Pos.x - window->Scroll.x + offset_from_start_x +
+                                 spacing_w + window->DC.GroupOffset.x + window->DC.ColumnsOffset.x;
+        window->DC.CursorPos.y = window->DC.CursorPosPrevLine.y;
+    }
+    else
+    {
+        if (spacing_w < 0.0f)
+            spacing_w = g.Style.ItemSpacing.x;
+        window->DC.CursorPos.x = window->DC.CursorPosPrevLine.x + spacing_w;
+        window->DC.CursorPos.y = window->DC.CursorPosPrevLine.y;
+    }
+    window->DC.CurrLineSize           = window->DC.PrevLineSize;
+    window->DC.CurrLineTextBaseOffset = window->DC.PrevLineTextBaseOffset;
+}
+
+void ImGui::Indent(float indent_w)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = GetCurrentWindow();
+    window->DC.Indent.x += (indent_w != 0.0f) ? indent_w : g.Style.IndentSpacing;
+    window->DC.CursorPos.x = window->Pos.x + window->DC.Indent.x + window->DC.ColumnsOffset.x;
+}
+
+void ImGui::Unindent(float indent_w)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = GetCurrentWindow();
+    window->DC.Indent.x -= (indent_w != 0.0f) ? indent_w : g.Style.IndentSpacing;
+    window->DC.CursorPos.x = window->Pos.x + window->DC.Indent.x + window->DC.ColumnsOffset.x;
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] TOOLTIPS
+//-----------------------------------------------------------------------------
+
+void ImGui::BeginTooltip()
+{
+    ImGuiContext &g = *GImGui;
+    if (g.DragDropWithinSourceOrTarget)
+    {
+        // The default tooltip position is a little offset to give space to see the context menu
+        // (it's also clamped within the current viewport/monitor) In the context of a dragging
+        // tooltip we try to reduce that offset and we enforce following the cursor. Whatever we do
+        // we want to call SetNextWindowPos() to enforce a tooltip position and disable clipping the
+        // tooltip without our display area, like regular tooltip do.
+        // ImVec2 tooltip_pos = g.IO.MousePos - g.ActiveIdClickOffset - g.Style.WindowPadding;
+        ImVec2 tooltip_pos =
+            g.IO.MousePos + ImVec2(16 * g.Style.MouseCursorScale, 8 * g.Style.MouseCursorScale);
+        SetNextWindowPos(tooltip_pos);
+        SetNextWindowBgAlpha(g.Style.Colors[ImGuiCol_PopupBg].w * 0.60f);
+        // PushStyleVar(ImGuiStyleVar_Alpha, g.Style.Alpha * 0.60f); // This would be nice but e.g
+        // ColorButton with checkboard has issue with transparent colors :(
+        BeginTooltipEx(0, true);
+    }
+    else
+    {
+        BeginTooltipEx(0, false);
+    }
+}
+
+// Not exposed publicly as BeginTooltip() because bool parameters are evil. Let's see if other needs
+// arise first.
+void ImGui::BeginTooltipEx(ImGuiWindowFlags extra_flags, bool override_previous_tooltip)
+{
+    ImGuiContext &g = *GImGui;
+    char window_name[16];
+    ImFormatString(window_name, IM_ARRAYSIZE(window_name), "##Tooltip_%02d",
+                   g.TooltipOverrideCount);
+    if (override_previous_tooltip)
+        if (ImGuiWindow *window = FindWindowByName(window_name))
+            if (window->Active)
+            {
+                // Hide previous tooltip from being displayed. We can't easily "reset" the content
+                // of a window so we create a new one.
+                window->Hidden                   = true;
+                window->HiddenFramesCanSkipItems = 1;
+                ImFormatString(window_name, IM_ARRAYSIZE(window_name), "##Tooltip_%02d",
+                               ++g.TooltipOverrideCount);
+            }
+    ImGuiWindowFlags flags = ImGuiWindowFlags_Tooltip | ImGuiWindowFlags_NoInputs |
+                             ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove |
+                             ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings |
+                             ImGuiWindowFlags_AlwaysAutoResize;
+    Begin(window_name, NULL, flags | extra_flags);
+}
+
+void ImGui::EndTooltip()
+{
+    IM_ASSERT(GetCurrentWindowRead()->Flags &
+              ImGuiWindowFlags_Tooltip);  // Mismatched BeginTooltip()/EndTooltip() calls
+    End();
+}
+
+void ImGui::SetTooltipV(const char *fmt, va_list args)
+{
+    ImGuiContext &g = *GImGui;
+    if (g.DragDropWithinSourceOrTarget)
+        BeginTooltip();
+    else
+        BeginTooltipEx(0, true);
+    TextV(fmt, args);
+    EndTooltip();
+}
+
+void ImGui::SetTooltip(const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    SetTooltipV(fmt, args);
+    va_end(args);
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] POPUPS
+//-----------------------------------------------------------------------------
+
+bool ImGui::IsPopupOpen(ImGuiID id)
+{
+    ImGuiContext &g = *GImGui;
+    return g.OpenPopupStack.Size > g.BeginPopupStack.Size &&
+           g.OpenPopupStack[g.BeginPopupStack.Size].PopupId == id;
+}
+
+bool ImGui::IsPopupOpen(const char *str_id)
+{
+    ImGuiContext &g = *GImGui;
+    return g.OpenPopupStack.Size > g.BeginPopupStack.Size &&
+           g.OpenPopupStack[g.BeginPopupStack.Size].PopupId == g.CurrentWindow->GetID(str_id);
+}
+
+ImGuiWindow *ImGui::GetTopMostPopupModal()
+{
+    ImGuiContext &g = *GImGui;
+    for (int n = g.OpenPopupStack.Size - 1; n >= 0; n--)
+        if (ImGuiWindow *popup = g.OpenPopupStack.Data[n].Window)
+            if (popup->Flags & ImGuiWindowFlags_Modal)
+                return popup;
+    return NULL;
+}
+
+void ImGui::OpenPopup(const char *str_id)
+{
+    ImGuiContext &g = *GImGui;
+    OpenPopupEx(g.CurrentWindow->GetID(str_id));
+}
+
+// Mark popup as open (toggle toward open state).
+// Popups are closed when user click outside, or activate a pressable item, or CloseCurrentPopup()
+// is called within a BeginPopup()/EndPopup() block. Popup identifiers are relative to the current
+// ID-stack (so OpenPopup and BeginPopup needs to be at the same level). One open popup per level of
+// the popup hierarchy (NB: when assigning we reset the Window member of ImGuiPopupRef to NULL)
+void ImGui::OpenPopupEx(ImGuiID id)
+{
+    ImGuiContext &g            = *GImGui;
+    ImGuiWindow *parent_window = g.CurrentWindow;
+    int current_stack_size     = g.BeginPopupStack.Size;
+    ImGuiPopupData popup_ref;  // Tagged as new ref as Window will be set back to NULL if we write
+                               // this into OpenPopupStack.
+    popup_ref.PopupId        = id;
+    popup_ref.Window         = NULL;
+    popup_ref.SourceWindow   = g.NavWindow;
+    popup_ref.OpenFrameCount = g.FrameCount;
+    popup_ref.OpenParentId   = parent_window->IDStack.back();
+    popup_ref.OpenPopupPos   = NavCalcPreferredRefPos();
+    popup_ref.OpenMousePos =
+        IsMousePosValid(&g.IO.MousePos) ? g.IO.MousePos : popup_ref.OpenPopupPos;
+
+    // IMGUI_DEBUG_LOG("OpenPopupEx(0x%08X)\n", g.FrameCount, id);
+    if (g.OpenPopupStack.Size < current_stack_size + 1)
+    {
+        g.OpenPopupStack.push_back(popup_ref);
+    }
+    else
+    {
+        // Gently handle the user mistakenly calling OpenPopup() every frame. It is a programming
+        // mistake! However, if we were to run the regular code path, the ui would become completely
+        // unusable because the popup will always be in hidden-while-calculating-size state _while_
+        // claiming focus. Which would be a very confusing situation for the programmer. Instead, we
+        // silently allow the popup to proceed, it will keep reappearing and the programming error
+        // will be more obvious to understand.
+        if (g.OpenPopupStack[current_stack_size].PopupId == id &&
+            g.OpenPopupStack[current_stack_size].OpenFrameCount == g.FrameCount - 1)
+        {
+            g.OpenPopupStack[current_stack_size].OpenFrameCount = popup_ref.OpenFrameCount;
+        }
+        else
+        {
+            // Close child popups if any, then flag popup for open/reopen
+            g.OpenPopupStack.resize(current_stack_size + 1);
+            g.OpenPopupStack[current_stack_size] = popup_ref;
+        }
+
+        // When reopening a popup we first refocus its parent, otherwise if its parent is itself a
+        // popup it would get closed by ClosePopupsOverWindow(). This is equivalent to what
+        // ClosePopupToLevel() does.
+        // if (g.OpenPopupStack[current_stack_size].PopupId == id)
+        //    FocusWindow(parent_window);
+    }
+}
+
+bool ImGui::OpenPopupOnItemClick(const char *str_id, int mouse_button)
+{
+    ImGuiWindow *window = GImGui->CurrentWindow;
+    if (IsMouseReleased(mouse_button) && IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup))
+    {
+        ImGuiID id =
+            str_id
+                ? window->GetID(str_id)
+                : window->DC.LastItemId;  // If user hasn't passed an ID, we can use the LastItemID.
+                                          // Using LastItemID as a Popup ID won't conflict!
+        IM_ASSERT(id != 0);  // You cannot pass a NULL str_id if the last item has no identifier
+                             // (e.g. a Text() item)
+        OpenPopupEx(id);
+        return true;
+    }
+    return false;
+}
+
+void ImGui::ClosePopupsOverWindow(ImGuiWindow *ref_window, bool restore_focus_to_window_under_popup)
+{
+    ImGuiContext &g = *GImGui;
+    if (g.OpenPopupStack.empty())
+        return;
+
+    // When popups are stacked, clicking on a lower level popups puts focus back to it and close
+    // popups above it. Don't close our own child popup windows.
+    int popup_count_to_keep = 0;
+    if (ref_window)
+    {
+        // Find the highest popup which is a descendant of the reference window (generally reference
+        // window = NavWindow)
+        for (; popup_count_to_keep < g.OpenPopupStack.Size; popup_count_to_keep++)
+        {
+            ImGuiPopupData &popup = g.OpenPopupStack[popup_count_to_keep];
+            if (!popup.Window)
+                continue;
+            IM_ASSERT((popup.Window->Flags & ImGuiWindowFlags_Popup) != 0);
+            if (popup.Window->Flags & ImGuiWindowFlags_ChildWindow)
+                continue;
+
+            // Trim the stack when popups are not direct descendant of the reference window (the
+            // reference window is often the NavWindow)
+            bool popup_or_descendent_is_ref_window = false;
+            for (int m = popup_count_to_keep;
+                 m < g.OpenPopupStack.Size && !popup_or_descendent_is_ref_window; m++)
+                if (ImGuiWindow *popup_window = g.OpenPopupStack[m].Window)
+                    if (popup_window->RootWindow == ref_window->RootWindow)
+                        popup_or_descendent_is_ref_window = true;
+            if (!popup_or_descendent_is_ref_window)
+                break;
+        }
+    }
+    if (popup_count_to_keep <
+        g.OpenPopupStack.Size)  // This test is not required but it allows to set a convenient
+                                // breakpoint on the statement below
+    {
+        // IMGUI_DEBUG_LOG("ClosePopupsOverWindow(%s) -> ClosePopupToLevel(%d)\n", ref_window->Name,
+        // popup_count_to_keep);
+        ClosePopupToLevel(popup_count_to_keep, restore_focus_to_window_under_popup);
+    }
+}
+
+void ImGui::ClosePopupToLevel(int remaining, bool restore_focus_to_window_under_popup)
+{
+    ImGuiContext &g = *GImGui;
+    IM_ASSERT(remaining >= 0 && remaining < g.OpenPopupStack.Size);
+    ImGuiWindow *focus_window = g.OpenPopupStack[remaining].SourceWindow;
+    ImGuiWindow *popup_window = g.OpenPopupStack[remaining].Window;
+    g.OpenPopupStack.resize(remaining);
+
+    if (restore_focus_to_window_under_popup)
+    {
+        if (focus_window && !focus_window->WasActive && popup_window)
+        {
+            // Fallback
+            FocusTopMostWindowUnderOne(popup_window, NULL);
+        }
+        else
+        {
+            if (g.NavLayer == 0 && focus_window)
+                focus_window = NavRestoreLastChildNavWindow(focus_window);
+            FocusWindow(focus_window);
+        }
+    }
+}
+
+// Close the popup we have begin-ed into.
+void ImGui::CloseCurrentPopup()
+{
+    ImGuiContext &g = *GImGui;
+    int popup_idx   = g.BeginPopupStack.Size - 1;
+    if (popup_idx < 0 || popup_idx >= g.OpenPopupStack.Size ||
+        g.BeginPopupStack[popup_idx].PopupId != g.OpenPopupStack[popup_idx].PopupId)
+        return;
+
+    // Closing a menu closes its top-most parent popup (unless a modal)
+    while (popup_idx > 0)
+    {
+        ImGuiWindow *popup_window        = g.OpenPopupStack[popup_idx].Window;
+        ImGuiWindow *parent_popup_window = g.OpenPopupStack[popup_idx - 1].Window;
+        bool close_parent                = false;
+        if (popup_window && (popup_window->Flags & ImGuiWindowFlags_ChildMenu))
+            if (parent_popup_window == NULL ||
+                !(parent_popup_window->Flags & ImGuiWindowFlags_Modal))
+                close_parent = true;
+        if (!close_parent)
+            break;
+        popup_idx--;
+    }
+    // IMGUI_DEBUG_LOG("CloseCurrentPopup %d -> %d\n", g.BeginPopupStack.Size - 1, popup_idx);
+    ClosePopupToLevel(popup_idx, true);
+
+    // A common pattern is to close a popup when selecting a menu item/selectable that will open
+    // another window. To improve this usage pattern, we avoid nav highlight for a single frame in
+    // the parent window. Similarly, we could avoid mouse hover highlight in this window but it is
+    // less visually problematic.
+    if (ImGuiWindow *window = g.NavWindow)
+        window->DC.NavHideHighlightOneFrame = true;
+}
+
+bool ImGui::BeginPopupEx(ImGuiID id, ImGuiWindowFlags extra_flags)
+{
+    ImGuiContext &g = *GImGui;
+    if (!IsPopupOpen(id))
+    {
+        g.NextWindowData.ClearFlags();  // We behave like Begin() and need to consume those values
+        return false;
+    }
+
+    char name[20];
+    if (extra_flags & ImGuiWindowFlags_ChildMenu)
+        ImFormatString(name, IM_ARRAYSIZE(name), "##Menu_%02d",
+                       g.BeginPopupStack.Size);  // Recycle windows based on depth
+    else
+        ImFormatString(name, IM_ARRAYSIZE(name), "##Popup_%08x",
+                       id);  // Not recycling, so we can close/open during the same frame
+
+    bool is_open = Begin(name, NULL, extra_flags | ImGuiWindowFlags_Popup);
+    if (!is_open)  // NB: Begin can return false when the popup is completely clipped (e.g. zero
+                   // size display)
+        EndPopup();
+
+    return is_open;
+}
+
+bool ImGui::BeginPopup(const char *str_id, ImGuiWindowFlags flags)
+{
+    ImGuiContext &g = *GImGui;
+    if (g.OpenPopupStack.Size <= g.BeginPopupStack.Size)  // Early out for performance
+    {
+        g.NextWindowData.ClearFlags();  // We behave like Begin() and need to consume those values
+        return false;
+    }
+    flags |= ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar |
+             ImGuiWindowFlags_NoSavedSettings;
+    return BeginPopupEx(g.CurrentWindow->GetID(str_id), flags);
+}
+
+// If 'p_open' is specified for a modal popup window, the popup will have a regular close button
+// which will close the popup. Note that popup visibility status is owned by Dear ImGui (and
+// manipulated with e.g. OpenPopup) so the actual value of *p_open is meaningless here.
+bool ImGui::BeginPopupModal(const char *name, bool *p_open, ImGuiWindowFlags flags)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+    const ImGuiID id    = window->GetID(name);
+    if (!IsPopupOpen(id))
+    {
+        g.NextWindowData.ClearFlags();  // We behave like Begin() and need to consume those values
+        return false;
+    }
+
+    // Center modal windows by default
+    // FIXME: Should test for (PosCond & window->SetWindowPosAllowFlags) with the upcoming window.
+    if ((g.NextWindowData.Flags & ImGuiNextWindowDataFlags_HasPos) == 0)
+        SetNextWindowPos(g.IO.DisplaySize * 0.5f, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+
+    flags |= ImGuiWindowFlags_Popup | ImGuiWindowFlags_Modal | ImGuiWindowFlags_NoCollapse |
+             ImGuiWindowFlags_NoSavedSettings;
+    const bool is_open = Begin(name, p_open, flags);
+    if (!is_open || (p_open && !*p_open))  // NB: is_open can be 'false' when the popup is
+                                           // completely clipped (e.g. zero size display)
+    {
+        EndPopup();
+        if (is_open)
+            ClosePopupToLevel(g.BeginPopupStack.Size, true);
+        return false;
+    }
+    return is_open;
+}
+
+void ImGui::EndPopup()
+{
+    ImGuiContext &g = *GImGui;
+    IM_ASSERT(g.CurrentWindow->Flags &
+              ImGuiWindowFlags_Popup);  // Mismatched BeginPopup()/EndPopup() calls
+    IM_ASSERT(g.BeginPopupStack.Size > 0);
+
+    // Make all menus and popups wrap around for now, may need to expose that policy.
+    NavMoveRequestTryWrapping(g.CurrentWindow, ImGuiNavMoveFlags_LoopY);
+
+    End();
+}
+
+// This is a helper to handle the simplest case of associating one named popup to one given widget.
+// You may want to handle this on user side if you have specific needs (e.g. tweaking
+// IsItemHovered() parameters). You can pass a NULL str_id to use the identifier of the last item.
+bool ImGui::BeginPopupContextItem(const char *str_id, int mouse_button)
+{
+    ImGuiWindow *window = GImGui->CurrentWindow;
+    if (window->SkipItems)
+        return false;
+    ImGuiID id =
+        str_id ? window->GetID(str_id)
+               : window->DC.LastItemId;  // If user hasn't passed an ID, we can use the LastItemID.
+                                         // Using LastItemID as a Popup ID won't conflict!
+    IM_ASSERT(id != 0);  // You cannot pass a NULL str_id if the last item has no identifier (e.g. a
+                         // Text() item)
+    if (IsMouseReleased(mouse_button) && IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup))
+        OpenPopupEx(id);
+    return BeginPopupEx(id, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar |
+                                ImGuiWindowFlags_NoSavedSettings);
+}
+
+bool ImGui::BeginPopupContextWindow(const char *str_id, int mouse_button, bool also_over_items)
+{
+    if (!str_id)
+        str_id = "window_context";
+    ImGuiID id = GImGui->CurrentWindow->GetID(str_id);
+    if (IsMouseReleased(mouse_button) && IsWindowHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup))
+        if (also_over_items || !IsAnyItemHovered())
+            OpenPopupEx(id);
+    return BeginPopupEx(id, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar |
+                                ImGuiWindowFlags_NoSavedSettings);
+}
+
+bool ImGui::BeginPopupContextVoid(const char *str_id, int mouse_button)
+{
+    if (!str_id)
+        str_id = "void_context";
+    ImGuiID id = GImGui->CurrentWindow->GetID(str_id);
+    if (IsMouseReleased(mouse_button) && !IsWindowHovered(ImGuiHoveredFlags_AnyWindow))
+        OpenPopupEx(id);
+    return BeginPopupEx(id, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar |
+                                ImGuiWindowFlags_NoSavedSettings);
+}
+
+// r_avoid = the rectangle to avoid (e.g. for tooltip it is a rectangle around the mouse cursor
+// which we want to avoid. for popups it's a small point around the cursor.) r_outer = the visible
+// area rectangle, minus safe area padding. If our popup size won't fit because of safe area padding
+// we ignore it.
+ImVec2 ImGui::FindBestWindowPosForPopupEx(const ImVec2 &ref_pos,
+                                          const ImVec2 &size,
+                                          ImGuiDir *last_dir,
+                                          const ImRect &r_outer,
+                                          const ImRect &r_avoid,
+                                          ImGuiPopupPositionPolicy policy)
+{
+    ImVec2 base_pos_clamped = ImClamp(ref_pos, r_outer.Min, r_outer.Max - size);
+    // GetForegroundDrawList()->AddRect(r_avoid.Min, r_avoid.Max, IM_COL32(255,0,0,255));
+    // GetForegroundDrawList()->AddRect(r_outer.Min, r_outer.Max, IM_COL32(0,255,0,255));
+
+    // Combo Box policy (we want a connecting edge)
+    if (policy == ImGuiPopupPositionPolicy_ComboBox)
+    {
+        const ImGuiDir dir_prefered_order[ImGuiDir_COUNT] = {ImGuiDir_Down, ImGuiDir_Right,
+                                                             ImGuiDir_Left, ImGuiDir_Up};
+        for (int n = (*last_dir != ImGuiDir_None) ? -1 : 0; n < ImGuiDir_COUNT; n++)
+        {
+            const ImGuiDir dir = (n == -1) ? *last_dir : dir_prefered_order[n];
+            if (n != -1 && dir == *last_dir)  // Already tried this direction?
+                continue;
+            ImVec2 pos;
+            if (dir == ImGuiDir_Down)
+                pos = ImVec2(r_avoid.Min.x, r_avoid.Max.y);  // Below, Toward Right (default)
+            if (dir == ImGuiDir_Right)
+                pos = ImVec2(r_avoid.Min.x, r_avoid.Min.y - size.y);  // Above, Toward Right
+            if (dir == ImGuiDir_Left)
+                pos = ImVec2(r_avoid.Max.x - size.x, r_avoid.Max.y);  // Below, Toward Left
+            if (dir == ImGuiDir_Up)
+                pos = ImVec2(r_avoid.Max.x - size.x, r_avoid.Min.y - size.y);  // Above, Toward Left
+            if (!r_outer.Contains(ImRect(pos, pos + size)))
+                continue;
+            *last_dir = dir;
+            return pos;
+        }
+    }
+
+    // Default popup policy
+    const ImGuiDir dir_prefered_order[ImGuiDir_COUNT] = {ImGuiDir_Right, ImGuiDir_Down, ImGuiDir_Up,
+                                                         ImGuiDir_Left};
+    for (int n = (*last_dir != ImGuiDir_None) ? -1 : 0; n < ImGuiDir_COUNT; n++)
+    {
+        const ImGuiDir dir = (n == -1) ? *last_dir : dir_prefered_order[n];
+        if (n != -1 && dir == *last_dir)  // Already tried this direction?
+            continue;
+        float avail_w = (dir == ImGuiDir_Left ? r_avoid.Min.x : r_outer.Max.x) -
+                        (dir == ImGuiDir_Right ? r_avoid.Max.x : r_outer.Min.x);
+        float avail_h = (dir == ImGuiDir_Up ? r_avoid.Min.y : r_outer.Max.y) -
+                        (dir == ImGuiDir_Down ? r_avoid.Max.y : r_outer.Min.y);
+        if (avail_w < size.x || avail_h < size.y)
+            continue;
+        ImVec2 pos;
+        pos.x = (dir == ImGuiDir_Left)
+                    ? r_avoid.Min.x - size.x
+                    : (dir == ImGuiDir_Right) ? r_avoid.Max.x : base_pos_clamped.x;
+        pos.y = (dir == ImGuiDir_Up) ? r_avoid.Min.y - size.y
+                                     : (dir == ImGuiDir_Down) ? r_avoid.Max.y : base_pos_clamped.y;
+        *last_dir = dir;
+        return pos;
+    }
+
+    // Fallback, try to keep within display
+    *last_dir  = ImGuiDir_None;
+    ImVec2 pos = ref_pos;
+    pos.x      = ImMax(ImMin(pos.x + size.x, r_outer.Max.x) - size.x, r_outer.Min.x);
+    pos.y      = ImMax(ImMin(pos.y + size.y, r_outer.Max.y) - size.y, r_outer.Min.y);
+    return pos;
+}
+
+ImRect ImGui::GetWindowAllowedExtentRect(ImGuiWindow *window)
+{
+    IM_UNUSED(window);
+    ImVec2 padding  = GImGui->Style.DisplaySafeAreaPadding;
+    ImRect r_screen = GetViewportRect();
+    r_screen.Expand(ImVec2((r_screen.GetWidth() > padding.x * 2) ? -padding.x : 0.0f,
+                           (r_screen.GetHeight() > padding.y * 2) ? -padding.y : 0.0f));
+    return r_screen;
+}
+
+ImVec2 ImGui::FindBestWindowPosForPopup(ImGuiWindow *window)
+{
+    ImGuiContext &g = *GImGui;
+
+    ImRect r_outer = GetWindowAllowedExtentRect(window);
+    if (window->Flags & ImGuiWindowFlags_ChildMenu)
+    {
+        // Child menus typically request _any_ position within the parent menu item, and then we
+        // move the new menu outside the parent bounds. This is how we end up with child menus
+        // appearing (most-commonly) on the right of the parent menu.
+        IM_ASSERT(g.CurrentWindow == window);
+        ImGuiWindow *parent_window = g.CurrentWindowStack[g.CurrentWindowStack.Size - 2];
+        float horizontal_overlap =
+            g.Style.ItemInnerSpacing
+                .x;  // We want some overlap to convey the relative depth of each menu (currently
+                     // the amount of overlap is hard-coded to style.ItemSpacing.x).
+        ImRect r_avoid;
+        if (parent_window->DC.MenuBarAppending)
+            r_avoid =
+                ImRect(-FLT_MAX, parent_window->Pos.y + parent_window->TitleBarHeight(), FLT_MAX,
+                       parent_window->Pos.y + parent_window->TitleBarHeight() +
+                           parent_window->MenuBarHeight());
+        else
+            r_avoid = ImRect(parent_window->Pos.x + horizontal_overlap, -FLT_MAX,
+                             parent_window->Pos.x + parent_window->Size.x - horizontal_overlap -
+                                 parent_window->ScrollbarSizes.x,
+                             FLT_MAX);
+        return FindBestWindowPosForPopupEx(window->Pos, window->Size, &window->AutoPosLastDirection,
+                                           r_outer, r_avoid);
+    }
+    if (window->Flags & ImGuiWindowFlags_Popup)
+    {
+        ImRect r_avoid =
+            ImRect(window->Pos.x - 1, window->Pos.y - 1, window->Pos.x + 1, window->Pos.y + 1);
+        return FindBestWindowPosForPopupEx(window->Pos, window->Size, &window->AutoPosLastDirection,
+                                           r_outer, r_avoid);
+    }
+    if (window->Flags & ImGuiWindowFlags_Tooltip)
+    {
+        // Position tooltip (always follows mouse)
+        float sc       = g.Style.MouseCursorScale;
+        ImVec2 ref_pos = NavCalcPreferredRefPos();
+        ImRect r_avoid;
+        if (!g.NavDisableHighlight && g.NavDisableMouseHover &&
+            !(g.IO.ConfigFlags & ImGuiConfigFlags_NavEnableSetMousePos))
+            r_avoid = ImRect(ref_pos.x - 16, ref_pos.y - 8, ref_pos.x + 16, ref_pos.y + 8);
+        else
+            r_avoid =
+                ImRect(ref_pos.x - 16, ref_pos.y - 8, ref_pos.x + 24 * sc,
+                       ref_pos.y + 24 * sc);  // FIXME: Hard-coded based on mouse cursor shape
+                                              // expectation. Exact dimension not very important.
+        ImVec2 pos = FindBestWindowPosForPopupEx(ref_pos, window->Size,
+                                                 &window->AutoPosLastDirection, r_outer, r_avoid);
+        if (window->AutoPosLastDirection == ImGuiDir_None)
+            pos =
+                ref_pos +
+                ImVec2(
+                    2,
+                    2);  // If there's not enough room, for tooltip we prefer avoiding the cursor at
+                         // all cost even if it means that part of the tooltip won't be visible.
+        return pos;
+    }
+    IM_ASSERT(0);
+    return window->Pos;
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] KEYBOARD/GAMEPAD NAVIGATION
+//-----------------------------------------------------------------------------
+
+ImGuiDir ImGetDirQuadrantFromDelta(float dx, float dy)
+{
+    if (ImFabs(dx) > ImFabs(dy))
+        return (dx > 0.0f) ? ImGuiDir_Right : ImGuiDir_Left;
+    return (dy > 0.0f) ? ImGuiDir_Down : ImGuiDir_Up;
+}
+
+static float inline NavScoreItemDistInterval(float a0, float a1, float b0, float b1)
+{
+    if (a1 < b0)
+        return a1 - b0;
+    if (b1 < a0)
+        return a0 - b1;
+    return 0.0f;
+}
+
+static void inline NavClampRectToVisibleAreaForMoveDir(ImGuiDir move_dir,
+                                                       ImRect &r,
+                                                       const ImRect &clip_rect)
+{
+    if (move_dir == ImGuiDir_Left || move_dir == ImGuiDir_Right)
+    {
+        r.Min.y = ImClamp(r.Min.y, clip_rect.Min.y, clip_rect.Max.y);
+        r.Max.y = ImClamp(r.Max.y, clip_rect.Min.y, clip_rect.Max.y);
+    }
+    else
+    {
+        r.Min.x = ImClamp(r.Min.x, clip_rect.Min.x, clip_rect.Max.x);
+        r.Max.x = ImClamp(r.Max.x, clip_rect.Min.x, clip_rect.Max.x);
+    }
+}
+
+// Scoring function for directional navigation. Based on https://gist.github.com/rygorous/6981057
+static bool NavScoreItem(ImGuiNavMoveResult *result, ImRect cand)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+    if (g.NavLayer != window->DC.NavLayerCurrent)
+        return false;
+
+    const ImRect &curr =
+        g.NavScoringRectScreen;  // Current modified source rect (NB: we've applied Max.x = Min.x in
+                                 // NavUpdate() to inhibit the effect of having varied item width)
+    g.NavScoringCount++;
+
+    // When entering through a NavFlattened border, we consider child window items as fully clipped
+    // for scoring
+    if (window->ParentWindow == g.NavWindow)
+    {
+        IM_ASSERT((window->Flags | g.NavWindow->Flags) & ImGuiWindowFlags_NavFlattened);
+        if (!window->ClipRect.Contains(cand))
+            return false;
+        cand.ClipWithFull(window->ClipRect);  // This allows the scored item to not overlap other
+                                              // candidates in the parent window
+    }
+
+    // We perform scoring on items bounding box clipped by the current clipping rectangle on the
+    // other axis (clipping on our movement axis would give us equal scores for all clipped items)
+    // For example, this ensure that items in one column are not reached when moving vertically from
+    // items in another column.
+    NavClampRectToVisibleAreaForMoveDir(g.NavMoveClipDir, cand, window->ClipRect);
+
+    // Compute distance between boxes
+    // FIXME-NAV: Introducing biases for vertical navigation, needs to be removed.
+    float dbx = NavScoreItemDistInterval(cand.Min.x, cand.Max.x, curr.Min.x, curr.Max.x);
+    float dby = NavScoreItemDistInterval(
+        ImLerp(cand.Min.y, cand.Max.y, 0.2f), ImLerp(cand.Min.y, cand.Max.y, 0.8f),
+        ImLerp(curr.Min.y, curr.Max.y, 0.2f),
+        ImLerp(curr.Min.y, curr.Max.y,
+               0.8f));  // Scale down on Y to keep using box-distance for vertically touching items
+    if (dby != 0.0f && dbx != 0.0f)
+        dbx = (dbx / 1000.0f) + ((dbx > 0.0f) ? +1.0f : -1.0f);
+    float dist_box = ImFabs(dbx) + ImFabs(dby);
+
+    // Compute distance between centers (this is off by a factor of 2, but we only compare center
+    // distances with each other so it doesn't matter)
+    float dcx = (cand.Min.x + cand.Max.x) - (curr.Min.x + curr.Max.x);
+    float dcy = (cand.Min.y + cand.Max.y) - (curr.Min.y + curr.Max.y);
+    float dist_center =
+        ImFabs(dcx) + ImFabs(dcy);  // L1 metric (need this for our connectedness guarantee)
+
+    // Determine which quadrant of 'curr' our candidate item 'cand' lies in based on distance
+    ImGuiDir quadrant;
+    float dax = 0.0f, day = 0.0f, dist_axial = 0.0f;
+    if (dbx != 0.0f || dby != 0.0f)
+    {
+        // For non-overlapping boxes, use distance between boxes
+        dax        = dbx;
+        day        = dby;
+        dist_axial = dist_box;
+        quadrant   = ImGetDirQuadrantFromDelta(dbx, dby);
+    }
+    else if (dcx != 0.0f || dcy != 0.0f)
+    {
+        // For overlapping boxes with different centers, use distance between centers
+        dax        = dcx;
+        day        = dcy;
+        dist_axial = dist_center;
+        quadrant   = ImGetDirQuadrantFromDelta(dcx, dcy);
+    }
+    else
+    {
+        // Degenerate case: two overlapping buttons with same center, break ties arbitrarily (note
+        // that LastItemId here is really the _previous_ item order, but it doesn't matter)
+        quadrant = (window->DC.LastItemId < g.NavId) ? ImGuiDir_Left : ImGuiDir_Right;
+    }
+
+#if IMGUI_DEBUG_NAV_SCORING
+    char buf[128];
+    if (ImGui::IsMouseHoveringRect(cand.Min, cand.Max))
+    {
+        ImFormatString(buf, IM_ARRAYSIZE(buf),
+                       "dbox (%.2f,%.2f->%.4f)\ndcen (%.2f,%.2f->%.4f)\nd (%.2f,%.2f->%.4f)\nnav "
+                       "%c, quadrant %c",
+                       dbx, dby, dist_box, dcx, dcy, dist_center, dax, day, dist_axial,
+                       "WENS"[g.NavMoveDir], "WENS"[quadrant]);
+        ImDrawList *draw_list = ImGui::GetForegroundDrawList(window);
+        draw_list->AddRect(curr.Min, curr.Max, IM_COL32(255, 200, 0, 100));
+        draw_list->AddRect(cand.Min, cand.Max, IM_COL32(255, 255, 0, 200));
+        draw_list->AddRectFilled(cand.Max - ImVec2(4, 4),
+                                 cand.Max + ImGui::CalcTextSize(buf) + ImVec2(4, 4),
+                                 IM_COL32(40, 0, 0, 150));
+        draw_list->AddText(g.IO.FontDefault, 13.0f, cand.Max, ~0U, buf);
+    }
+    else if (g.IO.KeyCtrl)  // Hold to preview score in matching quadrant. Press C to rotate.
+    {
+        if (ImGui::IsKeyPressedMap(ImGuiKey_C))
+        {
+            g.NavMoveDirLast                               = (ImGuiDir)((g.NavMoveDirLast + 1) & 3);
+            g.IO.KeysDownDuration[g.IO.KeyMap[ImGuiKey_C]] = 0.01f;
+        }
+        if (quadrant == g.NavMoveDir)
+        {
+            ImFormatString(buf, IM_ARRAYSIZE(buf), "%.0f/%.0f", dist_box, dist_center);
+            ImDrawList *draw_list = ImGui::GetForegroundDrawList(window);
+            draw_list->AddRectFilled(cand.Min, cand.Max, IM_COL32(255, 0, 0, 200));
+            draw_list->AddText(g.IO.FontDefault, 13.0f, cand.Min, IM_COL32(255, 255, 255, 255),
+                               buf);
+        }
+    }
+#endif
+
+    // Is it in the quadrant we're interesting in moving to?
+    bool new_best = false;
+    if (quadrant == g.NavMoveDir)
+    {
+        // Does it beat the current best candidate?
+        if (dist_box < result->DistBox)
+        {
+            result->DistBox    = dist_box;
+            result->DistCenter = dist_center;
+            return true;
+        }
+        if (dist_box == result->DistBox)
+        {
+            // Try using distance between center points to break ties
+            if (dist_center < result->DistCenter)
+            {
+                result->DistCenter = dist_center;
+                new_best           = true;
+            }
+            else if (dist_center == result->DistCenter)
+            {
+                // Still tied! we need to be extra-careful to make sure everything gets linked
+                // properly. We consistently break ties by symbolically moving "later" items (with
+                // higher index) to the right/downwards by an infinitesimal amount since we the
+                // current "best" button already (so it must have a lower index), this is fairly
+                // easy. This rule ensures that all buttons with dx==dy==0 will end up being linked
+                // in order of appearance along the x axis.
+                if (((g.NavMoveDir == ImGuiDir_Up || g.NavMoveDir == ImGuiDir_Down) ? dby : dbx) <
+                    0.0f)  // moving bj to the right/down decreases distance
+                    new_best = true;
+            }
+        }
+    }
+
+    // Axial check: if 'curr' has no link at all in some direction and 'cand' lies roughly in that
+    // direction, add a tentative link. This will only be kept if no "real" matches are found, so it
+    // only augments the graph produced by the above method using extra links. (important, since it
+    // doesn't guarantee strong connectedness) This is just to avoid buttons having no links in a
+    // particular direction when there's a suitable neighbor. you get good graphs without this too.
+    // 2017/09/29: FIXME: This now currently only enabled inside menu bars, ideally we'd disable it
+    // everywhere. Menus in particular need to catch failure. For general navigation it feels
+    // awkward. Disabling it may lead to disconnected graphs when nodes are very spaced out on
+    // different axis. Perhaps consider offering this as an option?
+    if (result->DistBox == FLT_MAX && dist_axial < result->DistAxial)  // Check axial match
+        if (g.NavLayer == 1 && !(g.NavWindow->Flags & ImGuiWindowFlags_ChildMenu))
+            if ((g.NavMoveDir == ImGuiDir_Left && dax < 0.0f) ||
+                (g.NavMoveDir == ImGuiDir_Right && dax > 0.0f) ||
+                (g.NavMoveDir == ImGuiDir_Up && day < 0.0f) ||
+                (g.NavMoveDir == ImGuiDir_Down && day > 0.0f))
+            {
+                result->DistAxial = dist_axial;
+                new_best          = true;
+            }
+
+    return new_best;
+}
+
+// We get there when either NavId == id, or when g.NavAnyRequest is set (which is updated by
+// NavUpdateAnyRequestFlag above)
+static void ImGui::NavProcessItem(ImGuiWindow *window, const ImRect &nav_bb, const ImGuiID id)
+{
+    ImGuiContext &g = *GImGui;
+    // if (!g.IO.NavActive)  // [2017/10/06] Removed this possibly redundant test but I am not sure
+    // of all the side-effects yet. Some of the feature here will need to work regardless of using a
+    // _NoNavInputs flag.
+    //    return;
+
+    const ImGuiItemFlags item_flags = window->DC.ItemFlags;
+    const ImRect nav_bb_rel(nav_bb.Min - window->Pos, nav_bb.Max - window->Pos);
+
+    // Process Init Request
+    if (g.NavInitRequest && g.NavLayer == window->DC.NavLayerCurrent)
+    {
+        // Even if 'ImGuiItemFlags_NoNavDefaultFocus' is on (typically collapse/close button) we
+        // record the first ResultId so they can be used as a fallback
+        if (!(item_flags & ImGuiItemFlags_NoNavDefaultFocus) || g.NavInitResultId == 0)
+        {
+            g.NavInitResultId      = id;
+            g.NavInitResultRectRel = nav_bb_rel;
+        }
+        if (!(item_flags & ImGuiItemFlags_NoNavDefaultFocus))
+        {
+            g.NavInitRequest = false;  // Found a match, clear request
+            NavUpdateAnyRequestFlag();
+        }
+    }
+
+    // Process Move Request (scoring for navigation)
+    // FIXME-NAV: Consider policy for double scoring (scoring from NavScoringRectScreen + scoring
+    // from a rect wrapped according to current wrapping policy)
+    if ((g.NavId != id || (g.NavMoveRequestFlags & ImGuiNavMoveFlags_AllowCurrentNavId)) &&
+        !(item_flags & (ImGuiItemFlags_Disabled | ImGuiItemFlags_NoNav)))
+    {
+        ImGuiNavMoveResult *result =
+            (window == g.NavWindow) ? &g.NavMoveResultLocal : &g.NavMoveResultOther;
+#if IMGUI_DEBUG_NAV_SCORING
+        // [DEBUG] Score all items in NavWindow at all times
+        if (!g.NavMoveRequest)
+            g.NavMoveDir = g.NavMoveDirLast;
+        bool new_best = NavScoreItem(result, nav_bb) && g.NavMoveRequest;
+#else
+        bool new_best = g.NavMoveRequest && NavScoreItem(result, nav_bb);
+#endif
+        if (new_best)
+        {
+            result->ID            = id;
+            result->SelectScopeId = g.MultiSelectScopeId;
+            result->Window        = window;
+            result->RectRel       = nav_bb_rel;
+        }
+
+        const float VISIBLE_RATIO = 0.70f;
+        if ((g.NavMoveRequestFlags & ImGuiNavMoveFlags_AlsoScoreVisibleSet) &&
+            window->ClipRect.Overlaps(nav_bb))
+            if (ImClamp(nav_bb.Max.y, window->ClipRect.Min.y, window->ClipRect.Max.y) -
+                    ImClamp(nav_bb.Min.y, window->ClipRect.Min.y, window->ClipRect.Max.y) >=
+                (nav_bb.Max.y - nav_bb.Min.y) * VISIBLE_RATIO)
+                if (NavScoreItem(&g.NavMoveResultLocalVisibleSet, nav_bb))
+                {
+                    result                = &g.NavMoveResultLocalVisibleSet;
+                    result->ID            = id;
+                    result->SelectScopeId = g.MultiSelectScopeId;
+                    result->Window        = window;
+                    result->RectRel       = nav_bb_rel;
+                }
+    }
+
+    // Update window-relative bounding box of navigated item
+    if (g.NavId == id)
+    {
+        g.NavWindow = window;  // Always refresh g.NavWindow, because some operations such as
+                               // FocusItem() don't have a window.
+        g.NavLayer        = window->DC.NavLayerCurrent;
+        g.NavIdIsAlive    = true;
+        g.NavIdTabCounter = window->DC.FocusCounterTab;
+        window->NavRectRel[window->DC.NavLayerCurrent] =
+            nav_bb_rel;  // Store item bounding box (relative to window position)
+    }
+}
+
+bool ImGui::NavMoveRequestButNoResultYet()
+{
+    ImGuiContext &g = *GImGui;
+    return g.NavMoveRequest && g.NavMoveResultLocal.ID == 0 && g.NavMoveResultOther.ID == 0;
+}
+
+void ImGui::NavMoveRequestCancel()
+{
+    ImGuiContext &g  = *GImGui;
+    g.NavMoveRequest = false;
+    NavUpdateAnyRequestFlag();
+}
+
+void ImGui::NavMoveRequestForward(ImGuiDir move_dir,
+                                  ImGuiDir clip_dir,
+                                  const ImRect &bb_rel,
+                                  ImGuiNavMoveFlags move_flags)
+{
+    ImGuiContext &g = *GImGui;
+    IM_ASSERT(g.NavMoveRequestForward == ImGuiNavForward_None);
+    ImGui::NavMoveRequestCancel();
+    g.NavMoveDir                        = move_dir;
+    g.NavMoveClipDir                    = clip_dir;
+    g.NavMoveRequestForward             = ImGuiNavForward_ForwardQueued;
+    g.NavMoveRequestFlags               = move_flags;
+    g.NavWindow->NavRectRel[g.NavLayer] = bb_rel;
+}
+
+void ImGui::NavMoveRequestTryWrapping(ImGuiWindow *window, ImGuiNavMoveFlags move_flags)
+{
+    ImGuiContext &g = *GImGui;
+    if (g.NavWindow != window || !NavMoveRequestButNoResultYet() ||
+        g.NavMoveRequestForward != ImGuiNavForward_None || g.NavLayer != 0)
+        return;
+    IM_ASSERT(move_flags != 0);  // No points calling this with no wrapping
+    ImRect bb_rel = window->NavRectRel[0];
+
+    ImGuiDir clip_dir = g.NavMoveDir;
+    if (g.NavMoveDir == ImGuiDir_Left &&
+        (move_flags & (ImGuiNavMoveFlags_WrapX | ImGuiNavMoveFlags_LoopX)))
+    {
+        bb_rel.Min.x = bb_rel.Max.x =
+            ImMax(window->SizeFull.x, window->ContentSize.x + window->WindowPadding.x * 2.0f) -
+            window->Scroll.x;
+        if (move_flags & ImGuiNavMoveFlags_WrapX)
+        {
+            bb_rel.TranslateY(-bb_rel.GetHeight());
+            clip_dir = ImGuiDir_Up;
+        }
+        NavMoveRequestForward(g.NavMoveDir, clip_dir, bb_rel, move_flags);
+    }
+    if (g.NavMoveDir == ImGuiDir_Right &&
+        (move_flags & (ImGuiNavMoveFlags_WrapX | ImGuiNavMoveFlags_LoopX)))
+    {
+        bb_rel.Min.x = bb_rel.Max.x = -window->Scroll.x;
+        if (move_flags & ImGuiNavMoveFlags_WrapX)
+        {
+            bb_rel.TranslateY(+bb_rel.GetHeight());
+            clip_dir = ImGuiDir_Down;
+        }
+        NavMoveRequestForward(g.NavMoveDir, clip_dir, bb_rel, move_flags);
+    }
+    if (g.NavMoveDir == ImGuiDir_Up &&
+        (move_flags & (ImGuiNavMoveFlags_WrapY | ImGuiNavMoveFlags_LoopY)))
+    {
+        bb_rel.Min.y = bb_rel.Max.y =
+            ImMax(window->SizeFull.y, window->ContentSize.y + window->WindowPadding.y * 2.0f) -
+            window->Scroll.y;
+        if (move_flags & ImGuiNavMoveFlags_WrapY)
+        {
+            bb_rel.TranslateX(-bb_rel.GetWidth());
+            clip_dir = ImGuiDir_Left;
+        }
+        NavMoveRequestForward(g.NavMoveDir, clip_dir, bb_rel, move_flags);
+    }
+    if (g.NavMoveDir == ImGuiDir_Down &&
+        (move_flags & (ImGuiNavMoveFlags_WrapY | ImGuiNavMoveFlags_LoopY)))
+    {
+        bb_rel.Min.y = bb_rel.Max.y = -window->Scroll.y;
+        if (move_flags & ImGuiNavMoveFlags_WrapY)
+        {
+            bb_rel.TranslateX(+bb_rel.GetWidth());
+            clip_dir = ImGuiDir_Right;
+        }
+        NavMoveRequestForward(g.NavMoveDir, clip_dir, bb_rel, move_flags);
+    }
+}
+
+// FIXME: This could be replaced by updating a frame number in each window when (window ==
+// NavWindow) and (NavLayer == 0). This way we could find the last focused window among our
+// children. It would be much less confusing this way?
+static void ImGui::NavSaveLastChildNavWindowIntoParent(ImGuiWindow *nav_window)
+{
+    ImGuiWindow *parent_window = nav_window;
+    while (parent_window && (parent_window->Flags & ImGuiWindowFlags_ChildWindow) != 0 &&
+           (parent_window->Flags & (ImGuiWindowFlags_Popup | ImGuiWindowFlags_ChildMenu)) == 0)
+        parent_window = parent_window->ParentWindow;
+    if (parent_window && parent_window != nav_window)
+        parent_window->NavLastChildNavWindow = nav_window;
+}
+
+// Restore the last focused child.
+// Call when we are expected to land on the Main Layer (0) after FocusWindow()
+static ImGuiWindow *ImGui::NavRestoreLastChildNavWindow(ImGuiWindow *window)
+{
+    return window->NavLastChildNavWindow ? window->NavLastChildNavWindow : window;
+}
+
+static void NavRestoreLayer(ImGuiNavLayer layer)
+{
+    ImGuiContext &g = *GImGui;
+    g.NavLayer      = layer;
+    if (layer == 0)
+        g.NavWindow = ImGui::NavRestoreLastChildNavWindow(g.NavWindow);
+    if (layer == 0 && g.NavWindow->NavLastIds[0] != 0)
+        ImGui::SetNavIDWithRectRel(g.NavWindow->NavLastIds[0], layer, g.NavWindow->NavRectRel[0]);
+    else
+        ImGui::NavInitWindow(g.NavWindow, true);
+}
+
+static inline void ImGui::NavUpdateAnyRequestFlag()
+{
+    ImGuiContext &g = *GImGui;
+    g.NavAnyRequest =
+        g.NavMoveRequest || g.NavInitRequest || (IMGUI_DEBUG_NAV_SCORING && g.NavWindow != NULL);
+    if (g.NavAnyRequest)
+        IM_ASSERT(g.NavWindow != NULL);
+}
+
+// This needs to be called before we submit any widget (aka in or before Begin)
+void ImGui::NavInitWindow(ImGuiWindow *window, bool force_reinit)
+{
+    ImGuiContext &g = *GImGui;
+    IM_ASSERT(window == g.NavWindow);
+    bool init_for_nav = false;
+    if (!(window->Flags & ImGuiWindowFlags_NoNavInputs))
+        if (!(window->Flags & ImGuiWindowFlags_ChildWindow) ||
+            (window->Flags & ImGuiWindowFlags_Popup) || (window->NavLastIds[0] == 0) ||
+            force_reinit)
+            init_for_nav = true;
+    if (init_for_nav)
+    {
+        SetNavID(0, g.NavLayer);
+        g.NavInitRequest         = true;
+        g.NavInitRequestFromMove = false;
+        g.NavInitResultId        = 0;
+        g.NavInitResultRectRel   = ImRect();
+        NavUpdateAnyRequestFlag();
+    }
+    else
+    {
+        g.NavId = window->NavLastIds[0];
+    }
+}
+
+static ImVec2 ImGui::NavCalcPreferredRefPos()
+{
+    ImGuiContext &g = *GImGui;
+    if (g.NavDisableHighlight || !g.NavDisableMouseHover || !g.NavWindow)
+    {
+        // Mouse (we need a fallback in case the mouse becomes invalid after being used)
+        if (IsMousePosValid(&g.IO.MousePos))
+            return g.IO.MousePos;
+        return g.LastValidMousePos;
+    }
+    else
+    {
+        // When navigation is active and mouse is disabled, decide on an arbitrary position around
+        // the bottom left of the currently navigated item.
+        const ImRect &rect_rel = g.NavWindow->NavRectRel[g.NavLayer];
+        ImVec2 pos             = g.NavWindow->Pos +
+                     ImVec2(rect_rel.Min.x + ImMin(g.Style.FramePadding.x * 4, rect_rel.GetWidth()),
+                            rect_rel.Max.y - ImMin(g.Style.FramePadding.y, rect_rel.GetHeight()));
+        ImRect visible_rect = GetViewportRect();
+        return ImFloor(ImClamp(
+            pos, visible_rect.Min,
+            visible_rect
+                .Max));  // ImFloor() is important because non-integer mouse position application in
+                         // back-end might be lossy and result in undesirable non-zero delta.
+    }
+}
+
+float ImGui::GetNavInputAmount(ImGuiNavInput n, ImGuiInputReadMode mode)
+{
+    ImGuiContext &g = *GImGui;
+    if (mode == ImGuiInputReadMode_Down)
+        return g.IO.NavInputs[n];  // Instant, read analog input (0.0f..1.0f, as provided by user)
+
+    const float t = g.IO.NavInputsDownDuration[n];
+    if (t < 0.0f && mode == ImGuiInputReadMode_Released)  // Return 1.0f when just released, no
+                                                          // repeat, ignore analog input.
+        return (g.IO.NavInputsDownDurationPrev[n] >= 0.0f ? 1.0f : 0.0f);
+    if (t < 0.0f)
+        return 0.0f;
+    if (mode == ImGuiInputReadMode_Pressed)  // Return 1.0f when just pressed, no repeat, ignore
+                                             // analog input.
+        return (t == 0.0f) ? 1.0f : 0.0f;
+    if (mode == ImGuiInputReadMode_Repeat)
+        return (float)CalcTypematicPressedRepeatAmount(
+            t, t - g.IO.DeltaTime, g.IO.KeyRepeatDelay * 0.80f, g.IO.KeyRepeatRate * 0.80f);
+    if (mode == ImGuiInputReadMode_RepeatSlow)
+        return (float)CalcTypematicPressedRepeatAmount(
+            t, t - g.IO.DeltaTime, g.IO.KeyRepeatDelay * 1.00f, g.IO.KeyRepeatRate * 2.00f);
+    if (mode == ImGuiInputReadMode_RepeatFast)
+        return (float)CalcTypematicPressedRepeatAmount(
+            t, t - g.IO.DeltaTime, g.IO.KeyRepeatDelay * 0.80f, g.IO.KeyRepeatRate * 0.30f);
+    return 0.0f;
+}
+
+ImVec2 ImGui::GetNavInputAmount2d(ImGuiNavDirSourceFlags dir_sources,
+                                  ImGuiInputReadMode mode,
+                                  float slow_factor,
+                                  float fast_factor)
+{
+    ImVec2 delta(0.0f, 0.0f);
+    if (dir_sources & ImGuiNavDirSourceFlags_Keyboard)
+        delta += ImVec2(GetNavInputAmount(ImGuiNavInput_KeyRight_, mode) -
+                            GetNavInputAmount(ImGuiNavInput_KeyLeft_, mode),
+                        GetNavInputAmount(ImGuiNavInput_KeyDown_, mode) -
+                            GetNavInputAmount(ImGuiNavInput_KeyUp_, mode));
+    if (dir_sources & ImGuiNavDirSourceFlags_PadDPad)
+        delta += ImVec2(GetNavInputAmount(ImGuiNavInput_DpadRight, mode) -
+                            GetNavInputAmount(ImGuiNavInput_DpadLeft, mode),
+                        GetNavInputAmount(ImGuiNavInput_DpadDown, mode) -
+                            GetNavInputAmount(ImGuiNavInput_DpadUp, mode));
+    if (dir_sources & ImGuiNavDirSourceFlags_PadLStick)
+        delta += ImVec2(GetNavInputAmount(ImGuiNavInput_LStickRight, mode) -
+                            GetNavInputAmount(ImGuiNavInput_LStickLeft, mode),
+                        GetNavInputAmount(ImGuiNavInput_LStickDown, mode) -
+                            GetNavInputAmount(ImGuiNavInput_LStickUp, mode));
+    if (slow_factor != 0.0f && IsNavInputDown(ImGuiNavInput_TweakSlow))
+        delta *= slow_factor;
+    if (fast_factor != 0.0f && IsNavInputDown(ImGuiNavInput_TweakFast))
+        delta *= fast_factor;
+    return delta;
+}
+
+// Scroll to keep newly navigated item fully into view
+// NB: We modify rect_rel by the amount we scrolled for, so it is immediately updated.
+static void NavScrollToBringItemIntoView(ImGuiWindow *window, const ImRect &item_rect)
+{
+    ImRect window_rect(window->InnerRect.Min - ImVec2(1, 1), window->InnerRect.Max + ImVec2(1, 1));
+    // GetForegroundDrawList(window)->AddRect(window_rect.Min, window_rect.Max, IM_COL32_WHITE); //
+    // [DEBUG]
+    if (window_rect.Contains(item_rect))
+        return;
+
+    ImGuiContext &g = *GImGui;
+    if (window->ScrollbarX && item_rect.Min.x < window_rect.Min.x)
+    {
+        window->ScrollTarget.x =
+            item_rect.Min.x - window->Pos.x + window->Scroll.x - g.Style.ItemSpacing.x;
+        window->ScrollTargetCenterRatio.x = 0.0f;
+    }
+    else if (window->ScrollbarX && item_rect.Max.x >= window_rect.Max.x)
+    {
+        window->ScrollTarget.x =
+            item_rect.Max.x - window->Pos.x + window->Scroll.x + g.Style.ItemSpacing.x;
+        window->ScrollTargetCenterRatio.x = 1.0f;
+    }
+    if (item_rect.Min.y < window_rect.Min.y)
+    {
+        window->ScrollTarget.y =
+            item_rect.Min.y - window->Pos.y + window->Scroll.y - g.Style.ItemSpacing.y;
+        window->ScrollTargetCenterRatio.y = 0.0f;
+    }
+    else if (item_rect.Max.y >= window_rect.Max.y)
+    {
+        window->ScrollTarget.y =
+            item_rect.Max.y - window->Pos.y + window->Scroll.y + g.Style.ItemSpacing.y;
+        window->ScrollTargetCenterRatio.y = 1.0f;
+    }
+}
+
+static void ImGui::NavUpdate()
+{
+    ImGuiContext &g      = *GImGui;
+    g.IO.WantSetMousePos = false;
+#if 0
+    if (g.NavScoringCount > 0) IMGUI_DEBUG_LOG("NavScoringCount %d for '%s' layer %d (Init:%d, Move:%d)\n", g.FrameCount, g.NavScoringCount, g.NavWindow ? g.NavWindow->Name : "NULL", g.NavLayer, g.NavInitRequest || g.NavInitResultId != 0, g.NavMoveRequest);
+#endif
+
+    // Set input source as Gamepad when buttons are pressed before we map Keyboard (some features
+    // differs when used with Gamepad vs Keyboard)
+    bool nav_keyboard_active = (g.IO.ConfigFlags & ImGuiConfigFlags_NavEnableKeyboard) != 0;
+    bool nav_gamepad_active  = (g.IO.ConfigFlags & ImGuiConfigFlags_NavEnableGamepad) != 0 &&
+                              (g.IO.BackendFlags & ImGuiBackendFlags_HasGamepad) != 0;
+    if (nav_gamepad_active)
+        if (g.IO.NavInputs[ImGuiNavInput_Activate] > 0.0f ||
+            g.IO.NavInputs[ImGuiNavInput_Input] > 0.0f ||
+            g.IO.NavInputs[ImGuiNavInput_Cancel] > 0.0f ||
+            g.IO.NavInputs[ImGuiNavInput_Menu] > 0.0f)
+            g.NavInputSource = ImGuiInputSource_NavGamepad;
+
+    // Update Keyboard->Nav inputs mapping
+    if (nav_keyboard_active)
+    {
+#define NAV_MAP_KEY(_KEY, _NAV_INPUT)                              \
+    if (IsKeyDown(g.IO.KeyMap[_KEY]))                              \
+    {                                                              \
+        g.IO.NavInputs[_NAV_INPUT] = 1.0f;                         \
+        g.NavInputSource           = ImGuiInputSource_NavKeyboard; \
+    }
+        NAV_MAP_KEY(ImGuiKey_Space, ImGuiNavInput_Activate);
+        NAV_MAP_KEY(ImGuiKey_Enter, ImGuiNavInput_Input);
+        NAV_MAP_KEY(ImGuiKey_Escape, ImGuiNavInput_Cancel);
+        NAV_MAP_KEY(ImGuiKey_LeftArrow, ImGuiNavInput_KeyLeft_);
+        NAV_MAP_KEY(ImGuiKey_RightArrow, ImGuiNavInput_KeyRight_);
+        NAV_MAP_KEY(ImGuiKey_UpArrow, ImGuiNavInput_KeyUp_);
+        NAV_MAP_KEY(ImGuiKey_DownArrow, ImGuiNavInput_KeyDown_);
+        NAV_MAP_KEY(ImGuiKey_Tab, ImGuiNavInput_KeyTab_);
+        if (g.IO.KeyCtrl)
+            g.IO.NavInputs[ImGuiNavInput_TweakSlow] = 1.0f;
+        if (g.IO.KeyShift)
+            g.IO.NavInputs[ImGuiNavInput_TweakFast] = 1.0f;
+        if (g.IO.KeyAlt && !g.IO.KeyCtrl)  // AltGR is Alt+Ctrl, also even on keyboards without
+                                           // AltGR we don't want Alt+Ctrl to open menu.
+            g.IO.NavInputs[ImGuiNavInput_KeyMenu_] = 1.0f;
+#undef NAV_MAP_KEY
+    }
+    memcpy(g.IO.NavInputsDownDurationPrev, g.IO.NavInputsDownDuration,
+           sizeof(g.IO.NavInputsDownDuration));
+    for (int i = 0; i < IM_ARRAYSIZE(g.IO.NavInputs); i++)
+        g.IO.NavInputsDownDuration[i] = (g.IO.NavInputs[i] > 0.0f)
+                                            ? (g.IO.NavInputsDownDuration[i] < 0.0f
+                                                   ? 0.0f
+                                                   : g.IO.NavInputsDownDuration[i] + g.IO.DeltaTime)
+                                            : -1.0f;
+
+    // Process navigation init request (select first/default focus)
+    // In very rare cases g.NavWindow may be null (e.g. clearing focus after requesting an init
+    // request, which does happen when releasing Alt while clicking on void)
+    if (g.NavInitResultId != 0 && (!g.NavDisableHighlight || g.NavInitRequestFromMove) &&
+        g.NavWindow)
+    {
+        // Apply result from previous navigation init request (will typically select the first item,
+        // unless SetItemDefaultFocus() has been called)
+        if (g.NavInitRequestFromMove)
+            SetNavIDWithRectRel(g.NavInitResultId, g.NavLayer, g.NavInitResultRectRel);
+        else
+            SetNavID(g.NavInitResultId, g.NavLayer);
+        g.NavWindow->NavRectRel[g.NavLayer] = g.NavInitResultRectRel;
+    }
+    g.NavInitRequest         = false;
+    g.NavInitRequestFromMove = false;
+    g.NavInitResultId        = 0;
+    g.NavJustMovedToId       = 0;
+
+    // Process navigation move request
+    if (g.NavMoveRequest)
+        NavUpdateMoveResult();
+
+    // When a forwarded move request failed, we restore the highlight that we disabled during the
+    // forward frame
+    if (g.NavMoveRequestForward == ImGuiNavForward_ForwardActive)
+    {
+        IM_ASSERT(g.NavMoveRequest);
+        if (g.NavMoveResultLocal.ID == 0 && g.NavMoveResultOther.ID == 0)
+            g.NavDisableHighlight = false;
+        g.NavMoveRequestForward = ImGuiNavForward_None;
+    }
+
+    // Apply application mouse position movement, after we had a chance to process move request
+    // result.
+    if (g.NavMousePosDirty && g.NavIdIsAlive)
+    {
+        // Set mouse position given our knowledge of the navigated item position from last frame
+        if ((g.IO.ConfigFlags & ImGuiConfigFlags_NavEnableSetMousePos) &&
+            (g.IO.BackendFlags & ImGuiBackendFlags_HasSetMousePos))
+        {
+            if (!g.NavDisableHighlight && g.NavDisableMouseHover && g.NavWindow)
+            {
+                g.IO.MousePos = g.IO.MousePosPrev = NavCalcPreferredRefPos();
+                g.IO.WantSetMousePos              = true;
+            }
+        }
+        g.NavMousePosDirty = false;
+    }
+    g.NavIdIsAlive    = false;
+    g.NavJustTabbedId = 0;
+    IM_ASSERT(g.NavLayer == 0 || g.NavLayer == 1);
+
+    // Store our return window (for returning from Layer 1 to Layer 0) and clear it as soon as we
+    // step back in our own Layer 0
+    if (g.NavWindow)
+        NavSaveLastChildNavWindowIntoParent(g.NavWindow);
+    if (g.NavWindow && g.NavWindow->NavLastChildNavWindow != NULL && g.NavLayer == 0)
+        g.NavWindow->NavLastChildNavWindow = NULL;
+
+    // Update CTRL+TAB and Windowing features (hold Square to move/resize/etc.)
+    NavUpdateWindowing();
+
+    // Set output flags for user application
+    g.IO.NavActive = (nav_keyboard_active || nav_gamepad_active) && g.NavWindow &&
+                     !(g.NavWindow->Flags & ImGuiWindowFlags_NoNavInputs);
+    g.IO.NavVisible = (g.IO.NavActive && g.NavId != 0 && !g.NavDisableHighlight) ||
+                      (g.NavWindowingTarget != NULL);
+
+    // Process NavCancel input (to close a popup, get back to parent, clear focus)
+    if (IsNavInputPressed(ImGuiNavInput_Cancel, ImGuiInputReadMode_Pressed))
+    {
+        if (g.ActiveId != 0)
+        {
+            if (!(g.ActiveIdBlockNavInputFlags & (1 << ImGuiNavInput_Cancel)))
+                ClearActiveID();
+        }
+        else if (g.NavWindow && (g.NavWindow->Flags & ImGuiWindowFlags_ChildWindow) &&
+                 !(g.NavWindow->Flags & ImGuiWindowFlags_Popup) && g.NavWindow->ParentWindow)
+        {
+            // Exit child window
+            ImGuiWindow *child_window  = g.NavWindow;
+            ImGuiWindow *parent_window = g.NavWindow->ParentWindow;
+            IM_ASSERT(child_window->ChildId != 0);
+            FocusWindow(parent_window);
+            SetNavID(child_window->ChildId, 0);
+            g.NavIdIsAlive = false;
+            if (g.NavDisableMouseHover)
+                g.NavMousePosDirty = true;
+        }
+        else if (g.OpenPopupStack.Size > 0)
+        {
+            // Close open popup/menu
+            if (!(g.OpenPopupStack.back().Window->Flags & ImGuiWindowFlags_Modal))
+                ClosePopupToLevel(g.OpenPopupStack.Size - 1, true);
+        }
+        else if (g.NavLayer != 0)
+        {
+            // Leave the "menu" layer
+            NavRestoreLayer(ImGuiNavLayer_Main);
+        }
+        else
+        {
+            // Clear NavLastId for popups but keep it for regular child window so we can leave one
+            // and come back where we were
+            if (g.NavWindow && ((g.NavWindow->Flags & ImGuiWindowFlags_Popup) ||
+                                !(g.NavWindow->Flags & ImGuiWindowFlags_ChildWindow)))
+                g.NavWindow->NavLastIds[0] = 0;
+            g.NavId = 0;
+        }
+    }
+
+    // Process manual activation request
+    g.NavActivateId = g.NavActivateDownId = g.NavActivatePressedId = g.NavInputId = 0;
+    if (g.NavId != 0 && !g.NavDisableHighlight && !g.NavWindowingTarget && g.NavWindow &&
+        !(g.NavWindow->Flags & ImGuiWindowFlags_NoNavInputs))
+    {
+        bool activate_down = IsNavInputDown(ImGuiNavInput_Activate);
+        bool activate_pressed =
+            activate_down && IsNavInputPressed(ImGuiNavInput_Activate, ImGuiInputReadMode_Pressed);
+        if (g.ActiveId == 0 && activate_pressed)
+            g.NavActivateId = g.NavId;
+        if ((g.ActiveId == 0 || g.ActiveId == g.NavId) && activate_down)
+            g.NavActivateDownId = g.NavId;
+        if ((g.ActiveId == 0 || g.ActiveId == g.NavId) && activate_pressed)
+            g.NavActivatePressedId = g.NavId;
+        if ((g.ActiveId == 0 || g.ActiveId == g.NavId) &&
+            IsNavInputPressed(ImGuiNavInput_Input, ImGuiInputReadMode_Pressed))
+            g.NavInputId = g.NavId;
+    }
+    if (g.NavWindow && (g.NavWindow->Flags & ImGuiWindowFlags_NoNavInputs))
+        g.NavDisableHighlight = true;
+    if (g.NavActivateId != 0)
+        IM_ASSERT(g.NavActivateDownId == g.NavActivateId);
+    g.NavMoveRequest = false;
+
+    // Process programmatic activation request
+    if (g.NavNextActivateId != 0)
+        g.NavActivateId = g.NavActivateDownId = g.NavActivatePressedId = g.NavInputId =
+            g.NavNextActivateId;
+    g.NavNextActivateId = 0;
+
+    // Initiate directional inputs request
+    const int allowed_dir_flags = (g.ActiveId == 0) ? ~0 : g.ActiveIdAllowNavDirFlags;
+    if (g.NavMoveRequestForward == ImGuiNavForward_None)
+    {
+        g.NavMoveDir          = ImGuiDir_None;
+        g.NavMoveRequestFlags = ImGuiNavMoveFlags_None;
+        if (g.NavWindow && !g.NavWindowingTarget && allowed_dir_flags &&
+            !(g.NavWindow->Flags & ImGuiWindowFlags_NoNavInputs))
+        {
+            if ((allowed_dir_flags & (1 << ImGuiDir_Left)) &&
+                IsNavInputPressedAnyOfTwo(ImGuiNavInput_DpadLeft, ImGuiNavInput_KeyLeft_,
+                                          ImGuiInputReadMode_Repeat))
+                g.NavMoveDir = ImGuiDir_Left;
+            if ((allowed_dir_flags & (1 << ImGuiDir_Right)) &&
+                IsNavInputPressedAnyOfTwo(ImGuiNavInput_DpadRight, ImGuiNavInput_KeyRight_,
+                                          ImGuiInputReadMode_Repeat))
+                g.NavMoveDir = ImGuiDir_Right;
+            if ((allowed_dir_flags & (1 << ImGuiDir_Up)) &&
+                IsNavInputPressedAnyOfTwo(ImGuiNavInput_DpadUp, ImGuiNavInput_KeyUp_,
+                                          ImGuiInputReadMode_Repeat))
+                g.NavMoveDir = ImGuiDir_Up;
+            if ((allowed_dir_flags & (1 << ImGuiDir_Down)) &&
+                IsNavInputPressedAnyOfTwo(ImGuiNavInput_DpadDown, ImGuiNavInput_KeyDown_,
+                                          ImGuiInputReadMode_Repeat))
+                g.NavMoveDir = ImGuiDir_Down;
+        }
+        g.NavMoveClipDir = g.NavMoveDir;
+    }
+    else
+    {
+        // Forwarding previous request (which has been modified, e.g. wrap around menus rewrite the
+        // requests with a starting rectangle at the other side of the window) (Preserve
+        // g.NavMoveRequestFlags, g.NavMoveClipDir which were set by the NavMoveRequestForward()
+        // function)
+        IM_ASSERT(g.NavMoveDir != ImGuiDir_None && g.NavMoveClipDir != ImGuiDir_None);
+        IM_ASSERT(g.NavMoveRequestForward == ImGuiNavForward_ForwardQueued);
+        g.NavMoveRequestForward = ImGuiNavForward_ForwardActive;
+    }
+
+    // Update PageUp/PageDown scroll
+    float nav_scoring_rect_offset_y = 0.0f;
+    if (nav_keyboard_active)
+        nav_scoring_rect_offset_y = NavUpdatePageUpPageDown(allowed_dir_flags);
+
+    // If we initiate a movement request and have no current NavId, we initiate a InitDefautRequest
+    // that will be used as a fallback if the direction fails to find a match
+    if (g.NavMoveDir != ImGuiDir_None)
+    {
+        g.NavMoveRequest = true;
+        g.NavMoveDirLast = g.NavMoveDir;
+    }
+    if (g.NavMoveRequest && g.NavId == 0)
+    {
+        g.NavInitRequest = g.NavInitRequestFromMove = true;
+        g.NavInitResultId                           = 0;
+        g.NavDisableHighlight                       = false;
+    }
+    NavUpdateAnyRequestFlag();
+
+    // Scrolling
+    if (g.NavWindow && !(g.NavWindow->Flags & ImGuiWindowFlags_NoNavInputs) &&
+        !g.NavWindowingTarget)
+    {
+        // *Fallback* manual-scroll with Nav directional keys when window has no navigable item
+        ImGuiWindow *window      = g.NavWindow;
+        const float scroll_speed = ImFloor(window->CalcFontSize() * 100 * g.IO.DeltaTime +
+                                           0.5f);  // We need round the scrolling speed because
+                                                   // sub-pixel scroll isn't reliably supported.
+        if (window->DC.NavLayerActiveMask == 0x00 && window->DC.NavHasScroll && g.NavMoveRequest)
+        {
+            if (g.NavMoveDir == ImGuiDir_Left || g.NavMoveDir == ImGuiDir_Right)
+                SetWindowScrollX(window, ImFloor(window->Scroll.x +
+                                                 ((g.NavMoveDir == ImGuiDir_Left) ? -1.0f : +1.0f) *
+                                                     scroll_speed));
+            if (g.NavMoveDir == ImGuiDir_Up || g.NavMoveDir == ImGuiDir_Down)
+                SetWindowScrollY(window, ImFloor(window->Scroll.y +
+                                                 ((g.NavMoveDir == ImGuiDir_Up) ? -1.0f : +1.0f) *
+                                                     scroll_speed));
+        }
+
+        // *Normal* Manual scroll with NavScrollXXX keys
+        // Next movement request will clamp the NavId reference rectangle to the visible area, so
+        // navigation will resume within those bounds.
+        ImVec2 scroll_dir = GetNavInputAmount2d(ImGuiNavDirSourceFlags_PadLStick,
+                                                ImGuiInputReadMode_Down, 1.0f / 10.0f, 10.0f);
+        if (scroll_dir.x != 0.0f && window->ScrollbarX)
+        {
+            SetWindowScrollX(window, ImFloor(window->Scroll.x + scroll_dir.x * scroll_speed));
+            g.NavMoveFromClampedRefRect = true;
+        }
+        if (scroll_dir.y != 0.0f)
+        {
+            SetWindowScrollY(window, ImFloor(window->Scroll.y + scroll_dir.y * scroll_speed));
+            g.NavMoveFromClampedRefRect = true;
+        }
+    }
+
+    // Reset search results
+    g.NavMoveResultLocal.Clear();
+    g.NavMoveResultLocalVisibleSet.Clear();
+    g.NavMoveResultOther.Clear();
+
+    // When we have manually scrolled (without using navigation) and NavId becomes out of bounds, we
+    // project its bounding box to the visible area to restart navigation within visible items
+    if (g.NavMoveRequest && g.NavMoveFromClampedRefRect && g.NavLayer == 0)
+    {
+        ImGuiWindow *window = g.NavWindow;
+        ImRect window_rect_rel(window->InnerRect.Min - window->Pos - ImVec2(1, 1),
+                               window->InnerRect.Max - window->Pos + ImVec2(1, 1));
+        if (!window_rect_rel.Contains(window->NavRectRel[g.NavLayer]))
+        {
+            float pad = window->CalcFontSize() * 0.5f;
+            window_rect_rel.Expand(
+                ImVec2(-ImMin(window_rect_rel.GetWidth(), pad),
+                       -ImMin(window_rect_rel.GetHeight(),
+                              pad)));  // Terrible approximation for the intent of starting
+                                       // navigation from first fully visible item
+            window->NavRectRel[g.NavLayer].ClipWith(window_rect_rel);
+            g.NavId = 0;
+        }
+        g.NavMoveFromClampedRefRect = false;
+    }
+
+    // For scoring we use a single segment on the left side our current item bounding box (not
+    // touching the edge to avoid box overlap with zero-spaced items)
+    ImRect nav_rect_rel = (g.NavWindow && !g.NavWindow->NavRectRel[g.NavLayer].IsInverted())
+                              ? g.NavWindow->NavRectRel[g.NavLayer]
+                              : ImRect(0, 0, 0, 0);
+    g.NavScoringRectScreen = g.NavWindow ? ImRect(g.NavWindow->Pos + nav_rect_rel.Min,
+                                                  g.NavWindow->Pos + nav_rect_rel.Max)
+                                         : GetViewportRect();
+    g.NavScoringRectScreen.TranslateY(nav_scoring_rect_offset_y);
+    g.NavScoringRectScreen.Min.x =
+        ImMin(g.NavScoringRectScreen.Min.x + 1.0f, g.NavScoringRectScreen.Max.x);
+    g.NavScoringRectScreen.Max.x = g.NavScoringRectScreen.Min.x;
+    IM_ASSERT(
+        !g.NavScoringRectScreen
+             .IsInverted());  // Ensure if we have a finite, non-inverted bounding box here will
+                              // allows us to remove extraneous ImFabs() calls in NavScoreItem().
+    // GetForegroundDrawList()->AddRect(g.NavScoringRectScreen.Min, g.NavScoringRectScreen.Max,
+    // IM_COL32(255,200,0,255)); // [DEBUG]
+    g.NavScoringCount = 0;
+#if IMGUI_DEBUG_NAV_RECTS
+    if (g.NavWindow)
+    {
+        ImDrawList *draw_list = GetForegroundDrawList(g.NavWindow);
+        if (1)
+        {
+            for (int layer = 0; layer < 2; layer++)
+                draw_list->AddRect(g.NavWindow->Pos + g.NavWindow->NavRectRel[layer].Min,
+                                   g.NavWindow->Pos + g.NavWindow->NavRectRel[layer].Max,
+                                   IM_COL32(255, 200, 0, 255));
+        }  // [DEBUG]
+        if (1)
+        {
+            ImU32 col =
+                (!g.NavWindow->Hidden) ? IM_COL32(255, 0, 255, 255) : IM_COL32(255, 0, 0, 255);
+            ImVec2 p = NavCalcPreferredRefPos();
+            char buf[32];
+            ImFormatString(buf, 32, "%d", g.NavLayer);
+            draw_list->AddCircleFilled(p, 3.0f, col);
+            draw_list->AddText(NULL, 13.0f, p + ImVec2(8, -4), col, buf);
+        }
+    }
+#endif
+}
+
+// Apply result from previous frame navigation directional move request
+static void ImGui::NavUpdateMoveResult()
+{
+    ImGuiContext &g = *GImGui;
+    if (g.NavMoveResultLocal.ID == 0 && g.NavMoveResultOther.ID == 0)
+    {
+        // In a situation when there is no results but NavId != 0, re-enable the Navigation
+        // highlight (because g.NavId is not considered as a possible result)
+        if (g.NavId != 0)
+        {
+            g.NavDisableHighlight  = false;
+            g.NavDisableMouseHover = true;
+        }
+        return;
+    }
+
+    // Select which result to use
+    ImGuiNavMoveResult *result =
+        (g.NavMoveResultLocal.ID != 0) ? &g.NavMoveResultLocal : &g.NavMoveResultOther;
+
+    // PageUp/PageDown behavior first jumps to the bottom/top mostly visible item, _otherwise_ use
+    // the result from the previous/next page.
+    if (g.NavMoveRequestFlags & ImGuiNavMoveFlags_AlsoScoreVisibleSet)
+        if (g.NavMoveResultLocalVisibleSet.ID != 0 && g.NavMoveResultLocalVisibleSet.ID != g.NavId)
+            result = &g.NavMoveResultLocalVisibleSet;
+
+    // Maybe entering a flattened child from the outside? In this case solve the tie using the
+    // regular scoring rules.
+    if (result != &g.NavMoveResultOther && g.NavMoveResultOther.ID != 0 &&
+        g.NavMoveResultOther.Window->ParentWindow == g.NavWindow)
+        if ((g.NavMoveResultOther.DistBox < result->DistBox) ||
+            (g.NavMoveResultOther.DistBox == result->DistBox &&
+             g.NavMoveResultOther.DistCenter < result->DistCenter))
+            result = &g.NavMoveResultOther;
+    IM_ASSERT(g.NavWindow && result->Window);
+
+    // Scroll to keep newly navigated item fully into view.
+    if (g.NavLayer == 0)
+    {
+        ImRect rect_abs = ImRect(result->RectRel.Min + result->Window->Pos,
+                                 result->RectRel.Max + result->Window->Pos);
+        NavScrollToBringItemIntoView(result->Window, rect_abs);
+
+        // Estimate upcoming scroll so we can offset our result position so mouse position can be
+        // applied immediately after in NavUpdate()
+        ImVec2 next_scroll  = CalcNextScrollFromScrollTargetAndClamp(result->Window, false);
+        ImVec2 delta_scroll = result->Window->Scroll - next_scroll;
+        result->RectRel.Translate(delta_scroll);
+
+        // Also scroll parent window to keep us into view if necessary (we could/should technically
+        // recurse back the whole the parent hierarchy).
+        if (result->Window->Flags & ImGuiWindowFlags_ChildWindow)
+            NavScrollToBringItemIntoView(
+                result->Window->ParentWindow,
+                ImRect(rect_abs.Min + delta_scroll, rect_abs.Max + delta_scroll));
+    }
+
+    ClearActiveID();
+    g.NavWindow = result->Window;
+    if (g.NavId != result->ID)
+    {
+        // Don't set NavJustMovedToId if just landed on the same spot (which may happen with
+        // ImGuiNavMoveFlags_AllowCurrentNavId)
+        g.NavJustMovedToId                 = result->ID;
+        g.NavJustMovedToMultiSelectScopeId = result->SelectScopeId;
+    }
+    SetNavIDWithRectRel(result->ID, g.NavLayer, result->RectRel);
+    g.NavMoveFromClampedRefRect = false;
+}
+
+static float ImGui::NavUpdatePageUpPageDown(int allowed_dir_flags)
+{
+    ImGuiContext &g = *GImGui;
+    if (g.NavMoveDir == ImGuiDir_None && g.NavWindow &&
+        !(g.NavWindow->Flags & ImGuiWindowFlags_NoNavInputs) && !g.NavWindowingTarget &&
+        g.NavLayer == 0)
+    {
+        ImGuiWindow *window = g.NavWindow;
+        bool page_up_held =
+            IsKeyDown(g.IO.KeyMap[ImGuiKey_PageUp]) && (allowed_dir_flags & (1 << ImGuiDir_Up));
+        bool page_down_held =
+            IsKeyDown(g.IO.KeyMap[ImGuiKey_PageDown]) && (allowed_dir_flags & (1 << ImGuiDir_Down));
+        if (page_up_held != page_down_held)  // If either (not both) are pressed
+        {
+            if (window->DC.NavLayerActiveMask == 0x00 && window->DC.NavHasScroll)
+            {
+                // Fallback manual-scroll when window has no navigable item
+                if (IsKeyPressed(g.IO.KeyMap[ImGuiKey_PageUp], true))
+                    SetWindowScrollY(window, window->Scroll.y - window->InnerRect.GetHeight());
+                else if (IsKeyPressed(g.IO.KeyMap[ImGuiKey_PageDown], true))
+                    SetWindowScrollY(window, window->Scroll.y + window->InnerRect.GetHeight());
+            }
+            else
+            {
+                const ImRect &nav_rect_rel = window->NavRectRel[g.NavLayer];
+                const float page_offset_y =
+                    ImMax(0.0f, window->InnerRect.GetHeight() - window->CalcFontSize() * 1.0f +
+                                    nav_rect_rel.GetHeight());
+                float nav_scoring_rect_offset_y = 0.0f;
+                if (IsKeyPressed(g.IO.KeyMap[ImGuiKey_PageUp], true))
+                {
+                    nav_scoring_rect_offset_y = -page_offset_y;
+                    g.NavMoveDir = ImGuiDir_Down;  // Because our scoring rect is offset, we
+                                                   // intentionally request the opposite direction
+                                                   // (so we can always land on the last item)
+                    g.NavMoveClipDir = ImGuiDir_Up;
+                    g.NavMoveRequestFlags =
+                        ImGuiNavMoveFlags_AllowCurrentNavId | ImGuiNavMoveFlags_AlsoScoreVisibleSet;
+                }
+                else if (IsKeyPressed(g.IO.KeyMap[ImGuiKey_PageDown], true))
+                {
+                    nav_scoring_rect_offset_y = +page_offset_y;
+                    g.NavMoveDir = ImGuiDir_Up;  // Because our scoring rect is offset, we
+                                                 // intentionally request the opposite direction (so
+                                                 // we can always land on the last item)
+                    g.NavMoveClipDir = ImGuiDir_Down;
+                    g.NavMoveRequestFlags =
+                        ImGuiNavMoveFlags_AllowCurrentNavId | ImGuiNavMoveFlags_AlsoScoreVisibleSet;
+                }
+                return nav_scoring_rect_offset_y;
+            }
+        }
+    }
+    return 0.0f;
+}
+
+static int ImGui::FindWindowFocusIndex(ImGuiWindow *window)  // FIXME-OPT O(N)
+{
+    ImGuiContext &g = *GImGui;
+    for (int i = g.WindowsFocusOrder.Size - 1; i >= 0; i--)
+        if (g.WindowsFocusOrder[i] == window)
+            return i;
+    return -1;
+}
+
+static ImGuiWindow *FindWindowNavFocusable(int i_start, int i_stop, int dir)  // FIXME-OPT O(N)
+{
+    ImGuiContext &g = *GImGui;
+    for (int i = i_start; i >= 0 && i < g.WindowsFocusOrder.Size && i != i_stop; i += dir)
+        if (ImGui::IsWindowNavFocusable(g.WindowsFocusOrder[i]))
+            return g.WindowsFocusOrder[i];
+    return NULL;
+}
+
+static void NavUpdateWindowingHighlightWindow(int focus_change_dir)
+{
+    ImGuiContext &g = *GImGui;
+    IM_ASSERT(g.NavWindowingTarget);
+    if (g.NavWindowingTarget->Flags & ImGuiWindowFlags_Modal)
+        return;
+
+    const int i_current = ImGui::FindWindowFocusIndex(g.NavWindowingTarget);
+    ImGuiWindow *window_target =
+        FindWindowNavFocusable(i_current + focus_change_dir, -INT_MAX, focus_change_dir);
+    if (!window_target)
+        window_target =
+            FindWindowNavFocusable((focus_change_dir < 0) ? (g.WindowsFocusOrder.Size - 1) : 0,
+                                   i_current, focus_change_dir);
+    if (window_target)  // Don't reset windowing target if there's a single window in the list
+        g.NavWindowingTarget = g.NavWindowingTargetAnim = window_target;
+    g.NavWindowingToggleLayer = false;
+}
+
+// Windowing management mode
+// Keyboard: CTRL+Tab (change focus/move/resize), Alt (toggle menu layer)
+// Gamepad:  Hold Menu/Square (change focus/move/resize), Tap Menu/Square (toggle menu layer)
+static void ImGui::NavUpdateWindowing()
+{
+    ImGuiContext &g                 = *GImGui;
+    ImGuiWindow *apply_focus_window = NULL;
+    bool apply_toggle_layer         = false;
+
+    ImGuiWindow *modal_window = GetTopMostPopupModal();
+    if (modal_window != NULL)
+    {
+        g.NavWindowingTarget = NULL;
+        return;
+    }
+
+    // Fade out
+    if (g.NavWindowingTargetAnim && g.NavWindowingTarget == NULL)
+    {
+        g.NavWindowingHighlightAlpha =
+            ImMax(g.NavWindowingHighlightAlpha - g.IO.DeltaTime * 10.0f, 0.0f);
+        if (g.DimBgRatio <= 0.0f && g.NavWindowingHighlightAlpha <= 0.0f)
+            g.NavWindowingTargetAnim = NULL;
+    }
+
+    // Start CTRL-TAB or Square+L/R window selection
+    bool start_windowing_with_gamepad =
+        !g.NavWindowingTarget && IsNavInputPressed(ImGuiNavInput_Menu, ImGuiInputReadMode_Pressed);
+    bool start_windowing_with_keyboard = !g.NavWindowingTarget && g.IO.KeyCtrl &&
+                                         IsKeyPressedMap(ImGuiKey_Tab) &&
+                                         (g.IO.ConfigFlags & ImGuiConfigFlags_NavEnableKeyboard);
+    if (start_windowing_with_gamepad || start_windowing_with_keyboard)
+        if (ImGuiWindow *window =
+                g.NavWindow ? g.NavWindow
+                            : FindWindowNavFocusable(g.WindowsFocusOrder.Size - 1, -INT_MAX, -1))
+        {
+            g.NavWindowingTarget = g.NavWindowingTargetAnim = window;
+            g.NavWindowingTimer = g.NavWindowingHighlightAlpha = 0.0f;
+            g.NavWindowingToggleLayer = start_windowing_with_keyboard ? false : true;
+            g.NavInputSource          = start_windowing_with_keyboard ? ImGuiInputSource_NavKeyboard
+                                                             : ImGuiInputSource_NavGamepad;
+        }
+
+    // Gamepad update
+    g.NavWindowingTimer += g.IO.DeltaTime;
+    if (g.NavWindowingTarget && g.NavInputSource == ImGuiInputSource_NavGamepad)
+    {
+        // Highlight only appears after a brief time holding the button, so that a fast tap on
+        // PadMenu (to toggle NavLayer) doesn't add visual noise
+        g.NavWindowingHighlightAlpha =
+            ImMax(g.NavWindowingHighlightAlpha,
+                  ImSaturate((g.NavWindowingTimer - NAV_WINDOWING_HIGHLIGHT_DELAY) / 0.05f));
+
+        // Select window to focus
+        const int focus_change_dir =
+            (int)IsNavInputPressed(ImGuiNavInput_FocusPrev, ImGuiInputReadMode_RepeatSlow) -
+            (int)IsNavInputPressed(ImGuiNavInput_FocusNext, ImGuiInputReadMode_RepeatSlow);
+        if (focus_change_dir != 0)
+        {
+            NavUpdateWindowingHighlightWindow(focus_change_dir);
+            g.NavWindowingHighlightAlpha = 1.0f;
+        }
+
+        // Single press toggles NavLayer, long press with L/R apply actual focus on release (until
+        // then the window was merely rendered top-most)
+        if (!IsNavInputDown(ImGuiNavInput_Menu))
+        {
+            g.NavWindowingToggleLayer &=
+                (g.NavWindowingHighlightAlpha <
+                 1.0f);  // Once button was held long enough we don't consider it a
+                         // tap-to-toggle-layer press anymore.
+            if (g.NavWindowingToggleLayer && g.NavWindow)
+                apply_toggle_layer = true;
+            else if (!g.NavWindowingToggleLayer)
+                apply_focus_window = g.NavWindowingTarget;
+            g.NavWindowingTarget = NULL;
+        }
+    }
+
+    // Keyboard: Focus
+    if (g.NavWindowingTarget && g.NavInputSource == ImGuiInputSource_NavKeyboard)
+    {
+        // Visuals only appears after a brief time after pressing TAB the first time, so that a fast
+        // CTRL+TAB doesn't add visual noise
+        g.NavWindowingHighlightAlpha = ImMax(
+            g.NavWindowingHighlightAlpha,
+            ImSaturate((g.NavWindowingTimer - NAV_WINDOWING_HIGHLIGHT_DELAY) / 0.05f));  // 1.0f
+        if (IsKeyPressedMap(ImGuiKey_Tab, true))
+            NavUpdateWindowingHighlightWindow(g.IO.KeyShift ? +1 : -1);
+        if (!g.IO.KeyCtrl)
+            apply_focus_window = g.NavWindowingTarget;
+    }
+
+    // Keyboard: Press and Release ALT to toggle menu layer
+    // FIXME: We lack an explicit IO variable for "is the imgui window focused", so compare mouse
+    // validity to detect the common case of back-end clearing releases all keys on ALT-TAB
+    if (IsNavInputPressed(ImGuiNavInput_KeyMenu_, ImGuiInputReadMode_Pressed))
+        g.NavWindowingToggleLayer = true;
+    if ((g.ActiveId == 0 || g.ActiveIdAllowOverlap) && g.NavWindowingToggleLayer &&
+        IsNavInputPressed(ImGuiNavInput_KeyMenu_, ImGuiInputReadMode_Released))
+        if (IsMousePosValid(&g.IO.MousePos) == IsMousePosValid(&g.IO.MousePosPrev))
+            apply_toggle_layer = true;
+
+    // Move window
+    if (g.NavWindowingTarget && !(g.NavWindowingTarget->Flags & ImGuiWindowFlags_NoMove))
+    {
+        ImVec2 move_delta;
+        if (g.NavInputSource == ImGuiInputSource_NavKeyboard && !g.IO.KeyShift)
+            move_delta =
+                GetNavInputAmount2d(ImGuiNavDirSourceFlags_Keyboard, ImGuiInputReadMode_Down);
+        if (g.NavInputSource == ImGuiInputSource_NavGamepad)
+            move_delta =
+                GetNavInputAmount2d(ImGuiNavDirSourceFlags_PadLStick, ImGuiInputReadMode_Down);
+        if (move_delta.x != 0.0f || move_delta.y != 0.0f)
+        {
+            const float NAV_MOVE_SPEED = 800.0f;
+            const float move_speed =
+                ImFloor(NAV_MOVE_SPEED * g.IO.DeltaTime *
+                        ImMin(g.IO.DisplayFramebufferScale.x,
+                              g.IO.DisplayFramebufferScale
+                                  .y));  // FIXME: Doesn't code variable framerate very well
+            SetWindowPos(g.NavWindowingTarget->RootWindow,
+                         g.NavWindowingTarget->RootWindow->Pos + move_delta * move_speed,
+                         ImGuiCond_Always);
+            g.NavDisableMouseHover = true;
+            MarkIniSettingsDirty(g.NavWindowingTarget);
+        }
+    }
+
+    // Apply final focus
+    if (apply_focus_window &&
+        (g.NavWindow == NULL || apply_focus_window != g.NavWindow->RootWindow))
+    {
+        ClearActiveID();
+        g.NavDisableHighlight  = false;
+        g.NavDisableMouseHover = true;
+        apply_focus_window     = NavRestoreLastChildNavWindow(apply_focus_window);
+        ClosePopupsOverWindow(apply_focus_window, false);
+        FocusWindow(apply_focus_window);
+        if (apply_focus_window->NavLastIds[0] == 0)
+            NavInitWindow(apply_focus_window, false);
+
+        // If the window only has a menu layer, select it directly
+        if (apply_focus_window->DC.NavLayerActiveMask == (1 << ImGuiNavLayer_Menu))
+            g.NavLayer = ImGuiNavLayer_Menu;
+    }
+    if (apply_focus_window)
+        g.NavWindowingTarget = NULL;
+
+    // Apply menu/layer toggle
+    if (apply_toggle_layer && g.NavWindow)
+    {
+        // Move to parent menu if necessary
+        ImGuiWindow *new_nav_window = g.NavWindow;
+        while (new_nav_window->ParentWindow &&
+               (new_nav_window->DC.NavLayerActiveMask & (1 << ImGuiNavLayer_Menu)) == 0 &&
+               (new_nav_window->Flags & ImGuiWindowFlags_ChildWindow) != 0 &&
+               (new_nav_window->Flags & (ImGuiWindowFlags_Popup | ImGuiWindowFlags_ChildMenu)) == 0)
+            new_nav_window = new_nav_window->ParentWindow;
+        if (new_nav_window != g.NavWindow)
+        {
+            ImGuiWindow *old_nav_window = g.NavWindow;
+            FocusWindow(new_nav_window);
+            new_nav_window->NavLastChildNavWindow = old_nav_window;
+        }
+        g.NavDisableHighlight  = false;
+        g.NavDisableMouseHover = true;
+
+        // When entering a regular menu bar with the Alt key, we always reinitialize the navigation
+        // ID.
+        const ImGuiNavLayer new_nav_layer =
+            (g.NavWindow->DC.NavLayerActiveMask & (1 << ImGuiNavLayer_Menu))
+                ? (ImGuiNavLayer)((int)g.NavLayer ^ 1)
+                : ImGuiNavLayer_Main;
+        NavRestoreLayer(new_nav_layer);
+    }
+}
+
+// Window has already passed the IsWindowNavFocusable()
+static const char *GetFallbackWindowNameForWindowingList(ImGuiWindow *window)
+{
+    if (window->Flags & ImGuiWindowFlags_Popup)
+        return "(Popup)";
+    if ((window->Flags & ImGuiWindowFlags_MenuBar) && strcmp(window->Name, "##MainMenuBar") == 0)
+        return "(Main menu bar)";
+    return "(Untitled)";
+}
+
+// Overlay displayed when using CTRL+TAB. Called by EndFrame().
+void ImGui::NavUpdateWindowingList()
+{
+    ImGuiContext &g = *GImGui;
+    IM_ASSERT(g.NavWindowingTarget != NULL);
+
+    if (g.NavWindowingTimer < NAV_WINDOWING_LIST_APPEAR_DELAY)
+        return;
+
+    if (g.NavWindowingList == NULL)
+        g.NavWindowingList = FindWindowByName("###NavWindowingList");
+    SetNextWindowSizeConstraints(ImVec2(g.IO.DisplaySize.x * 0.20f, g.IO.DisplaySize.y * 0.20f),
+                                 ImVec2(FLT_MAX, FLT_MAX));
+    SetNextWindowPos(g.IO.DisplaySize * 0.5f, ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+    PushStyleVar(ImGuiStyleVar_WindowPadding, g.Style.WindowPadding * 2.0f);
+    Begin("###NavWindowingList", NULL,
+          ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoFocusOnAppearing |
+              ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoInputs |
+              ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings);
+    for (int n = g.WindowsFocusOrder.Size - 1; n >= 0; n--)
+    {
+        ImGuiWindow *window = g.WindowsFocusOrder[n];
+        if (!IsWindowNavFocusable(window))
+            continue;
+        const char *label = window->Name;
+        if (label == FindRenderedTextEnd(label))
+            label = GetFallbackWindowNameForWindowingList(window);
+        Selectable(label, g.NavWindowingTarget == window);
+    }
+    End();
+    PopStyleVar();
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] COLUMNS
+// In the current version, Columns are very weak. Needs to be replaced with a more full-featured
+// system.
+//-----------------------------------------------------------------------------
+
+void ImGui::NextColumn()
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems || window->DC.CurrentColumns == NULL)
+        return;
+
+    ImGuiContext &g       = *GImGui;
+    ImGuiColumns *columns = window->DC.CurrentColumns;
+
+    if (columns->Count == 1)
+    {
+        window->DC.CursorPos.x =
+            (float)(int)(window->Pos.x + window->DC.Indent.x + window->DC.ColumnsOffset.x);
+        IM_ASSERT(columns->Current == 0);
+        return;
+    }
+
+    PopItemWidth();
+    PopClipRect();
+
+    columns->LineMaxY = ImMax(columns->LineMaxY, window->DC.CursorPos.y);
+    if (++columns->Current < columns->Count)
+    {
+        // Columns 1+ cancel out IndentX
+        // FIXME-COLUMNS: Unnecessary, could be locked?
+        window->DC.ColumnsOffset.x =
+            GetColumnOffset(columns->Current) - window->DC.Indent.x + g.Style.ItemSpacing.x;
+        window->DrawList->ChannelsSetCurrent(columns->Current + 1);
+    }
+    else
+    {
+        // New row/line
+        window->DC.ColumnsOffset.x = 0.0f;
+        window->DrawList->ChannelsSetCurrent(1);
+        columns->Current  = 0;
+        columns->LineMinY = columns->LineMaxY;
+    }
+    window->DC.CursorPos.x =
+        (float)(int)(window->Pos.x + window->DC.Indent.x + window->DC.ColumnsOffset.x);
+    window->DC.CursorPos.y            = columns->LineMinY;
+    window->DC.CurrLineSize           = ImVec2(0.0f, 0.0f);
+    window->DC.CurrLineTextBaseOffset = 0.0f;
+
+    PushColumnClipRect(columns->Current);  // FIXME-COLUMNS: Could it be an overwrite?
+
+    // FIXME-COLUMNS: Share code with BeginColumns() - move code on columns setup.
+    float offset_0 = GetColumnOffset(columns->Current);
+    float offset_1 = GetColumnOffset(columns->Current + 1);
+    float width    = offset_1 - offset_0;
+    PushItemWidth(width * 0.65f);
+    window->WorkRect.Max.x = window->Pos.x + offset_1 - window->WindowPadding.x;
+}
+
+int ImGui::GetColumnIndex()
+{
+    ImGuiWindow *window = GetCurrentWindowRead();
+    return window->DC.CurrentColumns ? window->DC.CurrentColumns->Current : 0;
+}
+
+int ImGui::GetColumnsCount()
+{
+    ImGuiWindow *window = GetCurrentWindowRead();
+    return window->DC.CurrentColumns ? window->DC.CurrentColumns->Count : 1;
+}
+
+static float OffsetNormToPixels(const ImGuiColumns *columns, float offset_norm)
+{
+    return offset_norm * (columns->OffMaxX - columns->OffMinX);
+}
+
+static float PixelsToOffsetNorm(const ImGuiColumns *columns, float offset)
+{
+    return offset / (columns->OffMaxX - columns->OffMinX);
+}
+
+static const float COLUMNS_HIT_RECT_HALF_WIDTH = 4.0f;
+
+static float GetDraggedColumnOffset(ImGuiColumns *columns, int column_index)
+{
+    // Active (dragged) column always follow mouse. The reason we need this is that dragging a
+    // column to the right edge of an auto-resizing window creates a feedback loop because we store
+    // normalized positions. So while dragging we enforce absolute positioning.
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+    IM_ASSERT(column_index > 0);  // We are not supposed to drag column 0.
+    IM_ASSERT(g.ActiveId == columns->ID + ImGuiID(column_index));
+
+    float x =
+        g.IO.MousePos.x - g.ActiveIdClickOffset.x + COLUMNS_HIT_RECT_HALF_WIDTH - window->Pos.x;
+    x = ImMax(x, ImGui::GetColumnOffset(column_index - 1) + g.Style.ColumnsMinSpacing);
+    if ((columns->Flags & ImGuiColumnsFlags_NoPreserveWidths))
+        x = ImMin(x, ImGui::GetColumnOffset(column_index + 1) - g.Style.ColumnsMinSpacing);
+
+    return x;
+}
+
+float ImGui::GetColumnOffset(int column_index)
+{
+    ImGuiWindow *window   = GetCurrentWindowRead();
+    ImGuiColumns *columns = window->DC.CurrentColumns;
+    IM_ASSERT(columns != NULL);
+
+    if (column_index < 0)
+        column_index = columns->Current;
+    IM_ASSERT(column_index < columns->Columns.Size);
+
+    const float t        = columns->Columns[column_index].OffsetNorm;
+    const float x_offset = ImLerp(columns->OffMinX, columns->OffMaxX, t);
+    return x_offset;
+}
+
+static float GetColumnWidthEx(ImGuiColumns *columns, int column_index, bool before_resize = false)
+{
+    if (column_index < 0)
+        column_index = columns->Current;
+
+    float offset_norm;
+    if (before_resize)
+        offset_norm = columns->Columns[column_index + 1].OffsetNormBeforeResize -
+                      columns->Columns[column_index].OffsetNormBeforeResize;
+    else
+        offset_norm = columns->Columns[column_index + 1].OffsetNorm -
+                      columns->Columns[column_index].OffsetNorm;
+    return OffsetNormToPixels(columns, offset_norm);
+}
+
+float ImGui::GetColumnWidth(int column_index)
+{
+    ImGuiWindow *window   = GetCurrentWindowRead();
+    ImGuiColumns *columns = window->DC.CurrentColumns;
+    IM_ASSERT(columns != NULL);
+
+    if (column_index < 0)
+        column_index = columns->Current;
+    return OffsetNormToPixels(columns, columns->Columns[column_index + 1].OffsetNorm -
+                                           columns->Columns[column_index].OffsetNorm);
+}
+
+void ImGui::SetColumnOffset(int column_index, float offset)
+{
+    ImGuiContext &g       = *GImGui;
+    ImGuiWindow *window   = g.CurrentWindow;
+    ImGuiColumns *columns = window->DC.CurrentColumns;
+    IM_ASSERT(columns != NULL);
+
+    if (column_index < 0)
+        column_index = columns->Current;
+    IM_ASSERT(column_index < columns->Columns.Size);
+
+    const bool preserve_width = !(columns->Flags & ImGuiColumnsFlags_NoPreserveWidths) &&
+                                (column_index < columns->Count - 1);
+    const float width =
+        preserve_width ? GetColumnWidthEx(columns, column_index, columns->IsBeingResized) : 0.0f;
+
+    if (!(columns->Flags & ImGuiColumnsFlags_NoForceWithinWindow))
+        offset = ImMin(
+            offset, columns->OffMaxX - g.Style.ColumnsMinSpacing * (columns->Count - column_index));
+    columns->Columns[column_index].OffsetNorm =
+        PixelsToOffsetNorm(columns, offset - columns->OffMinX);
+
+    if (preserve_width)
+        SetColumnOffset(column_index + 1, offset + ImMax(g.Style.ColumnsMinSpacing, width));
+}
+
+void ImGui::SetColumnWidth(int column_index, float width)
+{
+    ImGuiWindow *window   = GetCurrentWindowRead();
+    ImGuiColumns *columns = window->DC.CurrentColumns;
+    IM_ASSERT(columns != NULL);
+
+    if (column_index < 0)
+        column_index = columns->Current;
+    SetColumnOffset(column_index + 1, GetColumnOffset(column_index) + width);
+}
+
+void ImGui::PushColumnClipRect(int column_index)
+{
+    ImGuiWindow *window   = GetCurrentWindowRead();
+    ImGuiColumns *columns = window->DC.CurrentColumns;
+    if (column_index < 0)
+        column_index = columns->Current;
+
+    ImGuiColumnData *column = &columns->Columns[column_index];
+    PushClipRect(column->ClipRect.Min, column->ClipRect.Max, false);
+}
+
+// Get into the columns background draw command (which is generally the same draw command as before
+// we called BeginColumns)
+void ImGui::PushColumnsBackground()
+{
+    ImGuiWindow *window   = GetCurrentWindowRead();
+    ImGuiColumns *columns = window->DC.CurrentColumns;
+    window->DrawList->ChannelsSetCurrent(0);
+    int cmd_size = window->DrawList->CmdBuffer.Size;
+    PushClipRect(columns->HostClipRect.Min, columns->HostClipRect.Max, false);
+    IM_UNUSED(cmd_size);
+    IM_ASSERT(cmd_size ==
+              window->DrawList->CmdBuffer
+                  .Size);  // Being in channel 0 this should not have created an ImDrawCmd
+}
+
+void ImGui::PopColumnsBackground()
+{
+    ImGuiWindow *window   = GetCurrentWindowRead();
+    ImGuiColumns *columns = window->DC.CurrentColumns;
+    window->DrawList->ChannelsSetCurrent(columns->Current + 1);
+    PopClipRect();
+}
+
+ImGuiColumns *ImGui::FindOrCreateColumns(ImGuiWindow *window, ImGuiID id)
+{
+    // We have few columns per window so for now we don't need bother much with turning this into a
+    // faster lookup.
+    for (int n = 0; n < window->ColumnsStorage.Size; n++)
+        if (window->ColumnsStorage[n].ID == id)
+            return &window->ColumnsStorage[n];
+
+    window->ColumnsStorage.push_back(ImGuiColumns());
+    ImGuiColumns *columns = &window->ColumnsStorage.back();
+    columns->ID           = id;
+    return columns;
+}
+
+ImGuiID ImGui::GetColumnsID(const char *str_id, int columns_count)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+
+    // Differentiate column ID with an arbitrary prefix for cases where users name their columns set
+    // the same as another widget. In addition, when an identifier isn't explicitly provided we
+    // include the number of columns in the hash to make it uniquer.
+    PushID(0x11223347 + (str_id ? 0 : columns_count));
+    ImGuiID id = window->GetID(str_id ? str_id : "columns");
+    PopID();
+
+    return id;
+}
+
+void ImGui::BeginColumns(const char *str_id, int columns_count, ImGuiColumnsFlags flags)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = GetCurrentWindow();
+
+    IM_ASSERT(columns_count >= 1);
+    IM_ASSERT(window->DC.CurrentColumns == NULL);  // Nested columns are currently not supported
+
+    // Acquire storage for the columns set
+    ImGuiID id            = GetColumnsID(str_id, columns_count);
+    ImGuiColumns *columns = FindOrCreateColumns(window, id);
+    IM_ASSERT(columns->ID == id);
+    columns->Current          = 0;
+    columns->Count            = columns_count;
+    columns->Flags            = flags;
+    window->DC.CurrentColumns = columns;
+
+    // Set state for first column
+    columns->OffMinX = window->DC.Indent.x - g.Style.ItemSpacing.x;
+    columns->OffMaxX = ImMax(window->WorkRect.Max.x - window->Pos.x, columns->OffMinX + 1.0f);
+    columns->HostCursorPosY    = window->DC.CursorPos.y;
+    columns->HostCursorMaxPosX = window->DC.CursorMaxPos.x;
+    columns->HostClipRect      = window->ClipRect;
+    columns->HostWorkRect      = window->WorkRect;
+    columns->LineMinY = columns->LineMaxY = window->DC.CursorPos.y;
+    window->DC.ColumnsOffset.x            = 0.0f;
+    window->DC.CursorPos.x =
+        (float)(int)(window->Pos.x + window->DC.Indent.x + window->DC.ColumnsOffset.x);
+
+    // Clear data if columns count changed
+    if (columns->Columns.Size != 0 && columns->Columns.Size != columns_count + 1)
+        columns->Columns.resize(0);
+
+    // Initialize default widths
+    columns->IsFirstFrame = (columns->Columns.Size == 0);
+    if (columns->Columns.Size == 0)
+    {
+        columns->Columns.reserve(columns_count + 1);
+        for (int n = 0; n < columns_count + 1; n++)
+        {
+            ImGuiColumnData column;
+            column.OffsetNorm = n / (float)columns_count;
+            columns->Columns.push_back(column);
+        }
+    }
+
+    for (int n = 0; n < columns_count; n++)
+    {
+        // Compute clipping rectangle
+        ImGuiColumnData *column = &columns->Columns[n];
+        float clip_x1           = ImFloor(0.5f + window->Pos.x + GetColumnOffset(n));
+        float clip_x2           = ImFloor(0.5f + window->Pos.x + GetColumnOffset(n + 1) - 1.0f);
+        column->ClipRect        = ImRect(clip_x1, -FLT_MAX, clip_x2, +FLT_MAX);
+        column->ClipRect.ClipWith(window->ClipRect);
+    }
+
+    if (columns->Count > 1)
+    {
+        window->DrawList->ChannelsSplit(1 + columns->Count);
+        window->DrawList->ChannelsSetCurrent(1);
+        PushColumnClipRect(0);
+    }
+
+    float offset_0 = GetColumnOffset(columns->Current);
+    float offset_1 = GetColumnOffset(columns->Current + 1);
+    float width    = offset_1 - offset_0;
+    PushItemWidth(width * 0.65f);
+    window->WorkRect.Max.x = window->Pos.x + offset_1 - window->WindowPadding.x;
+}
+
+void ImGui::EndColumns()
+{
+    ImGuiContext &g       = *GImGui;
+    ImGuiWindow *window   = GetCurrentWindow();
+    ImGuiColumns *columns = window->DC.CurrentColumns;
+    IM_ASSERT(columns != NULL);
+
+    PopItemWidth();
+    if (columns->Count > 1)
+    {
+        PopClipRect();
+        window->DrawList->ChannelsMerge();
+    }
+
+    const ImGuiColumnsFlags flags = columns->Flags;
+    columns->LineMaxY             = ImMax(columns->LineMaxY, window->DC.CursorPos.y);
+    window->DC.CursorPos.y        = columns->LineMaxY;
+    if (!(flags & ImGuiColumnsFlags_GrowParentContentsSize))
+        window->DC.CursorMaxPos.x =
+            columns->HostCursorMaxPosX;  // Restore cursor max pos, as columns don't grow parent
+
+    // Draw columns borders and handle resize
+    // The IsBeingResized flag ensure we preserve pre-resize columns width so back-and-forth are not
+    // lossy
+    bool is_being_resized = false;
+    if (!(flags & ImGuiColumnsFlags_NoBorder) && !window->SkipItems)
+    {
+        // We clip Y boundaries CPU side because very long triangles are mishandled by some GPU
+        // drivers.
+        const float y1      = ImMax(columns->HostCursorPosY, window->ClipRect.Min.y);
+        const float y2      = ImMin(window->DC.CursorPos.y, window->ClipRect.Max.y);
+        int dragging_column = -1;
+        for (int n = 1; n < columns->Count; n++)
+        {
+            ImGuiColumnData *column   = &columns->Columns[n];
+            float x                   = window->Pos.x + GetColumnOffset(n);
+            const ImGuiID column_id   = columns->ID + ImGuiID(n);
+            const float column_hit_hw = COLUMNS_HIT_RECT_HALF_WIDTH;
+            const ImRect column_hit_rect(ImVec2(x - column_hit_hw, y1),
+                                         ImVec2(x + column_hit_hw, y2));
+            KeepAliveID(column_id);
+            if (IsClippedEx(column_hit_rect, column_id, false))
+                continue;
+
+            bool hovered = false, held = false;
+            if (!(flags & ImGuiColumnsFlags_NoResize))
+            {
+                ButtonBehavior(column_hit_rect, column_id, &hovered, &held);
+                if (hovered || held)
+                    g.MouseCursor = ImGuiMouseCursor_ResizeEW;
+                if (held && !(column->Flags & ImGuiColumnsFlags_NoResize))
+                    dragging_column = n;
+            }
+
+            // Draw column
+            const ImU32 col =
+                GetColorU32(held ? ImGuiCol_SeparatorActive
+                                 : hovered ? ImGuiCol_SeparatorHovered : ImGuiCol_Separator);
+            const float xi = (float)(int)x;
+            window->DrawList->AddLine(ImVec2(xi, y1 + 1.0f), ImVec2(xi, y2), col);
+        }
+
+        // Apply dragging after drawing the column lines, so our rendered lines are in sync with how
+        // items were displayed during the frame.
+        if (dragging_column != -1)
+        {
+            if (!columns->IsBeingResized)
+                for (int n = 0; n < columns->Count + 1; n++)
+                    columns->Columns[n].OffsetNormBeforeResize = columns->Columns[n].OffsetNorm;
+            columns->IsBeingResized = is_being_resized = true;
+            float x = GetDraggedColumnOffset(columns, dragging_column);
+            SetColumnOffset(dragging_column, x);
+        }
+    }
+    columns->IsBeingResized = is_being_resized;
+
+    window->WorkRect           = columns->HostWorkRect;
+    window->DC.CurrentColumns  = NULL;
+    window->DC.ColumnsOffset.x = 0.0f;
+    window->DC.CursorPos.x =
+        (float)(int)(window->Pos.x + window->DC.Indent.x + window->DC.ColumnsOffset.x);
+}
+
+// [2018-03: This is currently the only public API, while we are working on making
+// BeginColumns/EndColumns user-facing]
+void ImGui::Columns(int columns_count, const char *id, bool border)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    IM_ASSERT(columns_count >= 1);
+
+    ImGuiColumnsFlags flags = (border ? 0 : ImGuiColumnsFlags_NoBorder);
+    // flags |= ImGuiColumnsFlags_NoPreserveWidths; // NB: Legacy behavior
+    ImGuiColumns *columns = window->DC.CurrentColumns;
+    if (columns != NULL && columns->Count == columns_count && columns->Flags == flags)
+        return;
+
+    if (columns != NULL)
+        EndColumns();
+
+    if (columns_count != 1)
+        BeginColumns(id, columns_count, flags);
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] DRAG AND DROP
+//-----------------------------------------------------------------------------
+
+void ImGui::ClearDragDrop()
+{
+    ImGuiContext &g  = *GImGui;
+    g.DragDropActive = false;
+    g.DragDropPayload.Clear();
+    g.DragDropAcceptFlags  = ImGuiDragDropFlags_None;
+    g.DragDropAcceptIdCurr = g.DragDropAcceptIdPrev = 0;
+    g.DragDropAcceptIdCurrRectSurface               = FLT_MAX;
+    g.DragDropAcceptFrameCount                      = -1;
+
+    g.DragDropPayloadBufHeap.clear();
+    memset(&g.DragDropPayloadBufLocal, 0, sizeof(g.DragDropPayloadBufLocal));
+}
+
+// Call when current ID is active.
+// When this returns true you need to: a) call SetDragDropPayload() exactly once, b) you may render
+// the payload visual/description, c) call EndDragDropSource()
+bool ImGui::BeginDragDropSource(ImGuiDragDropFlags flags)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+
+    bool source_drag_active  = false;
+    ImGuiID source_id        = 0;
+    ImGuiID source_parent_id = 0;
+    int mouse_button         = 0;
+    if (!(flags & ImGuiDragDropFlags_SourceExtern))
+    {
+        source_id = window->DC.LastItemId;
+        if (source_id != 0 && g.ActiveId != source_id)  // Early out for most common case
+            return false;
+        if (g.IO.MouseDown[mouse_button] == false)
+            return false;
+
+        if (source_id == 0)
+        {
+            // If you want to use BeginDragDropSource() on an item with no unique identifier for
+            // interaction, such as Text() or Image(), you need to: A) Read the explanation below,
+            // B) Use the ImGuiDragDropFlags_SourceAllowNullID flag, C) Swallow your programmer
+            // pride.
+            if (!(flags & ImGuiDragDropFlags_SourceAllowNullID))
+            {
+                IM_ASSERT(0);
+                return false;
+            }
+
+            // Early out
+            if ((window->DC.LastItemStatusFlags & ImGuiItemStatusFlags_HoveredRect) == 0 &&
+                (g.ActiveId == 0 || g.ActiveIdWindow != window))
+                return false;
+
+            // Magic fallback (=somehow reprehensible) to handle items with no assigned ID, e.g.
+            // Text(), Image() We build a throwaway ID based on current ID stack + relative AABB of
+            // items in window. THE IDENTIFIER WON'T SURVIVE ANY REPOSITIONING OF THE WIDGET, so if
+            // your widget moves your dragging operation will be canceled. We don't need to
+            // maintain/call ClearActiveID() as releasing the button will early out this function
+            // and trigger !ActiveIdIsAlive.
+            source_id = window->DC.LastItemId = window->GetIDFromRectangle(window->DC.LastItemRect);
+            bool is_hovered                   = ItemHoverable(window->DC.LastItemRect, source_id);
+            if (is_hovered && g.IO.MouseClicked[mouse_button])
+            {
+                SetActiveID(source_id, window);
+                FocusWindow(window);
+            }
+            if (g.ActiveId ==
+                source_id)  // Allow the underlying widget to display/return hovered during the
+                            // mouse release frame, else we would get a flicker.
+                g.ActiveIdAllowOverlap = is_hovered;
+        }
+        else
+        {
+            g.ActiveIdAllowOverlap = false;
+        }
+        if (g.ActiveId != source_id)
+            return false;
+        source_parent_id   = window->IDStack.back();
+        source_drag_active = IsMouseDragging(mouse_button);
+    }
+    else
+    {
+        window             = NULL;
+        source_id          = ImHashStr("#SourceExtern");
+        source_drag_active = true;
+    }
+
+    if (source_drag_active)
+    {
+        if (!g.DragDropActive)
+        {
+            IM_ASSERT(source_id != 0);
+            ClearDragDrop();
+            ImGuiPayload &payload  = g.DragDropPayload;
+            payload.SourceId       = source_id;
+            payload.SourceParentId = source_parent_id;
+            g.DragDropActive       = true;
+            g.DragDropSourceFlags  = flags;
+            g.DragDropMouseButton  = mouse_button;
+        }
+        g.DragDropSourceFrameCount     = g.FrameCount;
+        g.DragDropWithinSourceOrTarget = true;
+
+        if (!(flags & ImGuiDragDropFlags_SourceNoPreviewTooltip))
+        {
+            // Target can request the Source to not display its tooltip (we use a dedicated flag to
+            // make this request explicit) We unfortunately can't just modify the source flags and
+            // skip the call to BeginTooltip, as caller may be emitting contents.
+            BeginTooltip();
+            if (g.DragDropAcceptIdPrev &&
+                (g.DragDropAcceptFlags & ImGuiDragDropFlags_AcceptNoPreviewTooltip))
+            {
+                ImGuiWindow *tooltip_window              = g.CurrentWindow;
+                tooltip_window->SkipItems                = true;
+                tooltip_window->HiddenFramesCanSkipItems = 1;
+            }
+        }
+
+        if (!(flags & ImGuiDragDropFlags_SourceNoDisableHover) &&
+            !(flags & ImGuiDragDropFlags_SourceExtern))
+            window->DC.LastItemStatusFlags &= ~ImGuiItemStatusFlags_HoveredRect;
+
+        return true;
+    }
+    return false;
+}
+
+void ImGui::EndDragDropSource()
+{
+    ImGuiContext &g = *GImGui;
+    IM_ASSERT(g.DragDropActive);
+    IM_ASSERT(g.DragDropWithinSourceOrTarget && "Not after a BeginDragDropSource()?");
+
+    if (!(g.DragDropSourceFlags & ImGuiDragDropFlags_SourceNoPreviewTooltip))
+        EndTooltip();
+
+    // Discard the drag if have not called SetDragDropPayload()
+    if (g.DragDropPayload.DataFrameCount == -1)
+        ClearDragDrop();
+    g.DragDropWithinSourceOrTarget = false;
+}
+
+// Use 'cond' to choose to submit payload on drag start or every frame
+bool ImGui::SetDragDropPayload(const char *type, const void *data, size_t data_size, ImGuiCond cond)
+{
+    ImGuiContext &g       = *GImGui;
+    ImGuiPayload &payload = g.DragDropPayload;
+    if (cond == 0)
+        cond = ImGuiCond_Always;
+
+    IM_ASSERT(type != NULL);
+    IM_ASSERT(strlen(type) < IM_ARRAYSIZE(payload.DataType) &&
+              "Payload type can be at most 32 characters long");
+    IM_ASSERT((data != NULL && data_size > 0) || (data == NULL && data_size == 0));
+    IM_ASSERT(cond == ImGuiCond_Always || cond == ImGuiCond_Once);
+    IM_ASSERT(payload.SourceId !=
+              0);  // Not called between BeginDragDropSource() and EndDragDropSource()
+
+    if (cond == ImGuiCond_Always || payload.DataFrameCount == -1)
+    {
+        // Copy payload
+        ImStrncpy(payload.DataType, type, IM_ARRAYSIZE(payload.DataType));
+        g.DragDropPayloadBufHeap.resize(0);
+        if (data_size > sizeof(g.DragDropPayloadBufLocal))
+        {
+            // Store in heap
+            g.DragDropPayloadBufHeap.resize((int)data_size);
+            payload.Data = g.DragDropPayloadBufHeap.Data;
+            memcpy(payload.Data, data, data_size);
+        }
+        else if (data_size > 0)
+        {
+            // Store locally
+            memset(&g.DragDropPayloadBufLocal, 0, sizeof(g.DragDropPayloadBufLocal));
+            payload.Data = g.DragDropPayloadBufLocal;
+            memcpy(payload.Data, data, data_size);
+        }
+        else
+        {
+            payload.Data = NULL;
+        }
+        payload.DataSize = (int)data_size;
+    }
+    payload.DataFrameCount = g.FrameCount;
+
+    return (g.DragDropAcceptFrameCount == g.FrameCount) ||
+           (g.DragDropAcceptFrameCount == g.FrameCount - 1);
+}
+
+bool ImGui::BeginDragDropTargetCustom(const ImRect &bb, ImGuiID id)
+{
+    ImGuiContext &g = *GImGui;
+    if (!g.DragDropActive)
+        return false;
+
+    ImGuiWindow *window = g.CurrentWindow;
+    if (g.HoveredWindow == NULL || window->RootWindow != g.HoveredWindow->RootWindow)
+        return false;
+    IM_ASSERT(id != 0);
+    if (!IsMouseHoveringRect(bb.Min, bb.Max) || (id == g.DragDropPayload.SourceId))
+        return false;
+    if (window->SkipItems)
+        return false;
+
+    IM_ASSERT(g.DragDropWithinSourceOrTarget == false);
+    g.DragDropTargetRect           = bb;
+    g.DragDropTargetId             = id;
+    g.DragDropWithinSourceOrTarget = true;
+    return true;
+}
+
+// We don't use BeginDragDropTargetCustom() and duplicate its code because:
+// 1) we use LastItemRectHoveredRect which handles items that pushes a temporarily clip rectangle in
+// their code. Calling BeginDragDropTargetCustom(LastItemRect) would not handle them. 2) and it's
+// faster. as this code may be very frequently called, we want to early out as fast as we can. Also
+// note how the HoveredWindow test is positioned differently in both functions (in both functions we
+// optimize for the cheapest early out case)
+bool ImGui::BeginDragDropTarget()
+{
+    ImGuiContext &g = *GImGui;
+    if (!g.DragDropActive)
+        return false;
+
+    ImGuiWindow *window = g.CurrentWindow;
+    if (!(window->DC.LastItemStatusFlags & ImGuiItemStatusFlags_HoveredRect))
+        return false;
+    if (g.HoveredWindow == NULL || window->RootWindow != g.HoveredWindow->RootWindow)
+        return false;
+
+    const ImRect &display_rect =
+        (window->DC.LastItemStatusFlags & ImGuiItemStatusFlags_HasDisplayRect)
+            ? window->DC.LastItemDisplayRect
+            : window->DC.LastItemRect;
+    ImGuiID id = window->DC.LastItemId;
+    if (id == 0)
+        id = window->GetIDFromRectangle(display_rect);
+    if (g.DragDropPayload.SourceId == id)
+        return false;
+
+    IM_ASSERT(g.DragDropWithinSourceOrTarget == false);
+    g.DragDropTargetRect           = display_rect;
+    g.DragDropTargetId             = id;
+    g.DragDropWithinSourceOrTarget = true;
+    return true;
+}
+
+bool ImGui::IsDragDropPayloadBeingAccepted()
+{
+    ImGuiContext &g = *GImGui;
+    return g.DragDropActive && g.DragDropAcceptIdPrev != 0;
+}
+
+const ImGuiPayload *ImGui::AcceptDragDropPayload(const char *type, ImGuiDragDropFlags flags)
+{
+    ImGuiContext &g       = *GImGui;
+    ImGuiWindow *window   = g.CurrentWindow;
+    ImGuiPayload &payload = g.DragDropPayload;
+    IM_ASSERT(
+        g.DragDropActive);  // Not called between BeginDragDropTarget() and EndDragDropTarget() ?
+    IM_ASSERT(payload.DataFrameCount != -1);  // Forgot to call EndDragDropTarget() ?
+    if (type != NULL && !payload.IsDataType(type))
+        return NULL;
+
+    // Accept smallest drag target bounding box, this allows us to nest drag targets conveniently
+    // without ordering constraints. NB: We currently accept NULL id as target. However, overlapping
+    // targets requires a unique ID to function!
+    const bool was_accepted_previously = (g.DragDropAcceptIdPrev == g.DragDropTargetId);
+    ImRect r                           = g.DragDropTargetRect;
+    float r_surface                    = r.GetWidth() * r.GetHeight();
+    if (r_surface < g.DragDropAcceptIdCurrRectSurface)
+    {
+        g.DragDropAcceptFlags             = flags;
+        g.DragDropAcceptIdCurr            = g.DragDropTargetId;
+        g.DragDropAcceptIdCurrRectSurface = r_surface;
+    }
+
+    // Render default drop visuals
+    payload.Preview = was_accepted_previously;
+    flags |= (g.DragDropSourceFlags &
+              ImGuiDragDropFlags_AcceptNoDrawDefaultRect);  // Source can also inhibit the preview
+                                                            // (useful for external sources that
+                                                            // lives for 1 frame)
+    if (!(flags & ImGuiDragDropFlags_AcceptNoDrawDefaultRect) && payload.Preview)
+    {
+        // FIXME-DRAG: Settle on a proper default visuals for drop target.
+        r.Expand(3.5f);
+        bool push_clip_rect = !window->ClipRect.Contains(r);
+        if (push_clip_rect)
+            window->DrawList->PushClipRect(r.Min - ImVec2(1, 1), r.Max + ImVec2(1, 1));
+        window->DrawList->AddRect(r.Min, r.Max, GetColorU32(ImGuiCol_DragDropTarget), 0.0f, ~0,
+                                  2.0f);
+        if (push_clip_rect)
+            window->DrawList->PopClipRect();
+    }
+
+    g.DragDropAcceptFrameCount = g.FrameCount;
+    payload.Delivery =
+        was_accepted_previously &&
+        !IsMouseDown(g.DragDropMouseButton);  // For extern drag sources affecting os window focus,
+                                              // it's easier to just test !IsMouseDown() instead of
+                                              // IsMouseReleased()
+    if (!payload.Delivery && !(flags & ImGuiDragDropFlags_AcceptBeforeDelivery))
+        return NULL;
+
+    return &payload;
+}
+
+const ImGuiPayload *ImGui::GetDragDropPayload()
+{
+    ImGuiContext &g = *GImGui;
+    return g.DragDropActive ? &g.DragDropPayload : NULL;
+}
+
+// We don't really use/need this now, but added it for the sake of consistency and because we might
+// need it later.
+void ImGui::EndDragDropTarget()
+{
+    ImGuiContext &g = *GImGui;
+    IM_ASSERT(g.DragDropActive);
+    IM_ASSERT(g.DragDropWithinSourceOrTarget);
+    g.DragDropWithinSourceOrTarget = false;
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] LOGGING/CAPTURING
+//-----------------------------------------------------------------------------
+// All text output from the interface can be captured into tty/file/clipboard.
+// By default, tree nodes are automatically opened during logging.
+//-----------------------------------------------------------------------------
+
+// Pass text data straight to log (without being displayed)
+void ImGui::LogText(const char *fmt, ...)
+{
+    ImGuiContext &g = *GImGui;
+    if (!g.LogEnabled)
+        return;
+
+    va_list args;
+    va_start(args, fmt);
+    if (g.LogFile)
+        vfprintf(g.LogFile, fmt, args);
+    else
+        g.LogBuffer.appendfv(fmt, args);
+    va_end(args);
+}
+
+// Internal version that takes a position to decide on newline placement and pad items according to
+// their depth. We split text into individual lines to add current tree level padding
+void ImGui::LogRenderedText(const ImVec2 *ref_pos, const char *text, const char *text_end)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+
+    if (!text_end)
+        text_end = FindRenderedTextEnd(text, text_end);
+
+    const bool log_new_line = ref_pos && (ref_pos->y > g.LogLinePosY + 1);
+    if (ref_pos)
+        g.LogLinePosY = ref_pos->y;
+    if (log_new_line)
+        g.LogLineFirstItem = true;
+
+    const char *text_remaining = text;
+    if (g.LogDepthRef >
+        window->DC.TreeDepth)  // Re-adjust padding if we have popped out of our starting depth
+        g.LogDepthRef = window->DC.TreeDepth;
+    const int tree_depth = (window->DC.TreeDepth - g.LogDepthRef);
+    for (;;)
+    {
+        // Split the string. Each new line (after a '\n') is followed by spacing corresponding to
+        // the current depth of our log entry. We don't add a trailing \n to allow a subsequent item
+        // on the same line to be captured.
+        const char *line_start   = text_remaining;
+        const char *line_end     = ImStreolRange(line_start, text_end);
+        const bool is_first_line = (line_start == text);
+        const bool is_last_line  = (line_end == text_end);
+        if (!is_last_line || (line_start != line_end))
+        {
+            const int char_count = (int)(line_end - line_start);
+            if (log_new_line || !is_first_line)
+                LogText(IM_NEWLINE "%*s%.*s", tree_depth * 4, "", char_count, line_start);
+            else if (g.LogLineFirstItem)
+                LogText("%*s%.*s", tree_depth * 4, "", char_count, line_start);
+            else
+                LogText(" %.*s", char_count, line_start);
+            g.LogLineFirstItem = false;
+        }
+        else if (log_new_line)
+        {
+            // An empty "" string at a different Y position should output a carriage return.
+            LogText(IM_NEWLINE);
+            break;
+        }
+
+        if (is_last_line)
+            break;
+        text_remaining = line_end + 1;
+    }
+}
+
+// Start logging/capturing text output
+void ImGui::LogBegin(ImGuiLogType type, int auto_open_depth)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+    IM_ASSERT(g.LogEnabled == false);
+    IM_ASSERT(g.LogFile == NULL);
+    IM_ASSERT(g.LogBuffer.empty());
+    g.LogEnabled       = true;
+    g.LogType          = type;
+    g.LogDepthRef      = window->DC.TreeDepth;
+    g.LogDepthToExpand = ((auto_open_depth >= 0) ? auto_open_depth : g.LogDepthToExpandDefault);
+    g.LogLinePosY      = FLT_MAX;
+    g.LogLineFirstItem = true;
+}
+
+void ImGui::LogToTTY(int auto_open_depth)
+{
+    ImGuiContext &g = *GImGui;
+    if (g.LogEnabled)
+        return;
+    LogBegin(ImGuiLogType_TTY, auto_open_depth);
+    g.LogFile = stdout;
+}
+
+// Start logging/capturing text output to given file
+void ImGui::LogToFile(int auto_open_depth, const char *filename)
+{
+    ImGuiContext &g = *GImGui;
+    if (g.LogEnabled)
+        return;
+
+    // FIXME: We could probably open the file in text mode "at", however note that clipboard/buffer
+    // logging will still be subject to outputting OS-incompatible carriage return if within strings
+    // the user doesn't use IM_NEWLINE. By opening the file in binary mode "ab" we have consistent
+    // output everywhere.
+    if (!filename)
+        filename = g.IO.LogFilename;
+    if (!filename || !filename[0])
+        return;
+    FILE *f = ImFileOpen(filename, "ab");
+    if (f == NULL)
+    {
+        IM_ASSERT(0);
+        return;
+    }
+
+    LogBegin(ImGuiLogType_File, auto_open_depth);
+    g.LogFile = f;
+}
+
+// Start logging/capturing text output to clipboard
+void ImGui::LogToClipboard(int auto_open_depth)
+{
+    ImGuiContext &g = *GImGui;
+    if (g.LogEnabled)
+        return;
+    LogBegin(ImGuiLogType_Clipboard, auto_open_depth);
+}
+
+void ImGui::LogToBuffer(int auto_open_depth)
+{
+    ImGuiContext &g = *GImGui;
+    if (g.LogEnabled)
+        return;
+    LogBegin(ImGuiLogType_Buffer, auto_open_depth);
+}
+
+void ImGui::LogFinish()
+{
+    ImGuiContext &g = *GImGui;
+    if (!g.LogEnabled)
+        return;
+
+    LogText(IM_NEWLINE);
+    switch (g.LogType)
+    {
+        case ImGuiLogType_TTY:
+            fflush(g.LogFile);
+            break;
+        case ImGuiLogType_File:
+            fclose(g.LogFile);
+            break;
+        case ImGuiLogType_Buffer:
+            break;
+        case ImGuiLogType_Clipboard:
+            if (!g.LogBuffer.empty())
+                SetClipboardText(g.LogBuffer.begin());
+            break;
+        case ImGuiLogType_None:
+            IM_ASSERT(0);
+            break;
+    }
+
+    g.LogEnabled = false;
+    g.LogType    = ImGuiLogType_None;
+    g.LogFile    = NULL;
+    g.LogBuffer.clear();
+}
+
+// Helper to display logging buttons
+// FIXME-OBSOLETE: We should probably obsolete this and let the user have their own helper (this is
+// one of the oldest function alive!)
+void ImGui::LogButtons()
+{
+    ImGuiContext &g = *GImGui;
+
+    PushID("LogButtons");
+    const bool log_to_tty = Button("Log To TTY");
+    SameLine();
+    const bool log_to_file = Button("Log To File");
+    SameLine();
+    const bool log_to_clipboard = Button("Log To Clipboard");
+    SameLine();
+    PushAllowKeyboardFocus(false);
+    SetNextItemWidth(80.0f);
+    SliderInt("Default Depth", &g.LogDepthToExpandDefault, 0, 9, NULL);
+    PopAllowKeyboardFocus();
+    PopID();
+
+    // Start logging at the end of the function so that the buttons don't appear in the log
+    if (log_to_tty)
+        LogToTTY();
+    if (log_to_file)
+        LogToFile();
+    if (log_to_clipboard)
+        LogToClipboard();
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] SETTINGS
+//-----------------------------------------------------------------------------
+
+void ImGui::MarkIniSettingsDirty()
+{
+    ImGuiContext &g = *GImGui;
+    if (g.SettingsDirtyTimer <= 0.0f)
+        g.SettingsDirtyTimer = g.IO.IniSavingRate;
+}
+
+void ImGui::MarkIniSettingsDirty(ImGuiWindow *window)
+{
+    ImGuiContext &g = *GImGui;
+    if (!(window->Flags & ImGuiWindowFlags_NoSavedSettings))
+        if (g.SettingsDirtyTimer <= 0.0f)
+            g.SettingsDirtyTimer = g.IO.IniSavingRate;
+}
+
+ImGuiWindowSettings *ImGui::CreateNewWindowSettings(const char *name)
+{
+    ImGuiContext &g = *GImGui;
+    g.SettingsWindows.push_back(ImGuiWindowSettings());
+    ImGuiWindowSettings *settings = &g.SettingsWindows.back();
+    settings->Name                = ImStrdup(name);
+    settings->ID                  = ImHashStr(name);
+    return settings;
+}
+
+ImGuiWindowSettings *ImGui::FindWindowSettings(ImGuiID id)
+{
+    ImGuiContext &g = *GImGui;
+    for (int i = 0; i != g.SettingsWindows.Size; i++)
+        if (g.SettingsWindows[i].ID == id)
+            return &g.SettingsWindows[i];
+    return NULL;
+}
+
+ImGuiWindowSettings *ImGui::FindOrCreateWindowSettings(const char *name)
+{
+    if (ImGuiWindowSettings *settings = FindWindowSettings(ImHashStr(name)))
+        return settings;
+    return CreateNewWindowSettings(name);
+}
+
+void ImGui::LoadIniSettingsFromDisk(const char *ini_filename)
+{
+    size_t file_data_size = 0;
+    char *file_data       = (char *)ImFileLoadToMemory(ini_filename, "rb", &file_data_size);
+    if (!file_data)
+        return;
+    LoadIniSettingsFromMemory(file_data, (size_t)file_data_size);
+    IM_FREE(file_data);
+}
+
+ImGuiSettingsHandler *ImGui::FindSettingsHandler(const char *type_name)
+{
+    ImGuiContext &g         = *GImGui;
+    const ImGuiID type_hash = ImHashStr(type_name);
+    for (int handler_n = 0; handler_n < g.SettingsHandlers.Size; handler_n++)
+        if (g.SettingsHandlers[handler_n].TypeHash == type_hash)
+            return &g.SettingsHandlers[handler_n];
+    return NULL;
+}
+
+// Zero-tolerance, no error reporting, cheap .ini parsing
+void ImGui::LoadIniSettingsFromMemory(const char *ini_data, size_t ini_size)
+{
+    ImGuiContext &g = *GImGui;
+    IM_ASSERT(g.Initialized);
+    IM_ASSERT(g.SettingsLoaded == false && g.FrameCount == 0);
+
+    // For user convenience, we allow passing a non zero-terminated string (hence the ini_size
+    // parameter). For our convenience and to make the code simpler, we'll also write
+    // zero-terminators within the buffer. So let's create a writable copy..
+    if (ini_size == 0)
+        ini_size = strlen(ini_data);
+    char *buf     = (char *)IM_ALLOC(ini_size + 1);
+    char *buf_end = buf + ini_size;
+    memcpy(buf, ini_data, ini_size);
+    buf[ini_size] = 0;
+
+    void *entry_data                    = NULL;
+    ImGuiSettingsHandler *entry_handler = NULL;
+
+    char *line_end = NULL;
+    for (char *line = buf; line < buf_end; line = line_end + 1)
+    {
+        // Skip new lines markers, then find end of the line
+        while (*line == '\n' || *line == '\r')
+            line++;
+        line_end = line;
+        while (line_end < buf_end && *line_end != '\n' && *line_end != '\r')
+            line_end++;
+        line_end[0] = 0;
+        if (line[0] == ';')
+            continue;
+        if (line[0] == '[' && line_end > line && line_end[-1] == ']')
+        {
+            // Parse "[Type][Name]". Note that 'Name' can itself contains [] characters, which is
+            // acceptable with the current format and parsing code.
+            line_end[-1]           = 0;
+            const char *name_end   = line_end - 1;
+            const char *type_start = line + 1;
+            char *type_end         = (char *)(intptr_t)ImStrchrRange(type_start, name_end, ']');
+            const char *name_start = type_end ? ImStrchrRange(type_end + 1, name_end, '[') : NULL;
+            if (!type_end || !name_start)
+            {
+                name_start = type_start;  // Import legacy entries that have no type
+                type_start = "Window";
+            }
+            else
+            {
+                *type_end = 0;  // Overwrite first ']'
+                name_start++;   // Skip second '['
+            }
+            entry_handler = FindSettingsHandler(type_start);
+            entry_data =
+                entry_handler ? entry_handler->ReadOpenFn(&g, entry_handler, name_start) : NULL;
+        }
+        else if (entry_handler != NULL && entry_data != NULL)
+        {
+            // Let type handler parse the line
+            entry_handler->ReadLineFn(&g, entry_handler, entry_data, line);
+        }
+    }
+    IM_FREE(buf);
+    g.SettingsLoaded = true;
+}
+
+void ImGui::SaveIniSettingsToDisk(const char *ini_filename)
+{
+    ImGuiContext &g      = *GImGui;
+    g.SettingsDirtyTimer = 0.0f;
+    if (!ini_filename)
+        return;
+
+    size_t ini_data_size = 0;
+    const char *ini_data = SaveIniSettingsToMemory(&ini_data_size);
+    FILE *f              = ImFileOpen(ini_filename, "wt");
+    if (!f)
+        return;
+    fwrite(ini_data, sizeof(char), ini_data_size, f);
+    fclose(f);
+}
+
+// Call registered handlers (e.g. SettingsHandlerWindow_WriteAll() + custom handlers) to write their
+// stuff into a text buffer
+const char *ImGui::SaveIniSettingsToMemory(size_t *out_size)
+{
+    ImGuiContext &g      = *GImGui;
+    g.SettingsDirtyTimer = 0.0f;
+    g.SettingsIniData.Buf.resize(0);
+    g.SettingsIniData.Buf.push_back(0);
+    for (int handler_n = 0; handler_n < g.SettingsHandlers.Size; handler_n++)
+    {
+        ImGuiSettingsHandler *handler = &g.SettingsHandlers[handler_n];
+        handler->WriteAllFn(&g, handler, &g.SettingsIniData);
+    }
+    if (out_size)
+        *out_size = (size_t)g.SettingsIniData.size();
+    return g.SettingsIniData.c_str();
+}
+
+static void *SettingsHandlerWindow_ReadOpen(ImGuiContext *,
+                                            ImGuiSettingsHandler *,
+                                            const char *name)
+{
+    ImGuiWindowSettings *settings = ImGui::FindWindowSettings(ImHashStr(name));
+    if (!settings)
+        settings = ImGui::CreateNewWindowSettings(name);
+    return (void *)settings;
+}
+
+static void SettingsHandlerWindow_ReadLine(ImGuiContext *ctx,
+                                           ImGuiSettingsHandler *,
+                                           void *entry,
+                                           const char *line)
+{
+    ImGuiContext &g               = *ctx;
+    ImGuiWindowSettings *settings = (ImGuiWindowSettings *)entry;
+    float x, y;
+    int i;
+    if (sscanf(line, "Pos=%f,%f", &x, &y) == 2)
+        settings->Pos = ImVec2(x, y);
+    else if (sscanf(line, "Size=%f,%f", &x, &y) == 2)
+        settings->Size = ImMax(ImVec2(x, y), g.Style.WindowMinSize);
+    else if (sscanf(line, "Collapsed=%d", &i) == 1)
+        settings->Collapsed = (i != 0);
+}
+
+static void SettingsHandlerWindow_WriteAll(ImGuiContext *ctx,
+                                           ImGuiSettingsHandler *handler,
+                                           ImGuiTextBuffer *buf)
+{
+    // Gather data from windows that were active during this session
+    // (if a window wasn't opened in this session we preserve its settings)
+    ImGuiContext &g = *ctx;
+    for (int i = 0; i != g.Windows.Size; i++)
+    {
+        ImGuiWindow *window = g.Windows[i];
+        if (window->Flags & ImGuiWindowFlags_NoSavedSettings)
+            continue;
+
+        ImGuiWindowSettings *settings = (window->SettingsIdx != -1)
+                                            ? &g.SettingsWindows[window->SettingsIdx]
+                                            : ImGui::FindWindowSettings(window->ID);
+        if (!settings)
+        {
+            settings            = ImGui::CreateNewWindowSettings(window->Name);
+            window->SettingsIdx = g.SettingsWindows.index_from_ptr(settings);
+        }
+        IM_ASSERT(settings->ID == window->ID);
+        settings->Pos       = window->Pos;
+        settings->Size      = window->SizeFull;
+        settings->Collapsed = window->Collapsed;
+    }
+
+    // Write to text buffer
+    buf->reserve(buf->size() + g.SettingsWindows.Size * 96);  // ballpark reserve
+    for (int i = 0; i != g.SettingsWindows.Size; i++)
+    {
+        const ImGuiWindowSettings *settings = &g.SettingsWindows[i];
+        if (settings->Pos.x == FLT_MAX)
+            continue;
+        const char *name = settings->Name;
+        if (const char *p = strstr(name, "###"))  // Skip to the "###" marker if any. We don't skip
+                                                  // past to match the behavior of GetID()
+            name = p;
+        buf->appendf("[%s][%s]\n", handler->TypeName, name);
+        buf->appendf("Pos=%d,%d\n", (int)settings->Pos.x, (int)settings->Pos.y);
+        buf->appendf("Size=%d,%d\n", (int)settings->Size.x, (int)settings->Size.y);
+        buf->appendf("Collapsed=%d\n", settings->Collapsed);
+        buf->appendf("\n");
+    }
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] VIEWPORTS, PLATFORM WINDOWS
+//-----------------------------------------------------------------------------
+
+// (this section is filled in the 'docking' branch)
+
+//-----------------------------------------------------------------------------
+// [SECTION] DOCKING
+//-----------------------------------------------------------------------------
+
+// (this section is filled in the 'docking' branch)
+
+//-----------------------------------------------------------------------------
+// [SECTION] PLATFORM DEPENDENT HELPERS
+//-----------------------------------------------------------------------------
+
+#if defined(_WIN32) && !defined(_WINDOWS_) && !defined(IMGUI_DISABLE_WIN32_FUNCTIONS) && \
+    (!defined(IMGUI_DISABLE_WIN32_DEFAULT_CLIPBOARD_FUNCTIONS) ||                        \
+     !defined(IMGUI_DISABLE_WIN32_DEFAULT_IME_FUNCTIONS))
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef __MINGW32__
+#include <Windows.h>
+#else
+#include <windows.h>
+#endif
+#elif defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
+
+#if defined(_WIN32) && !defined(IMGUI_DISABLE_WIN32_FUNCTIONS) && \
+    !defined(IMGUI_DISABLE_WIN32_DEFAULT_CLIPBOARD_FUNCTIONS)
+
+#ifdef _MSC_VER
+#pragma comment(lib, "user32")
+#endif
+
+// Win32 clipboard implementation
+static const char *GetClipboardTextFn_DefaultImpl(void *)
+{
+    static ImVector<char> buf_local;
+    buf_local.clear();
+    if (!::OpenClipboard(NULL))
+        return NULL;
+    HANDLE wbuf_handle = ::GetClipboardData(CF_UNICODETEXT);
+    if (wbuf_handle == NULL)
+    {
+        ::CloseClipboard();
+        return NULL;
+    }
+    if (ImWchar *wbuf_global = (ImWchar *)::GlobalLock(wbuf_handle))
+    {
+        int buf_len = ImTextCountUtf8BytesFromStr(wbuf_global, NULL) + 1;
+        buf_local.resize(buf_len);
+        ImTextStrToUtf8(buf_local.Data, buf_len, wbuf_global, NULL);
+    }
+    ::GlobalUnlock(wbuf_handle);
+    ::CloseClipboard();
+    return buf_local.Data;
+}
+
+static void SetClipboardTextFn_DefaultImpl(void *, const char *text)
+{
+    if (!::OpenClipboard(NULL))
+        return;
+    const int wbuf_length = ImTextCountCharsFromUtf8(text, NULL) + 1;
+    HGLOBAL wbuf_handle   = ::GlobalAlloc(GMEM_MOVEABLE, (SIZE_T)wbuf_length * sizeof(ImWchar));
+    if (wbuf_handle == NULL)
+    {
+        ::CloseClipboard();
+        return;
+    }
+    ImWchar *wbuf_global = (ImWchar *)::GlobalLock(wbuf_handle);
+    ImTextStrFromUtf8(wbuf_global, wbuf_length, text, NULL);
+    ::GlobalUnlock(wbuf_handle);
+    ::EmptyClipboard();
+    if (::SetClipboardData(CF_UNICODETEXT, wbuf_handle) == NULL)
+        ::GlobalFree(wbuf_handle);
+    ::CloseClipboard();
+}
+
+#elif defined(__APPLE__) && TARGET_OS_OSX && !defined(IMGUI_DISABLE_OSX_FUNCTIONS)
+
+#include <Carbon/Carbon.h>  // Use old API to avoid need for separate .mm file
+static PasteboardRef main_clipboard = 0;
+
+// OSX clipboard implementation
+static void SetClipboardTextFn_DefaultImpl(void *, const char *text)
+{
+    if (!main_clipboard)
+        PasteboardCreate(kPasteboardClipboard, &main_clipboard);
+    PasteboardClear(main_clipboard);
+    CFDataRef cf_data = CFDataCreate(kCFAllocatorDefault, (const UInt8 *)text, strlen(text));
+    if (cf_data)
+    {
+        PasteboardPutItemFlavor(main_clipboard, (PasteboardItemID)1,
+                                CFSTR("public.utf8-plain-text"), cf_data, 0);
+        CFRelease(cf_data);
+    }
+}
+
+static const char *GetClipboardTextFn_DefaultImpl(void *)
+{
+    if (!main_clipboard)
+        PasteboardCreate(kPasteboardClipboard, &main_clipboard);
+    PasteboardSynchronize(main_clipboard);
+
+    ItemCount item_count = 0;
+    PasteboardGetItemCount(main_clipboard, &item_count);
+    for (int i = 0; i < item_count; i++)
+    {
+        PasteboardItemID item_id = 0;
+        PasteboardGetItemIdentifier(main_clipboard, i + 1, &item_id);
+        CFArrayRef flavor_type_array = 0;
+        PasteboardCopyItemFlavors(main_clipboard, item_id, &flavor_type_array);
+        for (CFIndex j = 0, nj = CFArrayGetCount(flavor_type_array); j < nj; j++)
+        {
+            CFDataRef cf_data;
+            if (PasteboardCopyItemFlavorData(main_clipboard, item_id,
+                                             CFSTR("public.utf8-plain-text"), &cf_data) == noErr)
+            {
+                static ImVector<char> clipboard_text;
+                int length = (int)CFDataGetLength(cf_data);
+                clipboard_text.resize(length + 1);
+                CFDataGetBytes(cf_data, CFRangeMake(0, length), (UInt8 *)clipboard_text.Data);
+                clipboard_text[length] = 0;
+                CFRelease(cf_data);
+                return clipboard_text.Data;
+            }
+        }
+    }
+    return NULL;
+}
+
+#else
+
+// Local Dear ImGui-only clipboard implementation, if user hasn't defined better clipboard handlers.
+static const char *GetClipboardTextFn_DefaultImpl(void *)
+{
+    ImGuiContext &g = *GImGui;
+    return g.PrivateClipboard.empty() ? NULL : g.PrivateClipboard.begin();
+}
+
+static void SetClipboardTextFn_DefaultImpl(void *, const char *text)
+{
+    ImGuiContext &g = *GImGui;
+    g.PrivateClipboard.clear();
+    const char *text_end = text + strlen(text);
+    g.PrivateClipboard.resize((int)(text_end - text) + 1);
+    memcpy(&g.PrivateClipboard[0], text, (size_t)(text_end - text));
+    g.PrivateClipboard[(int)(text_end - text)] = 0;
+}
+
+#endif
+
+// Win32 API IME support (for Asian languages, etc.)
+#if defined(_WIN32) && !defined(__GNUC__) && !defined(IMGUI_DISABLE_WIN32_FUNCTIONS) && \
+    !defined(IMGUI_DISABLE_WIN32_DEFAULT_IME_FUNCTIONS)
+
+#include <imm.h>
+#ifdef _MSC_VER
+#pragma comment(lib, "imm32")
+#endif
+
+static void ImeSetInputScreenPosFn_DefaultImpl(int x, int y)
+{
+    // Notify OS Input Method Editor of text input position
+    if (HWND hwnd = (HWND)GImGui->IO.ImeWindowHandle)
+        if (HIMC himc = ::ImmGetContext(hwnd))
+        {
+            COMPOSITIONFORM cf;
+            cf.ptCurrentPos.x = x;
+            cf.ptCurrentPos.y = y;
+            cf.dwStyle        = CFS_FORCE_POSITION;
+            ::ImmSetCompositionWindow(himc, &cf);
+            ::ImmReleaseContext(hwnd, himc);
+        }
+}
+
+#else
+
+static void ImeSetInputScreenPosFn_DefaultImpl(int, int) {}
+
+#endif
+
+//-----------------------------------------------------------------------------
+// [SECTION] METRICS/DEBUG WINDOW
+//-----------------------------------------------------------------------------
+
+#ifndef IMGUI_DISABLE_METRICS_WINDOW
+void ImGui::ShowMetricsWindow(bool *p_open)
+{
+    if (!ImGui::Begin("Dear ImGui Metrics", p_open))
+    {
+        ImGui::End();
+        return;
+    }
+
+    enum
+    {
+        WRT_OuterRect,
+        WRT_OuterRectClipped,
+        WRT_InnerRect,
+        WRT_InnerClipRect,
+        WRT_WorkRect,
+        WRT_Contents,
+        WRT_ContentsRegionRect,
+        WRT_Count
+    };  // Windows Rect Type
+    const char *wrt_rects_names[WRT_Count] = {"OuterRect",         "OuterRectClipped", "InnerRect",
+                                              "InnerClipRect",     "WorkRect",         "Contents",
+                                              "ContentsRegionRect"};
+
+    static bool show_windows_begin_order = false;
+    static bool show_windows_rects       = false;
+    static int show_windows_rect_type    = WRT_WorkRect;
+    static bool show_drawcmd_clip_rects  = true;
+
+    ImGuiIO &io = ImGui::GetIO();
+    ImGui::Text("Dear ImGui %s", ImGui::GetVersion());
+    ImGui::Text("Application average %.3f ms/frame (%.1f FPS)", 1000.0f / io.Framerate,
+                io.Framerate);
+    ImGui::Text("%d vertices, %d indices (%d triangles)", io.MetricsRenderVertices,
+                io.MetricsRenderIndices, io.MetricsRenderIndices / 3);
+    ImGui::Text("%d active windows (%d visible)", io.MetricsActiveWindows, io.MetricsRenderWindows);
+    ImGui::Text("%d active allocations", io.MetricsActiveAllocations);
+    ImGui::Separator();
+
+    struct Funcs
+    {
+        static ImRect GetWindowRect(ImGuiWindow *window, int rect_type)
+        {
+            if (rect_type == WRT_OuterRect)
+            {
+                return window->Rect();
+            }
+            else if (rect_type == WRT_OuterRectClipped)
+            {
+                return window->OuterRectClipped;
+            }
+            else if (rect_type == WRT_InnerRect)
+            {
+                return window->InnerRect;
+            }
+            else if (rect_type == WRT_InnerClipRect)
+            {
+                return window->InnerClipRect;
+            }
+            else if (rect_type == WRT_WorkRect)
+            {
+                return window->WorkRect;
+            }
+            else if (rect_type == WRT_Contents)
+            {
+                ImVec2 min = window->InnerRect.Min - window->Scroll + window->WindowPadding;
+                return ImRect(min, min + window->ContentSize);
+            }
+            else if (rect_type == WRT_ContentsRegionRect)
+            {
+                return window->ContentsRegionRect;
+            }
+            IM_ASSERT(0);
+            return ImRect();
+        }
+
+        static void NodeDrawList(ImGuiWindow *window, ImDrawList *draw_list, const char *label)
+        {
+            bool node_open = ImGui::TreeNode(
+                draw_list, "%s: '%s' %d vtx, %d indices, %d cmds", label,
+                draw_list->_OwnerName ? draw_list->_OwnerName : "", draw_list->VtxBuffer.Size,
+                draw_list->IdxBuffer.Size, draw_list->CmdBuffer.Size);
+            if (draw_list == ImGui::GetWindowDrawList())
+            {
+                ImGui::SameLine();
+                ImGui::TextColored(
+                    ImVec4(1.0f, 0.4f, 0.4f, 1.0f),
+                    "CURRENTLY APPENDING");  // Can't display stats for active draw list! (we don't
+                                             // have the data double-buffered)
+                if (node_open)
+                    ImGui::TreePop();
+                return;
+            }
+
+            ImDrawList *fg_draw_list = GetForegroundDrawList(
+                window);  // Render additional visuals into the top-most draw list
+            if (window && IsItemHovered())
+                fg_draw_list->AddRect(window->Pos, window->Pos + window->Size,
+                                      IM_COL32(255, 255, 0, 255));
+            if (!node_open)
+                return;
+
+            int elem_offset = 0;
+            for (const ImDrawCmd *pcmd = draw_list->CmdBuffer.begin();
+                 pcmd < draw_list->CmdBuffer.end(); elem_offset += pcmd->ElemCount, pcmd++)
+            {
+                if (pcmd->UserCallback == NULL && pcmd->ElemCount == 0)
+                    continue;
+                if (pcmd->UserCallback)
+                {
+                    ImGui::BulletText("Callback %p, user_data %p", pcmd->UserCallback,
+                                      pcmd->UserCallbackData);
+                    continue;
+                }
+                ImDrawIdx *idx_buffer =
+                    (draw_list->IdxBuffer.Size > 0) ? draw_list->IdxBuffer.Data : NULL;
+                char buf[300];
+                ImFormatString(
+                    buf, IM_ARRAYSIZE(buf),
+                    "Draw %4d triangles, tex 0x%p, clip_rect (%4.0f,%4.0f)-(%4.0f,%4.0f)",
+                    pcmd->ElemCount / 3, (void *)(intptr_t)pcmd->TextureId, pcmd->ClipRect.x,
+                    pcmd->ClipRect.y, pcmd->ClipRect.z, pcmd->ClipRect.w);
+                bool pcmd_node_open =
+                    ImGui::TreeNode((void *)(pcmd - draw_list->CmdBuffer.begin()), "%s", buf);
+                if (show_drawcmd_clip_rects && fg_draw_list && ImGui::IsItemHovered())
+                {
+                    ImRect clip_rect = pcmd->ClipRect;
+                    ImRect vtxs_rect;
+                    for (int i = elem_offset; i < elem_offset + (int)pcmd->ElemCount; i++)
+                        vtxs_rect.Add(draw_list->VtxBuffer[idx_buffer ? idx_buffer[i] : i].pos);
+                    clip_rect.Floor();
+                    fg_draw_list->AddRect(clip_rect.Min, clip_rect.Max, IM_COL32(255, 0, 255, 255));
+                    vtxs_rect.Floor();
+                    fg_draw_list->AddRect(vtxs_rect.Min, vtxs_rect.Max, IM_COL32(255, 255, 0, 255));
+                }
+                if (!pcmd_node_open)
+                    continue;
+
+                // Display individual triangles/vertices. Hover on to get the corresponding triangle
+                // highlighted.
+                ImGui::Text("ElemCount: %d, ElemCount/3: %d, VtxOffset: +%d, IdxOffset: +%d",
+                            pcmd->ElemCount, pcmd->ElemCount / 3, pcmd->VtxOffset, pcmd->IdxOffset);
+                ImGuiListClipper clipper(
+                    pcmd->ElemCount / 3);  // Manually coarse clip our print out of individual
+                                           // vertices to save CPU, only items that may be visible.
+                while (clipper.Step())
+                    for (int prim  = clipper.DisplayStart,
+                             idx_i = elem_offset + clipper.DisplayStart * 3;
+                         prim < clipper.DisplayEnd; prim++)
+                    {
+                        char *buf_p = buf, *buf_end = buf + IM_ARRAYSIZE(buf);
+                        ImVec2 triangles_pos[3];
+                        for (int n = 0; n < 3; n++, idx_i++)
+                        {
+                            int vtx_i        = idx_buffer ? idx_buffer[idx_i] : idx_i;
+                            ImDrawVert &v    = draw_list->VtxBuffer[vtx_i];
+                            triangles_pos[n] = v.pos;
+                            buf_p += ImFormatString(
+                                buf_p, buf_end - buf_p,
+                                "%s %04d: pos (%8.2f,%8.2f), uv (%.6f,%.6f), col %08X\n",
+                                (n == 0) ? "elem" : "    ", idx_i, v.pos.x, v.pos.y, v.uv.x, v.uv.y,
+                                v.col);
+                        }
+                        ImGui::Selectable(buf, false);
+                        if (fg_draw_list && ImGui::IsItemHovered())
+                        {
+                            ImDrawListFlags backup_flags = fg_draw_list->Flags;
+                            fg_draw_list->Flags &=
+                                ~ImDrawListFlags_AntiAliasedLines;  // Disable AA on triangle
+                                                                    // outlines at is more readable
+                                                                    // for very large and thin
+                                                                    // triangles.
+                            fg_draw_list->AddPolyline(triangles_pos, 3, IM_COL32(255, 255, 0, 255),
+                                                      true, 1.0f);
+                            fg_draw_list->Flags = backup_flags;
+                        }
+                    }
+                ImGui::TreePop();
+            }
+            ImGui::TreePop();
+        }
+
+        static void NodeColumns(const ImGuiColumns *columns)
+        {
+            if (!ImGui::TreeNode((void *)(uintptr_t)columns->ID,
+                                 "Columns Id: 0x%08X, Count: %d, Flags: 0x%04X", columns->ID,
+                                 columns->Count, columns->Flags))
+                return;
+            ImGui::BulletText("Width: %.1f (MinX: %.1f, MaxX: %.1f)",
+                              columns->OffMaxX - columns->OffMinX, columns->OffMinX,
+                              columns->OffMaxX);
+            for (int column_n = 0; column_n < columns->Columns.Size; column_n++)
+                ImGui::BulletText(
+                    "Column %02d: OffsetNorm %.3f (= %.1f px)", column_n,
+                    columns->Columns[column_n].OffsetNorm,
+                    OffsetNormToPixels(columns, columns->Columns[column_n].OffsetNorm));
+            ImGui::TreePop();
+        }
+
+        static void NodeWindows(ImVector<ImGuiWindow *> &windows, const char *label)
+        {
+            if (!ImGui::TreeNode(label, "%s (%d)", label, windows.Size))
+                return;
+            for (int i = 0; i < windows.Size; i++)
+                Funcs::NodeWindow(windows[i], "Window");
+            ImGui::TreePop();
+        }
+
+        static void NodeWindow(ImGuiWindow *window, const char *label)
+        {
+            if (!ImGui::TreeNode(window, "%s '%s', %d @ 0x%p", label, window->Name,
+                                 window->Active || window->WasActive, window))
+                return;
+            ImGuiWindowFlags flags = window->Flags;
+            NodeDrawList(window, window->DrawList, "DrawList");
+            ImGui::BulletText("Pos: (%.1f,%.1f), Size: (%.1f,%.1f), ContentSize (%.1f,%.1f)",
+                              window->Pos.x, window->Pos.y, window->Size.x, window->Size.y,
+                              window->ContentSize.x, window->ContentSize.y);
+            ImGui::BulletText(
+                "Flags: 0x%08X (%s%s%s%s%s%s%s%s%s..)", flags,
+                (flags & ImGuiWindowFlags_ChildWindow) ? "Child " : "",
+                (flags & ImGuiWindowFlags_Tooltip) ? "Tooltip " : "",
+                (flags & ImGuiWindowFlags_Popup) ? "Popup " : "",
+                (flags & ImGuiWindowFlags_Modal) ? "Modal " : "",
+                (flags & ImGuiWindowFlags_ChildMenu) ? "ChildMenu " : "",
+                (flags & ImGuiWindowFlags_NoSavedSettings) ? "NoSavedSettings " : "",
+                (flags & ImGuiWindowFlags_NoMouseInputs) ? "NoMouseInputs" : "",
+                (flags & ImGuiWindowFlags_NoNavInputs) ? "NoNavInputs" : "",
+                (flags & ImGuiWindowFlags_AlwaysAutoResize) ? "AlwaysAutoResize" : "");
+            ImGui::BulletText("Scroll: (%.2f/%.2f,%.2f/%.2f)", window->Scroll.x,
+                              window->ScrollMax.x, window->Scroll.y, window->ScrollMax.y);
+            ImGui::BulletText(
+                "Active: %d/%d, WriteAccessed: %d, BeginOrderWithinContext: %d", window->Active,
+                window->WasActive, window->WriteAccessed,
+                (window->Active || window->WasActive) ? window->BeginOrderWithinContext : -1);
+            ImGui::BulletText("Appearing: %d, Hidden: %d (CanSkip %d Cannot %d), SkipItems: %d",
+                              window->Appearing, window->Hidden, window->HiddenFramesCanSkipItems,
+                              window->HiddenFramesCannotSkipItems, window->SkipItems);
+            ImGui::BulletText("NavLastIds: 0x%08X,0x%08X, NavLayerActiveMask: %X",
+                              window->NavLastIds[0], window->NavLastIds[1],
+                              window->DC.NavLayerActiveMask);
+            ImGui::BulletText("NavLastChildNavWindow: %s", window->NavLastChildNavWindow
+                                                               ? window->NavLastChildNavWindow->Name
+                                                               : "NULL");
+            if (!window->NavRectRel[0].IsInverted())
+                ImGui::BulletText("NavRectRel[0]: (%.1f,%.1f)(%.1f,%.1f)",
+                                  window->NavRectRel[0].Min.x, window->NavRectRel[0].Min.y,
+                                  window->NavRectRel[0].Max.x, window->NavRectRel[0].Max.y);
+            else
+                ImGui::BulletText("NavRectRel[0]: <None>");
+            if (window->RootWindow != window)
+                NodeWindow(window->RootWindow, "RootWindow");
+            if (window->ParentWindow != NULL)
+                NodeWindow(window->ParentWindow, "ParentWindow");
+            if (window->DC.ChildWindows.Size > 0)
+                NodeWindows(window->DC.ChildWindows, "ChildWindows");
+            if (window->ColumnsStorage.Size > 0 &&
+                ImGui::TreeNode("Columns", "Columns sets (%d)", window->ColumnsStorage.Size))
+            {
+                for (int n = 0; n < window->ColumnsStorage.Size; n++)
+                    NodeColumns(&window->ColumnsStorage[n]);
+                ImGui::TreePop();
+            }
+            ImGui::BulletText("Storage: %d bytes",
+                              window->StateStorage.Data.Size * (int)sizeof(ImGuiStorage::Pair));
+            ImGui::TreePop();
+        }
+
+        static void NodeTabBar(ImGuiTabBar *tab_bar)
+        {
+            // Standalone tab bars (not associated to docking/windows functionality) currently hold
+            // no discernible strings.
+            char buf[256];
+            char *p             = buf;
+            const char *buf_end = buf + IM_ARRAYSIZE(buf);
+            ImFormatString(
+                p, buf_end - p, "TabBar (%d tabs)%s", tab_bar->Tabs.Size,
+                (tab_bar->PrevFrameVisible < ImGui::GetFrameCount() - 2) ? " *Inactive*" : "");
+            if (ImGui::TreeNode(tab_bar, "%s", buf))
+            {
+                for (int tab_n = 0; tab_n < tab_bar->Tabs.Size; tab_n++)
+                {
+                    const ImGuiTabItem *tab = &tab_bar->Tabs[tab_n];
+                    ImGui::PushID(tab);
+                    if (ImGui::SmallButton("<"))
+                    {
+                        TabBarQueueChangeTabOrder(tab_bar, tab, -1);
+                    }
+                    ImGui::SameLine(0, 2);
+                    if (ImGui::SmallButton(">"))
+                    {
+                        TabBarQueueChangeTabOrder(tab_bar, tab, +1);
+                    }
+                    ImGui::SameLine();
+                    ImGui::Text("%02d%c Tab 0x%08X", tab_n,
+                                (tab->ID == tab_bar->SelectedTabId) ? '*' : ' ', tab->ID);
+                    ImGui::PopID();
+                }
+                ImGui::TreePop();
+            }
+        }
+    };
+
+    // Access private state, we are going to display the draw lists from last frame
+    ImGuiContext &g = *GImGui;
+    Funcs::NodeWindows(g.Windows, "Windows");
+    if (ImGui::TreeNode("DrawList", "Active DrawLists (%d)", g.DrawDataBuilder.Layers[0].Size))
+    {
+        for (int i = 0; i < g.DrawDataBuilder.Layers[0].Size; i++)
+            Funcs::NodeDrawList(NULL, g.DrawDataBuilder.Layers[0][i], "DrawList");
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Popups", "Popups (%d)", g.OpenPopupStack.Size))
+    {
+        for (int i = 0; i < g.OpenPopupStack.Size; i++)
+        {
+            ImGuiWindow *window = g.OpenPopupStack[i].Window;
+            ImGui::BulletText(
+                "PopupID: %08x, Window: '%s'%s%s", g.OpenPopupStack[i].PopupId,
+                window ? window->Name : "NULL",
+                window && (window->Flags & ImGuiWindowFlags_ChildWindow) ? " ChildWindow" : "",
+                window && (window->Flags & ImGuiWindowFlags_ChildMenu) ? " ChildMenu" : "");
+        }
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("TabBars", "Tab Bars (%d)", g.TabBars.Data.Size))
+    {
+        for (int n = 0; n < g.TabBars.Data.Size; n++)
+            Funcs::NodeTabBar(g.TabBars.GetByIndex(n));
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Internal state"))
+    {
+        const char *input_source_names[] = {"None", "Mouse", "Nav", "NavKeyboard", "NavGamepad"};
+        IM_ASSERT(IM_ARRAYSIZE(input_source_names) == ImGuiInputSource_COUNT);
+        ImGui::Text("HoveredWindow: '%s'", g.HoveredWindow ? g.HoveredWindow->Name : "NULL");
+        ImGui::Text("HoveredRootWindow: '%s'",
+                    g.HoveredRootWindow ? g.HoveredRootWindow->Name : "NULL");
+        ImGui::Text("HoveredId: 0x%08X/0x%08X (%.2f sec), AllowOverlap: %d", g.HoveredId,
+                    g.HoveredIdPreviousFrame, g.HoveredIdTimer,
+                    g.HoveredIdAllowOverlap);  // Data is "in-flight" so depending on when the
+                                               // Metrics window is called we may see current frame
+                                               // information or not
+        ImGui::Text("ActiveId: 0x%08X/0x%08X (%.2f sec), AllowOverlap: %d, Source: %s", g.ActiveId,
+                    g.ActiveIdPreviousFrame, g.ActiveIdTimer, g.ActiveIdAllowOverlap,
+                    input_source_names[g.ActiveIdSource]);
+        ImGui::Text("ActiveIdWindow: '%s'", g.ActiveIdWindow ? g.ActiveIdWindow->Name : "NULL");
+        ImGui::Text("MovingWindow: '%s'", g.MovingWindow ? g.MovingWindow->Name : "NULL");
+        ImGui::Text("NavWindow: '%s'", g.NavWindow ? g.NavWindow->Name : "NULL");
+        ImGui::Text("NavId: 0x%08X, NavLayer: %d", g.NavId, g.NavLayer);
+        ImGui::Text("NavInputSource: %s", input_source_names[g.NavInputSource]);
+        ImGui::Text("NavActive: %d, NavVisible: %d", g.IO.NavActive, g.IO.NavVisible);
+        ImGui::Text("NavActivateId: 0x%08X, NavInputId: 0x%08X", g.NavActivateId, g.NavInputId);
+        ImGui::Text("NavDisableHighlight: %d, NavDisableMouseHover: %d", g.NavDisableHighlight,
+                    g.NavDisableMouseHover);
+        ImGui::Text("NavWindowingTarget: '%s'",
+                    g.NavWindowingTarget ? g.NavWindowingTarget->Name : "NULL");
+        ImGui::Text("DragDrop: %d, SourceId = 0x%08X, Payload \"%s\" (%d bytes)", g.DragDropActive,
+                    g.DragDropPayload.SourceId, g.DragDropPayload.DataType,
+                    g.DragDropPayload.DataSize);
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Tools"))
+    {
+        ImGui::Checkbox("Show windows begin order", &show_windows_begin_order);
+        ImGui::Checkbox("Show windows rectangles", &show_windows_rects);
+        ImGui::SameLine();
+        ImGui::SetNextItemWidth(ImGui::GetFontSize() * 12);
+        show_windows_rects |= ImGui::Combo("##show_windows_rect_type", &show_windows_rect_type,
+                                           wrt_rects_names, WRT_Count);
+        if (show_windows_rects && g.NavWindow)
+        {
+            ImGui::BulletText("'%s':", g.NavWindow->Name);
+            ImGui::Indent();
+            for (int rect_n = 0; rect_n < WRT_Count; rect_n++)
+            {
+                ImRect r = Funcs::GetWindowRect(g.NavWindow, rect_n);
+                ImGui::Text("(%6.1f,%6.1f) (%6.1f,%6.1f) Size (%6.1f,%6.1f) %s", r.Min.x, r.Min.y,
+                            r.Max.x, r.Max.y, r.GetWidth(), r.GetHeight(), wrt_rects_names[rect_n]);
+            }
+            ImGui::Unindent();
+        }
+        ImGui::Checkbox("Show clipping rectangle when hovering ImDrawCmd node",
+                        &show_drawcmd_clip_rects);
+        ImGui::TreePop();
+    }
+
+    if (show_windows_rects || show_windows_begin_order)
+    {
+        for (int n = 0; n < g.Windows.Size; n++)
+        {
+            ImGuiWindow *window = g.Windows[n];
+            if (!window->WasActive)
+                continue;
+            ImDrawList *draw_list = GetForegroundDrawList(window);
+            if (show_windows_rects)
+            {
+                ImRect r = Funcs::GetWindowRect(window, show_windows_rect_type);
+                draw_list->AddRect(r.Min, r.Max, IM_COL32(255, 0, 128, 255));
+            }
+            if (show_windows_begin_order && !(window->Flags & ImGuiWindowFlags_ChildWindow))
+            {
+                char buf[32];
+                ImFormatString(buf, IM_ARRAYSIZE(buf), "%d", window->BeginOrderWithinContext);
+                float font_size = ImGui::GetFontSize();
+                draw_list->AddRectFilled(window->Pos, window->Pos + ImVec2(font_size, font_size),
+                                         IM_COL32(200, 100, 100, 255));
+                draw_list->AddText(window->Pos, IM_COL32(255, 255, 255, 255), buf);
+            }
+        }
+    }
+    ImGui::End();
+}
+#else
+void ImGui::ShowMetricsWindow(bool *) {}
+#endif
+
+//-----------------------------------------------------------------------------
+
+// Include imgui_user.inl at the end of imgui.cpp to access private data/functions that aren't
+// exposed. Prefer just including imgui_internal.h from your code rather than using this define. If
+// a declaration is missing from imgui_internal.h add it or request it on the github.
+#ifdef IMGUI_INCLUDE_IMGUI_USER_INL
+#include "imgui_user.inl"
+#endif
+
+//-----------------------------------------------------------------------------

--- a/third_party/imgui/imgui.h
+++ b/third_party/imgui/imgui.h
@@ -1,0 +1,4243 @@
+// dear imgui, v1.72 WIP
+// (headers)
+
+// See imgui.cpp file for documentation.
+// Call and read ImGui::ShowDemoWindow() in imgui_demo.cpp for demo code.
+// Newcomers, read 'Programmer guide' in imgui.cpp for notes on how to setup Dear ImGui in your
+// codebase. Get latest version at https://github.com/ocornut/imgui
+
+/*
+
+Index of this file:
+// Header mess
+// Forward declarations and basic types
+// ImGui API (Dear ImGui end-user API)
+// Flags & Enumerations
+// Memory allocations macros
+// ImVector<>
+// ImGuiStyle
+// ImGuiIO
+// Misc data structures (ImGuiInputTextCallbackData, ImGuiSizeCallbackData, ImGuiPayload)
+// Obsolete functions
+// Helpers (ImGuiOnceUponAFrame, ImGuiTextFilter, ImGuiTextBuffer, ImGuiStorage, ImGuiListClipper,
+ImColor)
+// Draw List API (ImDrawCallback, ImDrawCmd, ImDrawIdx, ImDrawVert, ImDrawChannel,
+ImDrawListSplitter, ImDrawListFlags, ImDrawList, ImDrawData)
+// Font API (ImFontConfig, ImFontGlyph, ImFontGlyphRangesBuilder, ImFontAtlasFlags, ImFontAtlas,
+ImFont)
+
+*/
+
+#pragma once
+
+// Configuration file with compile-time options (edit imconfig.h or define IMGUI_USER_CONFIG to your
+// own filename)
+#ifdef IMGUI_USER_CONFIG
+#include IMGUI_USER_CONFIG
+#endif
+#if !defined(IMGUI_DISABLE_INCLUDE_IMCONFIG_H) || defined(IMGUI_INCLUDE_IMCONFIG_H)
+#include "imconfig.h"
+#endif
+
+//-----------------------------------------------------------------------------
+// Header mess
+//-----------------------------------------------------------------------------
+
+#include <float.h>   // FLT_MAX
+#include <stdarg.h>  // va_list
+#include <stddef.h>  // ptrdiff_t, NULL
+#include <string.h>  // memset, memmove, memcpy, strlen, strchr, strcpy, strcmp
+
+// Version
+// (Integer encoded as XYYZZ for use in #if preprocessor conditionals. Work in progress versions
+// typically starts at XYY99 then bounce up to XYY00, XYY01 etc. when release tagging happens)
+#define IMGUI_VERSION "1.72 WIP"
+#define IMGUI_VERSION_NUM 17101
+#define IMGUI_CHECKVERSION()                                                                  \
+    ImGui::DebugCheckVersionAndDataLayout(IMGUI_VERSION, sizeof(ImGuiIO), sizeof(ImGuiStyle), \
+                                          sizeof(ImVec2), sizeof(ImVec4), sizeof(ImDrawVert), \
+                                          sizeof(ImDrawIdx))
+
+// Define attributes of all API symbols declarations (e.g. for DLL under Windows)
+// IMGUI_API is used for core imgui functions, IMGUI_IMPL_API is used for the default bindings files
+// (imgui_impl_xxx.h) Using dear imgui via a shared library is not recommended, because of function
+// call overhead and because we don't guarantee backward nor forward ABI compatibility.
+#ifndef IMGUI_API
+#define IMGUI_API
+#endif
+#ifndef IMGUI_IMPL_API
+#define IMGUI_IMPL_API IMGUI_API
+#endif
+
+// Helper Macros
+#ifndef IM_ASSERT
+#include <assert.h>
+#define IM_ASSERT(_EXPR) \
+    assert(_EXPR)  // You can override the default assert handler by editing imconfig.h
+#endif
+#if defined(__clang__) || defined(__GNUC__)
+#define IM_FMTARGS(FMT) \
+    __attribute__((format(printf, FMT, FMT + 1)))  // Apply printf-style warnings to user functions.
+#define IM_FMTLIST(FMT) __attribute__((format(printf, FMT, 0)))
+#else
+#define IM_FMTARGS(FMT)
+#define IM_FMTLIST(FMT)
+#endif
+#define IM_ARRAYSIZE(_ARR) \
+    ((int)(sizeof(_ARR) / sizeof(*_ARR)))  // Size of a static C-style array. Don't use on pointers!
+#define IM_OFFSETOF(_TYPE, _MEMBER) \
+    ((size_t) & (((_TYPE *)0)->_MEMBER))  // Offset of _MEMBER within _TYPE. Standardized as
+                                          // offsetof() in modern C++.
+#define IM_UNUSED(_VAR) \
+    ((void)_VAR)  // Used to silence "unused variable warnings". Often useful as asserts may be
+                  // stripped out from final builds.
+
+// Warnings
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#if __has_warning("-Wzero-as-null-pointer-constant")
+#pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
+#endif
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored \
+    "-Wpragmas"  // warning: unknown option after '#pragma GCC diagnostic' kind
+#pragma GCC diagnostic ignored \
+    "-Wclass-memaccess"  // [__GNUC__ >= 8] warning: 'memset/memcpy' clearing/writing an object of
+                         // type 'xxxx' with no trivial copy-assignment; use assignment or
+                         // value-initialization instead
+#endif
+
+//-----------------------------------------------------------------------------
+// Forward declarations and basic types
+//-----------------------------------------------------------------------------
+
+struct ImDrawChannel;  // Temporary storage to output draw commands out of order, used by
+                       // ImDrawListSplitter and ImDrawList::ChannelsSplit()
+struct ImDrawCmd;  // A single draw command within a parent ImDrawList (generally maps to 1 GPU draw
+                   // call, unless it is a callback)
+struct ImDrawData;  // All draw command lists required to render the frame + pos/size coordinates to
+                    // use for the projection matrix.
+struct ImDrawList;  // A single draw command list (generally one per window, conceptually you may
+                    // see this as a dynamic "mesh" builder)
+struct ImDrawListSharedData;  // Data shared among multiple draw lists (typically owned by parent
+                              // ImGui context, but you may create one yourself)
+struct ImDrawListSplitter;  // Helper to split a draw list into different layers which can be drawn
+                            // into out of order, then flattened back.
+struct ImDrawVert;    // A single vertex (pos + uv + col = 20 bytes by default. Override layout with
+                      // IMGUI_OVERRIDE_DRAWVERT_STRUCT_LAYOUT)
+struct ImFont;        // Runtime data for a single font within a parent ImFontAtlas
+struct ImFontAtlas;   // Runtime data for multiple fonts, bake multiple fonts into a single texture,
+                      // TTF/OTF font loader
+struct ImFontConfig;  // Configuration data when adding a font or merging fonts
+struct ImFontGlyph;   // A single font glyph (code point + coordinates within in ImFontAtlas +
+                      // offset)
+struct ImFontGlyphRangesBuilder;  // Helper to build glyph ranges from text/string data
+struct ImColor;  // Helper functions to create a color that can be converted to either u32 or float4
+                 // (*OBSOLETE* please avoid using)
+struct ImGuiContext;  // Dear ImGui context (opaque structure, unless including imgui_internal.h)
+struct ImGuiIO;       // Main configuration and I/O between your application and ImGui
+struct ImGuiInputTextCallbackData;  // Shared state of InputText() when using custom
+                                    // ImGuiInputTextCallback (rare/advanced use)
+struct ImGuiListClipper;            // Helper to manually clip large list of items
+struct ImGuiOnceUponAFrame;  // Helper for running a block of code not more than once a frame, used
+                             // by IMGUI_ONCE_UPON_A_FRAME macro
+struct ImGuiPayload;         // User data payload for drag and drop operations
+struct ImGuiSizeCallbackData;  // Callback data when using SetNextWindowSizeConstraints()
+                               // (rare/advanced use)
+struct ImGuiStorage;           // Helper for key->value storage
+struct ImGuiStyle;             // Runtime data for styling/colors
+struct ImGuiTextBuffer;        // Helper to hold and append into a text buffer (~string builder)
+struct ImGuiTextFilter;  // Helper to parse and apply text filters (e.g. "aaaaa[,bbbb][,ccccc]")
+
+// Typedefs and Enums/Flags (declared as int for compatibility with old C++, to allow using as flags
+// and to not pollute the top of this file) Use your programming IDE "Go to definition" facility on
+// the names of the center columns to find the actual flags/enum lists.
+#ifndef ImTextureID
+typedef void *ImTextureID;  // User data to identify a texture (this is whatever to you want it to
+                            // be! read the FAQ about ImTextureID in imgui.cpp)
+#endif
+typedef unsigned int
+    ImGuiID;  // Unique ID used by widgets (typically hashed from a stack of string)
+typedef unsigned short ImWchar;  // A single U16 character for keyboard input/display. We encode
+                                 // them as multi bytes UTF-8 when used in strings.
+typedef int ImGuiCol;       // -> enum ImGuiCol_             // Enum: A color identifier for styling
+typedef int ImGuiCond;      // -> enum ImGuiCond_            // Enum: A condition for Set*()
+typedef int ImGuiDataType;  // -> enum ImGuiDataType_        // Enum: A primary data type
+typedef int ImGuiDir;       // -> enum ImGuiDir_             // Enum: A cardinal direction
+typedef int ImGuiKey;  // -> enum ImGuiKey_             // Enum: A key identifier (ImGui-side enum)
+typedef int
+    ImGuiNavInput;  // -> enum ImGuiNavInput_        // Enum: An input identifier for navigation
+typedef int ImGuiMouseCursor;  // -> enum ImGuiMouseCursor_     // Enum: A mouse cursor identifier
+typedef int
+    ImGuiStyleVar;  // -> enum ImGuiStyleVar_        // Enum: A variable identifier for styling
+typedef int
+    ImDrawCornerFlags;  // -> enum ImDrawCornerFlags_    // Flags: for ImDrawList::AddRect*() etc.
+typedef int ImDrawListFlags;      // -> enum ImDrawListFlags_      // Flags: for ImDrawList
+typedef int ImFontAtlasFlags;     // -> enum ImFontAtlasFlags_     // Flags: for ImFontAtlas
+typedef int ImGuiBackendFlags;    // -> enum ImGuiBackendFlags_    // Flags: for io.BackendFlags
+typedef int ImGuiColorEditFlags;  // -> enum ImGuiColorEditFlags_  // Flags: for ColorEdit*(),
+                                  // ColorPicker*()
+typedef int
+    ImGuiColumnsFlags;  // -> enum ImGuiColumnsFlags_    // Flags: for Columns(), BeginColumns()
+typedef int ImGuiConfigFlags;      // -> enum ImGuiConfigFlags_     // Flags: for io.ConfigFlags
+typedef int ImGuiComboFlags;       // -> enum ImGuiComboFlags_      // Flags: for BeginCombo()
+typedef int ImGuiDragDropFlags;    // -> enum ImGuiDragDropFlags_   // Flags: for *DragDrop*()
+typedef int ImGuiFocusedFlags;     // -> enum ImGuiFocusedFlags_    // Flags: for IsWindowFocused()
+typedef int ImGuiHoveredFlags;     // -> enum ImGuiHoveredFlags_    // Flags: for IsItemHovered(),
+                                   // IsWindowHovered() etc.
+typedef int ImGuiInputTextFlags;   // -> enum ImGuiInputTextFlags_  // Flags: for InputText*()
+typedef int ImGuiSelectableFlags;  // -> enum ImGuiSelectableFlags_ // Flags: for Selectable()
+typedef int ImGuiTabBarFlags;      // -> enum ImGuiTabBarFlags_     // Flags: for BeginTabBar()
+typedef int ImGuiTabItemFlags;     // -> enum ImGuiTabItemFlags_    // Flags: for BeginTabItem()
+typedef int ImGuiTreeNodeFlags;    // -> enum ImGuiTreeNodeFlags_   // Flags: for
+                                   // TreeNode*(),CollapsingHeader()
+typedef int ImGuiWindowFlags;      // -> enum ImGuiWindowFlags_     // Flags: for Begin*()
+typedef int (*ImGuiInputTextCallback)(ImGuiInputTextCallbackData *data);
+typedef void (*ImGuiSizeCallback)(ImGuiSizeCallbackData *data);
+
+// Scalar data types
+typedef signed char ImS8;      // 8-bit signed integer == char
+typedef unsigned char ImU8;    // 8-bit unsigned integer
+typedef signed short ImS16;    // 16-bit signed integer
+typedef unsigned short ImU16;  // 16-bit unsigned integer
+typedef signed int ImS32;      // 32-bit signed integer == int
+typedef unsigned int ImU32;    // 32-bit unsigned integer (often used to store packed colors)
+#if defined(_MSC_VER) && !defined(__clang__)
+typedef signed __int64 ImS64;    // 64-bit signed integer (pre and post C++11 with Visual Studio)
+typedef unsigned __int64 ImU64;  // 64-bit unsigned integer (pre and post C++11 with Visual Studio)
+#elif (defined(__clang__) || defined(__GNUC__)) && (__cplusplus < 201100)
+#include <stdint.h>
+typedef int64_t ImS64;   // 64-bit signed integer (pre C++11)
+typedef uint64_t ImU64;  // 64-bit unsigned integer (pre C++11)
+#else
+typedef signed long long ImS64;    // 64-bit signed integer (post C++11)
+typedef unsigned long long ImU64;  // 64-bit unsigned integer (post C++11)
+#endif
+
+// 2D vector (often used to store positions, sizes, etc.)
+struct ImVec2
+{
+    float x, y;
+    ImVec2() { x = y = 0.0f; }
+    ImVec2(float _x, float _y)
+    {
+        x = _x;
+        y = _y;
+    }
+    float operator[](size_t idx) const
+    {
+        IM_ASSERT(idx <= 1);
+        return (&x)[idx];
+    }  // We very rarely use this [] operator, the assert overhead is fine.
+    float &operator[](size_t idx)
+    {
+        IM_ASSERT(idx <= 1);
+        return (&x)[idx];
+    }  // We very rarely use this [] operator, the assert overhead is fine.
+#ifdef IM_VEC2_CLASS_EXTRA
+    IM_VEC2_CLASS_EXTRA  // Define additional constructors and implicit cast operators in imconfig.h
+                         // to convert back and forth between your math types and ImVec2.
+#endif
+};
+
+// 4D vector (often used to store floating-point colors)
+struct ImVec4
+{
+    float x, y, z, w;
+    ImVec4() { x = y = z = w = 0.0f; }
+    ImVec4(float _x, float _y, float _z, float _w)
+    {
+        x = _x;
+        y = _y;
+        z = _z;
+        w = _w;
+    }
+#ifdef IM_VEC4_CLASS_EXTRA
+    IM_VEC4_CLASS_EXTRA  // Define additional constructors and implicit cast operators in imconfig.h
+                         // to convert back and forth between your math types and ImVec4.
+#endif
+};
+
+//-----------------------------------------------------------------------------
+// ImGui: Dear ImGui end-user API
+// (Inside a namespace so you can add extra functions in your own separate file. Please don't modify
+// imgui.cpp/.h!)
+//-----------------------------------------------------------------------------
+
+namespace ImGui
+{
+// Context creation and access
+// Each context create its own ImFontAtlas by default. You may instance one yourself and pass it to
+// CreateContext() to share a font atlas between imgui contexts. All those functions are not reliant
+// on the current context.
+IMGUI_API ImGuiContext *CreateContext(ImFontAtlas *shared_font_atlas = NULL);
+IMGUI_API void DestroyContext(ImGuiContext *ctx = NULL);  // NULL = destroy current context
+IMGUI_API ImGuiContext *GetCurrentContext();
+IMGUI_API void SetCurrentContext(ImGuiContext *ctx);
+IMGUI_API bool DebugCheckVersionAndDataLayout(const char *version_str,
+                                              size_t sz_io,
+                                              size_t sz_style,
+                                              size_t sz_vec2,
+                                              size_t sz_vec4,
+                                              size_t sz_drawvert,
+                                              size_t sz_drawidx);
+
+// Main
+IMGUI_API ImGuiIO &GetIO();        // access the IO structure (mouse/keyboard/gamepad inputs, time,
+                                   // various configuration options/flags)
+IMGUI_API ImGuiStyle &GetStyle();  // access the Style structure (colors, sizes). Always use
+                                   // PushStyleCol(), PushStyleVar() to modify style mid-frame.
+IMGUI_API void NewFrame();  // start a new Dear ImGui frame, you can submit any command from this
+                            // point until Render()/EndFrame().
+IMGUI_API void EndFrame();  // ends the Dear ImGui frame. automatically called by Render(), you
+                            // likely don't need to call that yourself directly. If you don't need
+                            // to render data (skipping rendering) you may call EndFrame() but
+                            // you'll have wasted CPU already! If you don't need to render, better
+                            // to not create any imgui windows and not call NewFrame() at all!
+IMGUI_API void Render();    // ends the Dear ImGui frame, finalize the draw data. You can get call
+                          // GetDrawData() to obtain it and run your rendering function. (Obsolete:
+                          // this used to call io.RenderDrawListsFn(). Nowadays, we allow and prefer
+                          // calling your render function yourself.)
+IMGUI_API ImDrawData *GetDrawData();  // valid after Render() and until the next call to NewFrame().
+                                      // this is what you have to render.
+
+// Demo, Debug, Information
+IMGUI_API void ShowDemoWindow(
+    bool *p_open = NULL);  // create Demo window (previously called ShowTestWindow). demonstrate
+                           // most ImGui features. call this to learn about the library! try to make
+                           // it always available in your application!
+IMGUI_API void ShowAboutWindow(
+    bool *p_open = NULL);  // create About window. display Dear ImGui version, credits and
+                           // build/system information.
+IMGUI_API void ShowMetricsWindow(
+    bool *p_open =
+        NULL);  // create Metrics/Debug window. display Dear ImGui internals: draw commands (with
+                // individual draw calls and vertices), window list, basic internal state, etc.
+IMGUI_API void ShowStyleEditor(
+    ImGuiStyle *ref =
+        NULL);  // add style editor block (not a window). you can pass in a reference ImGuiStyle
+                // structure to compare to, revert to and save to (else it uses the default style)
+IMGUI_API bool ShowStyleSelector(
+    const char *label);  // add style selector block (not a window), essentially a combo listing the
+                         // default styles.
+IMGUI_API void ShowFontSelector(
+    const char *label);  // add font selector block (not a window), essentially a combo listing the
+                         // loaded fonts.
+IMGUI_API void ShowUserGuide();      // add basic help/info block (not a window): how to manipulate
+                                     // ImGui as a end-user (mouse/keyboard controls).
+IMGUI_API const char *GetVersion();  // get the compiled version string e.g. "1.23" (essentially the
+                                     // compiled value for IMGUI_VERSION)
+
+// Styles
+IMGUI_API void StyleColorsDark(ImGuiStyle *dst = NULL);     // new, recommended style (default)
+IMGUI_API void StyleColorsClassic(ImGuiStyle *dst = NULL);  // classic imgui style
+IMGUI_API void StyleColorsLight(
+    ImGuiStyle *dst = NULL);  // best used with borders and a custom, thicker font
+
+// Windows
+// - Begin() = push window to the stack and start appending to it. End() = pop window from the
+// stack.
+// - You may append multiple times to the same window during the same frame.
+// - Passing 'bool* p_open != NULL' shows a window-closing widget in the upper-right corner of the
+// window,
+//   which clicking will set the boolean to false when clicked.
+// - Begin() return false to indicate the window is collapsed or fully clipped, so you may early out
+// and omit submitting
+//   anything to the window. Always call a matching End() for each Begin() call, regardless of its
+//   return value! [this is due to legacy reason and is inconsistent with most other functions such
+//   as BeginMenu/EndMenu, BeginPopup/EndPopup, etc.
+//    where the EndXXX call should only be called if the corresponding BeginXXX function returned
+//    true.]
+// - Note that the bottom of window stack always contains a window called "Debug".
+IMGUI_API bool Begin(const char *name, bool *p_open = NULL, ImGuiWindowFlags flags = 0);
+IMGUI_API void End();
+
+// Child Windows
+// - Use child windows to begin into a self-contained independent scrolling/clipping regions within
+// a host window. Child windows can embed their own child.
+// - For each independent axis of 'size': ==0.0f: use remaining host window size / >0.0f: fixed size
+// / <0.0f: use remaining window size minus abs(size) / Each axis can use a different mode, e.g.
+// ImVec2(0,400).
+// - BeginChild() returns false to indicate the window is collapsed or fully clipped, so you may
+// early out and omit submitting anything to the window.
+//   Always call a matching EndChild() for each BeginChild() call, regardless of its return value
+//   [this is due to legacy reason and is inconsistent with most other functions such as
+//   BeginMenu/EndMenu, BeginPopup/EndPopup, etc. where the EndXXX call should only be called if the
+//   corresponding BeginXXX function returned true.]
+IMGUI_API bool BeginChild(const char *str_id,
+                          const ImVec2 &size     = ImVec2(0, 0),
+                          bool border            = false,
+                          ImGuiWindowFlags flags = 0);
+IMGUI_API bool BeginChild(ImGuiID id,
+                          const ImVec2 &size     = ImVec2(0, 0),
+                          bool border            = false,
+                          ImGuiWindowFlags flags = 0);
+IMGUI_API void EndChild();
+
+// Windows Utilities
+// - "current window" = the window we are appending into while inside a Begin()/End() block. "next
+// window" = next window we will Begin() into.
+IMGUI_API bool IsWindowAppearing();
+IMGUI_API bool IsWindowCollapsed();
+IMGUI_API bool IsWindowFocused(
+    ImGuiFocusedFlags flags = 0);  // is current window focused? or its root/child, depending on
+                                   // flags. see flags for options.
+IMGUI_API bool IsWindowHovered(
+    ImGuiHoveredFlags flags =
+        0);  // is current window hovered (and typically: not blocked by a popup/modal)? see flags
+             // for options. NB: If you are trying to check whether your mouse should be dispatched
+             // to imgui or to your app, you should use the 'io.WantCaptureMouse' boolean for that!
+             // Please read the FAQ!
+IMGUI_API ImDrawList *GetWindowDrawList();  // get draw list associated to the current window, to
+                                            // append your own drawing primitives
+IMGUI_API ImVec2 GetWindowPos();  // get current window position in screen space (useful if you want
+                                  // to do your own drawing via the DrawList API)
+IMGUI_API ImVec2 GetWindowSize();   // get current window size
+IMGUI_API float GetWindowWidth();   // get current window width (shortcut for GetWindowSize().x)
+IMGUI_API float GetWindowHeight();  // get current window height (shortcut for GetWindowSize().y)
+
+// Prefer using SetNextXXX functions (before Begin) rather that SetXXX functions (after Begin).
+IMGUI_API void SetNextWindowPos(
+    const ImVec2 &pos,
+    ImGuiCond cond      = 0,
+    const ImVec2 &pivot = ImVec2(0, 0));  // set next window position. call before Begin(). use
+                                          // pivot=(0.5f,0.5f) to center on given point, etc.
+IMGUI_API void SetNextWindowSize(
+    const ImVec2 &size,
+    ImGuiCond cond = 0);  // set next window size. set axis to 0.0f to force an auto-fit on this
+                          // axis. call before Begin()
+IMGUI_API void SetNextWindowSizeConstraints(
+    const ImVec2 &size_min,
+    const ImVec2 &size_max,
+    ImGuiSizeCallback custom_callback = NULL,
+    void *custom_callback_data =
+        NULL);  // set next window size limits. use -1,-1 on either X/Y axis to preserve the current
+                // size. Sizes will be rounded down. Use callback to apply non-trivial programmatic
+                // constraints.
+IMGUI_API void SetNextWindowContentSize(
+    const ImVec2
+        &size);  // set next window content size (~ scrollable client area, which enforce the range
+                 // of scrollbars). Not including window decorations (title bar, menu bar, etc.) nor
+                 // WindowPadding. set an axis to 0.0f to leave it automatic. call before Begin()
+IMGUI_API void SetNextWindowCollapsed(
+    bool collapsed,
+    ImGuiCond cond = 0);  // set next window collapsed state. call before Begin()
+IMGUI_API void
+SetNextWindowFocus();  // set next window to be focused / top-most. call before Begin()
+IMGUI_API void SetNextWindowBgAlpha(
+    float alpha);  // set next window background color alpha. helper to easily modify
+                   // ImGuiCol_WindowBg/ChildBg/PopupBg. you may also use
+                   // ImGuiWindowFlags_NoBackground.
+IMGUI_API void SetWindowPos(
+    const ImVec2 &pos,
+    ImGuiCond cond =
+        0);  // (not recommended) set current window position - call within Begin()/End(). prefer
+             // using SetNextWindowPos(), as this may incur tearing and side-effects.
+IMGUI_API void SetWindowSize(
+    const ImVec2 &size,
+    ImGuiCond cond = 0);  // (not recommended) set current window size - call within Begin()/End().
+                          // set to ImVec2(0,0) to force an auto-fit. prefer using
+                          // SetNextWindowSize(), as this may incur tearing and minor side-effects.
+IMGUI_API void SetWindowCollapsed(
+    bool collapsed,
+    ImGuiCond cond = 0);  // (not recommended) set current window collapsed state. prefer using
+                          // SetNextWindowCollapsed().
+IMGUI_API void SetWindowFocus();  // (not recommended) set current window to be focused / top-most.
+                                  // prefer using SetNextWindowFocus().
+IMGUI_API void SetWindowFontScale(
+    float scale);  // set font scale. Adjust IO.FontGlobalScale if you want to scale all windows
+IMGUI_API void SetWindowPos(const char *name,
+                            const ImVec2 &pos,
+                            ImGuiCond cond = 0);  // set named window position.
+IMGUI_API void SetWindowSize(const char *name,
+                             const ImVec2 &size,
+                             ImGuiCond cond = 0);  // set named window size. set axis to 0.0f to
+                                                   // force an auto-fit on this axis.
+IMGUI_API void SetWindowCollapsed(const char *name,
+                                  bool collapsed,
+                                  ImGuiCond cond = 0);  // set named window collapsed state
+IMGUI_API void SetWindowFocus(
+    const char *name);  // set named window to be focused / top-most. use NULL to remove focus.
+
+// Content region
+// - Those functions are bound to be redesigned soon (they are confusing, incomplete and return
+// values in local window coordinates which increases confusion)
+IMGUI_API ImVec2
+GetContentRegionMax();  // current content boundaries (typically window boundaries including
+                        // scrolling, or current column boundaries), in windows coordinates
+IMGUI_API ImVec2 GetContentRegionAvail();      // == GetContentRegionMax() - GetCursorPos()
+IMGUI_API ImVec2 GetWindowContentRegionMin();  // content boundaries min (roughly (0,0)-Scroll), in
+                                               // window coordinates
+IMGUI_API ImVec2
+GetWindowContentRegionMax();  // content boundaries max (roughly (0,0)+Size-Scroll) where Size can
+                              // be override with SetNextWindowContentSize(), in window coordinates
+IMGUI_API float GetWindowContentRegionWidth();  //
+
+// Windows Scrolling
+IMGUI_API float GetScrollX();     // get scrolling amount [0..GetScrollMaxX()]
+IMGUI_API float GetScrollY();     // get scrolling amount [0..GetScrollMaxY()]
+IMGUI_API float GetScrollMaxX();  // get maximum scrolling amount ~~ ContentSize.X - WindowSize.X
+IMGUI_API float GetScrollMaxY();  // get maximum scrolling amount ~~ ContentSize.Y - WindowSize.Y
+IMGUI_API void SetScrollX(float scroll_x);  // set scrolling amount [0..GetScrollMaxX()]
+IMGUI_API void SetScrollY(float scroll_y);  // set scrolling amount [0..GetScrollMaxY()]
+IMGUI_API void SetScrollHereX(
+    float center_x_ratio =
+        0.5f);  // adjust scrolling amount to make current cursor position visible.
+                // center_x_ratio=0.0: left, 0.5: center, 1.0: right. When using to make a
+                // "default/current item" visible, consider using SetItemDefaultFocus() instead.
+IMGUI_API void SetScrollHereY(
+    float center_y_ratio =
+        0.5f);  // adjust scrolling amount to make current cursor position visible.
+                // center_y_ratio=0.0: top, 0.5: center, 1.0: bottom. When using to make a
+                // "default/current item" visible, consider using SetItemDefaultFocus() instead.
+IMGUI_API void SetScrollFromPosX(
+    float local_x,
+    float center_x_ratio =
+        0.5f);  // adjust scrolling amount to make given position visible. Generally
+                // GetCursorStartPos() + offset to compute a valid position.
+IMGUI_API void SetScrollFromPosY(
+    float local_y,
+    float center_y_ratio =
+        0.5f);  // adjust scrolling amount to make given position visible. Generally
+                // GetCursorStartPos() + offset to compute a valid position.
+
+// Parameters stacks (shared)
+IMGUI_API void PushFont(ImFont *font);  // use NULL as a shortcut to push default font
+IMGUI_API void PopFont();
+IMGUI_API void PushStyleColor(ImGuiCol idx, ImU32 col);
+IMGUI_API void PushStyleColor(ImGuiCol idx, const ImVec4 &col);
+IMGUI_API void PopStyleColor(int count = 1);
+IMGUI_API void PushStyleVar(ImGuiStyleVar idx, float val);
+IMGUI_API void PushStyleVar(ImGuiStyleVar idx, const ImVec2 &val);
+IMGUI_API void PopStyleVar(int count = 1);
+IMGUI_API const ImVec4 &GetStyleColorVec4(
+    ImGuiCol idx);  // retrieve style color as stored in ImGuiStyle structure. use to feed back into
+                    // PushStyleColor(), otherwise use GetColorU32() to get style color with style
+                    // alpha baked in.
+IMGUI_API ImFont *GetFont();    // get current font
+IMGUI_API float GetFontSize();  // get current font size (= height in pixels) of current font with
+                                // current scale applied
+IMGUI_API ImVec2 GetFontTexUvWhitePixel();  // get UV coordinate for a while pixel, useful to draw
+                                            // custom shapes via the ImDrawList API
+IMGUI_API ImU32 GetColorU32(ImGuiCol idx,
+                            float alpha_mul = 1.0f);  // retrieve given style color with style alpha
+                                                      // applied and optional extra alpha multiplier
+IMGUI_API ImU32 GetColorU32(const ImVec4 &col);  // retrieve given color with style alpha applied
+IMGUI_API ImU32 GetColorU32(ImU32 col);          // retrieve given color with style alpha applied
+
+// Parameters stacks (current window)
+IMGUI_API void PushItemWidth(
+    float item_width);  // set width of items for common large "item+label" widgets. >0.0f: width in
+                        // pixels, <0.0f align xx pixels to the right of window (so -1.0f always
+                        // align width to the right side). 0.0f = default to ~2/3 of windows width,
+IMGUI_API void PopItemWidth();
+IMGUI_API void SetNextItemWidth(
+    float item_width);  // set width of the _next_ common large "item+label" widget. >0.0f: width in
+                        // pixels, <0.0f align xx pixels to the right of window (so -1.0f always
+                        // align width to the right side)
+IMGUI_API float CalcItemWidth();  // width of item given pushed settings and current cursor position
+IMGUI_API void PushTextWrapPos(
+    float wrap_local_pos_x =
+        0.0f);  // word-wrapping for Text*() commands. < 0.0f: no wrapping; 0.0f: wrap to end of
+                // window (or column); > 0.0f: wrap at 'wrap_pos_x' position in window local space
+IMGUI_API void PopTextWrapPos();
+IMGUI_API void PushAllowKeyboardFocus(
+    bool allow_keyboard_focus);  // allow focusing using TAB/Shift-TAB, enabled by default but you
+                                 // can disable it for certain widgets
+IMGUI_API void PopAllowKeyboardFocus();
+IMGUI_API void PushButtonRepeat(
+    bool repeat);  // in 'repeat' mode, Button*() functions return repeated true in a typematic
+                   // manner (using io.KeyRepeatDelay/io.KeyRepeatRate setting). Note that you can
+                   // call IsItemActive() after any Button() to tell if the button is held in the
+                   // current frame.
+IMGUI_API void PopButtonRepeat();
+
+// Cursor / Layout
+// - By "cursor" we mean the current output position.
+// - The typical widget behavior is to output themselves at the current cursor position, then move
+// the cursor one line down.
+IMGUI_API void Separator();  // separator, generally horizontal. inside a menu bar or in horizontal
+                             // layout mode, this becomes a vertical separator.
+IMGUI_API void SameLine(
+    float offset_from_start_x = 0.0f,
+    float spacing = -1.0f);  // call between widgets or groups to layout them horizontally. X
+                             // position given in window coordinates.
+IMGUI_API void
+NewLine();  // undo a SameLine() or force a new line when in an horizontal-layout context.
+IMGUI_API void Spacing();  // add vertical spacing.
+IMGUI_API void Dummy(
+    const ImVec2 &size);  // add a dummy item of given size. unlike InvisibleButton(), Dummy() won't
+                          // take the mouse click or be navigable into.
+IMGUI_API void Indent(float indent_w = 0.0f);    // move content position toward the right, by
+                                                 // style.IndentSpacing or indent_w if != 0
+IMGUI_API void Unindent(float indent_w = 0.0f);  // move content position back to the left, by
+                                                 // style.IndentSpacing or indent_w if != 0
+IMGUI_API void BeginGroup();                     // lock horizontal starting position
+IMGUI_API void EndGroup();  // unlock horizontal starting position + capture the whole group
+                            // bounding box into one "item" (so you can use IsItemHovered() or
+                            // layout primitives such as SameLine() on whole group, etc.)
+IMGUI_API ImVec2
+GetCursorPos();  // cursor position in window coordinates (relative to window position)
+IMGUI_API float
+GetCursorPosX();  //   (some functions are using window-relative coordinates, such as: GetCursorPos,
+                  //   GetCursorStartPos, GetContentRegionMax, GetWindowContentRegion* etc.
+IMGUI_API float
+GetCursorPosY();  //    other functions such as GetCursorScreenPos or everything in ImDrawList::
+IMGUI_API void SetCursorPos(
+    const ImVec2 &local_pos);  //    are using the main, absolute coordinate system.
+IMGUI_API void SetCursorPosX(
+    float local_x);  //    GetWindowPos() + GetCursorPos() == GetCursorScreenPos() etc.)
+IMGUI_API void SetCursorPosY(float local_y);  //
+IMGUI_API ImVec2 GetCursorStartPos();         // initial cursor position in window coordinates
+IMGUI_API ImVec2 GetCursorScreenPos();        // cursor position in absolute screen coordinates
+                                        // [0..io.DisplaySize] (useful to work with ImDrawList API)
+IMGUI_API void SetCursorScreenPos(
+    const ImVec2 &pos);  // cursor position in absolute screen coordinates [0..io.DisplaySize]
+IMGUI_API void
+AlignTextToFramePadding();  // vertically align upcoming text baseline to FramePadding.y so that it
+                            // will align properly to regularly framed items (call if you have text
+                            // on a line before a framed item)
+IMGUI_API float GetTextLineHeight();             // ~ FontSize
+IMGUI_API float GetTextLineHeightWithSpacing();  // ~ FontSize + style.ItemSpacing.y (distance in
+                                                 // pixels between 2 consecutive lines of text)
+IMGUI_API float GetFrameHeight();                // ~ FontSize + style.FramePadding.y * 2
+IMGUI_API float
+GetFrameHeightWithSpacing();  // ~ FontSize + style.FramePadding.y * 2 + style.ItemSpacing.y
+                              // (distance in pixels between 2 consecutive lines of framed widgets)
+
+// ID stack/scopes
+// - Read the FAQ for more details about how ID are handled in dear imgui. If you are creating
+// widgets in a loop you most
+//   likely want to push a unique identifier (e.g. object pointer, loop index) to uniquely
+//   differentiate them.
+// - The resulting ID are hashes of the entire stack.
+// - You can also use the "Label##foobar" syntax within widget label to distinguish them from each
+// others.
+// - In this header file we use the "label"/"name" terminology to denote a string that will be
+// displayed and used as an ID,
+//   whereas "str_id" denote a string that is only used as an ID and not normally displayed.
+IMGUI_API void PushID(const char *str_id);  // push string into the ID stack (will hash string).
+IMGUI_API void PushID(const char *str_id_begin,
+                      const char *str_id_end);  // push string into the ID stack (will hash string).
+IMGUI_API void PushID(const void *ptr_id);  // push pointer into the ID stack (will hash pointer).
+IMGUI_API void PushID(int int_id);          // push integer into the ID stack (will hash integer).
+IMGUI_API void PopID();                     // pop from the ID stack.
+IMGUI_API ImGuiID
+GetID(const char *str_id);  // calculate unique ID (hash of whole ID stack + given parameter). e.g.
+                            // if you want to query into ImGuiStorage yourself
+IMGUI_API ImGuiID GetID(const char *str_id_begin, const char *str_id_end);
+IMGUI_API ImGuiID GetID(const void *ptr_id);
+
+// Widgets: Text
+IMGUI_API void TextUnformatted(
+    const char *text,
+    const char *text_end =
+        NULL);  // raw text without formatting. Roughly equivalent to Text("%s", text) but: A)
+                // doesn't require null terminated string if 'text_end' is specified, B) it's
+                // faster, no memory copy is done, no buffer size limits, recommended for long
+                // chunks of text.
+IMGUI_API void Text(const char *fmt, ...) IM_FMTARGS(1);  // simple formatted text
+IMGUI_API void TextV(const char *fmt, va_list args) IM_FMTLIST(1);
+IMGUI_API void TextColored(const ImVec4 &col, const char *fmt, ...) IM_FMTARGS(
+    2);  // shortcut for PushStyleColor(ImGuiCol_Text, col); Text(fmt, ...); PopStyleColor();
+IMGUI_API void TextColoredV(const ImVec4 &col, const char *fmt, va_list args) IM_FMTLIST(2);
+IMGUI_API void TextDisabled(const char *fmt, ...)
+    IM_FMTARGS(1);  // shortcut for PushStyleColor(ImGuiCol_Text,
+                    // style.Colors[ImGuiCol_TextDisabled]); Text(fmt, ...); PopStyleColor();
+IMGUI_API void TextDisabledV(const char *fmt, va_list args) IM_FMTLIST(1);
+IMGUI_API void TextWrapped(const char *fmt, ...) IM_FMTARGS(
+    1);  // shortcut for PushTextWrapPos(0.0f); Text(fmt, ...); PopTextWrapPos();. Note that this
+         // won't work on an auto-resizing window if there's no other widgets to extend the window
+         // width, yoy may need to set a size using SetNextWindowSize().
+IMGUI_API void TextWrappedV(const char *fmt, va_list args) IM_FMTLIST(1);
+IMGUI_API void LabelText(const char *label, const char *fmt, ...)
+    IM_FMTARGS(2);  // display text+label aligned the same way as value+label widgets
+IMGUI_API void LabelTextV(const char *label, const char *fmt, va_list args) IM_FMTLIST(2);
+IMGUI_API void BulletText(const char *fmt, ...) IM_FMTARGS(1);  // shortcut for Bullet()+Text()
+IMGUI_API void BulletTextV(const char *fmt, va_list args) IM_FMTLIST(1);
+
+// Widgets: Main
+// - Most widgets return true when the value has been changed or when pressed/selected
+IMGUI_API bool Button(const char *label, const ImVec2 &size = ImVec2(0, 0));  // button
+IMGUI_API bool SmallButton(
+    const char *label);  // button with FramePadding=(0,0) to easily embed within text
+IMGUI_API bool InvisibleButton(
+    const char *str_id,
+    const ImVec2
+        &size);  // button behavior without the visuals, frequently useful to build custom behaviors
+                 // using the public api (along with IsItemActive, IsItemHovered, etc.)
+IMGUI_API bool ArrowButton(const char *str_id, ImGuiDir dir);  // square button with an arrow shape
+IMGUI_API void Image(ImTextureID user_texture_id,
+                     const ImVec2 &size,
+                     const ImVec2 &uv0        = ImVec2(0, 0),
+                     const ImVec2 &uv1        = ImVec2(1, 1),
+                     const ImVec4 &tint_col   = ImVec4(1, 1, 1, 1),
+                     const ImVec4 &border_col = ImVec4(0, 0, 0, 0));
+IMGUI_API bool ImageButton(
+    ImTextureID user_texture_id,
+    const ImVec2 &size,
+    const ImVec2 &uv0      = ImVec2(0, 0),
+    const ImVec2 &uv1      = ImVec2(1, 1),
+    int frame_padding      = -1,
+    const ImVec4 &bg_col   = ImVec4(0, 0, 0, 0),
+    const ImVec4 &tint_col = ImVec4(1, 1, 1, 1));  // <0 frame_padding uses default frame padding
+                                                   // settings. 0 for no padding
+IMGUI_API bool Checkbox(const char *label, bool *v);
+IMGUI_API bool CheckboxFlags(const char *label, unsigned int *flags, unsigned int flags_value);
+IMGUI_API bool RadioButton(
+    const char *label,
+    bool active);  // use with e.g. if (RadioButton("one", my_value==1)) { my_value = 1; }
+IMGUI_API bool RadioButton(
+    const char *label,
+    int *v,
+    int v_button);  // shortcut to handle the above pattern when value is an integer
+IMGUI_API void ProgressBar(float fraction,
+                           const ImVec2 &size_arg = ImVec2(-1, 0),
+                           const char *overlay    = NULL);
+IMGUI_API void
+Bullet();  // draw a small circle and keep the cursor on the same line. advance cursor x position by
+           // GetTreeNodeToLabelSpacing(), same distance that TreeNode() uses
+
+// Widgets: Combo Box
+// - The new BeginCombo()/EndCombo() api allows you to manage your contents and selection state
+// however you want it, by creating e.g. Selectable() items.
+// - The old Combo() api are helpers over BeginCombo()/EndCombo() which are kept available for
+// convenience purpose.
+IMGUI_API bool BeginCombo(const char *label, const char *preview_value, ImGuiComboFlags flags = 0);
+IMGUI_API void EndCombo();  // only call EndCombo() if BeginCombo() returns true!
+IMGUI_API bool Combo(const char *label,
+                     int *current_item,
+                     const char *const items[],
+                     int items_count,
+                     int popup_max_height_in_items = -1);
+IMGUI_API bool Combo(
+    const char *label,
+    int *current_item,
+    const char *items_separated_by_zeros,
+    int popup_max_height_in_items = -1);  // Separate items with \0 within a string, end item-list
+                                          // with \0\0. e.g. "One\0Two\0Three\0"
+IMGUI_API bool Combo(const char *label,
+                     int *current_item,
+                     bool (*items_getter)(void *data, int idx, const char **out_text),
+                     void *data,
+                     int items_count,
+                     int popup_max_height_in_items = -1);
+
+// Widgets: Drags
+// - CTRL+Click on any drag box to turn them into an input box. Manually input values aren't clamped
+// and can go off-bounds.
+// - For all the Float2/Float3/Float4/Int2/Int3/Int4 versions of every functions, note that a 'float
+// v[X]' function argument is the same as 'float* v', the array syntax is just a way to document the
+// number of elements that are expected to be accessible. You can pass address of your first element
+// out of a contiguous set, e.g. &myvector.x
+// - Adjust format string to decorate the value with a prefix, a suffix, or adapt the editing and
+// display precision e.g. "%.3f" -> 1.234; "%5.2f secs" -> 01.23 secs; "Biscuit: %.0f" -> Biscuit:
+// 1; etc.
+// - Speed are per-pixel of mouse movement (v_speed=0.2f: mouse needs to move by 5 pixels to
+// increase value by 1). For gamepad/keyboard navigation, minimum speed is Max(v_speed,
+// minimum_step_at_given_precision).
+IMGUI_API bool DragFloat(const char *label,
+                         float *v,
+                         float v_speed      = 1.0f,
+                         float v_min        = 0.0f,
+                         float v_max        = 0.0f,
+                         const char *format = "%.3f",
+                         float power        = 1.0f);  // If v_min >= v_max we have no bound
+IMGUI_API bool DragFloat2(const char *label,
+                          float v[2],
+                          float v_speed      = 1.0f,
+                          float v_min        = 0.0f,
+                          float v_max        = 0.0f,
+                          const char *format = "%.3f",
+                          float power        = 1.0f);
+IMGUI_API bool DragFloat3(const char *label,
+                          float v[3],
+                          float v_speed      = 1.0f,
+                          float v_min        = 0.0f,
+                          float v_max        = 0.0f,
+                          const char *format = "%.3f",
+                          float power        = 1.0f);
+IMGUI_API bool DragFloat4(const char *label,
+                          float v[4],
+                          float v_speed      = 1.0f,
+                          float v_min        = 0.0f,
+                          float v_max        = 0.0f,
+                          const char *format = "%.3f",
+                          float power        = 1.0f);
+IMGUI_API bool DragFloatRange2(const char *label,
+                               float *v_current_min,
+                               float *v_current_max,
+                               float v_speed          = 1.0f,
+                               float v_min            = 0.0f,
+                               float v_max            = 0.0f,
+                               const char *format     = "%.3f",
+                               const char *format_max = NULL,
+                               float power            = 1.0f);
+IMGUI_API bool DragInt(const char *label,
+                       int *v,
+                       float v_speed      = 1.0f,
+                       int v_min          = 0,
+                       int v_max          = 0,
+                       const char *format = "%d");  // If v_min >= v_max we have no bound
+IMGUI_API bool DragInt2(const char *label,
+                        int v[2],
+                        float v_speed      = 1.0f,
+                        int v_min          = 0,
+                        int v_max          = 0,
+                        const char *format = "%d");
+IMGUI_API bool DragInt3(const char *label,
+                        int v[3],
+                        float v_speed      = 1.0f,
+                        int v_min          = 0,
+                        int v_max          = 0,
+                        const char *format = "%d");
+IMGUI_API bool DragInt4(const char *label,
+                        int v[4],
+                        float v_speed      = 1.0f,
+                        int v_min          = 0,
+                        int v_max          = 0,
+                        const char *format = "%d");
+IMGUI_API bool DragIntRange2(const char *label,
+                             int *v_current_min,
+                             int *v_current_max,
+                             float v_speed          = 1.0f,
+                             int v_min              = 0,
+                             int v_max              = 0,
+                             const char *format     = "%d",
+                             const char *format_max = NULL);
+IMGUI_API bool DragScalar(const char *label,
+                          ImGuiDataType data_type,
+                          void *v,
+                          float v_speed,
+                          const void *v_min  = NULL,
+                          const void *v_max  = NULL,
+                          const char *format = NULL,
+                          float power        = 1.0f);
+IMGUI_API bool DragScalarN(const char *label,
+                           ImGuiDataType data_type,
+                           void *v,
+                           int components,
+                           float v_speed,
+                           const void *v_min  = NULL,
+                           const void *v_max  = NULL,
+                           const char *format = NULL,
+                           float power        = 1.0f);
+
+// Widgets: Sliders
+// - CTRL+Click on any slider to turn them into an input box. Manually input values aren't clamped
+// and can go off-bounds.
+// - Adjust format string to decorate the value with a prefix, a suffix, or adapt the editing and
+// display precision e.g. "%.3f" -> 1.234; "%5.2f secs" -> 01.23 secs; "Biscuit: %.0f" -> Biscuit:
+// 1; etc.
+IMGUI_API bool SliderFloat(const char *label,
+                           float *v,
+                           float v_min,
+                           float v_max,
+                           const char *format = "%.3f",
+                           float power = 1.0f);  // adjust format to decorate the value with a
+                                                 // prefix or a suffix for in-slider labels or unit
+                                                 // display. Use power!=1.0 for power curve sliders
+IMGUI_API bool SliderFloat2(const char *label,
+                            float v[2],
+                            float v_min,
+                            float v_max,
+                            const char *format = "%.3f",
+                            float power        = 1.0f);
+IMGUI_API bool SliderFloat3(const char *label,
+                            float v[3],
+                            float v_min,
+                            float v_max,
+                            const char *format = "%.3f",
+                            float power        = 1.0f);
+IMGUI_API bool SliderFloat4(const char *label,
+                            float v[4],
+                            float v_min,
+                            float v_max,
+                            const char *format = "%.3f",
+                            float power        = 1.0f);
+IMGUI_API bool SliderAngle(const char *label,
+                           float *v_rad,
+                           float v_degrees_min = -360.0f,
+                           float v_degrees_max = +360.0f,
+                           const char *format  = "%.0f deg");
+IMGUI_API bool SliderInt(const char *label,
+                         int *v,
+                         int v_min,
+                         int v_max,
+                         const char *format = "%d");
+IMGUI_API bool SliderInt2(const char *label,
+                          int v[2],
+                          int v_min,
+                          int v_max,
+                          const char *format = "%d");
+IMGUI_API bool SliderInt3(const char *label,
+                          int v[3],
+                          int v_min,
+                          int v_max,
+                          const char *format = "%d");
+IMGUI_API bool SliderInt4(const char *label,
+                          int v[4],
+                          int v_min,
+                          int v_max,
+                          const char *format = "%d");
+IMGUI_API bool SliderScalar(const char *label,
+                            ImGuiDataType data_type,
+                            void *v,
+                            const void *v_min,
+                            const void *v_max,
+                            const char *format = NULL,
+                            float power        = 1.0f);
+IMGUI_API bool SliderScalarN(const char *label,
+                             ImGuiDataType data_type,
+                             void *v,
+                             int components,
+                             const void *v_min,
+                             const void *v_max,
+                             const char *format = NULL,
+                             float power        = 1.0f);
+IMGUI_API bool VSliderFloat(const char *label,
+                            const ImVec2 &size,
+                            float *v,
+                            float v_min,
+                            float v_max,
+                            const char *format = "%.3f",
+                            float power        = 1.0f);
+IMGUI_API bool VSliderInt(const char *label,
+                          const ImVec2 &size,
+                          int *v,
+                          int v_min,
+                          int v_max,
+                          const char *format = "%d");
+IMGUI_API bool VSliderScalar(const char *label,
+                             const ImVec2 &size,
+                             ImGuiDataType data_type,
+                             void *v,
+                             const void *v_min,
+                             const void *v_max,
+                             const char *format = NULL,
+                             float power        = 1.0f);
+
+// Widgets: Input with Keyboard
+// - If you want to use InputText() with a dynamic string type such as std::string or your own, see
+// misc/cpp/imgui_stdlib.h
+// - Most of the ImGuiInputTextFlags flags are only useful for InputText() and not for InputFloatX,
+// InputIntX, InputDouble etc.
+IMGUI_API bool InputText(const char *label,
+                         char *buf,
+                         size_t buf_size,
+                         ImGuiInputTextFlags flags       = 0,
+                         ImGuiInputTextCallback callback = NULL,
+                         void *user_data                 = NULL);
+IMGUI_API bool InputTextMultiline(const char *label,
+                                  char *buf,
+                                  size_t buf_size,
+                                  const ImVec2 &size              = ImVec2(0, 0),
+                                  ImGuiInputTextFlags flags       = 0,
+                                  ImGuiInputTextCallback callback = NULL,
+                                  void *user_data                 = NULL);
+IMGUI_API bool InputTextWithHint(const char *label,
+                                 const char *hint,
+                                 char *buf,
+                                 size_t buf_size,
+                                 ImGuiInputTextFlags flags       = 0,
+                                 ImGuiInputTextCallback callback = NULL,
+                                 void *user_data                 = NULL);
+IMGUI_API bool InputFloat(const char *label,
+                          float *v,
+                          float step                = 0.0f,
+                          float step_fast           = 0.0f,
+                          const char *format        = "%.3f",
+                          ImGuiInputTextFlags flags = 0);
+IMGUI_API bool InputFloat2(const char *label,
+                           float v[2],
+                           const char *format        = "%.3f",
+                           ImGuiInputTextFlags flags = 0);
+IMGUI_API bool InputFloat3(const char *label,
+                           float v[3],
+                           const char *format        = "%.3f",
+                           ImGuiInputTextFlags flags = 0);
+IMGUI_API bool InputFloat4(const char *label,
+                           float v[4],
+                           const char *format        = "%.3f",
+                           ImGuiInputTextFlags flags = 0);
+IMGUI_API bool InputInt(const char *label,
+                        int *v,
+                        int step                  = 1,
+                        int step_fast             = 100,
+                        ImGuiInputTextFlags flags = 0);
+IMGUI_API bool InputInt2(const char *label, int v[2], ImGuiInputTextFlags flags = 0);
+IMGUI_API bool InputInt3(const char *label, int v[3], ImGuiInputTextFlags flags = 0);
+IMGUI_API bool InputInt4(const char *label, int v[4], ImGuiInputTextFlags flags = 0);
+IMGUI_API bool InputDouble(const char *label,
+                           double *v,
+                           double step               = 0.0,
+                           double step_fast          = 0.0,
+                           const char *format        = "%.6f",
+                           ImGuiInputTextFlags flags = 0);
+IMGUI_API bool InputScalar(const char *label,
+                           ImGuiDataType data_type,
+                           void *v,
+                           const void *step          = NULL,
+                           const void *step_fast     = NULL,
+                           const char *format        = NULL,
+                           ImGuiInputTextFlags flags = 0);
+IMGUI_API bool InputScalarN(const char *label,
+                            ImGuiDataType data_type,
+                            void *v,
+                            int components,
+                            const void *step          = NULL,
+                            const void *step_fast     = NULL,
+                            const char *format        = NULL,
+                            ImGuiInputTextFlags flags = 0);
+
+// Widgets: Color Editor/Picker (tip: the ColorEdit* functions have a little colored preview square
+// that can be left-clicked to open a picker, and right-clicked to open an option menu.)
+// - Note that in C++ a 'float v[X]' function argument is the _same_ as 'float* v', the array syntax
+// is just a way to document the number of elements that are expected to be accessible.
+// - You can pass the address of a first float element out of a contiguous structure, e.g.
+// &myvector.x
+IMGUI_API bool ColorEdit3(const char *label, float col[3], ImGuiColorEditFlags flags = 0);
+IMGUI_API bool ColorEdit4(const char *label, float col[4], ImGuiColorEditFlags flags = 0);
+IMGUI_API bool ColorPicker3(const char *label, float col[3], ImGuiColorEditFlags flags = 0);
+IMGUI_API bool ColorPicker4(const char *label,
+                            float col[4],
+                            ImGuiColorEditFlags flags = 0,
+                            const float *ref_col      = NULL);
+IMGUI_API bool ColorButton(const char *desc_id,
+                           const ImVec4 &col,
+                           ImGuiColorEditFlags flags = 0,
+                           ImVec2 size = ImVec2(0, 0));  // display a colored square/button, hover
+                                                         // for details, return true when pressed.
+IMGUI_API void SetColorEditOptions(
+    ImGuiColorEditFlags
+        flags);  // initialize current options (generally on application startup) if you want to
+                 // select a default format, picker type, etc. User will be able to change many
+                 // settings, unless you pass the _NoOptions flag to your calls.
+
+// Widgets: Trees
+// - TreeNode functions return true when the node is open, in which case you need to also call
+// TreePop() when you are finished displaying the tree node contents.
+IMGUI_API bool TreeNode(const char *label);
+IMGUI_API bool TreeNode(const char *str_id, const char *fmt, ...)
+    IM_FMTARGS(2);  // helper variation to easily decorelate the id from the displayed string. Read
+                    // the FAQ about why and how to use ID. to align arbitrary text at the same
+                    // level as a TreeNode() you can use Bullet().
+IMGUI_API bool TreeNode(const void *ptr_id, const char *fmt, ...) IM_FMTARGS(2);  // "
+IMGUI_API bool TreeNodeV(const char *str_id, const char *fmt, va_list args) IM_FMTLIST(2);
+IMGUI_API bool TreeNodeV(const void *ptr_id, const char *fmt, va_list args) IM_FMTLIST(2);
+IMGUI_API bool TreeNodeEx(const char *label, ImGuiTreeNodeFlags flags = 0);
+IMGUI_API bool TreeNodeEx(const char *str_id, ImGuiTreeNodeFlags flags, const char *fmt, ...)
+    IM_FMTARGS(3);
+IMGUI_API bool TreeNodeEx(const void *ptr_id, ImGuiTreeNodeFlags flags, const char *fmt, ...)
+    IM_FMTARGS(3);
+IMGUI_API bool TreeNodeExV(const char *str_id,
+                           ImGuiTreeNodeFlags flags,
+                           const char *fmt,
+                           va_list args) IM_FMTLIST(3);
+IMGUI_API bool TreeNodeExV(const void *ptr_id,
+                           ImGuiTreeNodeFlags flags,
+                           const char *fmt,
+                           va_list args) IM_FMTLIST(3);
+IMGUI_API void TreePush(
+    const char *str_id);  // ~ Indent()+PushId(). Already called by TreeNode() when returning true,
+                          // but you can call TreePush/TreePop yourself if desired.
+IMGUI_API void TreePush(const void *ptr_id = NULL);  // "
+IMGUI_API void TreePop();                            // ~ Unindent()+PopId()
+IMGUI_API void TreeAdvanceToLabelPos();  // advance cursor x position by GetTreeNodeToLabelSpacing()
+IMGUI_API float
+GetTreeNodeToLabelSpacing();  // horizontal distance preceding label when using TreeNode*() or
+                              // Bullet() == (g.FontSize + style.FramePadding.x*2) for a regular
+                              // unframed TreeNode
+IMGUI_API bool CollapsingHeader(
+    const char *label,
+    ImGuiTreeNodeFlags flags = 0);  // if returning 'true' the header is open. doesn't indent nor
+                                    // push on ID stack. user doesn't have to call TreePop().
+IMGUI_API bool CollapsingHeader(
+    const char *label,
+    bool *p_open,
+    ImGuiTreeNodeFlags flags = 0);  // when 'p_open' isn't NULL, display an additional small close
+                                    // button on upper right of the header
+IMGUI_API void SetNextItemOpen(
+    bool is_open,
+    ImGuiCond cond = 0);  // set next TreeNode/CollapsingHeader open state.
+
+// Widgets: Selectables
+// - A selectable highlights when hovered, and can display another color when selected.
+// - Neighbors selectable extend their highlight bounds in order to leave no gap between them.
+IMGUI_API bool Selectable(
+    const char *label,
+    bool selected              = false,
+    ImGuiSelectableFlags flags = 0,
+    const ImVec2 &size =
+        ImVec2(0, 0));  // "bool selected" carry the selection state (read-only). Selectable() is
+                        // clicked is returns true so you can modify your selection state.
+                        // size.x==0.0: use remaining width, size.x>0.0: specify width. size.y==0.0:
+                        // use label height, size.y>0.0: specify height
+IMGUI_API bool Selectable(
+    const char *label,
+    bool *p_selected,
+    ImGuiSelectableFlags flags = 0,
+    const ImVec2 &size         = ImVec2(0, 0));  // "bool* p_selected" point to the selection state
+                                         // (read-write), as a convenient helper.
+
+// Widgets: List Boxes
+// - FIXME: To be consistent with all the newer API, ListBoxHeader/ListBoxFooter should in reality
+// be called BeginListBox/EndListBox. Will rename them.
+IMGUI_API bool ListBox(const char *label,
+                       int *current_item,
+                       const char *const items[],
+                       int items_count,
+                       int height_in_items = -1);
+IMGUI_API bool ListBox(const char *label,
+                       int *current_item,
+                       bool (*items_getter)(void *data, int idx, const char **out_text),
+                       void *data,
+                       int items_count,
+                       int height_in_items = -1);
+IMGUI_API bool ListBoxHeader(
+    const char *label,
+    const ImVec2 &size = ImVec2(
+        0,
+        0));  // use if you want to reimplement ListBox() will custom data or interactions. if the
+              // function return true, you can output elements then call ListBoxFooter() afterwards.
+IMGUI_API bool ListBoxHeader(const char *label, int items_count, int height_in_items = -1);  // "
+IMGUI_API void ListBoxFooter();  // terminate the scrolling region. only call ListBoxFooter() if
+                                 // ListBoxHeader() returned true!
+
+// Widgets: Data Plotting
+IMGUI_API void PlotLines(const char *label,
+                         const float *values,
+                         int values_count,
+                         int values_offset        = 0,
+                         const char *overlay_text = NULL,
+                         float scale_min          = FLT_MAX,
+                         float scale_max          = FLT_MAX,
+                         ImVec2 graph_size        = ImVec2(0, 0),
+                         int stride               = sizeof(float));
+IMGUI_API void PlotLines(const char *label,
+                         float (*values_getter)(void *data, int idx),
+                         void *data,
+                         int values_count,
+                         int values_offset        = 0,
+                         const char *overlay_text = NULL,
+                         float scale_min          = FLT_MAX,
+                         float scale_max          = FLT_MAX,
+                         ImVec2 graph_size        = ImVec2(0, 0));
+IMGUI_API void PlotHistogram(const char *label,
+                             const float *values,
+                             int values_count,
+                             int values_offset        = 0,
+                             const char *overlay_text = NULL,
+                             float scale_min          = FLT_MAX,
+                             float scale_max          = FLT_MAX,
+                             ImVec2 graph_size        = ImVec2(0, 0),
+                             int stride               = sizeof(float));
+IMGUI_API void PlotHistogram(const char *label,
+                             float (*values_getter)(void *data, int idx),
+                             void *data,
+                             int values_count,
+                             int values_offset        = 0,
+                             const char *overlay_text = NULL,
+                             float scale_min          = FLT_MAX,
+                             float scale_max          = FLT_MAX,
+                             ImVec2 graph_size        = ImVec2(0, 0));
+
+// Widgets: Value() Helpers.
+// - Those are merely shortcut to calling Text() with a format string. Output single value in "name:
+// value" format (tip: freely declare more in your code to handle your types. you can add functions
+// to the ImGui namespace)
+IMGUI_API void Value(const char *prefix, bool b);
+IMGUI_API void Value(const char *prefix, int v);
+IMGUI_API void Value(const char *prefix, unsigned int v);
+IMGUI_API void Value(const char *prefix, float v, const char *float_format = NULL);
+
+// Widgets: Menus
+IMGUI_API bool BeginMainMenuBar();  // create and append to a full screen menu-bar.
+IMGUI_API void EndMainMenuBar();  // only call EndMainMenuBar() if BeginMainMenuBar() returns true!
+IMGUI_API bool BeginMenuBar();    // append to menu-bar of current window (requires
+                                  // ImGuiWindowFlags_MenuBar flag set on parent window).
+IMGUI_API void EndMenuBar();      // only call EndMenuBar() if BeginMenuBar() returns true!
+IMGUI_API bool BeginMenu(
+    const char *label,
+    bool enabled = true);  // create a sub-menu entry. only call EndMenu() if this returns true!
+IMGUI_API void EndMenu();  // only call EndMenu() if BeginMenu() returns true!
+IMGUI_API bool MenuItem(
+    const char *label,
+    const char *shortcut = NULL,
+    bool selected        = false,
+    bool enabled = true);  // return true when activated. shortcuts are displayed for convenience
+                           // but not processed by ImGui at the moment
+IMGUI_API bool MenuItem(const char *label,
+                        const char *shortcut,
+                        bool *p_selected,
+                        bool enabled = true);  // return true when activated + toggle (*p_selected)
+                                               // if p_selected != NULL
+
+// Tooltips
+IMGUI_API void BeginTooltip();  // begin/append a tooltip window. to create full-featured tooltip
+                                // (with any kind of items).
+IMGUI_API void EndTooltip();
+IMGUI_API void SetTooltip(const char *fmt, ...)
+    IM_FMTARGS(1);  // set a text-only tooltip, typically use with ImGui::IsItemHovered(). override
+                    // any previous call to SetTooltip().
+IMGUI_API void SetTooltipV(const char *fmt, va_list args) IM_FMTLIST(1);
+
+// Popups, Modals
+// The properties of popups windows are:
+// - They block normal mouse hovering detection outside them. (*)
+// - Unless modal, they can be closed by clicking anywhere outside them, or by pressing ESCAPE.
+// - Their visibility state (~bool) is held internally by imgui instead of being held by the
+// programmer as we are used to with regular Begin() calls.
+//   User can manipulate the visibility state by calling OpenPopup().
+// (*) One can use IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup) to bypass it and detect
+// hovering even when normally blocked by a popup. Those three properties are connected. The library
+// needs to hold their visibility state because it can close popups at any time.
+IMGUI_API void OpenPopup(
+    const char
+        *str_id);  // call to mark popup as open (don't call every frame!). popups are closed when
+                   // user click outside, or if CloseCurrentPopup() is called within a
+                   // BeginPopup()/EndPopup() block. By default, Selectable()/MenuItem() are calling
+                   // CloseCurrentPopup(). Popup identifiers are relative to the current ID-stack
+                   // (so OpenPopup and BeginPopup needs to be at the same level).
+IMGUI_API bool BeginPopup(
+    const char *str_id,
+    ImGuiWindowFlags flags = 0);  // return true if the popup is open, and you can start outputting
+                                  // to it. only call EndPopup() if BeginPopup() returns true!
+IMGUI_API bool BeginPopupContextItem(
+    const char *str_id = NULL,
+    int mouse_button = 1);  // helper to open and begin popup when clicked on last item. if you can
+                            // pass a NULL str_id only if the previous item had an id. If you want
+                            // to use that on a non-interactive item such as Text() you need to pass
+                            // in an explicit ID here. read comments in .cpp!
+IMGUI_API bool BeginPopupContextWindow(
+    const char *str_id   = NULL,
+    int mouse_button     = 1,
+    bool also_over_items = true);  // helper to open and begin popup when clicked on current window.
+IMGUI_API bool BeginPopupContextVoid(
+    const char *str_id = NULL,
+    int mouse_button = 1);  // helper to open and begin popup when clicked in void (where there are
+                            // no imgui windows).
+IMGUI_API bool BeginPopupModal(
+    const char *name,
+    bool *p_open = NULL,
+    ImGuiWindowFlags flags =
+        0);  // modal dialog (regular window with title bar, block interactions behind the modal
+             // window, can't close the modal window by clicking outside)
+IMGUI_API void EndPopup();  // only call EndPopup() if BeginPopupXXX() returns true!
+IMGUI_API bool OpenPopupOnItemClick(
+    const char *str_id = NULL,
+    int mouse_button   = 1);  // helper to open popup when clicked on last item (note: actually
+                            // triggers on the mouse _released_ event to be consistent with popup
+                            // behaviors). return true when just opened.
+IMGUI_API bool IsPopupOpen(const char *str_id);  // return true if the popup is open at the current
+                                                 // begin-ed level of the popup stack.
+IMGUI_API void
+CloseCurrentPopup();  // close the popup we have begin-ed into. clicking on a MenuItem or Selectable
+                      // automatically close the current popup.
+
+// Columns
+// - You can also use SameLine(pos_x) to mimic simplified columns.
+// - The columns API is work-in-progress and rather lacking (columns are arguably the worst part of
+// dear imgui at the moment!)
+IMGUI_API void Columns(int count = 1, const char *id = NULL, bool border = true);
+IMGUI_API void
+NextColumn();  // next column, defaults to current row or next row if the current row is finished
+IMGUI_API int GetColumnIndex();  // get current column index
+IMGUI_API float GetColumnWidth(
+    int column_index = -1);  // get column width (in pixels). pass -1 to use current column
+IMGUI_API void SetColumnWidth(
+    int column_index,
+    float width);  // set column width (in pixels). pass -1 to use current column
+IMGUI_API float GetColumnOffset(
+    int column_index = -1);  // get position of column line (in pixels, from the left side of the
+                             // contents region). pass -1 to use current column, otherwise
+                             // 0..GetColumnsCount() inclusive. column 0 is typically 0.0f
+IMGUI_API void SetColumnOffset(
+    int column_index,
+    float offset_x);  // set position of column line (in pixels, from the left side of the contents
+                      // region). pass -1 to use current column
+IMGUI_API int GetColumnsCount();
+
+// Tab Bars, Tabs
+// [BETA API] API may evolve!
+IMGUI_API bool BeginTabBar(const char *str_id,
+                           ImGuiTabBarFlags flags = 0);  // create and append into a TabBar
+IMGUI_API void EndTabBar();  // only call EndTabBar() if BeginTabBar() returns true!
+IMGUI_API bool BeginTabItem(
+    const char *label,
+    bool *p_open            = NULL,
+    ImGuiTabItemFlags flags = 0);  // create a Tab. Returns true if the Tab is selected.
+IMGUI_API void EndTabItem();       // only call EndTabItem() if BeginTabItem() returns true!
+IMGUI_API void SetTabItemClosed(
+    const char
+        *tab_or_docked_window_label);  // notify TabBar or Docking system of a closed tab/window
+                                       // ahead (useful to reduce visual flicker on reorderable tab
+                                       // bars). For tab-bar: call after BeginTabBar() and before
+                                       // Tab submissions. Otherwise call with a window name.
+
+// Logging/Capture
+// - All text output from the interface can be captured into tty/file/clipboard. By default, tree
+// nodes are automatically opened during logging.
+IMGUI_API void LogToTTY(int auto_open_depth = -1);  // start logging to tty (stdout)
+IMGUI_API void LogToFile(int auto_open_depth  = -1,
+                         const char *filename = NULL);    // start logging to file
+IMGUI_API void LogToClipboard(int auto_open_depth = -1);  // start logging to OS clipboard
+IMGUI_API void LogFinish();                               // stop logging (close file, etc.)
+IMGUI_API void LogButtons();  // helper to display buttons for logging to tty/file/clipboard
+IMGUI_API void LogText(const char *fmt, ...)
+    IM_FMTARGS(1);  // pass text data straight to log (without being displayed)
+
+// Drag and Drop
+// [BETA API] API may evolve!
+IMGUI_API bool BeginDragDropSource(
+    ImGuiDragDropFlags flags = 0);  // call when the current item is active. If this return true,
+                                    // you can call SetDragDropPayload() + EndDragDropSource()
+IMGUI_API bool SetDragDropPayload(
+    const char *type,
+    const void *data,
+    size_t sz,
+    ImGuiCond cond =
+        0);  // type is a user defined string of maximum 32 characters. Strings starting with '_'
+             // are reserved for dear imgui internal types. Data is copied and held by imgui.
+IMGUI_API void
+EndDragDropSource();  // only call EndDragDropSource() if BeginDragDropSource() returns true!
+IMGUI_API bool
+BeginDragDropTarget();  // call after submitting an item that may receive a payload. If this returns
+                        // true, you can call AcceptDragDropPayload() + EndDragDropTarget()
+IMGUI_API const ImGuiPayload *AcceptDragDropPayload(
+    const char *type,
+    ImGuiDragDropFlags flags =
+        0);  // accept contents of a given type. If ImGuiDragDropFlags_AcceptBeforeDelivery is set
+             // you can peek into the payload before the mouse button is released.
+IMGUI_API void
+EndDragDropTarget();  // only call EndDragDropTarget() if BeginDragDropTarget() returns true!
+IMGUI_API const ImGuiPayload *
+GetDragDropPayload();  // peek directly into the current payload from anywhere. may return NULL. use
+                       // ImGuiPayload::IsDataType() to test for the payload type.
+
+// Clipping
+IMGUI_API void PushClipRect(const ImVec2 &clip_rect_min,
+                            const ImVec2 &clip_rect_max,
+                            bool intersect_with_current_clip_rect);
+IMGUI_API void PopClipRect();
+
+// Focus, Activation
+// - Prefer using "SetItemDefaultFocus()" over "if (IsWindowAppearing()) SetScrollHereY()" when
+// applicable to signify "this is the default item"
+IMGUI_API void SetItemDefaultFocus();  // make last item the default focused item of a window.
+IMGUI_API void SetKeyboardFocusHere(
+    int offset =
+        0);  // focus keyboard on the next widget. Use positive 'offset' to access sub components of
+             // a multiple component widget. Use -1 to access previous widget.
+
+// Item/Widgets Utilities
+// - Most of the functions are referring to the last/previous item we submitted.
+// - See Demo Window under "Widgets->Querying Status" for an interactive visualization of most of
+// those functions.
+IMGUI_API bool IsItemHovered(
+    ImGuiHoveredFlags flags = 0);  // is the last item hovered? (and usable, aka not blocked by a
+                                   // popup, etc.). See ImGuiHoveredFlags for more options.
+IMGUI_API bool
+IsItemActive();  // is the last item active? (e.g. button being held, text field being edited. This
+                 // will continuously return true while holding mouse button on an item. Items that
+                 // don't interact will always return false)
+IMGUI_API bool IsItemFocused();  // is the last item focused for keyboard/gamepad navigation?
+IMGUI_API bool IsItemClicked(
+    int mouse_button = 0);       // is the last item clicked? (e.g. button/node just clicked on) ==
+                                 // IsMouseClicked(mouse_button) && IsItemHovered()
+IMGUI_API bool IsItemVisible();  // is the last item visible? (items may be out of sight because of
+                                 // clipping/scrolling)
+IMGUI_API bool
+IsItemEdited();  // did the last item modify its underlying value this frame? or was pressed? This
+                 // is generally the same as the "bool" return value of many widgets.
+IMGUI_API bool
+IsItemActivated();  // was the last item just made active (item was previously inactive).
+IMGUI_API bool
+IsItemDeactivated();  // was the last item just made inactive (item was previously active). Useful
+                      // for Undo/Redo patterns with widgets that requires continuous editing.
+IMGUI_API bool
+IsItemDeactivatedAfterEdit();  // was the last item just made inactive and made a value change when
+                               // it was active? (e.g. Slider/Drag moved). Useful for Undo/Redo
+                               // patterns with widgets that requires continuous editing. Note that
+                               // you may get false positives (some widgets such as
+                               // Combo()/ListBox()/Selectable() will return true even when clicking
+                               // an already selected item).
+IMGUI_API bool IsAnyItemHovered();  // is any item hovered?
+IMGUI_API bool IsAnyItemActive();   // is any item active?
+IMGUI_API bool IsAnyItemFocused();  // is any item focused?
+IMGUI_API ImVec2
+GetItemRectMin();  // get upper-left bounding rectangle of the last item (screen space)
+IMGUI_API ImVec2
+GetItemRectMax();  // get lower-right bounding rectangle of the last item (screen space)
+IMGUI_API ImVec2 GetItemRectSize();  // get size of last item
+IMGUI_API void
+SetItemAllowOverlap();  // allow last item to be overlapped by a subsequent item. sometimes useful
+                        // with invisible buttons, selectables, etc. to catch unused area.
+
+// Miscellaneous Utilities
+IMGUI_API bool IsRectVisible(
+    const ImVec2 &size);  // test if rectangle (of given size, starting from cursor position) is
+                          // visible / not clipped.
+IMGUI_API bool IsRectVisible(
+    const ImVec2 &rect_min,
+    const ImVec2 &rect_max);    // test if rectangle (in screen space) is visible / not clipped. to
+                                // perform coarse clipping on user's side.
+IMGUI_API double GetTime();     // get global imgui time. incremented by io.DeltaTime every frame.
+IMGUI_API int GetFrameCount();  // get global imgui frame count. incremented by 1 every frame.
+IMGUI_API ImDrawList *
+GetBackgroundDrawList();  // this draw list will be the first rendering one. Useful to quickly draw
+                          // shapes/text behind dear imgui contents.
+IMGUI_API ImDrawList *
+GetForegroundDrawList();  // this draw list will be the last rendered one. Useful to quickly draw
+                          // shapes/text over dear imgui contents.
+IMGUI_API ImDrawListSharedData *
+GetDrawListSharedData();  // you may use this when creating your own ImDrawList instances.
+IMGUI_API const char *GetStyleColorName(
+    ImGuiCol idx);  // get a string corresponding to the enum value (for display, saving, etc.).
+IMGUI_API void SetStateStorage(
+    ImGuiStorage *storage);  // replace current window storage with our own (if you want to
+                             // manipulate it yourself, typically clear subsection of it)
+IMGUI_API ImGuiStorage *GetStateStorage();
+IMGUI_API ImVec2 CalcTextSize(const char *text,
+                              const char *text_end             = NULL,
+                              bool hide_text_after_double_hash = false,
+                              float wrap_width                 = -1.0f);
+IMGUI_API void CalcListClipping(
+    int items_count,
+    float items_height,
+    int *out_items_display_start,
+    int *out_items_display_end);  // calculate coarse clipping for large list of evenly sized items.
+                                  // Prefer using the ImGuiListClipper higher-level helper if you
+                                  // can.
+IMGUI_API bool BeginChildFrame(
+    ImGuiID id,
+    const ImVec2 &size,
+    ImGuiWindowFlags flags = 0);  // helper to create a child window / scrolling region that looks
+                                  // like a normal widget frame
+IMGUI_API void EndChildFrame();   // always call EndChildFrame() regardless of BeginChildFrame()
+                                  // return values (which indicates a collapsed/clipped window)
+
+// Color Utilities
+IMGUI_API ImVec4 ColorConvertU32ToFloat4(ImU32 in);
+IMGUI_API ImU32 ColorConvertFloat4ToU32(const ImVec4 &in);
+IMGUI_API void ColorConvertRGBtoHSV(float r,
+                                    float g,
+                                    float b,
+                                    float &out_h,
+                                    float &out_s,
+                                    float &out_v);
+IMGUI_API void ColorConvertHSVtoRGB(float h,
+                                    float s,
+                                    float v,
+                                    float &out_r,
+                                    float &out_g,
+                                    float &out_b);
+
+// Inputs Utilities
+IMGUI_API int GetKeyIndex(
+    ImGuiKey imgui_key);  // map ImGuiKey_* values into user's key index. == io.KeyMap[key]
+IMGUI_API bool IsKeyDown(
+    int user_key_index);  // is key being held. == io.KeysDown[user_key_index]. note that imgui
+                          // doesn't know the semantic of each entry of io.KeysDown[]. Use your own
+                          // indices/enums according to how your backend/engine stored them into
+                          // io.KeysDown[]!
+IMGUI_API bool IsKeyPressed(
+    int user_key_index,
+    bool repeat = true);  // was key pressed (went from !Down to Down). if repeat=true, uses
+                          // io.KeyRepeatDelay / KeyRepeatRate
+IMGUI_API bool IsKeyReleased(int user_key_index);  // was key released (went from Down to !Down)..
+IMGUI_API int GetKeyPressedAmount(
+    int key_index,
+    float repeat_delay,
+    float rate);  // uses provided repeat rate/delay. return a count, most often 0 or 1 but might be
+                  // >1 if RepeatRate is small enough that DeltaTime > RepeatRate
+IMGUI_API bool IsMouseDown(int button);  // is mouse button held (0=left, 1=right, 2=middle)
+IMGUI_API bool IsAnyMouseDown();         // is any mouse button held
+IMGUI_API bool IsMouseClicked(int button,
+                              bool repeat = false);  // did mouse button clicked (went from !Down to
+                                                     // Down) (0=left, 1=right, 2=middle)
+IMGUI_API bool IsMouseDoubleClicked(
+    int button);  // did mouse button double-clicked. a double-click returns false in
+                  // IsMouseClicked(). uses io.MouseDoubleClickTime.
+IMGUI_API bool IsMouseReleased(int button);  // did mouse button released (went from Down to !Down)
+IMGUI_API bool IsMouseDragging(
+    int button = 0,
+    float lock_threshold =
+        -1.0f);  // is mouse dragging. if lock_threshold < -1.0f uses io.MouseDraggingThreshold
+IMGUI_API bool IsMouseHoveringRect(
+    const ImVec2 &r_min,
+    const ImVec2 &r_max,
+    bool clip = true);  // is mouse hovering given bounding rect (in screen space). clipped by
+                        // current clipping settings, but disregarding of other consideration of
+                        // focus/window ordering/popup-block.
+IMGUI_API bool IsMousePosValid(
+    const ImVec2 *mouse_pos =
+        NULL);  // by convention we use (-FLT_MAX,-FLT_MAX) to denote that there is no mouse
+IMGUI_API ImVec2 GetMousePos();  // shortcut to ImGui::GetIO().MousePos provided by user, to be
+                                 // consistent with other calls
+IMGUI_API ImVec2
+GetMousePosOnOpeningCurrentPopup();  // retrieve backup of mouse position at the time of opening
+                                     // popup we have BeginPopup() into
+IMGUI_API ImVec2 GetMouseDragDelta(
+    int button = 0,
+    float lock_threshold =
+        -1.0f);  // return the delta from the initial clicking position while the mouse button is
+                 // pressed or was just released. This is locked and return 0.0f until the mouse
+                 // moves past a distance threshold at least once. If lock_threshold < -1.0f uses
+                 // io.MouseDraggingThreshold.
+IMGUI_API void ResetMouseDragDelta(int button = 0);  //
+IMGUI_API ImGuiMouseCursor
+GetMouseCursor();  // get desired cursor type, reset in ImGui::NewFrame(), this is updated during
+                   // the frame. valid before Render(). If you use software rendering by setting
+                   // io.MouseDrawCursor ImGui will render those for you
+IMGUI_API void SetMouseCursor(ImGuiMouseCursor type);  // set desired cursor type
+IMGUI_API void CaptureKeyboardFromApp(
+    bool want_capture_keyboard_value =
+        true);  // attention: misleading name! manually override io.WantCaptureKeyboard flag next
+                // frame (said flag is entirely left for your application to handle). e.g. force
+                // capture keyboard when your widget is being hovered. This is equivalent to setting
+                // "io.WantCaptureKeyboard = want_capture_keyboard_value"; after the next NewFrame()
+                // call.
+IMGUI_API void CaptureMouseFromApp(
+    bool want_capture_mouse_value =
+        true);  // attention: misleading name! manually override io.WantCaptureMouse flag next frame
+                // (said flag is entirely left for your application to handle). This is equivalent
+                // to setting "io.WantCaptureMouse = want_capture_mouse_value;" after the next
+                // NewFrame() call.
+
+// Clipboard Utilities (also see the LogToClipboard() function to capture or output text data to the
+// clipboard)
+IMGUI_API const char *GetClipboardText();
+IMGUI_API void SetClipboardText(const char *text);
+
+// Settings/.Ini Utilities
+// - The disk functions are automatically called if io.IniFilename != NULL (default is "imgui.ini").
+// - Set io.IniFilename to NULL to load/save manually. Read io.WantSaveIniSettings description about
+// handling .ini saving manually.
+IMGUI_API void LoadIniSettingsFromDisk(
+    const char
+        *ini_filename);  // call after CreateContext() and before the first call to NewFrame().
+                         // NewFrame() automatically calls LoadIniSettingsFromDisk(io.IniFilename).
+IMGUI_API void LoadIniSettingsFromMemory(
+    const char *ini_data,
+    size_t ini_size = 0);  // call after CreateContext() and before the first call to NewFrame() to
+                           // provide .ini data from your own data source.
+IMGUI_API void SaveIniSettingsToDisk(
+    const char *ini_filename);  // this is automatically called (if io.IniFilename is not empty) a
+                                // few seconds after any modification that should be reflected in
+                                // the .ini file (and also by DestroyContext).
+IMGUI_API const char *SaveIniSettingsToMemory(
+    size_t *out_ini_size =
+        NULL);  // return a zero-terminated string with the .ini data which you can save by your own
+                // mean. call when io.WantSaveIniSettings is set, then save data by your own mean
+                // and clear io.WantSaveIniSettings.
+
+// Memory Allocators
+// - All those functions are not reliant on the current context.
+// - If you reload the contents of imgui.cpp at runtime, you may need to call SetCurrentContext() +
+// SetAllocatorFunctions() again because we use global storage for those.
+IMGUI_API void SetAllocatorFunctions(void *(*alloc_func)(size_t sz, void *user_data),
+                                     void (*free_func)(void *ptr, void *user_data),
+                                     void *user_data = NULL);
+IMGUI_API void *MemAlloc(size_t size);
+IMGUI_API void MemFree(void *ptr);
+
+}  // namespace ImGui
+
+//-----------------------------------------------------------------------------
+// Flags & Enumerations
+//-----------------------------------------------------------------------------
+
+// Flags for ImGui::Begin()
+enum ImGuiWindowFlags_
+{
+    ImGuiWindowFlags_None       = 0,
+    ImGuiWindowFlags_NoTitleBar = 1 << 0,  // Disable title-bar
+    ImGuiWindowFlags_NoResize   = 1 << 1,  // Disable user resizing with the lower-right grip
+    ImGuiWindowFlags_NoMove     = 1 << 2,  // Disable user moving the window
+    ImGuiWindowFlags_NoScrollbar =
+        1 << 3,  // Disable scrollbars (window can still scroll with mouse or programmatically)
+    ImGuiWindowFlags_NoScrollWithMouse =
+        1 << 4,  // Disable user vertically scrolling with mouse wheel. On child window, mouse wheel
+                 // will be forwarded to the parent unless NoScrollbar is also set.
+    ImGuiWindowFlags_NoCollapse = 1
+                                  << 5,  // Disable user collapsing window by double-clicking on it
+    ImGuiWindowFlags_AlwaysAutoResize = 1 << 6,  // Resize every window to its content every frame
+    ImGuiWindowFlags_NoBackground =
+        1 << 7,  // Disable drawing background color (WindowBg, etc.) and outside border. Similar as
+                 // using SetNextWindowBgAlpha(0.0f).
+    ImGuiWindowFlags_NoSavedSettings = 1 << 8,  // Never load/save settings in .ini file
+    ImGuiWindowFlags_NoMouseInputs =
+        1 << 9,                          // Disable catching mouse, hovering test with pass through.
+    ImGuiWindowFlags_MenuBar = 1 << 10,  // Has a menu-bar
+    ImGuiWindowFlags_HorizontalScrollbar =
+        1 << 11,  // Allow horizontal scrollbar to appear (off by default). You may use
+                  // SetNextWindowContentSize(ImVec2(width,0.0f)); prior to calling Begin() to
+                  // specify width. Read code in imgui_demo in the "Horizontal Scrolling" section.
+    ImGuiWindowFlags_NoFocusOnAppearing =
+        1 << 12,  // Disable taking focus when transitioning from hidden to visible state
+    ImGuiWindowFlags_NoBringToFrontOnFocus =
+        1 << 13,  // Disable bringing window to front when taking focus (e.g. clicking on it or
+                  // programmatically giving it focus)
+    ImGuiWindowFlags_AlwaysVerticalScrollbar =
+        1 << 14,  // Always show vertical scrollbar (even if ContentSize.y < Size.y)
+    ImGuiWindowFlags_AlwaysHorizontalScrollbar =
+        1 << 15,  // Always show horizontal scrollbar (even if ContentSize.x < Size.x)
+    ImGuiWindowFlags_AlwaysUseWindowPadding =
+        1 << 16,  // Ensure child windows without border uses style.WindowPadding (ignored by
+                  // default for non-bordered child windows, because more convenient)
+    ImGuiWindowFlags_NoNavInputs = 1 << 18,  // No gamepad/keyboard navigation within the window
+    ImGuiWindowFlags_NoNavFocus  = 1 << 19,  // No focusing toward this window with gamepad/keyboard
+                                             // navigation (e.g. skipped by CTRL+TAB)
+    ImGuiWindowFlags_UnsavedDocument =
+        1 << 20,  // Append '*' to title without affecting the ID, as a convenience to avoid using
+                  // the ### operator. When used in a tab/docking context, tab is selected on
+                  // closure and closure is deferred by one frame to allow code to cancel the
+                  // closure (with a confirmation popup, etc.) without flicker.
+    ImGuiWindowFlags_NoNav        = ImGuiWindowFlags_NoNavInputs | ImGuiWindowFlags_NoNavFocus,
+    ImGuiWindowFlags_NoDecoration = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize |
+                                    ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoCollapse,
+    ImGuiWindowFlags_NoInputs =
+        ImGuiWindowFlags_NoMouseInputs | ImGuiWindowFlags_NoNavInputs | ImGuiWindowFlags_NoNavFocus,
+
+    // [Internal]
+    ImGuiWindowFlags_NavFlattened =
+        1 << 23,  // [BETA] Allow gamepad/keyboard navigation to cross over parent border to this
+                  // child (only use on child that have no scrolling!)
+    ImGuiWindowFlags_ChildWindow = 1 << 24,  // Don't use! For internal use by BeginChild()
+    ImGuiWindowFlags_Tooltip     = 1 << 25,  // Don't use! For internal use by BeginTooltip()
+    ImGuiWindowFlags_Popup       = 1 << 26,  // Don't use! For internal use by BeginPopup()
+    ImGuiWindowFlags_Modal       = 1 << 27,  // Don't use! For internal use by BeginPopupModal()
+    ImGuiWindowFlags_ChildMenu   = 1 << 28   // Don't use! For internal use by BeginMenu()
+
+    // [Obsolete]
+    // ImGuiWindowFlags_ShowBorders          = 1 << 7,   // --> Set style.FrameBorderSize=1.0f /
+    // style.WindowBorderSize=1.0f to enable borders around windows and items
+    // ImGuiWindowFlags_ResizeFromAnySide    = 1 << 17,  // --> Set io.ConfigWindowsResizeFromEdges
+    // and make sure mouse cursors are supported by back-end (io.BackendFlags &
+    // ImGuiBackendFlags_HasMouseCursors)
+};
+
+// Flags for ImGui::InputText()
+enum ImGuiInputTextFlags_
+{
+    ImGuiInputTextFlags_None             = 0,
+    ImGuiInputTextFlags_CharsDecimal     = 1 << 0,  // Allow 0123456789.+-*/
+    ImGuiInputTextFlags_CharsHexadecimal = 1 << 1,  // Allow 0123456789ABCDEFabcdef
+    ImGuiInputTextFlags_CharsUppercase   = 1 << 2,  // Turn a..z into A..Z
+    ImGuiInputTextFlags_CharsNoBlank     = 1 << 3,  // Filter out spaces, tabs
+    ImGuiInputTextFlags_AutoSelectAll = 1 << 4,  // Select entire text when first taking mouse focus
+    ImGuiInputTextFlags_EnterReturnsTrue =
+        1 << 5,  // Return 'true' when Enter is pressed (as opposed to every time the value was
+                 // modified). Consider looking at the IsItemDeactivatedAfterEdit() function.
+    ImGuiInputTextFlags_CallbackCompletion =
+        1 << 6,  // Callback on pressing TAB (for completion handling)
+    ImGuiInputTextFlags_CallbackHistory =
+        1 << 7,  // Callback on pressing Up/Down arrows (for history handling)
+    ImGuiInputTextFlags_CallbackAlways = 1 << 8,  // Callback on each iteration. User code may query
+                                                  // cursor position, modify text buffer.
+    ImGuiInputTextFlags_CallbackCharFilter =
+        1 << 9,  // Callback on character inputs to replace or discard them. Modify 'EventChar' to
+                 // replace or discard, or return 1 in callback to discard.
+    ImGuiInputTextFlags_AllowTabInput =
+        1 << 10,  // Pressing TAB input a '\t' character into the text field
+    ImGuiInputTextFlags_CtrlEnterForNewLine =
+        1 << 11,  // In multi-line mode, unfocus with Enter, add new line with Ctrl+Enter (default
+                  // is opposite: unfocus with Ctrl+Enter, add line with Enter).
+    ImGuiInputTextFlags_NoHorizontalScroll = 1 << 12,  // Disable following the cursor horizontally
+    ImGuiInputTextFlags_AlwaysInsertMode   = 1 << 13,  // Insert mode
+    ImGuiInputTextFlags_ReadOnly           = 1 << 14,  // Read-only mode
+    ImGuiInputTextFlags_Password = 1 << 15,  // Password mode, display all characters as '*'
+    ImGuiInputTextFlags_NoUndoRedo =
+        1 << 16,  // Disable undo/redo. Note that input text owns the text data while active, if you
+                  // want to provide your own undo/redo stack you need e.g. to call ClearActiveID().
+    ImGuiInputTextFlags_CharsScientific =
+        1 << 17,  // Allow 0123456789.+-*/eE (Scientific notation input)
+    ImGuiInputTextFlags_CallbackResize =
+        1 << 18,  // Callback on buffer capacity changes request (beyond 'buf_size' parameter
+                  // value), allowing the string to grow. Notify when the string wants to be resized
+                  // (for string types which hold a cache of their Size). You will be provided a new
+                  // BufSize in the callback and NEED to honor it. (see misc/cpp/imgui_stdlib.h for
+                  // an example of using this)
+    // [Internal]
+    ImGuiInputTextFlags_Multiline = 1 << 20,  // For internal use by InputTextMultiline()
+    ImGuiInputTextFlags_NoMarkEdited =
+        1 << 21  // For internal use by functions using InputText() before reformatting data
+};
+
+// Flags for ImGui::TreeNodeEx(), ImGui::CollapsingHeader*()
+enum ImGuiTreeNodeFlags_
+{
+    ImGuiTreeNodeFlags_None     = 0,
+    ImGuiTreeNodeFlags_Selected = 1 << 0,  // Draw as selected
+    ImGuiTreeNodeFlags_Framed   = 1 << 1,  // Full colored frame (e.g. for CollapsingHeader)
+    ImGuiTreeNodeFlags_AllowItemOverlap =
+        1 << 2,  // Hit testing to allow subsequent widgets to overlap this one
+    ImGuiTreeNodeFlags_NoTreePushOnOpen =
+        1 << 3,  // Don't do a TreePush() when open (e.g. for CollapsingHeader) = no extra indent
+                 // nor pushing on ID stack
+    ImGuiTreeNodeFlags_NoAutoOpenOnLog =
+        1 << 4,  // Don't automatically and temporarily open node when Logging is active (by default
+                 // logging will automatically open tree nodes)
+    ImGuiTreeNodeFlags_DefaultOpen       = 1 << 5,  // Default node to be open
+    ImGuiTreeNodeFlags_OpenOnDoubleClick = 1 << 6,  // Need double-click to open node
+    ImGuiTreeNodeFlags_OpenOnArrow =
+        1
+        << 7,  // Only open when clicking on the arrow part. If ImGuiTreeNodeFlags_OpenOnDoubleClick
+               // is also set, single-click arrow or double-click all box to open.
+    ImGuiTreeNodeFlags_Leaf =
+        1 << 8,  // No collapsing, no arrow (use as a convenience for leaf nodes).
+    ImGuiTreeNodeFlags_Bullet = 1 << 9,  // Display a bullet instead of arrow
+    ImGuiTreeNodeFlags_FramePadding =
+        1 << 10,  // Use FramePadding (even for an unframed text node) to vertically align text
+                  // baseline to regular widget height. Equivalent to calling
+                  // AlignTextToFramePadding().
+    // ImGuiTreeNodeFlags_SpanAllAvailWidth  = 1 << 11,  // FIXME: TODO: Extend hit box horizontally
+    // even if not framed ImGuiTreeNodeFlags_NoScrollOnOpen     = 1 << 12,  // FIXME: TODO: Disable
+    // automatic scroll on TreePop() if node got just open and contents is not visible
+    ImGuiTreeNodeFlags_NavLeftJumpsBackHere =
+        1 << 13,  // (WIP) Nav: left direction may move to this TreeNode() from any of its child
+                  // (items submitted between TreeNode and TreePop)
+    ImGuiTreeNodeFlags_CollapsingHeader = ImGuiTreeNodeFlags_Framed |
+                                          ImGuiTreeNodeFlags_NoTreePushOnOpen |
+                                          ImGuiTreeNodeFlags_NoAutoOpenOnLog
+
+// Obsolete names (will be removed)
+#ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+    ,
+    ImGuiTreeNodeFlags_AllowOverlapMode = ImGuiTreeNodeFlags_AllowItemOverlap  // [renamed in 1.53]
+#endif
+};
+
+// Flags for ImGui::Selectable()
+enum ImGuiSelectableFlags_
+{
+    ImGuiSelectableFlags_None            = 0,
+    ImGuiSelectableFlags_DontClosePopups = 1 << 0,  // Clicking this don't close parent popup window
+    ImGuiSelectableFlags_SpanAllColumns =
+        1 << 1,  // Selectable frame can span all columns (text will still fit in current column)
+    ImGuiSelectableFlags_AllowDoubleClick = 1 << 2,  // Generate press events on double clicks too
+    ImGuiSelectableFlags_Disabled         = 1 << 3   // Cannot be selected, display grayed out text
+};
+
+// Flags for ImGui::BeginCombo()
+enum ImGuiComboFlags_
+{
+    ImGuiComboFlags_None           = 0,
+    ImGuiComboFlags_PopupAlignLeft = 1 << 0,  // Align the popup toward the left by default
+    ImGuiComboFlags_HeightSmall =
+        1 << 1,  // Max ~4 items visible. Tip: If you want your combo popup to be a specific size
+                 // you can use SetNextWindowSizeConstraints() prior to calling BeginCombo()
+    ImGuiComboFlags_HeightRegular = 1 << 2,  // Max ~8 items visible (default)
+    ImGuiComboFlags_HeightLarge   = 1 << 3,  // Max ~20 items visible
+    ImGuiComboFlags_HeightLargest = 1 << 4,  // As many fitting items as possible
+    ImGuiComboFlags_NoArrowButton =
+        1 << 5,  // Display on the preview box without the square arrow button
+    ImGuiComboFlags_NoPreview   = 1 << 6,  // Display only a square arrow button
+    ImGuiComboFlags_HeightMask_ = ImGuiComboFlags_HeightSmall | ImGuiComboFlags_HeightRegular |
+                                  ImGuiComboFlags_HeightLarge | ImGuiComboFlags_HeightLargest
+};
+
+// Flags for ImGui::BeginTabBar()
+enum ImGuiTabBarFlags_
+{
+    ImGuiTabBarFlags_None        = 0,
+    ImGuiTabBarFlags_Reorderable = 1 << 0,  // Allow manually dragging tabs to re-order them + New
+                                            // tabs are appended at the end of list
+    ImGuiTabBarFlags_AutoSelectNewTabs  = 1 << 1,  // Automatically select new tabs when they appear
+    ImGuiTabBarFlags_TabListPopupButton = 1 << 2,  // Disable buttons to open the tab list popup
+    ImGuiTabBarFlags_NoCloseWithMiddleMouseButton =
+        1 << 3,  // Disable behavior of closing tabs (that are submitted with p_open != NULL) with
+                 // middle mouse button. You can still repro this behavior on user's side with if
+                 // (IsItemHovered() && IsMouseClicked(2)) *p_open = false.
+    ImGuiTabBarFlags_NoTabListScrollingButtons =
+        1 << 4,  // Disable scrolling buttons (apply when fitting policy is
+                 // ImGuiTabBarFlags_FittingPolicyScroll)
+    ImGuiTabBarFlags_NoTooltip               = 1 << 5,  // Disable tooltips when hovering a tab
+    ImGuiTabBarFlags_FittingPolicyResizeDown = 1 << 6,  // Resize tabs when they don't fit
+    ImGuiTabBarFlags_FittingPolicyScroll     = 1 << 7,  // Add scroll buttons when tabs don't fit
+    ImGuiTabBarFlags_FittingPolicyMask_ =
+        ImGuiTabBarFlags_FittingPolicyResizeDown | ImGuiTabBarFlags_FittingPolicyScroll,
+    ImGuiTabBarFlags_FittingPolicyDefault_ = ImGuiTabBarFlags_FittingPolicyResizeDown
+};
+
+// Flags for ImGui::BeginTabItem()
+enum ImGuiTabItemFlags_
+{
+    ImGuiTabItemFlags_None = 0,
+    ImGuiTabItemFlags_UnsavedDocument =
+        1 << 0,  // Append '*' to title without affecting the ID, as a convenience to avoid using
+                 // the ### operator. Also: tab is selected on closure and closure is deferred by
+                 // one frame to allow code to undo it without flicker.
+    ImGuiTabItemFlags_SetSelected =
+        1
+        << 1,  // Trigger flag to programmatically make the tab selected when calling BeginTabItem()
+    ImGuiTabItemFlags_NoCloseWithMiddleMouseButton =
+        1 << 2,  // Disable behavior of closing tabs (that are submitted with p_open != NULL) with
+                 // middle mouse button. You can still repro this behavior on user's side with if
+                 // (IsItemHovered() && IsMouseClicked(2)) *p_open = false.
+    ImGuiTabItemFlags_NoPushId =
+        1 << 3  // Don't call PushID(tab->ID)/PopID() on BeginTabItem()/EndTabItem()
+};
+
+// Flags for ImGui::IsWindowFocused()
+enum ImGuiFocusedFlags_
+{
+    ImGuiFocusedFlags_None = 0,
+    ImGuiFocusedFlags_ChildWindows =
+        1 << 0,  // IsWindowFocused(): Return true if any children of the window is focused
+    ImGuiFocusedFlags_RootWindow = 1 << 1,  // IsWindowFocused(): Test from root window (top most
+                                            // parent of the current hierarchy)
+    ImGuiFocusedFlags_AnyWindow =
+        1 << 2,  // IsWindowFocused(): Return true if any window is focused. Important: If you are
+                 // trying to tell how to dispatch your low-level inputs, do NOT use this. Use
+                 // ImGui::GetIO().WantCaptureMouse instead.
+    ImGuiFocusedFlags_RootAndChildWindows =
+        ImGuiFocusedFlags_RootWindow | ImGuiFocusedFlags_ChildWindows
+};
+
+// Flags for ImGui::IsItemHovered(), ImGui::IsWindowHovered()
+// Note: if you are trying to check whether your mouse should be dispatched to imgui or to your app,
+// you should use the 'io.WantCaptureMouse' boolean for that. Please read the FAQ! Note: windows
+// with the ImGuiWindowFlags_NoInputs flag are ignored by IsWindowHovered() calls.
+enum ImGuiHoveredFlags_
+{
+    ImGuiHoveredFlags_None =
+        0,  // Return true if directly over the item/window, not obstructed by another window, not
+            // obstructed by an active popup or modal blocking inputs under them.
+    ImGuiHoveredFlags_ChildWindows =
+        1 << 0,  // IsWindowHovered() only: Return true if any children of the window is hovered
+    ImGuiHoveredFlags_RootWindow = 1 << 1,  // IsWindowHovered() only: Test from root window (top
+                                            // most parent of the current hierarchy)
+    ImGuiHoveredFlags_AnyWindow =
+        1 << 2,  // IsWindowHovered() only: Return true if any window is hovered
+    ImGuiHoveredFlags_AllowWhenBlockedByPopup =
+        1
+        << 3,  // Return true even if a popup window is normally blocking access to this item/window
+    // ImGuiHoveredFlags_AllowWhenBlockedByModal     = 1 << 4,   // Return true even if a modal
+    // popup window is normally blocking access to this item/window. FIXME-TODO: Unavailable yet.
+    ImGuiHoveredFlags_AllowWhenBlockedByActiveItem =
+        1 << 5,  // Return true even if an active item is blocking access to this item/window.
+                 // Useful for Drag and Drop patterns.
+    ImGuiHoveredFlags_AllowWhenOverlapped =
+        1 << 6,  // Return true even if the position is overlapped by another window
+    ImGuiHoveredFlags_AllowWhenDisabled = 1 << 7,  // Return true even if the item is disabled
+    ImGuiHoveredFlags_RectOnly          = ImGuiHoveredFlags_AllowWhenBlockedByPopup |
+                                 ImGuiHoveredFlags_AllowWhenBlockedByActiveItem |
+                                 ImGuiHoveredFlags_AllowWhenOverlapped,
+    ImGuiHoveredFlags_RootAndChildWindows =
+        ImGuiHoveredFlags_RootWindow | ImGuiHoveredFlags_ChildWindows
+};
+
+// Flags for ImGui::BeginDragDropSource(), ImGui::AcceptDragDropPayload()
+enum ImGuiDragDropFlags_
+{
+    ImGuiDragDropFlags_None = 0,
+    // BeginDragDropSource() flags
+    ImGuiDragDropFlags_SourceNoPreviewTooltip =
+        1 << 0,  // By default, a successful call to BeginDragDropSource opens a tooltip so you can
+                 // display a preview or description of the source contents. This flag disable this
+                 // behavior.
+    ImGuiDragDropFlags_SourceNoDisableHover =
+        1 << 1,  // By default, when dragging we clear data so that IsItemHovered() will return
+                 // false, to avoid subsequent user code submitting tooltips. This flag disable this
+                 // behavior so you can still call IsItemHovered() on the source item.
+    ImGuiDragDropFlags_SourceNoHoldToOpenOthers =
+        1 << 2,  // Disable the behavior that allows to open tree nodes and collapsing header by
+                 // holding over them while dragging a source item.
+    ImGuiDragDropFlags_SourceAllowNullID =
+        1 << 3,  // Allow items such as Text(), Image() that have no unique identifier to be used as
+                 // drag source, by manufacturing a temporary identifier based on their
+                 // window-relative position. This is extremely unusual within the dear imgui
+                 // ecosystem and so we made it explicit.
+    ImGuiDragDropFlags_SourceExtern =
+        1 << 4,  // External source (from outside of dear imgui), won't attempt to read current
+                 // item/window info. Will always return true. Only one Extern source can be active
+                 // simultaneously.
+    ImGuiDragDropFlags_SourceAutoExpirePayload =
+        1 << 5,  // Automatically expire the payload if the source cease to be submitted (otherwise
+                 // payloads are persisting while being dragged)
+    // AcceptDragDropPayload() flags
+    ImGuiDragDropFlags_AcceptBeforeDelivery =
+        1 << 10,  // AcceptDragDropPayload() will returns true even before the mouse button is
+                  // released. You can then call IsDelivery() to test if the payload needs to be
+                  // delivered.
+    ImGuiDragDropFlags_AcceptNoDrawDefaultRect =
+        1 << 11,  // Do not draw the default highlight rectangle when hovering over target.
+    ImGuiDragDropFlags_AcceptNoPreviewTooltip =
+        1
+        << 12,  // Request hiding the BeginDragDropSource tooltip from the BeginDragDropTarget site.
+    ImGuiDragDropFlags_AcceptPeekOnly =
+        ImGuiDragDropFlags_AcceptBeforeDelivery |
+        ImGuiDragDropFlags_AcceptNoDrawDefaultRect  // For peeking ahead and inspecting the payload
+                                                    // before delivery.
+};
+
+// Standard Drag and Drop payload types. You can define you own payload types using short strings.
+// Types starting with '_' are defined by Dear ImGui.
+#define IMGUI_PAYLOAD_TYPE_COLOR_3F \
+    "_COL3F"  // float[3]: Standard type for colors, without alpha. User code may use this type.
+#define IMGUI_PAYLOAD_TYPE_COLOR_4F \
+    "_COL4F"  // float[4]: Standard type for colors. User code may use this type.
+
+// A primary data type
+enum ImGuiDataType_
+{
+    ImGuiDataType_S8,      // char
+    ImGuiDataType_U8,      // unsigned char
+    ImGuiDataType_S16,     // short
+    ImGuiDataType_U16,     // unsigned short
+    ImGuiDataType_S32,     // int
+    ImGuiDataType_U32,     // unsigned int
+    ImGuiDataType_S64,     // long long / __int64
+    ImGuiDataType_U64,     // unsigned long long / unsigned __int64
+    ImGuiDataType_Float,   // float
+    ImGuiDataType_Double,  // double
+    ImGuiDataType_COUNT
+};
+
+// A cardinal direction
+enum ImGuiDir_
+{
+    ImGuiDir_None  = -1,
+    ImGuiDir_Left  = 0,
+    ImGuiDir_Right = 1,
+    ImGuiDir_Up    = 2,
+    ImGuiDir_Down  = 3,
+    ImGuiDir_COUNT
+};
+
+// User fill ImGuiIO.KeyMap[] array with indices into the ImGuiIO.KeysDown[512] array
+enum ImGuiKey_
+{
+    ImGuiKey_Tab,
+    ImGuiKey_LeftArrow,
+    ImGuiKey_RightArrow,
+    ImGuiKey_UpArrow,
+    ImGuiKey_DownArrow,
+    ImGuiKey_PageUp,
+    ImGuiKey_PageDown,
+    ImGuiKey_Home,
+    ImGuiKey_End,
+    ImGuiKey_Insert,
+    ImGuiKey_Delete,
+    ImGuiKey_Backspace,
+    ImGuiKey_Space,
+    ImGuiKey_Enter,
+    ImGuiKey_Escape,
+    ImGuiKey_A,  // for text edit CTRL+A: select all
+    ImGuiKey_C,  // for text edit CTRL+C: copy
+    ImGuiKey_V,  // for text edit CTRL+V: paste
+    ImGuiKey_X,  // for text edit CTRL+X: cut
+    ImGuiKey_Y,  // for text edit CTRL+Y: redo
+    ImGuiKey_Z,  // for text edit CTRL+Z: undo
+    ImGuiKey_COUNT
+};
+
+// Gamepad/Keyboard directional navigation
+// Keyboard: Set io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard to enable. NewFrame() will
+// automatically fill io.NavInputs[] based on your io.KeysDown[] + io.KeyMap[] arrays. Gamepad:  Set
+// io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad to enable. Back-end: set
+// ImGuiBackendFlags_HasGamepad and fill the io.NavInputs[] fields before calling NewFrame(). Note
+// that io.NavInputs[] is cleared by EndFrame(). Read instructions in imgui.cpp for more details.
+// Download PNG/PSD at http://goo.gl/9LgVZW.
+enum ImGuiNavInput_
+{
+    // Gamepad Mapping
+    ImGuiNavInput_Activate,  // activate / open / toggle / tweak value       // e.g. Cross  (PS4), A
+                             // (Xbox), A (Switch), Space (Keyboard)
+    ImGuiNavInput_Cancel,    // cancel / close / exit                        // e.g. Circle (PS4), B
+                             // (Xbox), B (Switch), Escape (Keyboard)
+    ImGuiNavInput_Input,     // text input / on-screen keyboard              // e.g. Triang.(PS4), Y
+                             // (Xbox), X (Switch), Return (Keyboard)
+    ImGuiNavInput_Menu,      // tap: toggle menu / hold: focus, move, resize // e.g. Square (PS4), X
+                             // (Xbox), Y (Switch), Alt (Keyboard)
+    ImGuiNavInput_DpadLeft,  // move / tweak / resize window (w/ PadMenu)    // e.g. D-pad
+                             // Left/Right/Up/Down (Gamepads), Arrow keys (Keyboard)
+    ImGuiNavInput_DpadRight,    //
+    ImGuiNavInput_DpadUp,       //
+    ImGuiNavInput_DpadDown,     //
+    ImGuiNavInput_LStickLeft,   // scroll / move window (w/ PadMenu)            // e.g. Left Analog
+                                // Stick Left/Right/Up/Down
+    ImGuiNavInput_LStickRight,  //
+    ImGuiNavInput_LStickUp,     //
+    ImGuiNavInput_LStickDown,   //
+    ImGuiNavInput_FocusPrev,    // next window (w/ PadMenu)                     // e.g. L1 or L2
+                                // (PS4), LB or LT (Xbox), L or ZL (Switch)
+    ImGuiNavInput_FocusNext,    // prev window (w/ PadMenu)                     // e.g. R1 or R2
+                                // (PS4), RB or RT (Xbox), R or ZL (Switch)
+    ImGuiNavInput_TweakSlow,    // slower tweaks                                // e.g. L1 or L2
+                                // (PS4), LB or LT (Xbox), L or ZL (Switch)
+    ImGuiNavInput_TweakFast,    // faster tweaks                                // e.g. R1 or R2
+                                // (PS4), RB or RT (Xbox), R or ZL (Switch)
+
+    // [Internal] Don't use directly! This is used internally to differentiate keyboard from gamepad
+    // inputs for behaviors that require to differentiate them. Keyboard behavior that have no
+    // corresponding gamepad mapping (e.g. CTRL+TAB) will be directly reading from io.KeysDown[]
+    // instead of io.NavInputs[].
+    ImGuiNavInput_KeyMenu_,   // toggle menu                                  // = io.KeyAlt
+    ImGuiNavInput_KeyTab_,    // tab                                          // = Tab key
+    ImGuiNavInput_KeyLeft_,   // move left                                    // = Arrow keys
+    ImGuiNavInput_KeyRight_,  // move right
+    ImGuiNavInput_KeyUp_,     // move up
+    ImGuiNavInput_KeyDown_,   // move down
+    ImGuiNavInput_COUNT,
+    ImGuiNavInput_InternalStart_ = ImGuiNavInput_KeyMenu_
+};
+
+// Configuration flags stored in io.ConfigFlags. Set by user/application.
+enum ImGuiConfigFlags_
+{
+    ImGuiConfigFlags_None = 0,
+    ImGuiConfigFlags_NavEnableKeyboard =
+        1 << 0,  // Master keyboard navigation enable flag. NewFrame() will automatically fill
+                 // io.NavInputs[] based on io.KeysDown[].
+    ImGuiConfigFlags_NavEnableGamepad =
+        1 << 1,  // Master gamepad navigation enable flag. This is mostly to instruct your imgui
+                 // back-end to fill io.NavInputs[]. Back-end also needs to set
+                 // ImGuiBackendFlags_HasGamepad.
+    ImGuiConfigFlags_NavEnableSetMousePos =
+        1 << 2,  // Instruct navigation to move the mouse cursor. May be useful on TV/console
+                 // systems where moving a virtual mouse is awkward. Will update io.MousePos and set
+                 // io.WantSetMousePos=true. If enabled you MUST honor io.WantSetMousePos requests
+                 // in your binding, otherwise ImGui will react as if the mouse is jumping around
+                 // back and forth.
+    ImGuiConfigFlags_NavNoCaptureKeyboard =
+        1 << 3,  // Instruct navigation to not set the io.WantCaptureKeyboard flag when io.NavActive
+                 // is set.
+    ImGuiConfigFlags_NoMouse =
+        1 << 4,  // Instruct imgui to clear mouse position/buttons in NewFrame(). This allows
+                 // ignoring the mouse information set by the back-end.
+    ImGuiConfigFlags_NoMouseCursorChange =
+        1 << 5,  // Instruct back-end to not alter mouse cursor shape and visibility. Use if the
+                 // back-end cursor changes are interfering with yours and you don't want to use
+                 // SetMouseCursor() to change mouse cursor. You may want to honor requests from
+                 // imgui by reading GetMouseCursor() yourself instead.
+
+    // User storage (to allow your back-end/engine to communicate to code that may be shared between
+    // multiple projects. Those flags are not used by core Dear ImGui)
+    ImGuiConfigFlags_IsSRGB = 1 << 20,  // Application is SRGB-aware.
+    ImGuiConfigFlags_IsTouchScreen =
+        1 << 21  // Application is using a touch screen instead of a mouse.
+};
+
+// Back-end capabilities flags stored in io.BackendFlags. Set by imgui_impl_xxx or custom back-end.
+enum ImGuiBackendFlags_
+{
+    ImGuiBackendFlags_None = 0,
+    ImGuiBackendFlags_HasGamepad =
+        1 << 0,  // Back-end Platform supports gamepad and currently has one connected.
+    ImGuiBackendFlags_HasMouseCursors =
+        1 << 1,  // Back-end Platform supports honoring GetMouseCursor() value to change the OS
+                 // cursor shape.
+    ImGuiBackendFlags_HasSetMousePos =
+        1 << 2,  // Back-end Platform supports io.WantSetMousePos requests to reposition the OS
+                 // mouse position (only used if ImGuiConfigFlags_NavEnableSetMousePos is set).
+    ImGuiBackendFlags_RendererHasVtxOffset =
+        1 << 3  // Back-end Renderer supports ImDrawCmd::VtxOffset. This enables output of large
+                // meshes (64K+ vertices) while still using 16-bits indices.
+};
+
+// Enumeration for PushStyleColor() / PopStyleColor()
+enum ImGuiCol_
+{
+    ImGuiCol_Text,
+    ImGuiCol_TextDisabled,
+    ImGuiCol_WindowBg,  // Background of normal windows
+    ImGuiCol_ChildBg,   // Background of child windows
+    ImGuiCol_PopupBg,   // Background of popups, menus, tooltips windows
+    ImGuiCol_Border,
+    ImGuiCol_BorderShadow,
+    ImGuiCol_FrameBg,  // Background of checkbox, radio button, plot, slider, text input
+    ImGuiCol_FrameBgHovered,
+    ImGuiCol_FrameBgActive,
+    ImGuiCol_TitleBg,
+    ImGuiCol_TitleBgActive,
+    ImGuiCol_TitleBgCollapsed,
+    ImGuiCol_MenuBarBg,
+    ImGuiCol_ScrollbarBg,
+    ImGuiCol_ScrollbarGrab,
+    ImGuiCol_ScrollbarGrabHovered,
+    ImGuiCol_ScrollbarGrabActive,
+    ImGuiCol_CheckMark,
+    ImGuiCol_SliderGrab,
+    ImGuiCol_SliderGrabActive,
+    ImGuiCol_Button,
+    ImGuiCol_ButtonHovered,
+    ImGuiCol_ButtonActive,
+    ImGuiCol_Header,
+    ImGuiCol_HeaderHovered,
+    ImGuiCol_HeaderActive,
+    ImGuiCol_Separator,
+    ImGuiCol_SeparatorHovered,
+    ImGuiCol_SeparatorActive,
+    ImGuiCol_ResizeGrip,
+    ImGuiCol_ResizeGripHovered,
+    ImGuiCol_ResizeGripActive,
+    ImGuiCol_Tab,
+    ImGuiCol_TabHovered,
+    ImGuiCol_TabActive,
+    ImGuiCol_TabUnfocused,
+    ImGuiCol_TabUnfocusedActive,
+    ImGuiCol_PlotLines,
+    ImGuiCol_PlotLinesHovered,
+    ImGuiCol_PlotHistogram,
+    ImGuiCol_PlotHistogramHovered,
+    ImGuiCol_TextSelectedBg,
+    ImGuiCol_DragDropTarget,
+    ImGuiCol_NavHighlight,           // Gamepad/keyboard: current highlighted item
+    ImGuiCol_NavWindowingHighlight,  // Highlight window when using CTRL+TAB
+    ImGuiCol_NavWindowingDimBg,  // Darken/colorize entire screen behind the CTRL+TAB window list,
+                                 // when active
+    ImGuiCol_ModalWindowDimBg,   // Darken/colorize entire screen behind a modal window, when one is
+                                 // active
+    ImGuiCol_COUNT
+
+// Obsolete names (will be removed)
+#ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+    ,
+    ImGuiCol_ModalWindowDarkening = ImGuiCol_ModalWindowDimBg  // [renamed in 1.63]
+    ,
+    ImGuiCol_ChildWindowBg = ImGuiCol_ChildBg  // [renamed in 1.53]
+// ImGuiCol_CloseButton, ImGuiCol_CloseButtonActive, ImGuiCol_CloseButtonHovered, // [unused
+// since 1.60+] the close button now uses regular button colors. ImGuiCol_ComboBg, // [unused
+// since 1.53+] ComboBg has been merged with PopupBg, so a redirect isn't accurate.
+#endif
+};
+
+// Enumeration for PushStyleVar() / PopStyleVar() to temporarily modify the ImGuiStyle structure.
+// NB: the enum only refers to fields of ImGuiStyle which makes sense to be pushed/popped inside UI
+// code. During initialization, feel free to just poke into ImGuiStyle directly. NB: if changing
+// this enum, you need to update the associated internal table GStyleVarInfo[] accordingly. This is
+// where we link enum values to members offset/type.
+enum ImGuiStyleVar_
+{
+    // Enum name --------------------- // Member in ImGuiStyle structure (see ImGuiStyle for
+    // descriptions)
+    ImGuiStyleVar_Alpha,                // float     Alpha
+    ImGuiStyleVar_WindowPadding,        // ImVec2    WindowPadding
+    ImGuiStyleVar_WindowRounding,       // float     WindowRounding
+    ImGuiStyleVar_WindowBorderSize,     // float     WindowBorderSize
+    ImGuiStyleVar_WindowMinSize,        // ImVec2    WindowMinSize
+    ImGuiStyleVar_WindowTitleAlign,     // ImVec2    WindowTitleAlign
+    ImGuiStyleVar_ChildRounding,        // float     ChildRounding
+    ImGuiStyleVar_ChildBorderSize,      // float     ChildBorderSize
+    ImGuiStyleVar_PopupRounding,        // float     PopupRounding
+    ImGuiStyleVar_PopupBorderSize,      // float     PopupBorderSize
+    ImGuiStyleVar_FramePadding,         // ImVec2    FramePadding
+    ImGuiStyleVar_FrameRounding,        // float     FrameRounding
+    ImGuiStyleVar_FrameBorderSize,      // float     FrameBorderSize
+    ImGuiStyleVar_ItemSpacing,          // ImVec2    ItemSpacing
+    ImGuiStyleVar_ItemInnerSpacing,     // ImVec2    ItemInnerSpacing
+    ImGuiStyleVar_IndentSpacing,        // float     IndentSpacing
+    ImGuiStyleVar_ScrollbarSize,        // float     ScrollbarSize
+    ImGuiStyleVar_ScrollbarRounding,    // float     ScrollbarRounding
+    ImGuiStyleVar_GrabMinSize,          // float     GrabMinSize
+    ImGuiStyleVar_GrabRounding,         // float     GrabRounding
+    ImGuiStyleVar_TabRounding,          // float     TabRounding
+    ImGuiStyleVar_ButtonTextAlign,      // ImVec2    ButtonTextAlign
+    ImGuiStyleVar_SelectableTextAlign,  // ImVec2    SelectableTextAlign
+    ImGuiStyleVar_COUNT
+
+// Obsolete names (will be removed)
+#ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+    ,
+    ImGuiStyleVar_Count_ = ImGuiStyleVar_COUNT  // [renamed in 1.60]
+    ,
+    ImGuiStyleVar_ChildWindowRounding = ImGuiStyleVar_ChildRounding  // [renamed in 1.53]
+#endif
+};
+
+// Flags for ColorEdit3() / ColorEdit4() / ColorPicker3() / ColorPicker4() / ColorButton()
+enum ImGuiColorEditFlags_
+{
+    ImGuiColorEditFlags_None = 0,
+    ImGuiColorEditFlags_NoAlpha =
+        1 << 1,  //              // ColorEdit, ColorPicker, ColorButton: ignore Alpha component
+                 //              (will only read 3 components from the input pointer).
+    ImGuiColorEditFlags_NoPicker =
+        1 << 2,  //              // ColorEdit: disable picker when clicking on colored square.
+    ImGuiColorEditFlags_NoOptions =
+        1 << 3,  //              // ColorEdit: disable toggling options menu when right-clicking on
+                 //              inputs/small preview.
+    ImGuiColorEditFlags_NoSmallPreview =
+        1 << 4,  //              // ColorEdit, ColorPicker: disable colored square preview next to
+                 //              the inputs. (e.g. to show only the inputs)
+    ImGuiColorEditFlags_NoInputs =
+        1 << 5,  //              // ColorEdit, ColorPicker: disable inputs sliders/text widgets
+                 //              (e.g. to show only the small preview colored square).
+    ImGuiColorEditFlags_NoTooltip =
+        1 << 6,  //              // ColorEdit, ColorPicker, ColorButton: disable tooltip when
+                 //              hovering the preview.
+    ImGuiColorEditFlags_NoLabel =
+        1 << 7,  //              // ColorEdit, ColorPicker: disable display of inline text label
+                 //              (the label is still forwarded to the tooltip and picker).
+    ImGuiColorEditFlags_NoSidePreview =
+        1 << 8,  //              // ColorPicker: disable bigger color preview on right side of the
+                 //              picker, use small colored square preview instead.
+    ImGuiColorEditFlags_NoDragDrop =
+        1 << 9,  //              // ColorEdit: disable drag and drop target. ColorButton: disable
+                 //              drag and drop source.
+
+    // User Options (right-click on widget to change some of them).
+    ImGuiColorEditFlags_AlphaBar = 1 << 16,  //              // ColorEdit, ColorPicker: show
+                                             //              vertical alpha bar/gradient in picker.
+    ImGuiColorEditFlags_AlphaPreview =
+        1 << 17,  //              // ColorEdit, ColorPicker, ColorButton: display preview as a
+                  //              transparent color over a checkerboard, instead of opaque.
+    ImGuiColorEditFlags_AlphaPreviewHalf =
+        1 << 18,  //              // ColorEdit, ColorPicker, ColorButton: display half opaque / half
+                  //              checkerboard, instead of opaque.
+    ImGuiColorEditFlags_HDR =
+        1 << 19,  //              // (WIP) ColorEdit: Currently only disable 0.0f..1.0f limits in
+                  //              RGBA edition (note: you probably want to use
+                  //              ImGuiColorEditFlags_Float flag as well).
+    ImGuiColorEditFlags_DisplayRGB =
+        1 << 20,  // [Display]    // ColorEdit: override _display_ type among RGB/HSV/Hex.
+                  // ColorPicker: select any combination using one or more of RGB/HSV/Hex.
+    ImGuiColorEditFlags_DisplayHSV = 1 << 21,  // [Display]    // "
+    ImGuiColorEditFlags_DisplayHex = 1 << 22,  // [Display]    // "
+    ImGuiColorEditFlags_Uint8 = 1 << 23,  // [DataType]   // ColorEdit, ColorPicker, ColorButton:
+                                          // _display_ values formatted as 0..255.
+    ImGuiColorEditFlags_Float =
+        1 << 24,  // [DataType]   // ColorEdit, ColorPicker, ColorButton: _display_ values formatted
+                  // as 0.0f..1.0f floats instead of 0..255 integers. No round-trip of value via
+                  // integers.
+    ImGuiColorEditFlags_PickerHueBar =
+        1 << 25,  // [Picker]     // ColorPicker: bar for Hue, rectangle for Sat/Value.
+    ImGuiColorEditFlags_PickerHueWheel =
+        1 << 26,  // [Picker]     // ColorPicker: wheel for Hue, triangle for Sat/Value.
+    ImGuiColorEditFlags_InputRGB =
+        1 << 27,  // [Input]      // ColorEdit, ColorPicker: input and output data in RGB format.
+    ImGuiColorEditFlags_InputHSV =
+        1 << 28,  // [Input]      // ColorEdit, ColorPicker: input and output data in HSV format.
+
+    // Defaults Options. You can set application defaults using SetColorEditOptions(). The intent is
+    // that you probably don't want to override them in most of your calls. Let the user choose via
+    // the option menu and/or call SetColorEditOptions() once during startup.
+    ImGuiColorEditFlags__OptionsDefault =
+        ImGuiColorEditFlags_Uint8 | ImGuiColorEditFlags_DisplayRGB | ImGuiColorEditFlags_InputRGB |
+        ImGuiColorEditFlags_PickerHueBar,
+
+    // [Internal] Masks
+    ImGuiColorEditFlags__DisplayMask = ImGuiColorEditFlags_DisplayRGB |
+                                       ImGuiColorEditFlags_DisplayHSV |
+                                       ImGuiColorEditFlags_DisplayHex,
+    ImGuiColorEditFlags__DataTypeMask = ImGuiColorEditFlags_Uint8 | ImGuiColorEditFlags_Float,
+    ImGuiColorEditFlags__PickerMask =
+        ImGuiColorEditFlags_PickerHueWheel | ImGuiColorEditFlags_PickerHueBar,
+    ImGuiColorEditFlags__InputMask = ImGuiColorEditFlags_InputRGB | ImGuiColorEditFlags_InputHSV
+
+// Obsolete names (will be removed)
+#ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+    ,
+    ImGuiColorEditFlags_RGB = ImGuiColorEditFlags_DisplayRGB,
+    ImGuiColorEditFlags_HSV = ImGuiColorEditFlags_DisplayHSV,
+    ImGuiColorEditFlags_HEX = ImGuiColorEditFlags_DisplayHex  // [renamed in 1.69]
+#endif
+};
+
+// Enumeration for GetMouseCursor()
+// User code may request binding to display given cursor by calling SetMouseCursor(), which is why
+// we have some cursors that are marked unused here
+enum ImGuiMouseCursor_
+{
+    ImGuiMouseCursor_None  = -1,
+    ImGuiMouseCursor_Arrow = 0,
+    ImGuiMouseCursor_TextInput,   // When hovering over InputText, etc.
+    ImGuiMouseCursor_ResizeAll,   // (Unused by Dear ImGui functions)
+    ImGuiMouseCursor_ResizeNS,    // When hovering over an horizontal border
+    ImGuiMouseCursor_ResizeEW,    // When hovering over a vertical border or a column
+    ImGuiMouseCursor_ResizeNESW,  // When hovering over the bottom-left corner of a window
+    ImGuiMouseCursor_ResizeNWSE,  // When hovering over the bottom-right corner of a window
+    ImGuiMouseCursor_Hand,        // (Unused by Dear ImGui functions. Use for e.g. hyperlinks)
+    ImGuiMouseCursor_COUNT
+
+// Obsolete names (will be removed)
+#ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+    ,
+    ImGuiMouseCursor_Count_ = ImGuiMouseCursor_COUNT  // [renamed in 1.60]
+#endif
+};
+
+// Enumateration for ImGui::SetWindow***(), SetNextWindow***(), SetNextItem***() functions
+// Represent a condition.
+// Important: Treat as a regular enum! Do NOT combine multiple values using binary operators! All
+// the functions above treat 0 as a shortcut to ImGuiCond_Always.
+enum ImGuiCond_
+{
+    ImGuiCond_Always = 1 << 0,  // Set the variable
+    ImGuiCond_Once =
+        1 << 1,  // Set the variable once per runtime session (only the first call with succeed)
+    ImGuiCond_FirstUseEver = 1 << 2,  // Set the variable if the object/window has no persistently
+                                      // saved data (no entry in .ini file)
+    ImGuiCond_Appearing = 1 << 3  // Set the variable if the object/window is appearing after being
+                                  // hidden/inactive (or the first time)
+};
+
+//-----------------------------------------------------------------------------
+// Helpers: Memory allocations macros
+// IM_MALLOC(), IM_FREE(), IM_NEW(), IM_PLACEMENT_NEW(), IM_DELETE()
+// We call C++ constructor on own allocated memory via the placement "new(ptr) Type()" syntax.
+// Defining a custom placement new() with a dummy parameter allows us to bypass including <new>
+// which on some platforms complains when user has disabled exceptions.
+//-----------------------------------------------------------------------------
+
+struct ImNewDummy
+{
+};
+inline void *operator new(size_t, ImNewDummy, void *ptr)
+{
+    return ptr;
+}
+inline void operator delete(void *, ImNewDummy, void *) {
+}  // This is only required so we can use the symmetrical new()
+#define IM_ALLOC(_SIZE) ImGui::MemAlloc(_SIZE)
+#define IM_FREE(_PTR) ImGui::MemFree(_PTR)
+#define IM_PLACEMENT_NEW(_PTR) new (ImNewDummy(), _PTR)
+#define IM_NEW(_TYPE) new (ImNewDummy(), ImGui::MemAlloc(sizeof(_TYPE))) _TYPE
+template <typename T>
+void IM_DELETE(T *p)
+{
+    if (p)
+    {
+        p->~T();
+        ImGui::MemFree(p);
+    }
+}
+
+//-----------------------------------------------------------------------------
+// Helper: ImVector<>
+// Lightweight std::vector<>-like class to avoid dragging dependencies (also, some implementations
+// of STL with debug enabled are absurdly slow, we bypass it so our code runs fast in debug). You
+// generally do NOT need to care or use this ever. But we need to make it available in imgui.h
+// because some of our data structures are relying on it. Important: clear() frees memory, resize(0)
+// keep the allocated buffer. We use resize(0) a lot to intentionally recycle allocated buffers
+// across frames and amortize our costs. Important: our implementation does NOT call C++
+// constructors/destructors, we treat everything as raw data! This is intentional but be extra
+// mindful of that, do NOT use this class as a std::vector replacement in your own code! Many of the
+// structures used by dear imgui can be safely initialized by a zero-memset.
+//-----------------------------------------------------------------------------
+
+template <typename T>
+struct ImVector
+{
+    int Size;
+    int Capacity;
+    T *Data;
+
+    // Provide standard typedefs but we don't use them ourselves.
+    typedef T value_type;
+    typedef value_type *iterator;
+    typedef const value_type *const_iterator;
+
+    // Constructors, destructor
+    inline ImVector()
+    {
+        Size = Capacity = 0;
+        Data            = NULL;
+    }
+    inline ImVector(const ImVector<T> &src)
+    {
+        Size = Capacity = 0;
+        Data            = NULL;
+        operator        =(src);
+    }
+    inline ImVector<T> &operator=(const ImVector<T> &src)
+    {
+        clear();
+        resize(src.Size);
+        memcpy(Data, src.Data, (size_t)Size * sizeof(T));
+        return *this;
+    }
+    inline ~ImVector()
+    {
+        if (Data)
+            IM_FREE(Data);
+    }
+
+    inline bool empty() const { return Size == 0; }
+    inline int size() const { return Size; }
+    inline int size_in_bytes() const { return Size * (int)sizeof(T); }
+    inline int capacity() const { return Capacity; }
+    inline T &operator[](int i)
+    {
+        IM_ASSERT(i < Size);
+        return Data[i];
+    }
+    inline const T &operator[](int i) const
+    {
+        IM_ASSERT(i < Size);
+        return Data[i];
+    }
+
+    inline void clear()
+    {
+        if (Data)
+        {
+            Size = Capacity = 0;
+            IM_FREE(Data);
+            Data = NULL;
+        }
+    }
+    inline T *begin() { return Data; }
+    inline const T *begin() const { return Data; }
+    inline T *end() { return Data + Size; }
+    inline const T *end() const { return Data + Size; }
+    inline T &front()
+    {
+        IM_ASSERT(Size > 0);
+        return Data[0];
+    }
+    inline const T &front() const
+    {
+        IM_ASSERT(Size > 0);
+        return Data[0];
+    }
+    inline T &back()
+    {
+        IM_ASSERT(Size > 0);
+        return Data[Size - 1];
+    }
+    inline const T &back() const
+    {
+        IM_ASSERT(Size > 0);
+        return Data[Size - 1];
+    }
+    inline void swap(ImVector<T> &rhs)
+    {
+        int rhs_size = rhs.Size;
+        rhs.Size     = Size;
+        Size         = rhs_size;
+        int rhs_cap  = rhs.Capacity;
+        rhs.Capacity = Capacity;
+        Capacity     = rhs_cap;
+        T *rhs_data  = rhs.Data;
+        rhs.Data     = Data;
+        Data         = rhs_data;
+    }
+
+    inline int _grow_capacity(int sz) const
+    {
+        int new_capacity = Capacity ? (Capacity + Capacity / 2) : 8;
+        return new_capacity > sz ? new_capacity : sz;
+    }
+    inline void resize(int new_size)
+    {
+        if (new_size > Capacity)
+            reserve(_grow_capacity(new_size));
+        Size = new_size;
+    }
+    inline void resize(int new_size, const T &v)
+    {
+        if (new_size > Capacity)
+            reserve(_grow_capacity(new_size));
+        if (new_size > Size)
+            for (int n = Size; n < new_size; n++)
+                memcpy(&Data[n], &v, sizeof(v));
+        Size = new_size;
+    }
+    inline void reserve(int new_capacity)
+    {
+        if (new_capacity <= Capacity)
+            return;
+        T *new_data = (T *)IM_ALLOC((size_t)new_capacity * sizeof(T));
+        if (Data)
+        {
+            memcpy(new_data, Data, (size_t)Size * sizeof(T));
+            IM_FREE(Data);
+        }
+        Data     = new_data;
+        Capacity = new_capacity;
+    }
+
+    // NB: It is illegal to call push_back/push_front/insert with a reference pointing inside the
+    // ImVector data itself! e.g. v.push_back(v[10]) is forbidden.
+    inline void push_back(const T &v)
+    {
+        if (Size == Capacity)
+            reserve(_grow_capacity(Size + 1));
+        memcpy(&Data[Size], &v, sizeof(v));
+        Size++;
+    }
+    inline void pop_back()
+    {
+        IM_ASSERT(Size > 0);
+        Size--;
+    }
+    inline void push_front(const T &v)
+    {
+        if (Size == 0)
+            push_back(v);
+        else
+            insert(Data, v);
+    }
+    inline T *erase(const T *it)
+    {
+        IM_ASSERT(it >= Data && it < Data + Size);
+        const ptrdiff_t off = it - Data;
+        memmove(Data + off, Data + off + 1, ((size_t)Size - (size_t)off - 1) * sizeof(T));
+        Size--;
+        return Data + off;
+    }
+    inline T *erase(const T *it, const T *it_last)
+    {
+        IM_ASSERT(it >= Data && it < Data + Size && it_last > it && it_last <= Data + Size);
+        const ptrdiff_t count = it_last - it;
+        const ptrdiff_t off   = it - Data;
+        memmove(Data + off, Data + off + count, ((size_t)Size - (size_t)off - count) * sizeof(T));
+        Size -= (int)count;
+        return Data + off;
+    }
+    inline T *erase_unsorted(const T *it)
+    {
+        IM_ASSERT(it >= Data && it < Data + Size);
+        const ptrdiff_t off = it - Data;
+        if (it < Data + Size - 1)
+            memcpy(Data + off, Data + Size - 1, sizeof(T));
+        Size--;
+        return Data + off;
+    }
+    inline T *insert(const T *it, const T &v)
+    {
+        IM_ASSERT(it >= Data && it <= Data + Size);
+        const ptrdiff_t off = it - Data;
+        if (Size == Capacity)
+            reserve(_grow_capacity(Size + 1));
+        if (off < (int)Size)
+            memmove(Data + off + 1, Data + off, ((size_t)Size - (size_t)off) * sizeof(T));
+        memcpy(&Data[off], &v, sizeof(v));
+        Size++;
+        return Data + off;
+    }
+    inline bool contains(const T &v) const
+    {
+        const T *data     = Data;
+        const T *data_end = Data + Size;
+        while (data < data_end)
+            if (*data++ == v)
+                return true;
+        return false;
+    }
+    inline int index_from_ptr(const T *it) const
+    {
+        IM_ASSERT(it >= Data && it <= Data + Size);
+        const ptrdiff_t off = it - Data;
+        return (int)off;
+    }
+};
+
+//-----------------------------------------------------------------------------
+// ImGuiStyle
+// You may modify the ImGui::GetStyle() main instance during initialization and before NewFrame().
+// During the frame, use ImGui::PushStyleVar(ImGuiStyleVar_XXXX)/PopStyleVar() to alter the main
+// style values, and ImGui::PushStyleColor(ImGuiCol_XXX)/PopStyleColor() for colors.
+//-----------------------------------------------------------------------------
+
+struct ImGuiStyle
+{
+    float Alpha;              // Global alpha applies to everything in Dear ImGui.
+    ImVec2 WindowPadding;     // Padding within a window.
+    float WindowRounding;     // Radius of window corners rounding. Set to 0.0f to have rectangular
+                              // windows.
+    float WindowBorderSize;   // Thickness of border around windows. Generally set to 0.0f or 1.0f.
+                              // (Other values are not well tested and more CPU/GPU costly).
+    ImVec2 WindowMinSize;     // Minimum window size. This is a global setting. If you want to
+                              // constraint individual windows, use SetNextWindowSizeConstraints().
+    ImVec2 WindowTitleAlign;  // Alignment for title bar text. Defaults to (0.0f,0.5f) for
+                              // left-aligned,vertically centered.
+    ImGuiDir WindowMenuButtonPosition;  // Side of the collapsing/docking button in the title bar
+                                        // (left/right). Defaults to ImGuiDir_Left.
+    float ChildRounding;    // Radius of child window corners rounding. Set to 0.0f to have
+                            // rectangular windows.
+    float ChildBorderSize;  // Thickness of border around child windows. Generally set to 0.0f
+                            // or 1.0f. (Other values are not well tested and more CPU/GPU costly).
+    float PopupRounding;  // Radius of popup window corners rounding. (Note that tooltip windows use
+                          // WindowRounding)
+    float
+        PopupBorderSize;  // Thickness of border around popup/tooltip windows. Generally set to 0.0f
+                          // or 1.0f. (Other values are not well tested and more CPU/GPU costly).
+    ImVec2 FramePadding;  // Padding within a framed rectangle (used by most widgets).
+    float FrameRounding;  // Radius of frame corners rounding. Set to 0.0f to have rectangular frame
+                          // (used by most widgets).
+    float FrameBorderSize;     // Thickness of border around frames. Generally set to 0.0f or 1.0f.
+                               // (Other values are not well tested and more CPU/GPU costly).
+    ImVec2 ItemSpacing;        // Horizontal and vertical spacing between widgets/lines.
+    ImVec2 ItemInnerSpacing;   // Horizontal and vertical spacing between within elements of a
+                               // composed widget (e.g. a slider and its label).
+    ImVec2 TouchExtraPadding;  // Expand reactive bounding box for touch-based system where touch
+                               // position is not accurate enough. Unfortunately we don't sort
+                               // widgets so priority on overlap will always be given to the first
+                               // widget. So don't grow this too much!
+    float IndentSpacing;      // Horizontal indentation when e.g. entering a tree node. Generally ==
+                              // (FontSize + FramePadding.x*2).
+    float ColumnsMinSpacing;  // Minimum horizontal spacing between two columns. Preferably >
+                              // (FramePadding.x + 1).
+    float ScrollbarSize;  // Width of the vertical scrollbar, Height of the horizontal scrollbar.
+    float ScrollbarRounding;  // Radius of grab corners for scrollbar.
+    float GrabMinSize;        // Minimum width/height of a grab box for slider/scrollbar.
+    float GrabRounding;  // Radius of grabs corners rounding. Set to 0.0f to have rectangular slider
+                         // grabs.
+    float TabRounding;   // Radius of upper corners of a tab. Set to 0.0f to have rectangular tabs.
+    float TabBorderSize;     // Thickness of border around tabs.
+    ImVec2 ButtonTextAlign;  // Alignment of button text when button is larger than text. Defaults
+                             // to (0.5f, 0.5f) (centered).
+    ImVec2 SelectableTextAlign;   // Alignment of selectable text when selectable is larger than
+                                  // text. Defaults to (0.0f, 0.0f) (top-left aligned).
+    ImVec2 DisplayWindowPadding;  // Window position are clamped to be visible within the display
+                                  // area by at least this amount. Only applies to regular windows.
+    ImVec2
+        DisplaySafeAreaPadding;  // If you cannot see the edges of your screen (e.g. on a TV)
+                                 // increase the safe area padding. Apply to popups/tooltips as well
+                                 // regular windows. NB: Prefer configuring your TV sets correctly!
+    float MouseCursorScale;      // Scale software rendered mouse cursor (when io.MouseDrawCursor is
+                                 // enabled). May be removed later.
+    bool AntiAliasedLines;       // Enable anti-aliasing on lines/borders. Disable if you are really
+                                 // tight on CPU/GPU.
+    bool AntiAliasedFill;  // Enable anti-aliasing on filled shapes (rounded rectangles, circles,
+                           // etc.)
+    float CurveTessellationTol;  // Tessellation tolerance when using PathBezierCurveTo() without a
+                                 // specific number of segments. Decrease for highly tessellated
+                                 // curves (higher quality, more polygons), increase to reduce
+                                 // quality.
+    ImVec4 Colors[ImGuiCol_COUNT];
+
+    IMGUI_API ImGuiStyle();
+    IMGUI_API void ScaleAllSizes(float scale_factor);
+};
+
+//-----------------------------------------------------------------------------
+// ImGuiIO
+// Communicate most settings and inputs/outputs to Dear ImGui using this structure.
+// Access via ImGui::GetIO(). Read 'Programmer guide' section in .cpp file for general usage.
+//-----------------------------------------------------------------------------
+
+struct ImGuiIO
+{
+    //------------------------------------------------------------------
+    // Configuration (fill once)                // Default value
+    //------------------------------------------------------------------
+
+    ImGuiConfigFlags ConfigFlags;    // = 0              // See ImGuiConfigFlags_ enum. Set by
+                                     // user/application. Gamepad/keyboard navigation options, etc.
+    ImGuiBackendFlags BackendFlags;  // = 0              // See ImGuiBackendFlags_ enum. Set by
+                                     // back-end (imgui_impl_xxx files or custom back-end) to
+                                     // communicate features supported by the back-end.
+    ImVec2 DisplaySize;              // <unset>          // Main display size, in pixels.
+    float DeltaTime;      // = 1.0f/60.0f     // Time elapsed since last frame, in seconds.
+    float IniSavingRate;  // = 5.0f           // Minimum time between saving positions/sizes to .ini
+                          // file, in seconds.
+    const char
+        *IniFilename;  // = "imgui.ini"    // Path to .ini file. Set NULL to disable automatic .ini
+                       // loading/saving, if e.g. you want to manually load/save from memory.
+    const char *LogFilename;        // = "imgui_log.txt"// Path to .log file (default parameter to
+                                    // ImGui::LogToFile when no file is specified).
+    float MouseDoubleClickTime;     // = 0.30f          // Time for a double-click, in seconds.
+    float MouseDoubleClickMaxDist;  // = 6.0f           // Distance threshold to stay in to validate
+                                    // a double-click, in pixels.
+    float MouseDragThreshold;    // = 6.0f           // Distance threshold before considering we are
+                                 // dragging.
+    int KeyMap[ImGuiKey_COUNT];  // <unset>          // Map of indices into the KeysDown[512]
+                                 // entries array which represent your "native" keyboard state.
+    float KeyRepeatDelay;  // = 0.250f         // When holding a key/button, time before it starts
+                           // repeating, in seconds (for buttons in Repeat mode, etc.).
+    float KeyRepeatRate;   // = 0.050f         // When holding a key/button, rate at which it
+                           // repeats, in seconds.
+    void *UserData;        // = NULL           // Store your own data for retrieval by callbacks.
+
+    ImFontAtlas *Fonts;     // <auto>           // Load, rasterize and pack one or more fonts into a
+                            // single texture.
+    float FontGlobalScale;  // = 1.0f           // Global scale all fonts
+    bool FontAllowUserScaling;  // = false          // Allow user scaling text of individual window
+                                // with CTRL+Wheel.
+    ImFont *FontDefault;        // = NULL           // Font to use on NewFrame(). Use NULL to uses
+                                // Fonts->Fonts[0].
+    ImVec2 DisplayFramebufferScale;  // = (1, 1)         // For retina display or other situations
+                                     // where window coordinates are different from framebuffer
+                                     // coordinates. This generally ends up in
+                                     // ImDrawData::FramebufferScale.
+
+    // Miscellaneous options
+    bool MouseDrawCursor;  // = false          // Request ImGui to draw a mouse cursor for you (if
+                           // you are on a platform without a mouse cursor). Cannot be easily
+                           // renamed to 'io.ConfigXXX' because this is frequently used by back-end
+                           // implementations.
+    bool ConfigMacOSXBehaviors;  // = defined(__APPLE__) // OS X style: Text editing cursor movement
+                                 // using Alt instead of Ctrl, Shortcuts using Cmd/Super instead of
+                                 // Ctrl, Line/Text Start and End using Cmd+Arrows instead of
+                                 // Home/End, Double click selects by word instead of selecting
+                                 // whole text, Multi-selection in lists uses Cmd/Super instead of
+                                 // Ctrl (was called io.OptMacOSXBehaviors prior to 1.63)
+    bool ConfigInputTextCursorBlink;  // = true           // Set to false to disable blinking
+                                      // cursor, for users who consider it distracting. (was called:
+                                      // io.OptCursorBlink prior to 1.63)
+    bool ConfigWindowsResizeFromEdges;  // = true           // Enable resizing of windows from their
+                                        // edges and from the lower-left corner. This requires
+                                        // (io.BackendFlags & ImGuiBackendFlags_HasMouseCursors)
+                                        // because it needs mouse cursor feedback. (This used to be
+                                        // a per-window ImGuiWindowFlags_ResizeFromAnySide flag)
+    bool ConfigWindowsMoveFromTitleBarOnly;  // = false       // [BETA] Set to true to only allow
+                                             // moving windows when clicked+dragged from the title
+                                             // bar. Windows without a title bar are not affected.
+
+    //------------------------------------------------------------------
+    // Platform Functions
+    // (the imgui_impl_xxxx back-end files are setting those up for you)
+    //------------------------------------------------------------------
+
+    // Optional: Platform/Renderer back-end name (informational only! will be displayed in About
+    // Window) + User data for back-end/wrappers to store their own stuff.
+    const char *BackendPlatformName;  // = NULL
+    const char *BackendRendererName;  // = NULL
+    void *BackendPlatformUserData;    // = NULL
+    void *BackendRendererUserData;    // = NULL
+    void *BackendLanguageUserData;    // = NULL
+
+    // Optional: Access OS clipboard
+    // (default to use native Win32 clipboard on Windows, otherwise uses a private clipboard.
+    // Override to access OS clipboard on other architectures)
+    const char *(*GetClipboardTextFn)(void *user_data);
+    void (*SetClipboardTextFn)(void *user_data, const char *text);
+    void *ClipboardUserData;
+
+    // Optional: Notify OS Input Method Editor of the screen position of your cursor for text input
+    // position (e.g. when using Japanese/Chinese IME on Windows) (default to use native imm32 api
+    // on Windows)
+    void (*ImeSetInputScreenPosFn)(int x, int y);
+    void *ImeWindowHandle;  // = NULL           // (Windows) Set this to your HWND to get automatic
+                            // IME cursor positioning.
+
+#ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+    // [OBSOLETE since 1.60+] Rendering function, will be automatically called in Render(). Please
+    // call your rendering function yourself now! You can obtain the ImDrawData* by calling
+    // ImGui::GetDrawData() after Render(). See example applications if you are unsure of how to
+    // implement this.
+    void (*RenderDrawListsFn)(ImDrawData *data);
+#else
+    // This is only here to keep ImGuiIO the same size/layout, so that
+    // IMGUI_DISABLE_OBSOLETE_FUNCTIONS can exceptionally be used outside of imconfig.h.
+    void *RenderDrawListsFnUnused;
+#endif
+
+    //------------------------------------------------------------------
+    // Input - Fill before calling NewFrame()
+    //------------------------------------------------------------------
+
+    ImVec2 MousePos;     // Mouse position, in pixels. Set to ImVec2(-FLT_MAX,-FLT_MAX) if mouse is
+                         // unavailable (on another screen, etc.)
+    bool MouseDown[5];   // Mouse buttons: 0=left, 1=right, 2=middle + extras. ImGui itself mostly
+                         // only uses left button (BeginPopupContext** are using right button).
+                         // Others buttons allows us to track if the mouse is being used by your
+                         // application + available to user as a convenience via IsMouse** API.
+    float MouseWheel;    // Mouse wheel Vertical: 1 unit scrolls about 5 lines text.
+    float MouseWheelH;   // Mouse wheel Horizontal. Most users don't have a mouse with an horizontal
+                         // wheel, may not be filled by all back-ends.
+    bool KeyCtrl;        // Keyboard modifier pressed: Control
+    bool KeyShift;       // Keyboard modifier pressed: Shift
+    bool KeyAlt;         // Keyboard modifier pressed: Alt
+    bool KeySuper;       // Keyboard modifier pressed: Cmd/Super/Windows
+    bool KeysDown[512];  // Keyboard keys that are pressed (ideally left in the "native" order your
+                         // engine has access to keyboard keys, so you can use your own
+                         // defines/enums for keys).
+    float NavInputs[ImGuiNavInput_COUNT];  // Gamepad inputs. Cleared back to zero by EndFrame().
+                                           // Keyboard keys will be auto-mapped and be written here
+                                           // by NewFrame().
+
+    // Functions
+    IMGUI_API void AddInputCharacter(unsigned int c);  // Queue new character input
+    IMGUI_API void AddInputCharactersUTF8(
+        const char *str);                   // Queue new characters input from an UTF-8 string
+    IMGUI_API void ClearInputCharacters();  // Clear the text input buffer manually
+
+    //------------------------------------------------------------------
+    // Output - Retrieve after calling NewFrame()
+    //------------------------------------------------------------------
+
+    bool WantCaptureMouse;  // When io.WantCaptureMouse is true, imgui will use the mouse inputs, do
+                            // not dispatch them to your main game/application (in both cases,
+                            // always pass on mouse inputs to imgui). (e.g. unclicked mouse is
+                            // hovering over an imgui window, widget is active, mouse was clicked
+                            // over an imgui window, etc.).
+    bool WantCaptureKeyboard;  // When io.WantCaptureKeyboard is true, imgui will use the keyboard
+                               // inputs, do not dispatch them to your main game/application (in
+                               // both cases, always pass keyboard inputs to imgui). (e.g. InputText
+                               // active, or an imgui window is focused and navigation is enabled,
+                               // etc.).
+    bool WantTextInput;        // Mobile/console: when io.WantTextInput is true, you may display an
+                         // on-screen keyboard. This is set by ImGui when it wants textual keyboard
+                         // input to happen (e.g. when a InputText widget is active).
+    bool WantSetMousePos;  // MousePos has been altered, back-end should reposition mouse on next
+                           // frame. Set only when ImGuiConfigFlags_NavEnableSetMousePos flag is
+                           // enabled.
+    bool WantSaveIniSettings;  // When manual .ini load/save is active (io.IniFilename == NULL),
+                               // this will be set to notify your application that you can call
+                               // SaveIniSettingsToMemory() and save yourself. IMPORTANT: You need
+                               // to clear io.WantSaveIniSettings yourself.
+    bool NavActive;   // Directional navigation is currently allowed (will handle ImGuiKey_NavXXX
+                      // events) = a window is focused and it doesn't use the
+                      // ImGuiWindowFlags_NoNavInputs flag.
+    bool NavVisible;  // Directional navigation is visible and allowed (will handle ImGuiKey_NavXXX
+                      // events).
+    float
+        Framerate;  // Application framerate estimation, in frame per second. Solely for
+                    // convenience. Rolling average estimation based on IO.DeltaTime over 120 frames
+    int MetricsRenderVertices;  // Vertices output during last call to Render()
+    int MetricsRenderIndices;   // Indices output during last call to Render() = number of triangles
+                                // * 3
+    int MetricsRenderWindows;   // Number of visible windows
+    int MetricsActiveWindows;   // Number of active windows
+    int MetricsActiveAllocations;  // Number of active allocations, updated by MemAlloc/MemFree
+                                   // based on current context. May be off if you have multiple
+                                   // imgui contexts.
+    ImVec2 MouseDelta;  // Mouse delta. Note that this is zero if either current or previous
+                        // position are invalid (-FLT_MAX,-FLT_MAX), so a disappearing/reappearing
+                        // mouse won't have a huge delta.
+
+    //------------------------------------------------------------------
+    // [Internal] ImGui will maintain those fields. Forward compatibility not guaranteed!
+    //------------------------------------------------------------------
+
+    ImVec2 MousePosPrev;        // Previous mouse position (note that MouseDelta is not necessary ==
+                                // MousePos-MousePosPrev, in case either position is invalid)
+    ImVec2 MouseClickedPos[5];  // Position at time of clicking
+    double MouseClickedTime[5];  // Time of last click (used to figure out double-click)
+    bool MouseClicked[5];        // Mouse button went from !Down to Down
+    bool MouseDoubleClicked[5];  // Has mouse button been double-clicked?
+    bool MouseReleased[5];       // Mouse button went from Down to !Down
+    bool MouseDownOwned[5];      // Track if button was clicked inside a dear imgui window. We don't
+                             // request mouse capture from the application if click started outside
+                             // ImGui bounds.
+    bool MouseDownWasDoubleClick[5];  // Track if button down was a double-click
+    float MouseDownDuration[5];  // Duration the mouse button has been down (0.0f == just clicked)
+    float MouseDownDurationPrev[5];     // Previous time the mouse button has been down
+    ImVec2 MouseDragMaxDistanceAbs[5];  // Maximum distance, absolute, on each axis, of how much
+                                        // mouse has traveled from the clicking point
+    float MouseDragMaxDistanceSqr[5];   // Squared maximum distance of how much mouse has traveled
+                                        // from the clicking point
+    float KeysDownDuration[512];  // Duration the keyboard key has been down (0.0f == just pressed)
+    float KeysDownDurationPrev[512];  // Previous duration the key has been down
+    float NavInputsDownDuration[ImGuiNavInput_COUNT];
+    float NavInputsDownDurationPrev[ImGuiNavInput_COUNT];
+    ImVector<ImWchar> InputQueueCharacters;  // Queue of _characters_ input (obtained by platform
+                                             // back-end). Fill using AddInputCharacter() helper.
+
+    IMGUI_API ImGuiIO();
+};
+
+//-----------------------------------------------------------------------------
+// Misc data structures
+//-----------------------------------------------------------------------------
+
+// Shared state of InputText(), passed as an argument to your callback when a
+// ImGuiInputTextFlags_Callback* flag is used. The callback function should return 0 by default.
+// Callbacks (follow a flag name and see comments in ImGuiInputTextFlags_ declarations for more
+// details)
+// - ImGuiInputTextFlags_CallbackCompletion:  Callback on pressing TAB
+// - ImGuiInputTextFlags_CallbackHistory:     Callback on pressing Up/Down arrows
+// - ImGuiInputTextFlags_CallbackAlways:      Callback on each iteration
+// - ImGuiInputTextFlags_CallbackCharFilter:  Callback on character inputs to replace or discard
+// them. Modify 'EventChar' to replace or discard, or return 1 in callback to discard.
+// - ImGuiInputTextFlags_CallbackResize:      Callback on buffer capacity changes request (beyond
+// 'buf_size' parameter value), allowing the string to grow.
+struct ImGuiInputTextCallbackData
+{
+    ImGuiInputTextFlags EventFlag;  // One ImGuiInputTextFlags_Callback*    // Read-only
+    ImGuiInputTextFlags Flags;      // What user passed to InputText()      // Read-only
+    void *UserData;                 // What user passed to InputText()      // Read-only
+
+    // Arguments for the different callback events
+    // - To modify the text buffer in a callback, prefer using the InsertChars() / DeleteChars()
+    // function. InsertChars() will take care of calling the resize callback if necessary.
+    // - If you know your edits are not going to resize the underlying buffer allocation, you may
+    // modify the contents of 'Buf[]' directly. You need to update 'BufTextLen' accordingly (0 <=
+    // BufTextLen < BufSize) and set 'BufDirty'' to true so InputText can update its internal state.
+    ImWchar EventChar;  // Character input                      // Read-write   // [CharFilter]
+                        // Replace character with another one, or set to zero to drop. return 1 is
+                        // equivalent to setting EventChar=0;
+    ImGuiKey
+        EventKey;  // Key pressed (Up/Down/TAB)            // Read-only    // [Completion,History]
+    char *Buf;     // Text buffer                          // Read-write   // [Resize] Can replace
+                // pointer / [Completion,History,Always] Only write to pointed data, don't replace
+                // the actual pointer!
+    int BufTextLen;  // Text length (in bytes)               // Read-write   //
+                     // [Resize,Completion,History,Always] Exclude zero-terminator storage. In C
+                     // land: == strlen(some_text), in C++ land: string.length()
+    int BufSize;     // Buffer size (in bytes) = capacity+1  // Read-only    //
+                  // [Resize,Completion,History,Always] Include zero-terminator storage. In C land
+                  // == ARRAYSIZE(my_char_array), in C++ land: string.capacity()+1
+    bool BufDirty;       // Set if you modify Buf/BufTextLen!    // Write        //
+                         // [Completion,History,Always]
+    int CursorPos;       //                                      // Read-write   //
+                         //                                      [Completion,History,Always]
+    int SelectionStart;  //                                      // Read-write   //
+                         //                                      [Completion,History,Always] == to
+                         //                                      SelectionEnd when no selection)
+    int SelectionEnd;    //                                      // Read-write   //
+                         //                                      [Completion,History,Always]
+
+    // Helper functions for text manipulation.
+    // Use those function to benefit from the CallbackResize behaviors. Calling those function reset
+    // the selection.
+    IMGUI_API ImGuiInputTextCallbackData();
+    IMGUI_API void DeleteChars(int pos, int bytes_count);
+    IMGUI_API void InsertChars(int pos, const char *text, const char *text_end = NULL);
+    bool HasSelection() const { return SelectionStart != SelectionEnd; }
+};
+
+// Resizing callback data to apply custom constraint. As enabled by SetNextWindowSizeConstraints().
+// Callback is called during the next Begin(). NB: For basic min/max size constraint on each axis
+// you don't need to use the callback! The SetNextWindowSizeConstraints() parameters are enough.
+struct ImGuiSizeCallbackData
+{
+    void *UserData;      // Read-only.   What user passed to SetNextWindowSizeConstraints()
+    ImVec2 Pos;          // Read-only.   Window position, for reference.
+    ImVec2 CurrentSize;  // Read-only.   Current window size.
+    ImVec2 DesiredSize;  // Read-write.  Desired size, based on user's mouse position. Write to this
+                         // field to restrain resizing.
+};
+
+// Data payload for Drag and Drop operations: AcceptDragDropPayload(), GetDragDropPayload()
+struct ImGuiPayload
+{
+    // Members
+    void *Data;    // Data (copied and owned by dear imgui)
+    int DataSize;  // Data size
+
+    // [Internal]
+    ImGuiID SourceId;        // Source item id
+    ImGuiID SourceParentId;  // Source parent id (if available)
+    int DataFrameCount;      // Data timestamp
+    char DataType[32 + 1];   // Data type tag (short user-supplied string, 32 characters max)
+    bool Preview;   // Set when AcceptDragDropPayload() was called and mouse has been hovering the
+                    // target item (nb: handle overlapping drag targets)
+    bool Delivery;  // Set when AcceptDragDropPayload() was called and mouse button is released over
+                    // the target item.
+
+    ImGuiPayload() { Clear(); }
+    void Clear()
+    {
+        SourceId = SourceParentId = 0;
+        Data                      = NULL;
+        DataSize                  = 0;
+        memset(DataType, 0, sizeof(DataType));
+        DataFrameCount = -1;
+        Preview = Delivery = false;
+    }
+    bool IsDataType(const char *type) const
+    {
+        return DataFrameCount != -1 && strcmp(type, DataType) == 0;
+    }
+    bool IsPreview() const { return Preview; }
+    bool IsDelivery() const { return Delivery; }
+};
+
+//-----------------------------------------------------------------------------
+// Obsolete functions (Will be removed! Read 'API BREAKING CHANGES' section in imgui.cpp for
+// details) Please keep your copy of dear imgui up to date! Occasionally set '#define
+// IMGUI_DISABLE_OBSOLETE_FUNCTIONS' in imconfig.h to stay ahead.
+//-----------------------------------------------------------------------------
+
+#ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+namespace ImGui
+{
+// OBSOLETED in 1.71 (from June 2019)
+static inline void SetNextTreeNodeOpen(bool open, ImGuiCond cond = 0)
+{
+    SetNextItemOpen(open, cond);
+}
+// OBSOLETED in 1.70 (from May 2019)
+static inline float GetContentRegionAvailWidth()
+{
+    return GetContentRegionAvail().x;
+}
+// OBSOLETED in 1.69 (from Mar 2019)
+static inline ImDrawList *GetOverlayDrawList()
+{
+    return GetForegroundDrawList();
+}
+// OBSOLETED in 1.66 (from Sep 2018)
+static inline void SetScrollHere(float center_ratio = 0.5f)
+{
+    SetScrollHereY(center_ratio);
+}
+// OBSOLETED in 1.63 (between Aug 2018 and Sept 2018)
+static inline bool IsItemDeactivatedAfterChange()
+{
+    return IsItemDeactivatedAfterEdit();
+}
+// OBSOLETED in 1.61 (between Apr 2018 and Aug 2018)
+IMGUI_API bool InputFloat(const char *label,
+                          float *v,
+                          float step,
+                          float step_fast,
+                          int decimal_precision,
+                          ImGuiInputTextFlags flags = 0);  // Use the 'const char* format' version
+                                                           // instead of 'decimal_precision'!
+IMGUI_API bool InputFloat2(const char *label,
+                           float v[2],
+                           int decimal_precision,
+                           ImGuiInputTextFlags flags = 0);
+IMGUI_API bool InputFloat3(const char *label,
+                           float v[3],
+                           int decimal_precision,
+                           ImGuiInputTextFlags flags = 0);
+IMGUI_API bool InputFloat4(const char *label,
+                           float v[4],
+                           int decimal_precision,
+                           ImGuiInputTextFlags flags = 0);
+// OBSOLETED in 1.60 (between Dec 2017 and Apr 2018)
+static inline bool IsAnyWindowFocused()
+{
+    return IsWindowFocused(ImGuiFocusedFlags_AnyWindow);
+}
+static inline bool IsAnyWindowHovered()
+{
+    return IsWindowHovered(ImGuiHoveredFlags_AnyWindow);
+}
+static inline ImVec2 CalcItemRectClosestPoint(const ImVec2 &pos,
+                                              bool on_edge  = false,
+                                              float outward = 0.f)
+{
+    IM_UNUSED(on_edge);
+    IM_UNUSED(outward);
+    IM_ASSERT(0);
+    return pos;
+}
+// OBSOLETED in 1.53 (between Oct 2017 and Dec 2017)
+static inline void ShowTestWindow()
+{
+    return ShowDemoWindow();
+}
+static inline bool IsRootWindowFocused()
+{
+    return IsWindowFocused(ImGuiFocusedFlags_RootWindow);
+}
+static inline bool IsRootWindowOrAnyChildFocused()
+{
+    return IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows);
+}
+static inline void SetNextWindowContentWidth(float w)
+{
+    SetNextWindowContentSize(ImVec2(w, 0.0f));
+}
+static inline float GetItemsLineHeightWithSpacing()
+{
+    return GetFrameHeightWithSpacing();
+}
+// OBSOLETED in 1.52 (between Aug 2017 and Oct 2017)
+IMGUI_API bool Begin(
+    const char *name,
+    bool *p_open,
+    const ImVec2 &size_on_first_use,
+    float bg_alpha_override = -1.0f,
+    ImGuiWindowFlags flags  = 0);  // Use SetNextWindowSize(size, ImGuiCond_FirstUseEver) +
+                                  // SetNextWindowBgAlpha() instead.
+static inline bool IsRootWindowOrAnyChildHovered()
+{
+    return IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
+}
+static inline void AlignFirstTextHeightToWidgets()
+{
+    AlignTextToFramePadding();
+}
+static inline void SetNextWindowPosCenter(ImGuiCond c = 0)
+{
+    ImGuiIO &io = GetIO();
+    SetNextWindowPos(ImVec2(io.DisplaySize.x * 0.5f, io.DisplaySize.y * 0.5f), c,
+                     ImVec2(0.5f, 0.5f));
+}
+}  // namespace ImGui
+typedef ImGuiInputTextCallback
+    ImGuiTextEditCallback;  // OBSOLETED in 1.63 (from Aug 2018): made the names consistent
+typedef ImGuiInputTextCallbackData ImGuiTextEditCallbackData;
+#endif
+
+//-----------------------------------------------------------------------------
+// Helpers
+//-----------------------------------------------------------------------------
+
+// Helper: Execute a block of code at maximum once a frame. Convenient if you want to quickly create
+// an UI within deep-nested code that runs multiple times every frame. Usage: static
+// ImGuiOnceUponAFrame oaf; if (oaf) ImGui::Text("This will be called only once per frame");
+struct ImGuiOnceUponAFrame
+{
+    ImGuiOnceUponAFrame() { RefFrame = -1; }
+    mutable int RefFrame;
+    operator bool() const
+    {
+        int current_frame = ImGui::GetFrameCount();
+        if (RefFrame == current_frame)
+            return false;
+        RefFrame = current_frame;
+        return true;
+    }
+};
+
+// Helper: Parse and apply text filters. In format "aaaaa[,bbbb][,ccccc]"
+struct ImGuiTextFilter
+{
+    IMGUI_API ImGuiTextFilter(const char *default_filter = "");
+    IMGUI_API bool Draw(const char *label = "Filter (inc,-exc)",
+                        float width       = 0.0f);  // Helper calling InputText+Build
+    IMGUI_API bool PassFilter(const char *text, const char *text_end = NULL) const;
+    IMGUI_API void Build();
+    void Clear()
+    {
+        InputBuf[0] = 0;
+        Build();
+    }
+    bool IsActive() const { return !Filters.empty(); }
+
+    // [Internal]
+    struct TextRange
+    {
+        const char *b;
+        const char *e;
+
+        TextRange() { b = e = NULL; }
+        TextRange(const char *_b, const char *_e)
+        {
+            b = _b;
+            e = _e;
+        }
+        const char *begin() const { return b; }
+        const char *end() const { return e; }
+        bool empty() const { return b == e; }
+        IMGUI_API void split(char separator, ImVector<TextRange> *out) const;
+    };
+    char InputBuf[256];
+    ImVector<TextRange> Filters;
+    int CountGrep;
+};
+
+// Helper: Growable text buffer for logging/accumulating text
+// (this could be called 'ImGuiTextBuilder' / 'ImGuiStringBuilder')
+struct ImGuiTextBuffer
+{
+    ImVector<char> Buf;
+    static char EmptyString[1];
+
+    ImGuiTextBuffer() {}
+    inline char operator[](int i)
+    {
+        IM_ASSERT(Buf.Data != NULL);
+        return Buf.Data[i];
+    }
+    const char *begin() const { return Buf.Data ? &Buf.front() : EmptyString; }
+    const char *end() const
+    {
+        return Buf.Data ? &Buf.back() : EmptyString;
+    }  // Buf is zero-terminated, so end() will point on the zero-terminator
+    int size() const { return Buf.Size ? Buf.Size - 1 : 0; }
+    bool empty() { return Buf.Size <= 1; }
+    void clear() { Buf.clear(); }
+    void reserve(int capacity) { Buf.reserve(capacity); }
+    const char *c_str() const { return Buf.Data ? Buf.Data : EmptyString; }
+    IMGUI_API void append(const char *str, const char *str_end = NULL);
+    IMGUI_API void appendf(const char *fmt, ...) IM_FMTARGS(2);
+    IMGUI_API void appendfv(const char *fmt, va_list args) IM_FMTLIST(2);
+};
+
+// Helper: Key->Value storage
+// Typically you don't have to worry about this since a storage is held within each Window.
+// We use it to e.g. store collapse state for a tree (Int 0/1)
+// This is optimized for efficient lookup (dichotomy into a contiguous buffer) and rare insertion
+// (typically tied to user interactions aka max once a frame) You can use it as custom user storage
+// for temporary values. Declare your own storage if, for example:
+// - You want to manipulate the open/close state of a particular sub-tree in your interface (tree
+// node uses Int 0/1 to store their state).
+// - You want to store custom debug data easily without adding or editing structures in your code
+// (probably not efficient, but convenient) Types are NOT stored, so it is up to you to make sure
+// your Key don't collide with different types.
+struct ImGuiStorage
+{
+    struct Pair
+    {
+        ImGuiID key;
+        union {
+            int val_i;
+            float val_f;
+            void *val_p;
+        };
+        Pair(ImGuiID _key, int _val_i)
+        {
+            key   = _key;
+            val_i = _val_i;
+        }
+        Pair(ImGuiID _key, float _val_f)
+        {
+            key   = _key;
+            val_f = _val_f;
+        }
+        Pair(ImGuiID _key, void *_val_p)
+        {
+            key   = _key;
+            val_p = _val_p;
+        }
+    };
+    ImVector<Pair> Data;
+
+    // - Get***() functions find pair, never add/allocate. Pairs are sorted so a query is O(log N)
+    // - Set***() functions find pair, insertion on demand if missing.
+    // - Sorted insertion is costly, paid once. A typical frame shouldn't need to insert any new
+    // pair.
+    void Clear() { Data.clear(); }
+    IMGUI_API int GetInt(ImGuiID key, int default_val = 0) const;
+    IMGUI_API void SetInt(ImGuiID key, int val);
+    IMGUI_API bool GetBool(ImGuiID key, bool default_val = false) const;
+    IMGUI_API void SetBool(ImGuiID key, bool val);
+    IMGUI_API float GetFloat(ImGuiID key, float default_val = 0.0f) const;
+    IMGUI_API void SetFloat(ImGuiID key, float val);
+    IMGUI_API void *GetVoidPtr(ImGuiID key) const;  // default_val is NULL
+    IMGUI_API void SetVoidPtr(ImGuiID key, void *val);
+
+    // - Get***Ref() functions finds pair, insert on demand if missing, return pointer. Useful if
+    // you intend to do Get+Set.
+    // - References are only valid until a new value is added to the storage. Calling a Set***()
+    // function or a Get***Ref() function invalidates the pointer.
+    // - A typical use case where this is convenient for quick hacking (e.g. add storage during a
+    // live Edit&Continue session if you can't modify existing struct)
+    //      float* pvar = ImGui::GetFloatRef(key); ImGui::SliderFloat("var", pvar, 0, 100.0f);
+    //      some_var += *pvar;
+    IMGUI_API int *GetIntRef(ImGuiID key, int default_val = 0);
+    IMGUI_API bool *GetBoolRef(ImGuiID key, bool default_val = false);
+    IMGUI_API float *GetFloatRef(ImGuiID key, float default_val = 0.0f);
+    IMGUI_API void **GetVoidPtrRef(ImGuiID key, void *default_val = NULL);
+
+    // Use on your own storage if you know only integer are being stored (open/close all tree nodes)
+    IMGUI_API void SetAllInt(int val);
+
+    // For quicker full rebuild of a storage (instead of an incremental one), you may add all your
+    // contents and then sort once.
+    IMGUI_API void BuildSortByKey();
+};
+
+// Helper: Manually clip large list of items.
+// If you are submitting lots of evenly spaced items and you have a random access to the list, you
+// can perform coarse clipping based on visibility to save yourself from processing those items at
+// all. The clipper calculates the range of visible items and advance the cursor to compensate for
+// the non-visible items we have skipped. ImGui already clip items based on their bounds but it
+// needs to measure text size to do so. Coarse clipping before submission makes this cost and your
+// own data fetching/submission cost null. Usage:
+//     ImGuiListClipper clipper(1000);  // we have 1000 elements, evenly spaced.
+//     while (clipper.Step())
+//         for (int i = clipper.DisplayStart; i < clipper.DisplayEnd; i++)
+//             ImGui::Text("line number %d", i);
+// - Step 0: the clipper let you process the first element, regardless of it being visible or not,
+// so we can measure the element height (step skipped if we passed a known height as second arg to
+// constructor).
+// - Step 1: the clipper infer height from first element, calculate the actual range of elements to
+// display, and position the cursor before the first element.
+// - (Step 2: dummy step only required if an explicit items_height was passed to constructor or
+// Begin() and user call Step(). Does nothing and switch to Step 3.)
+// - Step 3: the clipper validate that we have reached the expected Y position (corresponding to
+// element DisplayEnd), advance the cursor to the end of the list and then returns 'false' to end
+// the loop.
+struct ImGuiListClipper
+{
+    float StartPosY;
+    float ItemsHeight;
+    int ItemsCount, StepNo, DisplayStart, DisplayEnd;
+
+    // items_count:  Use -1 to ignore (you can call Begin later). Use INT_MAX if you don't know how
+    // many items you have (in which case the cursor won't be advanced in the final step).
+    // items_height: Use -1.0f to be calculated automatically on first step. Otherwise pass in the
+    // distance between your items, typically GetTextLineHeightWithSpacing() or
+    // GetFrameHeightWithSpacing(). If you don't specify an items_height, you NEED to call Step().
+    // If you specify items_height you may call the old Begin()/End() api directly, but prefer
+    // calling Step().
+    ImGuiListClipper(int items_count = -1, float items_height = -1.0f)
+    {
+        Begin(items_count, items_height);
+    }  // NB: Begin() initialize every fields (as we allow user to call Begin/End multiple times on
+       // a same instance if they want).
+    ~ImGuiListClipper()
+    {
+        IM_ASSERT(ItemsCount == -1);
+    }  // Assert if user forgot to call End() or Step() until false.
+
+    IMGUI_API bool Step();  // Call until it returns false. The DisplayStart/DisplayEnd fields will
+                            // be set and you can process/draw those items.
+    IMGUI_API void Begin(
+        int items_count,
+        float items_height = -1.0f);  // Automatically called by constructor if you passed
+                                      // 'items_count' or by Step() in Step 1.
+    IMGUI_API void End();  // Automatically called on the last call of Step() that returns false.
+};
+
+// Helpers macros to generate 32-bits encoded colors
+#ifdef IMGUI_USE_BGRA_PACKED_COLOR
+#define IM_COL32_R_SHIFT 16
+#define IM_COL32_G_SHIFT 8
+#define IM_COL32_B_SHIFT 0
+#define IM_COL32_A_SHIFT 24
+#define IM_COL32_A_MASK 0xFF000000
+#else
+#define IM_COL32_R_SHIFT 0
+#define IM_COL32_G_SHIFT 8
+#define IM_COL32_B_SHIFT 16
+#define IM_COL32_A_SHIFT 24
+#define IM_COL32_A_MASK 0xFF000000
+#endif
+#define IM_COL32(R, G, B, A)                                               \
+    (((ImU32)(A) << IM_COL32_A_SHIFT) | ((ImU32)(B) << IM_COL32_B_SHIFT) | \
+     ((ImU32)(G) << IM_COL32_G_SHIFT) | ((ImU32)(R) << IM_COL32_R_SHIFT))
+#define IM_COL32_WHITE IM_COL32(255, 255, 255, 255)  // Opaque white = 0xFFFFFFFF
+#define IM_COL32_BLACK IM_COL32(0, 0, 0, 255)        // Opaque black
+#define IM_COL32_BLACK_TRANS IM_COL32(0, 0, 0, 0)    // Transparent black = 0x00000000
+
+// Helper: ImColor() implicitly converts colors to either ImU32 (packed 4x1 byte) or ImVec4 (4x1
+// float) Prefer using IM_COL32() macros if you want a guaranteed compile-time ImU32 for usage with
+// ImDrawList API.
+// **Avoid storing ImColor! Store either u32 of ImVec4. This is not a full-featured color class. MAY
+// OBSOLETE.
+// **None of the ImGui API are using ImColor directly but you can use it as a convenience to pass
+// colors in either ImU32 or ImVec4 formats. Explicitly cast to ImU32 or ImVec4 if needed.
+struct ImColor
+{
+    ImVec4 Value;
+
+    ImColor() { Value.x = Value.y = Value.z = Value.w = 0.0f; }
+    ImColor(int r, int g, int b, int a = 255)
+    {
+        float sc = 1.0f / 255.0f;
+        Value.x  = (float)r * sc;
+        Value.y  = (float)g * sc;
+        Value.z  = (float)b * sc;
+        Value.w  = (float)a * sc;
+    }
+    ImColor(ImU32 rgba)
+    {
+        float sc = 1.0f / 255.0f;
+        Value.x  = (float)((rgba >> IM_COL32_R_SHIFT) & 0xFF) * sc;
+        Value.y  = (float)((rgba >> IM_COL32_G_SHIFT) & 0xFF) * sc;
+        Value.z  = (float)((rgba >> IM_COL32_B_SHIFT) & 0xFF) * sc;
+        Value.w  = (float)((rgba >> IM_COL32_A_SHIFT) & 0xFF) * sc;
+    }
+    ImColor(float r, float g, float b, float a = 1.0f)
+    {
+        Value.x = r;
+        Value.y = g;
+        Value.z = b;
+        Value.w = a;
+    }
+    ImColor(const ImVec4 &col) { Value = col; }
+    inline operator ImU32() const { return ImGui::ColorConvertFloat4ToU32(Value); }
+    inline operator ImVec4() const { return Value; }
+
+    // FIXME-OBSOLETE: May need to obsolete/cleanup those helpers.
+    inline void SetHSV(float h, float s, float v, float a = 1.0f)
+    {
+        ImGui::ColorConvertHSVtoRGB(h, s, v, Value.x, Value.y, Value.z);
+        Value.w = a;
+    }
+    static ImColor HSV(float h, float s, float v, float a = 1.0f)
+    {
+        float r, g, b;
+        ImGui::ColorConvertHSVtoRGB(h, s, v, r, g, b);
+        return ImColor(r, g, b, a);
+    }
+};
+
+//-----------------------------------------------------------------------------
+// Draw List API (ImDrawCmd, ImDrawIdx, ImDrawVert, ImDrawChannel, ImDrawListSplitter,
+// ImDrawListFlags, ImDrawList, ImDrawData) Hold a series of drawing commands. The user provides a
+// renderer for ImDrawData which essentially contains an array of ImDrawList.
+//-----------------------------------------------------------------------------
+
+// Draw callbacks for advanced uses.
+// NB: You most likely do NOT need to use draw callbacks just to create your own widget or
+// customized UI rendering, you can poke into the draw list for that! Draw callback may be useful
+// for example to:
+//  A) Change your GPU render state,
+//  B) render a complex 3D scene inside a UI element without an intermediate texture/render target,
+//  etc.
+// The expected behavior from your rendering function is 'if (cmd.UserCallback != NULL) {
+// cmd.UserCallback(parent_list, cmd); } else { RenderTriangles() }' If you want to override the
+// signature of ImDrawCallback, you can simply use e.g. '#define ImDrawCallback MyDrawCallback' (in
+// imconfig.h) + update rendering back-end accordingly.
+#ifndef ImDrawCallback
+typedef void (*ImDrawCallback)(const ImDrawList *parent_list, const ImDrawCmd *cmd);
+#endif
+
+// Special Draw callback value to request renderer back-end to reset the graphics/render state.
+// The renderer back-end needs to handle this special value, otherwise it will crash trying to call
+// a function at this address. This is useful for example if you submitted callbacks which you know
+// have altered the render state and you want it to be restored. It is not done by default because
+// they are many perfectly useful way of altering render state for imgui contents (e.g. changing
+// shader/blending settings before an Image call).
+#define ImDrawCallback_ResetRenderState (ImDrawCallback)(-1)
+
+// Typically, 1 command = 1 GPU draw call (unless command is a callback)
+// Pre 1.71 back-ends will typically ignore the VtxOffset/IdxOffset fields. When 'io.BackendFlags &
+// ImGuiBackendFlags_RendererHasVtxOffset' is enabled, those fields allow us to render meshes larger
+// than 64K vertices while keeping 16-bits indices.
+struct ImDrawCmd
+{
+    unsigned int ElemCount;  // Number of indices (multiple of 3) to be rendered as triangles.
+                             // Vertices are stored in the callee ImDrawList's vtx_buffer[] array,
+                             // indices in idx_buffer[].
+    ImVec4 ClipRect;  // Clipping rectangle (x1, y1, x2, y2). Subtract ImDrawData->DisplayPos to get
+                      // clipping rectangle in "viewport" coordinates
+    ImTextureID TextureId;   // User-provided texture ID. Set by user in ImfontAtlas::SetTexID() for
+                             // fonts or passed to Image*() functions. Ignore if never using images
+                             // or multiple fonts atlas.
+    unsigned int VtxOffset;  // Start offset in vertex buffer. Pre-1.71 or without
+                             // ImGuiBackendFlags_RendererHasVtxOffset: always 0. With
+                             // ImGuiBackendFlags_RendererHasVtxOffset: may be >0 to support meshes
+                             // larger than 64K vertices with 16-bits indices.
+    unsigned int
+        IdxOffset;  // Start offset in index buffer. Always equal to sum of ElemCount drawn so far.
+    ImDrawCallback UserCallback;  // If != NULL, call the function instead of rendering the
+                                  // vertices. clip_rect and texture_id will be set normally.
+    void *UserCallbackData;       // The draw callback code can access this.
+
+    ImDrawCmd()
+    {
+        ElemCount  = 0;
+        ClipRect.x = ClipRect.y = ClipRect.z = ClipRect.w = 0.0f;
+        TextureId                                         = (ImTextureID)NULL;
+        VtxOffset = IdxOffset = 0;
+        UserCallback          = NULL;
+        UserCallbackData      = NULL;
+    }
+};
+
+// Vertex index
+// (to allow large meshes with 16-bits indices: set 'io.BackendFlags |=
+// ImGuiBackendFlags_RendererHasVtxOffset' and handle ImDrawCmd::VtxOffset in the renderer back-end)
+// (to use 32-bits indices: override with '#define ImDrawIdx unsigned int' in imconfig.h)
+#ifndef ImDrawIdx
+typedef unsigned short ImDrawIdx;
+#endif
+
+// Vertex layout
+#ifndef IMGUI_OVERRIDE_DRAWVERT_STRUCT_LAYOUT
+struct ImDrawVert
+{
+    ImVec2 pos;
+    ImVec2 uv;
+    ImU32 col;
+};
+#else
+// You can override the vertex format layout by defining IMGUI_OVERRIDE_DRAWVERT_STRUCT_LAYOUT in
+// imconfig.h The code expect ImVec2 pos (8 bytes), ImVec2 uv (8 bytes), ImU32 col (4 bytes), but
+// you can re-order them or add other fields as needed to simplify integration in your engine. The
+// type has to be described within the macro (you can either declare the struct or use a typedef).
+// This is because ImVec2/ImU32 are likely not declared a the time you'd want to set your type up.
+// NOTE: IMGUI DOESN'T CLEAR THE STRUCTURE AND DOESN'T CALL A CONSTRUCTOR SO ANY CUSTOM FIELD WILL
+// BE UNINITIALIZED. IF YOU ADD EXTRA FIELDS (SUCH AS A 'Z' COORDINATES) YOU WILL NEED TO CLEAR THEM
+// DURING RENDER OR TO IGNORE THEM.
+IMGUI_OVERRIDE_DRAWVERT_STRUCT_LAYOUT;
+#endif
+
+// For use by ImDrawListSplitter.
+struct ImDrawChannel
+{
+    ImVector<ImDrawCmd> _CmdBuffer;
+    ImVector<ImDrawIdx> _IdxBuffer;
+};
+
+// Split/Merge functions are used to split the draw list into different layers which can be drawn
+// into out of order. This is used by the Columns api, so items of each column can be batched
+// together in a same draw call.
+struct ImDrawListSplitter
+{
+    int _Current;  // Current channel number (0)
+    int _Count;    // Number of active channels (1+)
+    ImVector<ImDrawChannel>
+        _Channels;  // Draw channels (not resized down so _Count might be < Channels.Size)
+
+    inline ImDrawListSplitter() { Clear(); }
+    inline ~ImDrawListSplitter() { ClearFreeMemory(); }
+    inline void Clear()
+    {
+        _Current = 0;
+        _Count   = 1;
+    }  // Do not clear Channels[] so our allocations are reused next frame
+    IMGUI_API void ClearFreeMemory();
+    IMGUI_API void Split(ImDrawList *draw_list, int count);
+    IMGUI_API void Merge(ImDrawList *draw_list);
+    IMGUI_API void SetCurrentChannel(ImDrawList *draw_list, int channel_idx);
+};
+
+enum ImDrawCornerFlags_
+{
+    ImDrawCornerFlags_TopLeft  = 1 << 0,                                                   // 0x1
+    ImDrawCornerFlags_TopRight = 1 << 1,                                                   // 0x2
+    ImDrawCornerFlags_BotLeft  = 1 << 2,                                                   // 0x4
+    ImDrawCornerFlags_BotRight = 1 << 3,                                                   // 0x8
+    ImDrawCornerFlags_Top      = ImDrawCornerFlags_TopLeft | ImDrawCornerFlags_TopRight,   // 0x3
+    ImDrawCornerFlags_Bot      = ImDrawCornerFlags_BotLeft | ImDrawCornerFlags_BotRight,   // 0xC
+    ImDrawCornerFlags_Left     = ImDrawCornerFlags_TopLeft | ImDrawCornerFlags_BotLeft,    // 0x5
+    ImDrawCornerFlags_Right    = ImDrawCornerFlags_TopRight | ImDrawCornerFlags_BotRight,  // 0xA
+    ImDrawCornerFlags_All = 0xF  // In your function calls you may use ~0 (= all bits sets) instead
+                                 // of ImDrawCornerFlags_All, as a convenience
+};
+
+enum ImDrawListFlags_
+{
+    ImDrawListFlags_None = 0,
+    ImDrawListFlags_AntiAliasedLines =
+        1 << 0,  // Lines are anti-aliased (*2 the number of triangles for 1.0f wide line, otherwise
+                 // *3 the number of triangles)
+    ImDrawListFlags_AntiAliasedFill =
+        1 << 1,  // Filled shapes have anti-aliased edges (*2 the number of vertices)
+    ImDrawListFlags_AllowVtxOffset =
+        1 << 2  // Can emit 'VtxOffset > 0' to allow large meshes. Set when
+                // 'ImGuiBackendFlags_RendererHasVtxOffset' is enabled.
+};
+
+// Draw command list
+// This is the low-level list of polygons that ImGui:: functions are filling. At the end of the
+// frame, all command lists are passed to your ImGuiIO::RenderDrawListFn function for rendering.
+// Each dear imgui window contains its own ImDrawList. You can use ImGui::GetWindowDrawList() to
+// access the current window draw list and draw custom primitives.
+// You can interleave normal ImGui:: calls and adding primitives to the current draw list.
+// All positions are generally in pixel coordinates (top-left at (0,0), bottom-right at
+// io.DisplaySize), but you are totally free to apply whatever transformation matrix to want to the
+// data (if you apply such transformation you'll want to apply it to ClipRect as well) Important:
+// Primitives are always added to the list and not culled (culling is done at higher-level by
+// ImGui:: functions), if you use this API a lot consider coarse culling your drawn objects.
+struct ImDrawList
+{
+    // This is what you have to render
+    ImVector<ImDrawCmd> CmdBuffer;  // Draw commands. Typically 1 command = 1 GPU draw call, unless
+                                    // the command is a callback.
+    ImVector<ImDrawIdx>
+        IdxBuffer;  // Index buffer. Each command consume ImDrawCmd::ElemCount of those
+    ImVector<ImDrawVert> VtxBuffer;  // Vertex buffer.
+    ImDrawListFlags
+        Flags;  // Flags, you may poke into these to adjust anti-aliasing settings per-primitive.
+
+    // [Internal, used while building lists]
+    const ImDrawListSharedData
+        *_Data;  // Pointer to shared draw data (you can use ImGui::GetDrawListSharedData() to get
+                 // the one from current ImGui context)
+    const char *_OwnerName;  // Pointer to owner window's name for debugging
+    unsigned int
+        _VtxCurrentOffset;  // [Internal] Always 0 unless 'Flags & ImDrawListFlags_AllowVtxOffset'.
+    unsigned int _VtxCurrentIdx;  // [Internal] Generally == VtxBuffer.Size unless we are past 64K
+                                  // vertices, in which case this gets reset to 0.
+    ImDrawVert *_VtxWritePtr;  // [Internal] point within VtxBuffer.Data after each add command (to
+                               // avoid using the ImVector<> operators too much)
+    ImDrawIdx *_IdxWritePtr;   // [Internal] point within IdxBuffer.Data after each add command (to
+                               // avoid using the ImVector<> operators too much)
+    ImVector<ImVec4> _ClipRectStack;        // [Internal]
+    ImVector<ImTextureID> _TextureIdStack;  // [Internal]
+    ImVector<ImVec2> _Path;                 // [Internal] current path building
+    ImDrawListSplitter _Splitter;           // [Internal] for channels api
+
+    // If you want to create ImDrawList instances, pass them ImGui::GetDrawListSharedData() or
+    // create and use your own ImDrawListSharedData (so you can use ImDrawList without ImGui)
+    ImDrawList(const ImDrawListSharedData *shared_data)
+    {
+        _Data      = shared_data;
+        _OwnerName = NULL;
+        Clear();
+    }
+    ~ImDrawList() { ClearFreeMemory(); }
+    IMGUI_API void PushClipRect(
+        ImVec2 clip_rect_min,
+        ImVec2 clip_rect_max,
+        bool intersect_with_current_clip_rect =
+            false);  // Render-level scissoring. This is passed down to your render function but not
+                     // used for CPU-side coarse clipping. Prefer using higher-level
+                     // ImGui::PushClipRect() to affect logic (hit-testing and widget culling)
+    IMGUI_API void PushClipRectFullScreen();
+    IMGUI_API void PopClipRect();
+    IMGUI_API void PushTextureID(ImTextureID texture_id);
+    IMGUI_API void PopTextureID();
+    inline ImVec2 GetClipRectMin() const
+    {
+        const ImVec4 &cr = _ClipRectStack.back();
+        return ImVec2(cr.x, cr.y);
+    }
+    inline ImVec2 GetClipRectMax() const
+    {
+        const ImVec4 &cr = _ClipRectStack.back();
+        return ImVec2(cr.z, cr.w);
+    }
+
+    // Primitives
+    IMGUI_API void AddLine(const ImVec2 &a, const ImVec2 &b, ImU32 col, float thickness = 1.0f);
+    IMGUI_API void AddRect(const ImVec2 &a,
+                           const ImVec2 &b,
+                           ImU32 col,
+                           float rounding             = 0.0f,
+                           int rounding_corners_flags = ImDrawCornerFlags_All,
+                           float thickness = 1.0f);  // a: upper-left, b: lower-right (== upper-left
+                                                     // + size), rounding_corners_flags: 4-bits
+                                                     // corresponding to which corner to round
+    IMGUI_API void AddRectFilled(
+        const ImVec2 &a,
+        const ImVec2 &b,
+        ImU32 col,
+        float rounding = 0.0f,
+        int rounding_corners_flags =
+            ImDrawCornerFlags_All);  // a: upper-left, b: lower-right (== upper-left + size)
+    IMGUI_API void AddRectFilledMultiColor(const ImVec2 &a,
+                                           const ImVec2 &b,
+                                           ImU32 col_upr_left,
+                                           ImU32 col_upr_right,
+                                           ImU32 col_bot_right,
+                                           ImU32 col_bot_left);
+    IMGUI_API void AddQuad(const ImVec2 &a,
+                           const ImVec2 &b,
+                           const ImVec2 &c,
+                           const ImVec2 &d,
+                           ImU32 col,
+                           float thickness = 1.0f);
+    IMGUI_API void AddQuadFilled(const ImVec2 &a,
+                                 const ImVec2 &b,
+                                 const ImVec2 &c,
+                                 const ImVec2 &d,
+                                 ImU32 col);
+    IMGUI_API void AddTriangle(const ImVec2 &a,
+                               const ImVec2 &b,
+                               const ImVec2 &c,
+                               ImU32 col,
+                               float thickness = 1.0f);
+    IMGUI_API void AddTriangleFilled(const ImVec2 &a, const ImVec2 &b, const ImVec2 &c, ImU32 col);
+    IMGUI_API void AddCircle(const ImVec2 &centre,
+                             float radius,
+                             ImU32 col,
+                             int num_segments = 12,
+                             float thickness  = 1.0f);
+    IMGUI_API void AddCircleFilled(const ImVec2 &centre,
+                                   float radius,
+                                   ImU32 col,
+                                   int num_segments = 12);
+    IMGUI_API void AddText(const ImVec2 &pos,
+                           ImU32 col,
+                           const char *text_begin,
+                           const char *text_end = NULL);
+    IMGUI_API void AddText(const ImFont *font,
+                           float font_size,
+                           const ImVec2 &pos,
+                           ImU32 col,
+                           const char *text_begin,
+                           const char *text_end             = NULL,
+                           float wrap_width                 = 0.0f,
+                           const ImVec4 *cpu_fine_clip_rect = NULL);
+    IMGUI_API void AddImage(ImTextureID user_texture_id,
+                            const ImVec2 &a,
+                            const ImVec2 &b,
+                            const ImVec2 &uv_a = ImVec2(0, 0),
+                            const ImVec2 &uv_b = ImVec2(1, 1),
+                            ImU32 col          = IM_COL32_WHITE);
+    IMGUI_API void AddImageQuad(ImTextureID user_texture_id,
+                                const ImVec2 &a,
+                                const ImVec2 &b,
+                                const ImVec2 &c,
+                                const ImVec2 &d,
+                                const ImVec2 &uv_a = ImVec2(0, 0),
+                                const ImVec2 &uv_b = ImVec2(1, 0),
+                                const ImVec2 &uv_c = ImVec2(1, 1),
+                                const ImVec2 &uv_d = ImVec2(0, 1),
+                                ImU32 col          = IM_COL32_WHITE);
+    IMGUI_API void AddImageRounded(ImTextureID user_texture_id,
+                                   const ImVec2 &a,
+                                   const ImVec2 &b,
+                                   const ImVec2 &uv_a,
+                                   const ImVec2 &uv_b,
+                                   ImU32 col,
+                                   float rounding,
+                                   int rounding_corners = ImDrawCornerFlags_All);
+    IMGUI_API void AddPolyline(const ImVec2 *points,
+                               int num_points,
+                               ImU32 col,
+                               bool closed,
+                               float thickness);
+    IMGUI_API void AddConvexPolyFilled(
+        const ImVec2 *points,
+        int num_points,
+        ImU32 col);  // Note: Anti-aliased filling requires points to be in clockwise order.
+    IMGUI_API void AddBezierCurve(const ImVec2 &pos0,
+                                  const ImVec2 &cp0,
+                                  const ImVec2 &cp1,
+                                  const ImVec2 &pos1,
+                                  ImU32 col,
+                                  float thickness,
+                                  int num_segments = 0);
+
+    // Stateful path API, add points then finish with PathFillConvex() or PathStroke()
+    inline void PathClear() { _Path.Size = 0; }
+    inline void PathLineTo(const ImVec2 &pos) { _Path.push_back(pos); }
+    inline void PathLineToMergeDuplicate(const ImVec2 &pos)
+    {
+        if (_Path.Size == 0 || memcmp(&_Path.Data[_Path.Size - 1], &pos, 8) != 0)
+            _Path.push_back(pos);
+    }
+    inline void PathFillConvex(ImU32 col)
+    {
+        AddConvexPolyFilled(_Path.Data, _Path.Size, col);
+        _Path.Size = 0;
+    }  // Note: Anti-aliased filling requires points to be in clockwise order.
+    inline void PathStroke(ImU32 col, bool closed, float thickness = 1.0f)
+    {
+        AddPolyline(_Path.Data, _Path.Size, col, closed, thickness);
+        _Path.Size = 0;
+    }
+    IMGUI_API void PathArcTo(const ImVec2 &centre,
+                             float radius,
+                             float a_min,
+                             float a_max,
+                             int num_segments = 10);
+    IMGUI_API void PathArcToFast(const ImVec2 &centre,
+                                 float radius,
+                                 int a_min_of_12,
+                                 int a_max_of_12);  // Use precomputed angles for a 12 steps circle
+    IMGUI_API void PathBezierCurveTo(const ImVec2 &p1,
+                                     const ImVec2 &p2,
+                                     const ImVec2 &p3,
+                                     int num_segments = 0);
+    IMGUI_API void PathRect(const ImVec2 &rect_min,
+                            const ImVec2 &rect_max,
+                            float rounding             = 0.0f,
+                            int rounding_corners_flags = ImDrawCornerFlags_All);
+
+    // Advanced
+    IMGUI_API void AddCallback(
+        ImDrawCallback callback,
+        void *callback_data);  // Your rendering function must check for 'UserCallback' in ImDrawCmd
+                               // and call the function instead of rendering triangles.
+    IMGUI_API void
+    AddDrawCmd();  // This is useful if you need to forcefully create a new draw call (to allow for
+                   // dependent rendering / blending). Otherwise primitives are merged into the same
+                   // draw-call as much as possible
+    IMGUI_API ImDrawList *CloneOutput()
+        const;  // Create a clone of the CmdBuffer/IdxBuffer/VtxBuffer.
+
+    // Advanced: Channels
+    // - Use to split render into layers. By switching channels to can render out-of-order (e.g.
+    // submit foreground primitives before background primitives)
+    // - Use to minimize draw calls (e.g. if going back-and-forth between multiple non-overlapping
+    // clipping rectangles, prefer to append into separate channels then merge at the end)
+    inline void ChannelsSplit(int count) { _Splitter.Split(this, count); }
+    inline void ChannelsMerge() { _Splitter.Merge(this); }
+    inline void ChannelsSetCurrent(int n) { _Splitter.SetCurrentChannel(this, n); }
+
+    // Internal helpers
+    // NB: all primitives needs to be reserved via PrimReserve() beforehand!
+    IMGUI_API void Clear();
+    IMGUI_API void ClearFreeMemory();
+    IMGUI_API void PrimReserve(int idx_count, int vtx_count);
+    IMGUI_API void PrimRect(const ImVec2 &a,
+                            const ImVec2 &b,
+                            ImU32 col);  // Axis aligned rectangle (composed of two triangles)
+    IMGUI_API void PrimRectUV(const ImVec2 &a,
+                              const ImVec2 &b,
+                              const ImVec2 &uv_a,
+                              const ImVec2 &uv_b,
+                              ImU32 col);
+    IMGUI_API void PrimQuadUV(const ImVec2 &a,
+                              const ImVec2 &b,
+                              const ImVec2 &c,
+                              const ImVec2 &d,
+                              const ImVec2 &uv_a,
+                              const ImVec2 &uv_b,
+                              const ImVec2 &uv_c,
+                              const ImVec2 &uv_d,
+                              ImU32 col);
+    inline void PrimWriteVtx(const ImVec2 &pos, const ImVec2 &uv, ImU32 col)
+    {
+        _VtxWritePtr->pos = pos;
+        _VtxWritePtr->uv  = uv;
+        _VtxWritePtr->col = col;
+        _VtxWritePtr++;
+        _VtxCurrentIdx++;
+    }
+    inline void PrimWriteIdx(ImDrawIdx idx)
+    {
+        *_IdxWritePtr = idx;
+        _IdxWritePtr++;
+    }
+    inline void PrimVtx(const ImVec2 &pos, const ImVec2 &uv, ImU32 col)
+    {
+        PrimWriteIdx((ImDrawIdx)_VtxCurrentIdx);
+        PrimWriteVtx(pos, uv, col);
+    }
+    IMGUI_API void UpdateClipRect();
+    IMGUI_API void UpdateTextureID();
+};
+
+// All draw data to render a Dear ImGui frame
+// (NB: the style and the naming convention here is a little inconsistent, we currently preserve
+// them for backward compatibility purpose, as this is one of the oldest structure exposed by the
+// library! Basically, ImDrawList == CmdList)
+struct ImDrawData
+{
+    bool Valid;  // Only valid after Render() is called and before the next NewFrame() is called.
+    ImDrawList **CmdLists;  // Array of ImDrawList* to render. The ImDrawList are owned by
+                            // ImGuiContext and only pointed to from here.
+    int CmdListsCount;      // Number of ImDrawList* to render
+    int TotalIdxCount;      // For convenience, sum of all ImDrawList's IdxBuffer.Size
+    int TotalVtxCount;      // For convenience, sum of all ImDrawList's VtxBuffer.Size
+    ImVec2 DisplayPos;      // Upper-left position of the viewport to render (== upper-left of the
+                            // orthogonal projection matrix to use)
+    ImVec2 DisplaySize;  // Size of the viewport to render (== io.DisplaySize for the main viewport)
+                         // (DisplayPos + DisplaySize == lower-right of the orthogonal projection
+                         // matrix to use)
+    ImVec2 FramebufferScale;  // Amount of pixels for each unit of DisplaySize. Based on
+                              // io.DisplayFramebufferScale. Generally (1,1) on normal display,
+                              // (2,2) on OSX with Retina display.
+
+    // Functions
+    ImDrawData()
+    {
+        Valid = false;
+        Clear();
+    }
+    ~ImDrawData() { Clear(); }
+    void Clear()
+    {
+        Valid         = false;
+        CmdLists      = NULL;
+        CmdListsCount = TotalVtxCount = TotalIdxCount = 0;
+        DisplayPos = DisplaySize = FramebufferScale = ImVec2(0.f, 0.f);
+    }  // The ImDrawList are owned by ImGuiContext!
+    IMGUI_API void
+    DeIndexAllBuffers();  // Helper to convert all buffers from indexed to non-indexed, in case you
+                          // cannot render indexed. Note: this is slow and most likely a waste of
+                          // resources. Always prefer indexed rendering!
+    IMGUI_API void ScaleClipRects(
+        const ImVec2 &fb_scale);  // Helper to scale the ClipRect field of each ImDrawCmd. Use if
+                                  // your final output buffer is at a different scale than Dear
+                                  // ImGui expects, or if there is a difference between your window
+                                  // resolution and framebuffer resolution.
+};
+
+//-----------------------------------------------------------------------------
+// Font API (ImFontConfig, ImFontGlyph, ImFontAtlasFlags, ImFontAtlas, ImFontGlyphRangesBuilder,
+// ImFont)
+//-----------------------------------------------------------------------------
+
+struct ImFontConfig
+{
+    void *FontData;             //          // TTF/OTF data
+    int FontDataSize;           //          // TTF/OTF data size
+    bool FontDataOwnedByAtlas;  // true     // TTF/OTF data ownership taken by the container
+                                // ImFontAtlas (will delete memory itself).
+    int FontNo;                 // 0        // Index of font within TTF/OTF file
+    float SizePixels;  //          // Size in pixels for rasterizer (more or less maps to the
+                       //          resulting font height).
+    int OversampleH;   // 3        // Rasterize at higher quality for sub-pixel positioning. Read
+                       // https://github.com/nothings/stb/blob/master/tests/oversample/README.md for
+                       // details.
+    int OversampleV;  // 1        // Rasterize at higher quality for sub-pixel positioning. We don't
+                      // use sub-pixel positions on the Y axis.
+    bool PixelSnapH;  // false    // Align every glyph to pixel boundary. Useful e.g. if you are
+                      // merging a non-pixel aligned font with the default font. If enabled, you can
+                      // set OversampleH/V to 1.
+    ImVec2 GlyphExtraSpacing;  // 0, 0     // Extra spacing (in pixels) between glyphs. Only X axis
+                               // is supported for now.
+    ImVec2 GlyphOffset;        // 0, 0     // Offset all glyphs from this font input.
+    const ImWchar *GlyphRanges;  // NULL     // Pointer to a user-provided list of Unicode range (2
+                                 // value per range, values are inclusive, zero-terminated list).
+                                 // THE ARRAY DATA NEEDS TO PERSIST AS LONG AS THE FONT IS ALIVE.
+    float GlyphMinAdvanceX;      // 0        // Minimum AdvanceX for glyphs, set Min to align font
+                                 // icons, set both Min/Max to enforce mono-space font
+    float GlyphMaxAdvanceX;      // FLT_MAX  // Maximum AdvanceX for glyphs
+    bool MergeMode;  // false    // Merge into previous ImFont, so you can combine multiple inputs
+                     // font into one ImFont (e.g. ASCII font + icons + Japanese glyphs). You may
+                     // want to use GlyphOffset.y when merge font of different heights.
+    unsigned int RasterizerFlags;  // 0x00     // Settings for custom font rasterizer (e.g.
+                                   // ImGuiFreeType). Leave as zero if you aren't using one.
+    float RasterizerMultiply;      // 1.0f     // Brighten (>1.0f) or darken (<1.0f) font output.
+                               // Brightening small fonts may be a good workaround to make them more
+                               // readable.
+
+    // [Internal]
+    char Name[40];  // Name (strictly to ease debugging)
+    ImFont *DstFont;
+
+    IMGUI_API ImFontConfig();
+};
+
+struct ImFontGlyph
+{
+    ImWchar Codepoint;     // 0x0000..0xFFFF
+    float AdvanceX;        // Distance to next character (= data from font +
+                           // ImFontConfig::GlyphExtraSpacing.x baked in)
+    float X0, Y0, X1, Y1;  // Glyph corners
+    float U0, V0, U1, V1;  // Texture coordinates
+};
+
+// Helper to build glyph ranges from text/string data. Feed your application strings/characters to
+// it then call BuildRanges(). This is essentially a tightly packed of vector of 64k booleans = 8KB
+// storage.
+struct ImFontGlyphRangesBuilder
+{
+    ImVector<ImU32> UsedChars;  // Store 1-bit per Unicode code point (0=unused, 1=used)
+
+    ImFontGlyphRangesBuilder() { Clear(); }
+    inline void Clear()
+    {
+        int size_in_bytes = 0x10000 / 8;
+        UsedChars.resize(size_in_bytes / (int)sizeof(ImU32));
+        memset(UsedChars.Data, 0, (size_t)size_in_bytes);
+    }
+    inline bool GetBit(int n) const
+    {
+        int off    = (n >> 5);
+        ImU32 mask = 1u << (n & 31);
+        return (UsedChars[off] & mask) != 0;
+    }  // Get bit n in the array
+    inline void SetBit(int n)
+    {
+        int off    = (n >> 5);
+        ImU32 mask = 1u << (n & 31);
+        UsedChars[off] |= mask;
+    }                                              // Set bit n in the array
+    inline void AddChar(ImWchar c) { SetBit(c); }  // Add character
+    IMGUI_API void AddText(
+        const char *text,
+        const char *text_end = NULL);  // Add string (each character of the UTF-8 string are added)
+    IMGUI_API void AddRanges(
+        const ImWchar *ranges);  // Add ranges, e.g.
+                                 // builder.AddRanges(ImFontAtlas::GetGlyphRangesDefault())
+                                 // to force add all of ASCII/Latin+Ext
+    IMGUI_API void BuildRanges(ImVector<ImWchar> *out_ranges);  // Output new ranges
+};
+
+enum ImFontAtlasFlags_
+{
+    ImFontAtlasFlags_None               = 0,
+    ImFontAtlasFlags_NoPowerOfTwoHeight = 1 << 0,  // Don't round the height to next power of two
+    ImFontAtlasFlags_NoMouseCursors = 1 << 1  // Don't build software mouse cursors into the atlas
+};
+
+// Load and rasterize multiple TTF/OTF fonts into a same texture. The font atlas will build a single
+// texture holding:
+//  - One or more fonts.
+//  - Custom graphics data needed to render the shapes needed by Dear ImGui.
+//  - Mouse cursor shapes for software cursor rendering (unless setting 'Flags |=
+//  ImFontAtlasFlags_NoMouseCursors' in the font atlas).
+// It is the user-code responsibility to setup/build the atlas, then upload the pixel data into a
+// texture accessible by your graphics api.
+//  - Optionally, call any of the AddFont*** functions. If you don't call any, the default font
+//  embedded in the code will be loaded for you.
+//  - Call GetTexDataAsAlpha8() or GetTexDataAsRGBA32() to build and retrieve pixels data.
+//  - Upload the pixels data into a texture within your graphics system (see imgui_impl_xxxx.cpp
+//  examples)
+//  - Call SetTexID(my_tex_id); and pass the pointer/identifier to your texture in a format natural
+//  to your graphics API.
+//    This value will be passed back to you during rendering to identify the texture. Read FAQ entry
+//    about ImTextureID for more details.
+// Common pitfalls:
+// - If you pass a 'glyph_ranges' array to AddFont*** functions, you need to make sure that your
+// array persist up until the
+//   atlas is build (when calling GetTexData*** or Build()). We only copy the pointer, not the data.
+// - Important: By default, AddFontFromMemoryTTF() takes ownership of the data. Even though we are
+// not writing to it, we will free the pointer on destruction.
+//   You can set font_cfg->FontDataOwnedByAtlas=false to keep ownership of your data and it won't be
+//   freed,
+// - Even though many functions are suffixed with "TTF", OTF data is supported just as well.
+// - This is an old API and it is currently awkward for those and and various other reasons! We will
+// address them in the future!
+struct ImFontAtlas
+{
+    IMGUI_API ImFontAtlas();
+    IMGUI_API ~ImFontAtlas();
+    IMGUI_API ImFont *AddFont(const ImFontConfig *font_cfg);
+    IMGUI_API ImFont *AddFontDefault(const ImFontConfig *font_cfg = NULL);
+    IMGUI_API ImFont *AddFontFromFileTTF(const char *filename,
+                                         float size_pixels,
+                                         const ImFontConfig *font_cfg = NULL,
+                                         const ImWchar *glyph_ranges  = NULL);
+    IMGUI_API ImFont *AddFontFromMemoryTTF(
+        void *font_data,
+        int font_size,
+        float size_pixels,
+        const ImFontConfig *font_cfg = NULL,
+        const ImWchar *glyph_ranges =
+            NULL);  // Note: Transfer ownership of 'ttf_data' to ImFontAtlas! Will be deleted after
+                    // destruction of the atlas. Set font_cfg->FontDataOwnedByAtlas=false to keep
+                    // ownership of your data and it won't be freed.
+    IMGUI_API ImFont *AddFontFromMemoryCompressedTTF(
+        const void *compressed_font_data,
+        int compressed_font_size,
+        float size_pixels,
+        const ImFontConfig *font_cfg = NULL,
+        const ImWchar *glyph_ranges  = NULL);  // 'compressed_font_data' still owned by caller.
+                                              // Compress with binary_to_compressed_c.cpp.
+    IMGUI_API ImFont *AddFontFromMemoryCompressedBase85TTF(
+        const char *compressed_font_data_base85,
+        float size_pixels,
+        const ImFontConfig *font_cfg = NULL,
+        const ImWchar *glyph_ranges =
+            NULL);  // 'compressed_font_data_base85' still owned by caller. Compress with
+                    // binary_to_compressed_c.cpp with -base85 parameter.
+    IMGUI_API void
+    ClearInputData();  // Clear input data (all ImFontConfig structures including sizes, TTF data,
+                       // glyph ranges, etc.) = all the data used to build the texture and fonts.
+    IMGUI_API void ClearTexData();  // Clear output texture data (CPU side). Saves RAM once the
+                                    // texture has been copied to graphics memory.
+    IMGUI_API void ClearFonts();    // Clear output font data (glyphs storage, UV coordinates).
+    IMGUI_API void Clear();         // Clear all input and output.
+
+    // Build atlas, retrieve pixel data.
+    // User is in charge of copying the pixels into graphics memory (e.g. create a texture with your
+    // engine). Then store your texture handle with SetTexID(). The pitch is always = Width *
+    // BytesPerPixels (1 or 4) Building in RGBA32 format is provided for convenience and
+    // compatibility, but note that unless you manually manipulate or copy color data into the
+    // texture (e.g. when using the AddCustomRect*** api), then the RGB pixels emitted will always
+    // be white (~75% of memory/bandwidth waste.
+    IMGUI_API bool Build();  // Build pixels data. This is called automatically for you by the
+                             // GetTexData*** functions.
+    IMGUI_API void GetTexDataAsAlpha8(unsigned char **out_pixels,
+                                      int *out_width,
+                                      int *out_height,
+                                      int *out_bytes_per_pixel = NULL);  // 1 byte per-pixel
+    IMGUI_API void GetTexDataAsRGBA32(unsigned char **out_pixels,
+                                      int *out_width,
+                                      int *out_height,
+                                      bool enableAlphaBlending,
+                                      int *out_bytes_per_pixel = NULL);  // 4 bytes-per-pixel
+    bool IsBuilt()
+    {
+        return Fonts.Size > 0 && (TexPixelsAlpha8 != NULL || TexPixelsRGBA32 != NULL);
+    }
+    void SetTexID(ImTextureID id) { TexID = id; }
+
+    //-------------------------------------------
+    // Glyph Ranges
+    //-------------------------------------------
+
+    // Helpers to retrieve list of common Unicode ranges (2 value per range, values are inclusive,
+    // zero-terminated list) NB: Make sure that your string are UTF-8 and NOT in your local code
+    // page. In C++11, you can create UTF-8 string literal using the u8"Hello world" syntax. See FAQ
+    // for details. NB: Consider using ImFontGlyphRangesBuilder to build glyph ranges from textual
+    // data.
+    IMGUI_API const ImWchar *GetGlyphRangesDefault();   // Basic Latin, Extended Latin
+    IMGUI_API const ImWchar *GetGlyphRangesKorean();    // Default + Korean characters
+    IMGUI_API const ImWchar *GetGlyphRangesJapanese();  // Default + Hiragana, Katakana, Half-Width,
+                                                        // Selection of 1946 Ideographs
+    IMGUI_API const ImWchar *
+    GetGlyphRangesChineseFull();  // Default + Half-Width + Japanese Hiragana/Katakana + full set of
+                                  // about 21000 CJK Unified Ideographs
+    IMGUI_API const ImWchar *
+    GetGlyphRangesChineseSimplifiedCommon();  // Default + Half-Width + Japanese Hiragana/Katakana +
+                                              // set of 2500 CJK Unified Ideographs for common
+                                              // simplified Chinese
+    IMGUI_API const ImWchar *GetGlyphRangesCyrillic();    // Default + about 400 Cyrillic characters
+    IMGUI_API const ImWchar *GetGlyphRangesThai();        // Default + Thai characters
+    IMGUI_API const ImWchar *GetGlyphRangesVietnamese();  // Default + Vietname characters
+
+    //-------------------------------------------
+    // [BETA] Custom Rectangles/Glyphs API
+    //-------------------------------------------
+
+    // You can request arbitrary rectangles to be packed into the atlas, for your own purposes.
+    // After calling Build(), you can query the rectangle position and render your pixels.
+    // You can also request your rectangles to be mapped as font glyph (given a font + Unicode
+    // point), so you can render e.g. custom colorful icons and use them as regular glyphs. Read
+    // misc/fonts/README.txt for more details about using colorful icons.
+    struct CustomRect
+    {
+        unsigned int ID;  // Input    // User ID. Use <0x10000 to map into a font glyph, >=0x10000
+                          // for other/internal/custom texture data.
+        unsigned short Width, Height;  // Input    // Desired rectangle dimension
+        unsigned short X, Y;           // Output   // Packed position in Atlas
+        float
+            GlyphAdvanceX;   // Input    // For custom font glyphs only (ID<0x10000): glyph xadvance
+        ImVec2 GlyphOffset;  // Input    // For custom font glyphs only (ID<0x10000): glyph display
+                             // offset
+        ImFont *Font;        // Input    // For custom font glyphs only (ID<0x10000): target font
+        CustomRect()
+        {
+            ID    = 0xFFFFFFFF;
+            Width = Height = 0;
+            X = Y         = 0xFFFF;
+            GlyphAdvanceX = 0.0f;
+            GlyphOffset   = ImVec2(0, 0);
+            Font          = NULL;
+        }
+        bool IsPacked() const { return X != 0xFFFF; }
+    };
+    IMGUI_API int AddCustomRectRegular(unsigned int id,
+                                       int width,
+                                       int height);  // Id needs to be >= 0x10000. Id >= 0x80000000
+                                                     // are reserved for ImGui and ImDrawList
+    IMGUI_API int AddCustomRectFontGlyph(
+        ImFont *font,
+        ImWchar id,
+        int width,
+        int height,
+        float advance_x,
+        const ImVec2 &offset = ImVec2(
+            0,
+            0));  // Id needs to be < 0x10000 to register a rectangle to map into a specific font.
+    const CustomRect *GetCustomRectByIndex(int index) const
+    {
+        if (index < 0)
+            return NULL;
+        return &CustomRects[index];
+    }
+
+    // [Internal]
+    IMGUI_API void CalcCustomRectUV(const CustomRect *rect, ImVec2 *out_uv_min, ImVec2 *out_uv_max);
+    IMGUI_API bool GetMouseCursorTexData(ImGuiMouseCursor cursor,
+                                         ImVec2 *out_offset,
+                                         ImVec2 *out_size,
+                                         ImVec2 out_uv_border[2],
+                                         ImVec2 out_uv_fill[2]);
+
+    //-------------------------------------------
+    // Members
+    //-------------------------------------------
+
+    bool Locked;  // Marked as Locked by ImGui::NewFrame() so attempt to modify the atlas will
+                  // assert.
+    ImFontAtlasFlags Flags;  // Build flags (see ImFontAtlasFlags_)
+    ImTextureID
+        TexID;  // User data to refer to the texture once it has been uploaded to user's graphic
+                // systems. It is passed back to you during rendering via the ImDrawCmd structure.
+    int TexDesiredWidth;  // Texture width desired by user before Build(). Must be a power-of-two.
+                          // If have many glyphs your graphics API have texture size restrictions
+                          // you may want to increase texture width to decrease height.
+    int TexGlyphPadding;  // Padding between glyphs within texture in pixels. Defaults to 1. If your
+                          // rendering method doesn't rely on bilinear filtering you may set this to
+                          // 0.
+
+    // [Internal]
+    // NB: Access texture data via GetTexData*() calls! Which will setup a default font for you.
+    unsigned char *TexPixelsAlpha8;  // 1 component per pixel, each component is unsigned 8-bit.
+                                     // Total size = TexWidth * TexHeight
+    unsigned int *TexPixelsRGBA32;   // 4 component per pixel, each component is unsigned 8-bit.
+                                     // Total size = TexWidth * TexHeight * 4
+    int TexWidth;                    // Texture width calculated during Build().
+    int TexHeight;                   // Texture height calculated during Build().
+    ImVec2 TexUvScale;               // = (1.0f/TexWidth, 1.0f/TexHeight)
+    ImVec2 TexUvWhitePixel;          // Texture coordinates to a white pixel
+    ImVector<ImFont *> Fonts;  // Hold all the fonts returned by AddFont*. Fonts[0] is the default
+                               // font upon calling ImGui::NewFrame(), use
+                               // ImGui::PushFont()/PopFont() to change the current font.
+    ImVector<CustomRect> CustomRects;  // Rectangles for packing custom texture data into the atlas.
+    ImVector<ImFontConfig> ConfigData;  // Internal data
+    int CustomRectIds[1];  // Identifiers of custom texture rectangle used by ImFontAtlas/ImDrawList
+
+#ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+    typedef ImFontGlyphRangesBuilder GlyphRangesBuilder;  // OBSOLETED in 1.67+
+#endif
+};
+
+// Font runtime data and rendering
+// ImFontAtlas automatically loads a default embedded font for you when you call
+// GetTexDataAsAlpha8() or GetTexDataAsRGBA32().
+struct ImFont
+{
+    // Members: Hot ~20/24 bytes (for CalcTextSize)
+    ImVector<float>
+        IndexAdvanceX;  // 12-16 // out //            // Sparse. Glyphs->AdvanceX in a directly
+                        // indexable way (cache-friendly for CalcTextSize functions which only this
+                        // this info, and are often bottleneck in large UI).
+    float FallbackAdvanceX;  // 4     // out // = FallbackGlyph->AdvanceX
+    float FontSize;  // 4     // in  //            // Height of characters/line, set during loading
+                     // (don't change after loading)
+
+    // Members: Hot ~36/48 bytes (for CalcTextSize + render loop)
+    ImVector<ImWchar>
+        IndexLookup;  // 12-16 // out //            // Sparse. Index glyphs by Unicode code-point.
+    ImVector<ImFontGlyph> Glyphs;      // 12-16 // out //            // All glyphs.
+    const ImFontGlyph *FallbackGlyph;  // 4-8   // out // = FindGlyph(FontFallbackChar)
+    ImVec2 DisplayOffset;  // 8     // in  // = (0,0)    // Offset font rendering by xx pixels
+
+    // Members: Cold ~32/40 bytes
+    ImFontAtlas *ContainerAtlas;  // 4-8   // out //            // What we has been loaded into
+    const ImFontConfig
+        *ConfigData;  // 4-8   // in  //            // Pointer within ContainerAtlas->ConfigData
+    short ConfigDataCount;  // 2     // in  // ~ 1        // Number of ImFontConfig involved in
+                            // creating this font. Bigger than 1 when merging multiple font sources
+                            // into one ImFont.
+    ImWchar FallbackChar;   // 2     // in  // = '?'      // Replacement glyph if one isn't found.
+                            // Only set via SetFallbackChar()
+    float Scale;  // 4     // in  // = 1.f      // Base font scale, multiplied by the per-window
+                  // font scale which you can adjust with SetWindowFontScale()
+    float Ascent, Descent;  // 4+4   // out //            // Ascent: distance from top to bottom of
+                            // e.g. 'A' [0..FontSize]
+    int MetricsTotalSurface;  // 4     // out //            // Total surface in pixels to get an
+                              // idea of the font rasterization/texture cost (not exact, we
+                              // approximate the cost of padding between glyphs)
+    bool DirtyLookupTables;   // 1     // out //
+
+    // Methods
+    IMGUI_API ImFont();
+    IMGUI_API ~ImFont();
+    IMGUI_API const ImFontGlyph *FindGlyph(ImWchar c) const;
+    IMGUI_API const ImFontGlyph *FindGlyphNoFallback(ImWchar c) const;
+    float GetCharAdvance(ImWchar c) const
+    {
+        return ((int)c < IndexAdvanceX.Size) ? IndexAdvanceX[(int)c] : FallbackAdvanceX;
+    }
+    bool IsLoaded() const { return ContainerAtlas != NULL; }
+    const char *GetDebugName() const { return ConfigData ? ConfigData->Name : "<unknown>"; }
+
+    // 'max_width' stops rendering after a certain width (could be turned into a 2d size). FLT_MAX
+    // to disable. 'wrap_width' enable automatic word-wrapping across multiple lines to fit into
+    // given width. 0.0f to disable.
+    IMGUI_API ImVec2 CalcTextSizeA(float size,
+                                   float max_width,
+                                   float wrap_width,
+                                   const char *text_begin,
+                                   const char *text_end   = NULL,
+                                   const char **remaining = NULL) const;  // utf8
+    IMGUI_API const char *CalcWordWrapPositionA(float scale,
+                                                const char *text,
+                                                const char *text_end,
+                                                float wrap_width) const;
+    IMGUI_API void RenderChar(ImDrawList *draw_list,
+                              float size,
+                              ImVec2 pos,
+                              ImU32 col,
+                              ImWchar c) const;
+    IMGUI_API void RenderText(ImDrawList *draw_list,
+                              float size,
+                              ImVec2 pos,
+                              ImU32 col,
+                              const ImVec4 &clip_rect,
+                              const char *text_begin,
+                              const char *text_end,
+                              float wrap_width   = 0.0f,
+                              bool cpu_fine_clip = false) const;
+
+    // [Internal] Don't use!
+    IMGUI_API void BuildLookupTable();
+    IMGUI_API void ClearOutputData();
+    IMGUI_API void GrowIndex(int new_size);
+    IMGUI_API void AddGlyph(ImWchar c,
+                            float x0,
+                            float y0,
+                            float x1,
+                            float y1,
+                            float u0,
+                            float v0,
+                            float u1,
+                            float v1,
+                            float advance_x);
+    IMGUI_API void AddRemapChar(
+        ImWchar dst,
+        ImWchar src,
+        bool overwrite_dst = true);  // Makes 'dst' character/glyph points to 'src' character/glyph.
+                                     // Currently needs to be called AFTER fonts have been built.
+    IMGUI_API void SetFallbackChar(ImWchar c);
+
+#ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+    typedef ImFontGlyph Glyph;  // OBSOLETED in 1.52+
+#endif
+};
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+// Include imgui_user.h at the end of imgui.h (convenient for user to only explicitly include
+// vanilla imgui.h)
+#ifdef IMGUI_INCLUDE_IMGUI_USER_H
+#include "imgui_user.h"
+#endif

--- a/third_party/imgui/imgui_demo.cpp
+++ b/third_party/imgui/imgui_demo.cpp
@@ -1,0 +1,6016 @@
+// dear imgui, v1.72 WIP
+// (demo code)
+
+// Message to the person tempted to delete this file when integrating Dear ImGui into their code
+// base: Do NOT remove this file from your project! Think again! It is the most useful reference
+// code that you and other coders will want to refer to and call. Have the ImGui::ShowDemoWindow()
+// function wired in an always-available debug menu of your game/app! Removing this file from your
+// project is hindering access to documentation for everyone in your team, likely leading you to
+// poorer usage of the library. Everything in this file will be stripped out by the linker if you
+// don't call ImGui::ShowDemoWindow(). If you want to link core Dear ImGui in your shipped builds
+// but want an easy guarantee that the demo will not be linked, you can setup your imconfig.h with
+// #define IMGUI_DISABLE_DEMO_WINDOWS and those functions will be empty. In other situation,
+// whenever you have Dear ImGui available you probably want this to be available for reference.
+// Thank you,
+// -Your beloved friend, imgui_demo.cpp (that you won't delete)
+
+// Message to beginner C/C++ programmers about the meaning of the 'static' keyword:
+// In this demo code, we frequently we use 'static' variables inside functions. A static variable
+// persist across calls, so it is essentially like a global variable but declared inside the scope
+// of the function. We do this as a way to gather code and data in the same place, to make the demo
+// source code faster to read, faster to write, and smaller in size. It also happens to be a
+// convenient way of storing simple UI related information as long as your function doesn't need to
+// be reentrant or used in multiple threads. This might be a pattern you will want to use in your
+// code, but most of the real data you would be editing is likely going to be stored outside your
+// functions.
+
+// The Demo code is this file is designed to be easy to copy-and-paste in into your application!
+// Because of this:
+// - We never omit the ImGui:: namespace when calling functions, even though most of our code is
+// already in the same namespace.
+// - We try to declare static variables in the local scope, as close as possible to the code using
+// them.
+// - We never use any of the helpers/facilities used internally by dear imgui, unless it has been
+// exposed in the public API (imgui.h).
+// - We never use maths operators on ImVec2/ImVec4. For other imgui sources files, they are provided
+// by imgui_internal.h w/ IMGUI_DEFINE_MATH_OPERATORS,
+//   for your own sources file they are optional and require you either enable those, either provide
+//   your own via IM_VEC2_CLASS_EXTRA in imconfig.h. Because we don't want to assume anything about
+//   your support of maths operators, we don't use them in imgui_demo.cpp.
+
+/*
+
+Index of this file:
+
+// [SECTION] Forward Declarations, Helpers
+// [SECTION] Demo Window / ShowDemoWindow()
+// [SECTION] About Window / ShowAboutWindow()
+// [SECTION] Style Editor / ShowStyleEditor()
+// [SECTION] Example App: Main Menu Bar / ShowExampleAppMainMenuBar()
+// [SECTION] Example App: Debug Console / ShowExampleAppConsole()
+// [SECTION] Example App: Debug Log / ShowExampleAppLog()
+// [SECTION] Example App: Simple Layout / ShowExampleAppLayout()
+// [SECTION] Example App: Property Editor / ShowExampleAppPropertyEditor()
+// [SECTION] Example App: Long Text / ShowExampleAppLongText()
+// [SECTION] Example App: Auto Resize / ShowExampleAppAutoResize()
+// [SECTION] Example App: Constrained Resize / ShowExampleAppConstrainedResize()
+// [SECTION] Example App: Simple Overlay / ShowExampleAppSimpleOverlay()
+// [SECTION] Example App: Manipulating Window Titles / ShowExampleAppWindowTitles()
+// [SECTION] Example App: Custom Rendering using ImDrawList API / ShowExampleAppCustomRendering()
+// [SECTION] Example App: Documents Handling / ShowExampleAppDocuments()
+
+*/
+
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#include <ctype.h>   // toupper
+#include <limits.h>  // INT_MIN, INT_MAX
+#include <math.h>    // sqrtf, powf, cosf, sinf, floorf, ceilf
+#include <stdio.h>   // vsnprintf, sscanf, printf
+#include <stdlib.h>  // NULL, malloc, free, atoi
+#include "imgui.h"
+#if defined(_MSC_VER) && _MSC_VER <= 1500  // MSVC 2008 or earlier
+#include <stddef.h>                        // intptr_t
+#else
+#include <stdint.h>  // intptr_t
+#endif
+
+#ifdef _MSC_VER
+#pragma warning(disable : 4996)  // 'This function or variable may be unsafe': strcpy, strdup,
+                                 // sprintf, vsnprintf, sscanf, fopen
+#endif
+#if defined(__clang__)
+#pragma clang diagnostic ignored "-Wold-style-cast"  // warning : use of old-style cast // yes, they
+                                                     // are more terse.
+#pragma clang diagnostic ignored \
+    "-Wdeprecated-declarations"  // warning : 'xx' is deprecated: The POSIX name for this
+                                 // item.. // for strdup used in demo code (so user can copy
+                                 // & paste the code)
+#pragma clang diagnostic ignored \
+    "-Wint-to-void-pointer-cast"  // warning : cast to 'void *' from smaller integer type 'int'
+#pragma clang diagnostic ignored \
+    "-Wformat-security"  // warning : warning: format string is not a string literal
+#pragma clang diagnostic ignored \
+    "-Wexit-time-destructors"  // warning : declaration requires an exit-time destructor       //
+                               // exit-time destruction order is undefined. if MemFree() leads to
+                               // users code that has been disabled before exit it might cause
+                               // problems. ImGui coding style welcomes static/globals.
+#pragma clang diagnostic ignored "-Wunused-macros"  // warning : warning: macro is not used // we
+                                                    // define snprintf/vsnprintf on Windows so they
+                                                    // are available, but not always used.
+#if __has_warning("-Wzero-as-null-pointer-constant")
+#pragma clang diagnostic ignored \
+    "-Wzero-as-null-pointer-constant"  // warning : zero as null pointer constant // some standard
+                                       // header variations use #define NULL 0
+#endif
+#if __has_warning("-Wdouble-promotion")
+#pragma clang diagnostic ignored \
+    "-Wdouble-promotion"  // warning: implicit conversion from 'float' to 'double' when passing
+                          // argument to function  // using printf() is a misery with this as C++
+                          // va_arg ellipsis changes float to double.
+#endif
+#if __has_warning("-Wreserved-id-macro")
+#pragma clang diagnostic ignored \
+    "-Wreserved-id-macro"  // warning : macro name is a reserved identifier                //
+#endif
+#elif defined(__GNUC__)
+#pragma GCC diagnostic ignored \
+    "-Wpragmas"  // warning: unknown option after '#pragma GCC diagnostic' kind
+#pragma GCC diagnostic ignored \
+    "-Wint-to-pointer-cast"  // warning: cast to pointer from integer of different size
+#pragma GCC diagnostic ignored \
+    "-Wformat-security"  // warning : format string is not a string literal (potentially insecure)
+#pragma GCC diagnostic ignored "-Wdouble-promotion"  // warning: implicit conversion from 'float' to
+                                                     // 'double' when passing argument to function
+#pragma GCC diagnostic ignored \
+    "-Wconversion"  // warning: conversion to 'xxxx' from 'xxxx' may alter its value
+#pragma GCC diagnostic ignored \
+    "-Wmisleading-indentation"  // [__GNUC__ >= 6] warning: this 'if' clause does not guard this
+                                // statement      // GCC 6.0+ only. See #883 on GitHub.
+#endif
+
+// Play it nice with Windows users. Notepad in 2017 still doesn't display text data with Unix-style
+// \n.
+#ifdef _WIN32
+#define IM_NEWLINE "\r\n"
+#define snprintf _snprintf
+#define vsnprintf _vsnprintf
+#else
+#define IM_NEWLINE "\n"
+#endif
+
+#define IM_MAX(_A, _B) (((_A) >= (_B)) ? (_A) : (_B))
+
+//-----------------------------------------------------------------------------
+// [SECTION] Forward Declarations, Helpers
+//-----------------------------------------------------------------------------
+
+#if !defined(IMGUI_DISABLE_OBSOLETE_FUNCTIONS) && defined(IMGUI_DISABLE_TEST_WINDOWS) && \
+    !defined(IMGUI_DISABLE_DEMO_WINDOWS)  // Obsolete name since 1.53, TEST->DEMO
+#define IMGUI_DISABLE_DEMO_WINDOWS
+#endif
+
+#if !defined(IMGUI_DISABLE_DEMO_WINDOWS)
+
+// Forward Declarations
+static void ShowExampleAppDocuments(bool *p_open);
+static void ShowExampleAppMainMenuBar();
+static void ShowExampleAppConsole(bool *p_open);
+static void ShowExampleAppLog(bool *p_open);
+static void ShowExampleAppLayout(bool *p_open);
+static void ShowExampleAppPropertyEditor(bool *p_open);
+static void ShowExampleAppLongText(bool *p_open);
+static void ShowExampleAppAutoResize(bool *p_open);
+static void ShowExampleAppConstrainedResize(bool *p_open);
+static void ShowExampleAppSimpleOverlay(bool *p_open);
+static void ShowExampleAppWindowTitles(bool *p_open);
+static void ShowExampleAppCustomRendering(bool *p_open);
+static void ShowExampleMenuFile();
+
+// Helper to display a little (?) mark which shows a tooltip when hovered.
+// In your own code you may want to display an actual icon if you are using a merged icon fonts (see
+// misc/fonts/README.txt)
+static void HelpMarker(const char *desc)
+{
+    ImGui::TextDisabled("(?)");
+    if (ImGui::IsItemHovered())
+    {
+        ImGui::BeginTooltip();
+        ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+        ImGui::TextUnformatted(desc);
+        ImGui::PopTextWrapPos();
+        ImGui::EndTooltip();
+    }
+}
+
+// Helper to display basic user controls.
+void ImGui::ShowUserGuide()
+{
+    ImGuiIO &io = ImGui::GetIO();
+    ImGui::BulletText("Double-click on title bar to collapse window.");
+    ImGui::BulletText(
+        "Click and drag on lower right corner to resize window\n(double-click to auto fit window "
+        "to its contents).");
+    ImGui::BulletText("Click and drag on any empty space to move window.");
+    ImGui::BulletText("TAB/SHIFT+TAB to cycle through keyboard editable fields.");
+    ImGui::BulletText("CTRL+Click on a slider or drag box to input value as text.");
+    if (io.FontAllowUserScaling)
+        ImGui::BulletText("CTRL+Mouse Wheel to zoom window contents.");
+    ImGui::BulletText("Mouse Wheel to scroll.");
+    ImGui::BulletText("While editing text:\n");
+    ImGui::Indent();
+    ImGui::BulletText("Hold SHIFT or use mouse to select text.");
+    ImGui::BulletText("CTRL+Left/Right to word jump.");
+    ImGui::BulletText("CTRL+A or double-click to select all.");
+    ImGui::BulletText("CTRL+X,CTRL+C,CTRL+V to use clipboard.");
+    ImGui::BulletText("CTRL+Z,CTRL+Y to undo/redo.");
+    ImGui::BulletText("ESCAPE to revert.");
+    ImGui::BulletText(
+        "You can apply arithmetic operators +,*,/ on numerical values.\nUse +- to subtract.");
+    ImGui::Unindent();
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Demo Window / ShowDemoWindow()
+//-----------------------------------------------------------------------------
+
+// We split the contents of the big ShowDemoWindow() function into smaller functions (because the
+// link time of very large functions grow non-linearly)
+static void ShowDemoWindowWidgets();
+static void ShowDemoWindowLayout();
+static void ShowDemoWindowPopups();
+static void ShowDemoWindowColumns();
+static void ShowDemoWindowMisc();
+
+// Demonstrate most Dear ImGui features (this is big function!)
+// You may execute this function to experiment with the UI and understand what it does. You may then
+// search for keywords in the code when you are interested by a specific feature.
+void ImGui::ShowDemoWindow(bool *p_open)
+{
+    IM_ASSERT(
+        ImGui::GetCurrentContext() != NULL &&
+        "Missing dear imgui context. Refer to examples app!");  // Exceptionally add an extra assert
+                                                                // here for people confused with
+                                                                // initial dear imgui setup
+
+    // Examples Apps (accessible from the "Examples" menu)
+    static bool show_app_documents          = false;
+    static bool show_app_main_menu_bar      = false;
+    static bool show_app_console            = false;
+    static bool show_app_log                = false;
+    static bool show_app_layout             = false;
+    static bool show_app_property_editor    = false;
+    static bool show_app_long_text          = false;
+    static bool show_app_auto_resize        = false;
+    static bool show_app_constrained_resize = false;
+    static bool show_app_simple_overlay     = false;
+    static bool show_app_window_titles      = false;
+    static bool show_app_custom_rendering   = false;
+
+    if (show_app_documents)
+        ShowExampleAppDocuments(&show_app_documents);
+    if (show_app_main_menu_bar)
+        ShowExampleAppMainMenuBar();
+    if (show_app_console)
+        ShowExampleAppConsole(&show_app_console);
+    if (show_app_log)
+        ShowExampleAppLog(&show_app_log);
+    if (show_app_layout)
+        ShowExampleAppLayout(&show_app_layout);
+    if (show_app_property_editor)
+        ShowExampleAppPropertyEditor(&show_app_property_editor);
+    if (show_app_long_text)
+        ShowExampleAppLongText(&show_app_long_text);
+    if (show_app_auto_resize)
+        ShowExampleAppAutoResize(&show_app_auto_resize);
+    if (show_app_constrained_resize)
+        ShowExampleAppConstrainedResize(&show_app_constrained_resize);
+    if (show_app_simple_overlay)
+        ShowExampleAppSimpleOverlay(&show_app_simple_overlay);
+    if (show_app_window_titles)
+        ShowExampleAppWindowTitles(&show_app_window_titles);
+    if (show_app_custom_rendering)
+        ShowExampleAppCustomRendering(&show_app_custom_rendering);
+
+    // Dear ImGui Apps (accessible from the "Help" menu)
+    static bool show_app_metrics      = false;
+    static bool show_app_style_editor = false;
+    static bool show_app_about        = false;
+
+    if (show_app_metrics)
+    {
+        ImGui::ShowMetricsWindow(&show_app_metrics);
+    }
+    if (show_app_style_editor)
+    {
+        ImGui::Begin("Style Editor", &show_app_style_editor);
+        ImGui::ShowStyleEditor();
+        ImGui::End();
+    }
+    if (show_app_about)
+    {
+        ImGui::ShowAboutWindow(&show_app_about);
+    }
+
+    // Demonstrate the various window flags. Typically you would just use the default!
+    static bool no_titlebar       = false;
+    static bool no_scrollbar      = false;
+    static bool no_menu           = false;
+    static bool no_move           = false;
+    static bool no_resize         = false;
+    static bool no_collapse       = false;
+    static bool no_close          = false;
+    static bool no_nav            = false;
+    static bool no_background     = false;
+    static bool no_bring_to_front = false;
+
+    ImGuiWindowFlags window_flags = 0;
+    if (no_titlebar)
+        window_flags |= ImGuiWindowFlags_NoTitleBar;
+    if (no_scrollbar)
+        window_flags |= ImGuiWindowFlags_NoScrollbar;
+    if (!no_menu)
+        window_flags |= ImGuiWindowFlags_MenuBar;
+    if (no_move)
+        window_flags |= ImGuiWindowFlags_NoMove;
+    if (no_resize)
+        window_flags |= ImGuiWindowFlags_NoResize;
+    if (no_collapse)
+        window_flags |= ImGuiWindowFlags_NoCollapse;
+    if (no_nav)
+        window_flags |= ImGuiWindowFlags_NoNav;
+    if (no_background)
+        window_flags |= ImGuiWindowFlags_NoBackground;
+    if (no_bring_to_front)
+        window_flags |= ImGuiWindowFlags_NoBringToFrontOnFocus;
+    if (no_close)
+        p_open = NULL;  // Don't pass our bool* to Begin
+
+    // We specify a default position/size in case there's no data in the .ini file. Typically this
+    // isn't required! We only do it to make the Demo applications a little more welcoming.
+    ImGui::SetNextWindowPos(ImVec2(650, 20), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(550, 680), ImGuiCond_FirstUseEver);
+
+    // Main body of the Demo window starts here.
+    if (!ImGui::Begin("Dear ImGui Demo", p_open, window_flags))
+    {
+        // Early out if the window is collapsed, as an optimization.
+        ImGui::End();
+        return;
+    }
+
+    // Most "big" widgets share a common width settings by default.
+    // ImGui::PushItemWidth(ImGui::GetWindowWidth() * 0.65f);    // Use 2/3 of the space for widgets
+    // and 1/3 for labels (default)
+    ImGui::PushItemWidth(
+        ImGui::GetFontSize() *
+        -12);  // Use fixed width for labels (by passing a negative value), the rest goes to
+               // widgets. We choose a width proportional to our font size.
+
+    // Menu Bar
+    if (ImGui::BeginMenuBar())
+    {
+        if (ImGui::BeginMenu("Menu"))
+        {
+            ShowExampleMenuFile();
+            ImGui::EndMenu();
+        }
+        if (ImGui::BeginMenu("Examples"))
+        {
+            ImGui::MenuItem("Main menu bar", NULL, &show_app_main_menu_bar);
+            ImGui::MenuItem("Console", NULL, &show_app_console);
+            ImGui::MenuItem("Log", NULL, &show_app_log);
+            ImGui::MenuItem("Simple layout", NULL, &show_app_layout);
+            ImGui::MenuItem("Property editor", NULL, &show_app_property_editor);
+            ImGui::MenuItem("Long text display", NULL, &show_app_long_text);
+            ImGui::MenuItem("Auto-resizing window", NULL, &show_app_auto_resize);
+            ImGui::MenuItem("Constrained-resizing window", NULL, &show_app_constrained_resize);
+            ImGui::MenuItem("Simple overlay", NULL, &show_app_simple_overlay);
+            ImGui::MenuItem("Manipulating window titles", NULL, &show_app_window_titles);
+            ImGui::MenuItem("Custom rendering", NULL, &show_app_custom_rendering);
+            ImGui::MenuItem("Documents", NULL, &show_app_documents);
+            ImGui::EndMenu();
+        }
+        if (ImGui::BeginMenu("Help"))
+        {
+            ImGui::MenuItem("Metrics", NULL, &show_app_metrics);
+            ImGui::MenuItem("Style Editor", NULL, &show_app_style_editor);
+            ImGui::MenuItem("About Dear ImGui", NULL, &show_app_about);
+            ImGui::EndMenu();
+        }
+        ImGui::EndMenuBar();
+    }
+
+    ImGui::Text("dear imgui says hello. (%s)", IMGUI_VERSION);
+    ImGui::Spacing();
+
+    if (ImGui::CollapsingHeader("Help"))
+    {
+        ImGui::Text("PROGRAMMER GUIDE:");
+        ImGui::BulletText(
+            "Please see the ShowDemoWindow() code in imgui_demo.cpp. <- you are here!");
+        ImGui::BulletText("Please see the comments in imgui.cpp.");
+        ImGui::BulletText("Please see the examples/ in application.");
+        ImGui::BulletText("Enable 'io.ConfigFlags |= NavEnableKeyboard' for keyboard controls.");
+        ImGui::BulletText("Enable 'io.ConfigFlags |= NavEnableGamepad' for gamepad controls.");
+        ImGui::Separator();
+
+        ImGui::Text("USER GUIDE:");
+        ImGui::ShowUserGuide();
+    }
+
+    if (ImGui::CollapsingHeader("Configuration"))
+    {
+        ImGuiIO &io = ImGui::GetIO();
+
+        if (ImGui::TreeNode("Configuration##2"))
+        {
+            ImGui::CheckboxFlags("io.ConfigFlags: NavEnableKeyboard",
+                                 (unsigned int *)&io.ConfigFlags,
+                                 ImGuiConfigFlags_NavEnableKeyboard);
+            ImGui::CheckboxFlags("io.ConfigFlags: NavEnableGamepad",
+                                 (unsigned int *)&io.ConfigFlags,
+                                 ImGuiConfigFlags_NavEnableGamepad);
+            ImGui::SameLine();
+            HelpMarker(
+                "Required back-end to feed in gamepad inputs in io.NavInputs[] and set "
+                "io.BackendFlags |= ImGuiBackendFlags_HasGamepad.\n\nRead instructions in "
+                "imgui.cpp for details.");
+            ImGui::CheckboxFlags("io.ConfigFlags: NavEnableSetMousePos",
+                                 (unsigned int *)&io.ConfigFlags,
+                                 ImGuiConfigFlags_NavEnableSetMousePos);
+            ImGui::SameLine();
+            HelpMarker(
+                "Instruct navigation to move the mouse cursor. See comment for "
+                "ImGuiConfigFlags_NavEnableSetMousePos.");
+            ImGui::CheckboxFlags("io.ConfigFlags: NoMouse", (unsigned int *)&io.ConfigFlags,
+                                 ImGuiConfigFlags_NoMouse);
+            if (io.ConfigFlags &
+                ImGuiConfigFlags_NoMouse)  // Create a way to restore this flag otherwise we could
+                                           // be stuck completely!
+            {
+                if (fmodf((float)ImGui::GetTime(), 0.40f) < 0.20f)
+                {
+                    ImGui::SameLine();
+                    ImGui::Text("<<PRESS SPACE TO DISABLE>>");
+                }
+                if (ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_Space)))
+                    io.ConfigFlags &= ~ImGuiConfigFlags_NoMouse;
+            }
+            ImGui::CheckboxFlags("io.ConfigFlags: NoMouseCursorChange",
+                                 (unsigned int *)&io.ConfigFlags,
+                                 ImGuiConfigFlags_NoMouseCursorChange);
+            ImGui::SameLine();
+            HelpMarker("Instruct back-end to not alter mouse cursor shape and visibility.");
+            ImGui::Checkbox("io.ConfigInputTextCursorBlink", &io.ConfigInputTextCursorBlink);
+            ImGui::SameLine();
+            HelpMarker(
+                "Set to false to disable blinking cursor, for users who consider it distracting");
+            ImGui::Checkbox("io.ConfigWindowsResizeFromEdges", &io.ConfigWindowsResizeFromEdges);
+            ImGui::SameLine();
+            HelpMarker(
+                "Enable resizing of windows from their edges and from the lower-left corner.\nThis "
+                "requires (io.BackendFlags & ImGuiBackendFlags_HasMouseCursors) because it needs "
+                "mouse cursor feedback.");
+            ImGui::Checkbox("io.ConfigWindowsMoveFromTitleBarOnly",
+                            &io.ConfigWindowsMoveFromTitleBarOnly);
+            ImGui::Checkbox("io.MouseDrawCursor", &io.MouseDrawCursor);
+            ImGui::SameLine();
+            HelpMarker(
+                "Instruct Dear ImGui to render a mouse cursor for you. Note that a mouse cursor "
+                "rendered via your application GPU rendering path will feel more laggy than "
+                "hardware cursor, but will be more in sync with your other visuals.\n\nSome "
+                "desktop applications may use both kinds of cursors (e.g. enable software cursor "
+                "only when resizing/dragging something).");
+            ImGui::TreePop();
+            ImGui::Separator();
+        }
+
+        if (ImGui::TreeNode("Backend Flags"))
+        {
+            HelpMarker(
+                "Those flags are set by the back-ends (imgui_impl_xxx files) to specify their "
+                "capabilities.");
+            ImGuiBackendFlags backend_flags =
+                io.BackendFlags;  // Make a local copy to avoid modifying actual back-end flags.
+            ImGui::CheckboxFlags("io.BackendFlags: HasGamepad", (unsigned int *)&backend_flags,
+                                 ImGuiBackendFlags_HasGamepad);
+            ImGui::CheckboxFlags("io.BackendFlags: HasMouseCursors", (unsigned int *)&backend_flags,
+                                 ImGuiBackendFlags_HasMouseCursors);
+            ImGui::CheckboxFlags("io.BackendFlags: HasSetMousePos", (unsigned int *)&backend_flags,
+                                 ImGuiBackendFlags_HasSetMousePos);
+            ImGui::CheckboxFlags("io.BackendFlags: RendererHasVtxOffset",
+                                 (unsigned int *)&backend_flags,
+                                 ImGuiBackendFlags_RendererHasVtxOffset);
+            ImGui::TreePop();
+            ImGui::Separator();
+        }
+
+        if (ImGui::TreeNode("Style"))
+        {
+            ImGui::ShowStyleEditor();
+            ImGui::TreePop();
+            ImGui::Separator();
+        }
+
+        if (ImGui::TreeNode("Capture/Logging"))
+        {
+            ImGui::TextWrapped(
+                "The logging API redirects all text output so you can easily capture the content "
+                "of a window or a block. Tree nodes can be automatically expanded.");
+            HelpMarker(
+                "Try opening any of the contents below in this window and then click one of the "
+                "\"Log To\" button.");
+            ImGui::LogButtons();
+            ImGui::TextWrapped(
+                "You can also call ImGui::LogText() to output directly to the log without a visual "
+                "output.");
+            if (ImGui::Button("Copy \"Hello, world!\" to clipboard"))
+            {
+                ImGui::LogToClipboard();
+                ImGui::LogText("Hello, world!");
+                ImGui::LogFinish();
+            }
+            ImGui::TreePop();
+        }
+    }
+
+    if (ImGui::CollapsingHeader("Window options"))
+    {
+        ImGui::Checkbox("No titlebar", &no_titlebar);
+        ImGui::SameLine(150);
+        ImGui::Checkbox("No scrollbar", &no_scrollbar);
+        ImGui::SameLine(300);
+        ImGui::Checkbox("No menu", &no_menu);
+        ImGui::Checkbox("No move", &no_move);
+        ImGui::SameLine(150);
+        ImGui::Checkbox("No resize", &no_resize);
+        ImGui::SameLine(300);
+        ImGui::Checkbox("No collapse", &no_collapse);
+        ImGui::Checkbox("No close", &no_close);
+        ImGui::SameLine(150);
+        ImGui::Checkbox("No nav", &no_nav);
+        ImGui::SameLine(300);
+        ImGui::Checkbox("No background", &no_background);
+        ImGui::Checkbox("No bring to front", &no_bring_to_front);
+    }
+
+    // All demo contents
+    ShowDemoWindowWidgets();
+    ShowDemoWindowLayout();
+    ShowDemoWindowPopups();
+    ShowDemoWindowColumns();
+    ShowDemoWindowMisc();
+
+    // End of ShowDemoWindow()
+    ImGui::End();
+}
+
+static void ShowDemoWindowWidgets()
+{
+    if (!ImGui::CollapsingHeader("Widgets"))
+        return;
+
+    if (ImGui::TreeNode("Basic"))
+    {
+        static int clicked = 0;
+        if (ImGui::Button("Button"))
+            clicked++;
+        if (clicked & 1)
+        {
+            ImGui::SameLine();
+            ImGui::Text("Thanks for clicking me!");
+        }
+
+        static bool check = true;
+        ImGui::Checkbox("checkbox", &check);
+
+        static int e = 0;
+        ImGui::RadioButton("radio a", &e, 0);
+        ImGui::SameLine();
+        ImGui::RadioButton("radio b", &e, 1);
+        ImGui::SameLine();
+        ImGui::RadioButton("radio c", &e, 2);
+
+        // Color buttons, demonstrate using PushID() to add unique identifier in the ID stack, and
+        // changing style.
+        for (int i = 0; i < 7; i++)
+        {
+            if (i > 0)
+                ImGui::SameLine();
+            ImGui::PushID(i);
+            ImGui::PushStyleColor(ImGuiCol_Button, (ImVec4)ImColor::HSV(i / 7.0f, 0.6f, 0.6f));
+            ImGui::PushStyleColor(ImGuiCol_ButtonHovered,
+                                  (ImVec4)ImColor::HSV(i / 7.0f, 0.7f, 0.7f));
+            ImGui::PushStyleColor(ImGuiCol_ButtonActive,
+                                  (ImVec4)ImColor::HSV(i / 7.0f, 0.8f, 0.8f));
+            ImGui::Button("Click");
+            ImGui::PopStyleColor(3);
+            ImGui::PopID();
+        }
+
+        // Use AlignTextToFramePadding() to align text baseline to the baseline of framed elements
+        // (otherwise a Text+SameLine+Button sequence will have the text a little too high by
+        // default)
+        ImGui::AlignTextToFramePadding();
+        ImGui::Text("Hold to repeat:");
+        ImGui::SameLine();
+
+        // Arrow buttons with Repeater
+        static int counter = 0;
+        float spacing      = ImGui::GetStyle().ItemInnerSpacing.x;
+        ImGui::PushButtonRepeat(true);
+        if (ImGui::ArrowButton("##left", ImGuiDir_Left))
+        {
+            counter--;
+        }
+        ImGui::SameLine(0.0f, spacing);
+        if (ImGui::ArrowButton("##right", ImGuiDir_Right))
+        {
+            counter++;
+        }
+        ImGui::PopButtonRepeat();
+        ImGui::SameLine();
+        ImGui::Text("%d", counter);
+
+        ImGui::Text("Hover over me");
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("I am a tooltip");
+
+        ImGui::SameLine();
+        ImGui::Text("- or me");
+        if (ImGui::IsItemHovered())
+        {
+            ImGui::BeginTooltip();
+            ImGui::Text("I am a fancy tooltip");
+            static float arr[] = {0.6f, 0.1f, 1.0f, 0.5f, 0.92f, 0.1f, 0.2f};
+            ImGui::PlotLines("Curve", arr, IM_ARRAYSIZE(arr));
+            ImGui::EndTooltip();
+        }
+
+        ImGui::Separator();
+
+        ImGui::LabelText("label", "Value");
+
+        {
+            // Using the _simplified_ one-liner Combo() api here
+            // See "Combo" section for examples of how to use the more complete
+            // BeginCombo()/EndCombo() api.
+            const char *items[]     = {"AAAA", "BBBB", "CCCC", "DDDD", "EEEE",    "FFFF", "GGGG",
+                                   "HHHH", "IIII", "JJJJ", "KKKK", "LLLLLLL", "MMMM", "OOOOOOO"};
+            static int item_current = 0;
+            ImGui::Combo("combo", &item_current, items, IM_ARRAYSIZE(items));
+            ImGui::SameLine();
+            HelpMarker(
+                "Refer to the \"Combo\" section below for an explanation of the full "
+                "BeginCombo/EndCombo API, and demonstration of various flags.\n");
+        }
+
+        {
+            static char str0[128] = "Hello, world!";
+            ImGui::InputText("input text", str0, IM_ARRAYSIZE(str0));
+            ImGui::SameLine();
+            HelpMarker(
+                "USER:\nHold SHIFT or use mouse to select text.\n"
+                "CTRL+Left/Right to word jump.\n"
+                "CTRL+A or double-click to select all.\n"
+                "CTRL+X,CTRL+C,CTRL+V clipboard.\n"
+                "CTRL+Z,CTRL+Y undo/redo.\n"
+                "ESCAPE to revert.\n\nPROGRAMMER:\nYou can use the "
+                "ImGuiInputTextFlags_CallbackResize facility if you need to wire InputText() to a "
+                "dynamic string type. See misc/cpp/imgui_stdlib.h for an example (this is not "
+                "demonstrated in imgui_demo.cpp).");
+
+            static char str1[128] = "";
+            ImGui::InputTextWithHint("input text (w/ hint)", "enter text here", str1,
+                                     IM_ARRAYSIZE(str1));
+
+            static int i0 = 123;
+            ImGui::InputInt("input int", &i0);
+            ImGui::SameLine();
+            HelpMarker(
+                "You can apply arithmetic operators +,*,/ on numerical values.\n  e.g. [ 100 ], "
+                "input \'*2\', result becomes [ 200 ]\nUse +- to subtract.\n");
+
+            static float f0 = 0.001f;
+            ImGui::InputFloat("input float", &f0, 0.01f, 1.0f, "%.3f");
+
+            static double d0 = 999999.00000001;
+            ImGui::InputDouble("input double", &d0, 0.01f, 1.0f, "%.8f");
+
+            static float f1 = 1.e10f;
+            ImGui::InputFloat("input scientific", &f1, 0.0f, 0.0f, "%e");
+            ImGui::SameLine();
+            HelpMarker(
+                "You can input value using the scientific notation,\n  e.g. \"1e+8\" becomes "
+                "\"100000000\".\n");
+
+            static float vec4a[4] = {0.10f, 0.20f, 0.30f, 0.44f};
+            ImGui::InputFloat3("input float3", vec4a);
+        }
+
+        {
+            static int i1 = 50, i2 = 42;
+            ImGui::DragInt("drag int", &i1, 1);
+            ImGui::SameLine();
+            HelpMarker(
+                "Click and drag to edit value.\nHold SHIFT/ALT for faster/slower "
+                "edit.\nDouble-click or CTRL+click to input value.");
+
+            ImGui::DragInt("drag int 0..100", &i2, 1, 0, 100, "%d%%");
+
+            static float f1 = 1.00f, f2 = 0.0067f;
+            ImGui::DragFloat("drag float", &f1, 0.005f);
+            ImGui::DragFloat("drag small float", &f2, 0.0001f, 0.0f, 0.0f, "%.06f ns");
+        }
+
+        {
+            static int i1 = 0;
+            ImGui::SliderInt("slider int", &i1, -1, 3);
+            ImGui::SameLine();
+            HelpMarker("CTRL+click to input value.");
+
+            static float f1 = 0.123f, f2 = 0.0f;
+            ImGui::SliderFloat("slider float", &f1, 0.0f, 1.0f, "ratio = %.3f");
+            ImGui::SliderFloat("slider float (curve)", &f2, -10.0f, 10.0f, "%.4f", 2.0f);
+            static float angle = 0.0f;
+            ImGui::SliderAngle("slider angle", &angle);
+        }
+
+        {
+            static float col1[3] = {1.0f, 0.0f, 0.2f};
+            static float col2[4] = {0.4f, 0.7f, 0.0f, 0.5f};
+            ImGui::ColorEdit3("color 1", col1);
+            ImGui::SameLine();
+            HelpMarker(
+                "Click on the colored square to open a color picker.\nClick and hold to use drag "
+                "and drop.\nRight-click on the colored square to show options.\nCTRL+click on "
+                "individual component to input value.\n");
+
+            ImGui::ColorEdit4("color 2", col2);
+        }
+
+        {
+            // List box
+            const char *listbox_items[]     = {"Apple",     "Banana",     "Cherry",
+                                           "Kiwi",      "Mango",      "Orange",
+                                           "Pineapple", "Strawberry", "Watermelon"};
+            static int listbox_item_current = 1;
+            ImGui::ListBox("listbox\n(single select)", &listbox_item_current, listbox_items,
+                           IM_ARRAYSIZE(listbox_items), 4);
+
+            // static int listbox_item_current2 = 2;
+            // ImGui::SetNextItemWidth(-1);
+            // ImGui::ListBox("##listbox2", &listbox_item_current2, listbox_items,
+            // IM_ARRAYSIZE(listbox_items), 4);
+        }
+
+        ImGui::TreePop();
+    }
+
+    // Testing ImGuiOnceUponAFrame helper.
+    // static ImGuiOnceUponAFrame once;
+    // for (int i = 0; i < 5; i++)
+    //    if (once)
+    //        ImGui::Text("This will be displayed only once.");
+
+    if (ImGui::TreeNode("Trees"))
+    {
+        if (ImGui::TreeNode("Basic trees"))
+        {
+            for (int i = 0; i < 5; i++)
+            {
+                // Use SetNextItemOpen() so set the default state of a node to be open.
+                // We could also use TreeNodeEx() with the ImGuiTreeNodeFlags_DefaultOpen flag to
+                // achieve the same thing!
+                if (i == 0)
+                    ImGui::SetNextItemOpen(true, ImGuiCond_Once);
+
+                if (ImGui::TreeNode((void *)(intptr_t)i, "Child %d", i))
+                {
+                    ImGui::Text("blah blah");
+                    ImGui::SameLine();
+                    if (ImGui::SmallButton("button"))
+                    {
+                    };
+                    ImGui::TreePop();
+                }
+            }
+            ImGui::TreePop();
+        }
+
+        if (ImGui::TreeNode("Advanced, with Selectable nodes"))
+        {
+            HelpMarker(
+                "This is a more typical looking tree with selectable nodes.\nClick to select, "
+                "CTRL+Click to toggle, click on arrows or double-click to open.");
+            static bool align_label_with_current_x_position = false;
+            ImGui::Checkbox("Align label with current X position)",
+                            &align_label_with_current_x_position);
+            ImGui::Text("Hello!");
+            if (align_label_with_current_x_position)
+                ImGui::Unindent(ImGui::GetTreeNodeToLabelSpacing());
+
+            static int selection_mask =
+                (1 << 2);  // Dumb representation of what may be user-side selection state. You may
+                           // carry selection state inside or outside your objects in whatever
+                           // format you see fit.
+            int node_clicked =
+                -1;  // Temporary storage of what node we have clicked to process selection at the
+                     // end of the loop. May be a pointer to your own node type, etc.
+            ImGui::PushStyleVar(
+                ImGuiStyleVar_IndentSpacing,
+                ImGui::GetFontSize() *
+                    3);  // Increase spacing to differentiate leaves from expanded contents.
+            for (int i = 0; i < 6; i++)
+            {
+                // Disable the default open on single-click behavior and pass in Selected flag
+                // according to our selection state.
+                ImGuiTreeNodeFlags node_flags =
+                    ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick;
+                if (selection_mask & (1 << i))
+                    node_flags |= ImGuiTreeNodeFlags_Selected;
+                if (i < 3)
+                {
+                    // Items 0..2 are Tree Node
+                    bool node_open =
+                        ImGui::TreeNodeEx((void *)(intptr_t)i, node_flags, "Selectable Node %d", i);
+                    if (ImGui::IsItemClicked())
+                        node_clicked = i;
+                    if (node_open)
+                    {
+                        ImGui::Text("Blah blah\nBlah Blah");
+                        ImGui::TreePop();
+                    }
+                }
+                else
+                {
+                    // Items 3..5 are Tree Leaves
+                    // The only reason we use TreeNode at all is to allow selection of the leaf.
+                    // Otherwise we can use BulletText() or TreeAdvanceToLabelPos()+Text().
+                    node_flags |= ImGuiTreeNodeFlags_Leaf |
+                                  ImGuiTreeNodeFlags_NoTreePushOnOpen;  // ImGuiTreeNodeFlags_Bullet
+                    ImGui::TreeNodeEx((void *)(intptr_t)i, node_flags, "Selectable Leaf %d", i);
+                    if (ImGui::IsItemClicked())
+                        node_clicked = i;
+                }
+            }
+            if (node_clicked != -1)
+            {
+                // Update selection state. Process outside of tree loop to avoid visual
+                // inconsistencies during the clicking-frame.
+                if (ImGui::GetIO().KeyCtrl)
+                    selection_mask ^= (1 << node_clicked);  // CTRL+click to toggle
+                else  // if (!(selection_mask & (1 << node_clicked))) // Depending on selection
+                      // behavior you want, this commented bit preserve selection when clicking on
+                      // item that is part of the selection
+                    selection_mask = (1 << node_clicked);  // Click to single-select
+            }
+            ImGui::PopStyleVar();
+            if (align_label_with_current_x_position)
+                ImGui::Indent(ImGui::GetTreeNodeToLabelSpacing());
+            ImGui::TreePop();
+        }
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Collapsing Headers"))
+    {
+        static bool closable_group = true;
+        ImGui::Checkbox("Show 2nd header", &closable_group);
+        if (ImGui::CollapsingHeader("Header"))
+        {
+            ImGui::Text("IsItemHovered: %d", ImGui::IsItemHovered());
+            for (int i = 0; i < 5; i++)
+                ImGui::Text("Some content %d", i);
+        }
+        if (ImGui::CollapsingHeader("Header with a close button", &closable_group))
+        {
+            ImGui::Text("IsItemHovered: %d", ImGui::IsItemHovered());
+            for (int i = 0; i < 5; i++)
+                ImGui::Text("More content %d", i);
+        }
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Bullets"))
+    {
+        ImGui::BulletText("Bullet point 1");
+        ImGui::BulletText("Bullet point 2\nOn multiple lines");
+        ImGui::Bullet();
+        ImGui::Text("Bullet point 3 (two calls)");
+        ImGui::Bullet();
+        ImGui::SmallButton("Button");
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Text"))
+    {
+        if (ImGui::TreeNode("Colored Text"))
+        {
+            // Using shortcut. You can use PushStyleColor()/PopStyleColor() for more flexibility.
+            ImGui::TextColored(ImVec4(1.0f, 0.0f, 1.0f, 1.0f), "Pink");
+            ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.0f, 1.0f), "Yellow");
+            ImGui::TextDisabled("Disabled");
+            ImGui::SameLine();
+            HelpMarker("The TextDisabled color is stored in ImGuiStyle.");
+            ImGui::TreePop();
+        }
+
+        if (ImGui::TreeNode("Word Wrapping"))
+        {
+            // Using shortcut. You can use PushTextWrapPos()/PopTextWrapPos() for more flexibility.
+            ImGui::TextWrapped(
+                "This text should automatically wrap on the edge of the window. The current "
+                "implementation for text wrapping follows simple rules suitable for English and "
+                "possibly other languages.");
+            ImGui::Spacing();
+
+            static float wrap_width = 200.0f;
+            ImGui::SliderFloat("Wrap width", &wrap_width, -20, 600, "%.0f");
+
+            ImGui::Text("Test paragraph 1:");
+            ImVec2 pos = ImGui::GetCursorScreenPos();
+            ImGui::GetWindowDrawList()->AddRectFilled(
+                ImVec2(pos.x + wrap_width, pos.y),
+                ImVec2(pos.x + wrap_width + 10, pos.y + ImGui::GetTextLineHeight()),
+                IM_COL32(255, 0, 255, 255));
+            ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + wrap_width);
+            ImGui::Text(
+                "The lazy dog is a good dog. This paragraph is made to fit within %.0f pixels. "
+                "Testing a 1 character word. The quick brown fox jumps over the lazy dog.",
+                wrap_width);
+            ImGui::GetWindowDrawList()->AddRect(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(),
+                                                IM_COL32(255, 255, 0, 255));
+            ImGui::PopTextWrapPos();
+
+            ImGui::Text("Test paragraph 2:");
+            pos = ImGui::GetCursorScreenPos();
+            ImGui::GetWindowDrawList()->AddRectFilled(
+                ImVec2(pos.x + wrap_width, pos.y),
+                ImVec2(pos.x + wrap_width + 10, pos.y + ImGui::GetTextLineHeight()),
+                IM_COL32(255, 0, 255, 255));
+            ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + wrap_width);
+            ImGui::Text(
+                "aaaaaaaa bbbbbbbb, c cccccccc,dddddddd. d eeeeeeee   ffffffff. gggggggg!hhhhhhhh");
+            ImGui::GetWindowDrawList()->AddRect(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(),
+                                                IM_COL32(255, 255, 0, 255));
+            ImGui::PopTextWrapPos();
+
+            ImGui::TreePop();
+        }
+
+        if (ImGui::TreeNode("UTF-8 Text"))
+        {
+            // UTF-8 test with Japanese characters
+            // (Needs a suitable font, try Noto, or Arial Unicode, or M+ fonts. Read
+            // misc/fonts/README.txt for details.)
+            // - From C++11 you can use the u8"my text" syntax to encode literal strings as UTF-8
+            // - For earlier compiler, you may be able to encode your sources as UTF-8 (e.g. Visual
+            // Studio save your file as 'UTF-8 without signature')
+            // - FOR THIS DEMO FILE ONLY, BECAUSE WE WANT TO SUPPORT OLD COMPILERS, WE ARE *NOT*
+            // INCLUDING RAW UTF-8 CHARACTERS IN THIS SOURCE FILE.
+            //   Instead we are encoding a few strings with hexadecimal constants. Don't do this in
+            //   your application! Please use u8"text in any language" in your application!
+            // Note that characters values are preserved even by InputText() if the font cannot be
+            // displayed, so you can safely copy & paste garbled characters into another
+            // application.
+            ImGui::TextWrapped(
+                "CJK text will only appears if the font was loaded with the appropriate CJK "
+                "character ranges. Call io.Font->AddFontFromFileTTF() manually to load extra "
+                "character ranges. Read misc/fonts/README.txt for details.");
+            ImGui::Text(
+                "Hiragana: \xe3\x81\x8b\xe3\x81\x8d\xe3\x81\x8f\xe3\x81\x91\xe3\x81\x93 "
+                "(kakikukeko)");  // Normally we would use u8"blah blah" with the proper characters
+                                  // directly in the string.
+            ImGui::Text("Kanjis: \xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e (nihongo)");
+            static char buf[32] = "\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e";
+            // static char buf[32] = u8"NIHONGO"; // <- this is how you would write it with C++11,
+            // using real kanjis
+            ImGui::InputText("UTF-8 input", buf, IM_ARRAYSIZE(buf));
+            ImGui::TreePop();
+        }
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Images"))
+    {
+        ImGuiIO &io = ImGui::GetIO();
+        ImGui::TextWrapped(
+            "Below we are displaying the font texture (which is the only texture we have access to "
+            "in this demo). Use the 'ImTextureID' type as storage to pass pointers or identifier "
+            "to your own texture data. Hover the texture for a zoomed view!");
+
+        // Here we are grabbing the font texture because that's the only one we have access to
+        // inside the demo code. Remember that ImTextureID is just storage for whatever you want it
+        // to be, it is essentially a value that will be passed to the render function inside the
+        // ImDrawCmd structure. If you use one of the default imgui_impl_XXXX.cpp renderer, they all
+        // have comments at the top of their file to specify what they expect to be stored in
+        // ImTextureID. (for example, the imgui_impl_dx11.cpp renderer expect a
+        // 'ID3D11ShaderResourceView*' pointer. The imgui_impl_glfw_gl3.cpp renderer expect a GLuint
+        // OpenGL texture identifier etc.) If you decided that ImTextureID = MyEngineTexture*, then
+        // you can pass your MyEngineTexture* pointers to ImGui::Image(), and gather width/height
+        // through your own functions, etc. Using ShowMetricsWindow() as a "debugger" to inspect the
+        // draw data that are being passed to your render will help you debug issues if you are
+        // confused about this. Consider using the lower-level ImDrawList::AddImage() API, via
+        // ImGui::GetWindowDrawList()->AddImage().
+        ImTextureID my_tex_id = io.Fonts->TexID;
+        float my_tex_w        = (float)io.Fonts->TexWidth;
+        float my_tex_h        = (float)io.Fonts->TexHeight;
+
+        ImGui::Text("%.0fx%.0f", my_tex_w, my_tex_h);
+        ImVec2 pos = ImGui::GetCursorScreenPos();
+        ImGui::Image(my_tex_id, ImVec2(my_tex_w, my_tex_h), ImVec2(0, 0), ImVec2(1, 1),
+                     ImVec4(1.0f, 1.0f, 1.0f, 1.0f), ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+        if (ImGui::IsItemHovered())
+        {
+            ImGui::BeginTooltip();
+            float region_sz = 32.0f;
+            float region_x  = io.MousePos.x - pos.x - region_sz * 0.5f;
+            if (region_x < 0.0f)
+                region_x = 0.0f;
+            else if (region_x > my_tex_w - region_sz)
+                region_x = my_tex_w - region_sz;
+            float region_y = io.MousePos.y - pos.y - region_sz * 0.5f;
+            if (region_y < 0.0f)
+                region_y = 0.0f;
+            else if (region_y > my_tex_h - region_sz)
+                region_y = my_tex_h - region_sz;
+            float zoom = 4.0f;
+            ImGui::Text("Min: (%.2f, %.2f)", region_x, region_y);
+            ImGui::Text("Max: (%.2f, %.2f)", region_x + region_sz, region_y + region_sz);
+            ImVec2 uv0 = ImVec2((region_x) / my_tex_w, (region_y) / my_tex_h);
+            ImVec2 uv1 =
+                ImVec2((region_x + region_sz) / my_tex_w, (region_y + region_sz) / my_tex_h);
+            ImGui::Image(my_tex_id, ImVec2(region_sz * zoom, region_sz * zoom), uv0, uv1,
+                         ImVec4(1.0f, 1.0f, 1.0f, 1.0f), ImVec4(1.0f, 1.0f, 1.0f, 0.5f));
+            ImGui::EndTooltip();
+        }
+        ImGui::TextWrapped("And now some textured buttons..");
+        static int pressed_count = 0;
+        for (int i = 0; i < 8; i++)
+        {
+            ImGui::PushID(i);
+            int frame_padding = -1 + i;  // -1 = uses default padding
+            if (ImGui::ImageButton(my_tex_id, ImVec2(32, 32), ImVec2(0, 0),
+                                   ImVec2(32.0f / my_tex_w, 32 / my_tex_h), frame_padding,
+                                   ImVec4(0.0f, 0.0f, 0.0f, 1.0f)))
+                pressed_count += 1;
+            ImGui::PopID();
+            ImGui::SameLine();
+        }
+        ImGui::NewLine();
+        ImGui::Text("Pressed %d times.", pressed_count);
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Combo"))
+    {
+        // Expose flags as checkbox for the demo
+        static ImGuiComboFlags flags = 0;
+        ImGui::CheckboxFlags("ImGuiComboFlags_PopupAlignLeft", (unsigned int *)&flags,
+                             ImGuiComboFlags_PopupAlignLeft);
+        ImGui::SameLine();
+        HelpMarker("Only makes a difference if the popup is larger than the combo");
+        if (ImGui::CheckboxFlags("ImGuiComboFlags_NoArrowButton", (unsigned int *)&flags,
+                                 ImGuiComboFlags_NoArrowButton))
+            flags &= ~ImGuiComboFlags_NoPreview;  // Clear the other flag, as we cannot combine both
+        if (ImGui::CheckboxFlags("ImGuiComboFlags_NoPreview", (unsigned int *)&flags,
+                                 ImGuiComboFlags_NoPreview))
+            flags &=
+                ~ImGuiComboFlags_NoArrowButton;  // Clear the other flag, as we cannot combine both
+
+        // General BeginCombo() API, you have full control over your selection data and display
+        // type. (your selection data could be an index, a pointer to the object, an id for the
+        // object, a flag stored in the object itself, etc.)
+        const char *items[] = {"AAAA", "BBBB", "CCCC", "DDDD", "EEEE",    "FFFF", "GGGG",
+                               "HHHH", "IIII", "JJJJ", "KKKK", "LLLLLLL", "MMMM", "OOOOOOO"};
+        static const char *item_current =
+            items[0];  // Here our selection is a single pointer stored outside the object.
+        if (ImGui::BeginCombo(
+                "combo 1", item_current,
+                flags))  // The second parameter is the label previewed before opening the combo.
+        {
+            for (int n = 0; n < IM_ARRAYSIZE(items); n++)
+            {
+                bool is_selected = (item_current == items[n]);
+                if (ImGui::Selectable(items[n], is_selected))
+                    item_current = items[n];
+                if (is_selected)
+                    ImGui::SetItemDefaultFocus();  // Set the initial focus when opening the combo
+                                                   // (scrolling + for keyboard navigation support
+                                                   // in the upcoming navigation branch)
+            }
+            ImGui::EndCombo();
+        }
+
+        // Simplified one-liner Combo() API, using values packed in a single constant string
+        static int item_current_2 = 0;
+        ImGui::Combo("combo 2 (one-liner)", &item_current_2, "aaaa\0bbbb\0cccc\0dddd\0eeee\0\0");
+
+        // Simplified one-liner Combo() using an array of const char*
+        static int item_current_3 =
+            -1;  // If the selection isn't within 0..count, Combo won't display a preview
+        ImGui::Combo("combo 3 (array)", &item_current_3, items, IM_ARRAYSIZE(items));
+
+        // Simplified one-liner Combo() using an accessor function
+        struct FuncHolder
+        {
+            static bool ItemGetter(void *data, int idx, const char **out_str)
+            {
+                *out_str = ((const char **)data)[idx];
+                return true;
+            }
+        };
+        static int item_current_4 = 0;
+        ImGui::Combo("combo 4 (function)", &item_current_4, &FuncHolder::ItemGetter, items,
+                     IM_ARRAYSIZE(items));
+
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Selectables"))
+    {
+        // Selectable() has 2 overloads:
+        // - The one taking "bool selected" as a read-only selection information. When Selectable()
+        // has been clicked is returns true and you can alter selection state accordingly.
+        // - The one taking "bool* p_selected" as a read-write selection information (convenient in
+        // some cases) The earlier is more flexible, as in real application your selection may be
+        // stored in a different manner (in flags within objects, as an external list, etc).
+        if (ImGui::TreeNode("Basic"))
+        {
+            static bool selection[5] = {false, true, false, false, false};
+            ImGui::Selectable("1. I am selectable", &selection[0]);
+            ImGui::Selectable("2. I am selectable", &selection[1]);
+            ImGui::Text("3. I am not selectable");
+            ImGui::Selectable("4. I am selectable", &selection[3]);
+            if (ImGui::Selectable("5. I am double clickable", selection[4],
+                                  ImGuiSelectableFlags_AllowDoubleClick))
+                if (ImGui::IsMouseDoubleClicked(0))
+                    selection[4] = !selection[4];
+            ImGui::TreePop();
+        }
+        if (ImGui::TreeNode("Selection State: Single Selection"))
+        {
+            static int selected = -1;
+            for (int n = 0; n < 5; n++)
+            {
+                char buf[32];
+                sprintf(buf, "Object %d", n);
+                if (ImGui::Selectable(buf, selected == n))
+                    selected = n;
+            }
+            ImGui::TreePop();
+        }
+        if (ImGui::TreeNode("Selection State: Multiple Selection"))
+        {
+            HelpMarker("Hold CTRL and click to select multiple items.");
+            static bool selection[5] = {false, false, false, false, false};
+            for (int n = 0; n < 5; n++)
+            {
+                char buf[32];
+                sprintf(buf, "Object %d", n);
+                if (ImGui::Selectable(buf, selection[n]))
+                {
+                    if (!ImGui::GetIO().KeyCtrl)  // Clear selection when CTRL is not held
+                        memset(selection, 0, sizeof(selection));
+                    selection[n] ^= 1;
+                }
+            }
+            ImGui::TreePop();
+        }
+        if (ImGui::TreeNode("Rendering more text into the same line"))
+        {
+            // Using the Selectable() override that takes "bool* p_selected" parameter and toggle
+            // your booleans automatically.
+            static bool selected[3] = {false, false, false};
+            ImGui::Selectable("main.c", &selected[0]);
+            ImGui::SameLine(300);
+            ImGui::Text(" 2,345 bytes");
+            ImGui::Selectable("Hello.cpp", &selected[1]);
+            ImGui::SameLine(300);
+            ImGui::Text("12,345 bytes");
+            ImGui::Selectable("Hello.h", &selected[2]);
+            ImGui::SameLine(300);
+            ImGui::Text(" 2,345 bytes");
+            ImGui::TreePop();
+        }
+        if (ImGui::TreeNode("In columns"))
+        {
+            ImGui::Columns(3, NULL, false);
+            static bool selected[16] = {0};
+            for (int i = 0; i < 16; i++)
+            {
+                char label[32];
+                sprintf(label, "Item %d", i);
+                if (ImGui::Selectable(label, &selected[i]))
+                {
+                }
+                ImGui::NextColumn();
+            }
+            ImGui::Columns(1);
+            ImGui::TreePop();
+        }
+        if (ImGui::TreeNode("Grid"))
+        {
+            static bool selected[4 * 4] = {true,  false, false, false, false, true,  false, false,
+                                           false, false, true,  false, false, false, false, true};
+            for (int i = 0; i < 4 * 4; i++)
+            {
+                ImGui::PushID(i);
+                if (ImGui::Selectable("Sailor", &selected[i], 0, ImVec2(50, 50)))
+                {
+                    // Note: We _unnecessarily_ test for both x/y and i here only to silence some
+                    // static analyzer. The second part of each test is unnecessary.
+                    int x = i % 4;
+                    int y = i / 4;
+                    if (x > 0)
+                    {
+                        selected[i - 1] ^= 1;
+                    }
+                    if (x < 3 && i < 15)
+                    {
+                        selected[i + 1] ^= 1;
+                    }
+                    if (y > 0 && i > 3)
+                    {
+                        selected[i - 4] ^= 1;
+                    }
+                    if (y < 3 && i < 12)
+                    {
+                        selected[i + 4] ^= 1;
+                    }
+                }
+                if ((i % 4) < 3)
+                    ImGui::SameLine();
+                ImGui::PopID();
+            }
+            ImGui::TreePop();
+        }
+        if (ImGui::TreeNode("Alignment"))
+        {
+            HelpMarker(
+                "Alignment applies when a selectable is larger than its text content.\nBy default, "
+                "Selectables uses style.SelectableTextAlign but it can be overriden on a per-item "
+                "basis using PushStyleVar().");
+            static bool selected[3 * 3] = {true,  false, true,  false, true,
+                                           false, true,  false, true};
+            for (int y = 0; y < 3; y++)
+            {
+                for (int x = 0; x < 3; x++)
+                {
+                    ImVec2 alignment = ImVec2((float)x / 2.0f, (float)y / 2.0f);
+                    char name[32];
+                    sprintf(name, "(%.1f,%.1f)", alignment.x, alignment.y);
+                    if (x > 0)
+                        ImGui::SameLine();
+                    ImGui::PushStyleVar(ImGuiStyleVar_SelectableTextAlign, alignment);
+                    ImGui::Selectable(name, &selected[3 * y + x], ImGuiSelectableFlags_None,
+                                      ImVec2(80, 80));
+                    ImGui::PopStyleVar();
+                }
+            }
+            ImGui::TreePop();
+        }
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Text Input"))
+    {
+        if (ImGui::TreeNode("Multi-line Text Input"))
+        {
+            // Note: we are using a fixed-sized buffer for simplicity here. See
+            // ImGuiInputTextFlags_CallbackResize and the code in misc/cpp/imgui_stdlib.h for how to
+            // setup InputText() for dynamically resizing strings.
+            static char text[1024 * 16] =
+                "/*\n"
+                " The Pentium F00F bug, shorthand for F0 0F C7 C8,\n"
+                " the hexadecimal encoding of one offending instruction,\n"
+                " more formally, the invalid operand with locked CMPXCHG8B\n"
+                " instruction bug, is a design flaw in the majority of\n"
+                " Intel Pentium, Pentium MMX, and Pentium OverDrive\n"
+                " processors (all in the P5 microarchitecture).\n"
+                "*/\n\n"
+                "label:\n"
+                "\tlock cmpxchg8b eax\n";
+
+            static ImGuiInputTextFlags flags = ImGuiInputTextFlags_AllowTabInput;
+            HelpMarker(
+                "You can use the ImGuiInputTextFlags_CallbackResize facility if you need to wire "
+                "InputTextMultiline() to a dynamic string type. See misc/cpp/imgui_stdlib.h for an "
+                "example. (This is not demonstrated in imgui_demo.cpp)");
+            ImGui::CheckboxFlags("ImGuiInputTextFlags_ReadOnly", (unsigned int *)&flags,
+                                 ImGuiInputTextFlags_ReadOnly);
+            ImGui::CheckboxFlags("ImGuiInputTextFlags_AllowTabInput", (unsigned int *)&flags,
+                                 ImGuiInputTextFlags_AllowTabInput);
+            ImGui::CheckboxFlags("ImGuiInputTextFlags_CtrlEnterForNewLine", (unsigned int *)&flags,
+                                 ImGuiInputTextFlags_CtrlEnterForNewLine);
+            ImGui::InputTextMultiline("##source", text, IM_ARRAYSIZE(text),
+                                      ImVec2(-FLT_MIN, ImGui::GetTextLineHeight() * 16), flags);
+            ImGui::TreePop();
+        }
+
+        if (ImGui::TreeNode("Filtered Text Input"))
+        {
+            static char buf1[64] = "";
+            ImGui::InputText("default", buf1, 64);
+            static char buf2[64] = "";
+            ImGui::InputText("decimal", buf2, 64, ImGuiInputTextFlags_CharsDecimal);
+            static char buf3[64] = "";
+            ImGui::InputText(
+                "hexadecimal", buf3, 64,
+                ImGuiInputTextFlags_CharsHexadecimal | ImGuiInputTextFlags_CharsUppercase);
+            static char buf4[64] = "";
+            ImGui::InputText("uppercase", buf4, 64, ImGuiInputTextFlags_CharsUppercase);
+            static char buf5[64] = "";
+            ImGui::InputText("no blank", buf5, 64, ImGuiInputTextFlags_CharsNoBlank);
+            struct TextFilters
+            {
+                static int FilterImGuiLetters(ImGuiInputTextCallbackData *data)
+                {
+                    if (data->EventChar < 256 && strchr("imgui", (char)data->EventChar))
+                        return 0;
+                    return 1;
+                }
+            };
+            static char buf6[64] = "";
+            ImGui::InputText("\"imgui\" letters", buf6, 64, ImGuiInputTextFlags_CallbackCharFilter,
+                             TextFilters::FilterImGuiLetters);
+
+            ImGui::Text("Password input");
+            static char bufpass[64] = "password123";
+            ImGui::InputText("password", bufpass, 64,
+                             ImGuiInputTextFlags_Password | ImGuiInputTextFlags_CharsNoBlank);
+            ImGui::SameLine();
+            HelpMarker(
+                "Display all characters as '*'.\nDisable clipboard cut and copy.\nDisable "
+                "logging.\n");
+            ImGui::InputTextWithHint(
+                "password (w/ hint)", "<password>", bufpass, 64,
+                ImGuiInputTextFlags_Password | ImGuiInputTextFlags_CharsNoBlank);
+            ImGui::InputText("password (clear)", bufpass, 64, ImGuiInputTextFlags_CharsNoBlank);
+            ImGui::TreePop();
+        }
+
+        if (ImGui::TreeNode("Resize Callback"))
+        {
+            // If you have a custom string type you would typically create a ImGui::InputText()
+            // wrapper than takes your type as input. See misc/cpp/imgui_stdlib.h and .cpp for an
+            // implementation of this using std::string.
+            HelpMarker(
+                "Demonstrate using ImGuiInputTextFlags_CallbackResize to wire your resizable "
+                "string type to InputText().\n\nSee misc/cpp/imgui_stdlib.h for an implementation "
+                "of this for std::string.");
+            struct Funcs
+            {
+                static int MyResizeCallback(ImGuiInputTextCallbackData *data)
+                {
+                    if (data->EventFlag == ImGuiInputTextFlags_CallbackResize)
+                    {
+                        ImVector<char> *my_str = (ImVector<char> *)data->UserData;
+                        IM_ASSERT(my_str->begin() == data->Buf);
+                        my_str->resize(data->BufSize);  // NB: On resizing calls, generally
+                                                        // data->BufSize == data->BufTextLen + 1
+                        data->Buf = my_str->begin();
+                    }
+                    return 0;
+                }
+
+                // Tip: Because ImGui:: is a namespace you would typicall add your own function into
+                // the namespace in your own source files. For example, you may add a function
+                // called ImGui::InputText(const char* label, MyString* my_str).
+                static bool MyInputTextMultiline(const char *label,
+                                                 ImVector<char> *my_str,
+                                                 const ImVec2 &size        = ImVec2(0, 0),
+                                                 ImGuiInputTextFlags flags = 0)
+                {
+                    IM_ASSERT((flags & ImGuiInputTextFlags_CallbackResize) == 0);
+                    return ImGui::InputTextMultiline(label, my_str->begin(), (size_t)my_str->size(),
+                                                     size,
+                                                     flags | ImGuiInputTextFlags_CallbackResize,
+                                                     Funcs::MyResizeCallback, (void *)my_str);
+                }
+            };
+
+            // For this demo we are using ImVector as a string container.
+            // Note that because we need to store a terminating zero character, our size/capacity
+            // are 1 more than usually reported by a typical string class.
+            static ImVector<char> my_str;
+            if (my_str.empty())
+                my_str.push_back(0);
+            Funcs::MyInputTextMultiline("##MyStr", &my_str,
+                                        ImVec2(-FLT_MIN, ImGui::GetTextLineHeight() * 16));
+            ImGui::Text("Data: %p\nSize: %d\nCapacity: %d", (void *)my_str.begin(), my_str.size(),
+                        my_str.capacity());
+            ImGui::TreePop();
+        }
+
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Plots Widgets"))
+    {
+        static bool animate = true;
+        ImGui::Checkbox("Animate", &animate);
+
+        static float arr[] = {0.6f, 0.1f, 1.0f, 0.5f, 0.92f, 0.1f, 0.2f};
+        ImGui::PlotLines("Frame Times", arr, IM_ARRAYSIZE(arr));
+
+        // Create a dummy array of contiguous float values to plot
+        // Tip: If your float aren't contiguous but part of a structure, you can pass a pointer to
+        // your first float and the sizeof() of your structure in the Stride parameter.
+        static float values[90]    = {0};
+        static int values_offset   = 0;
+        static double refresh_time = 0.0;
+        if (!animate || refresh_time == 0.0)
+            refresh_time = ImGui::GetTime();
+        while (refresh_time <
+               ImGui::GetTime())  // Create dummy data at fixed 60 hz rate for the demo
+        {
+            static float phase    = 0.0f;
+            values[values_offset] = cosf(phase);
+            values_offset         = (values_offset + 1) % IM_ARRAYSIZE(values);
+            phase += 0.10f * values_offset;
+            refresh_time += 1.0f / 60.0f;
+        }
+        ImGui::PlotLines("Lines", values, IM_ARRAYSIZE(values), values_offset, "avg 0.0", -1.0f,
+                         1.0f, ImVec2(0, 80));
+        ImGui::PlotHistogram("Histogram", arr, IM_ARRAYSIZE(arr), 0, NULL, 0.0f, 1.0f,
+                             ImVec2(0, 80));
+
+        // Use functions to generate output
+        // FIXME: This is rather awkward because current plot API only pass in indices. We probably
+        // want an API passing floats and user provide sample rate/count.
+        struct Funcs
+        {
+            static float Sin(void *, int i) { return sinf(i * 0.1f); }
+            static float Saw(void *, int i) { return (i & 1) ? 1.0f : -1.0f; }
+        };
+        static int func_type = 0, display_count = 70;
+        ImGui::Separator();
+        ImGui::SetNextItemWidth(100);
+        ImGui::Combo("func", &func_type, "Sin\0Saw\0");
+        ImGui::SameLine();
+        ImGui::SliderInt("Sample count", &display_count, 1, 400);
+        float (*func)(void *, int) = (func_type == 0) ? Funcs::Sin : Funcs::Saw;
+        ImGui::PlotLines("Lines", func, NULL, display_count, 0, NULL, -1.0f, 1.0f, ImVec2(0, 80));
+        ImGui::PlotHistogram("Histogram", func, NULL, display_count, 0, NULL, -1.0f, 1.0f,
+                             ImVec2(0, 80));
+        ImGui::Separator();
+
+        // Animate a simple progress bar
+        static float progress = 0.0f, progress_dir = 1.0f;
+        if (animate)
+        {
+            progress += progress_dir * 0.4f * ImGui::GetIO().DeltaTime;
+            if (progress >= +1.1f)
+            {
+                progress = +1.1f;
+                progress_dir *= -1.0f;
+            }
+            if (progress <= -0.1f)
+            {
+                progress = -0.1f;
+                progress_dir *= -1.0f;
+            }
+        }
+
+        // Typically we would use ImVec2(-1.0f,0.0f) or ImVec2(-FLT_MIN,0.0f) to use all available
+        // width, or ImVec2(width,0.0f) for a specified width. ImVec2(0.0f,0.0f) uses ItemWidth.
+        ImGui::ProgressBar(progress, ImVec2(0.0f, 0.0f));
+        ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+        ImGui::Text("Progress Bar");
+
+        float progress_saturated = (progress < 0.0f) ? 0.0f : (progress > 1.0f) ? 1.0f : progress;
+        char buf[32];
+        sprintf(buf, "%d/%d", (int)(progress_saturated * 1753), 1753);
+        ImGui::ProgressBar(progress, ImVec2(0.f, 0.f), buf);
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Color/Picker Widgets"))
+    {
+        static ImVec4 color =
+            ImVec4(114.0f / 255.0f, 144.0f / 255.0f, 154.0f / 255.0f, 200.0f / 255.0f);
+
+        static bool alpha_preview      = true;
+        static bool alpha_half_preview = false;
+        static bool drag_and_drop      = true;
+        static bool options_menu       = true;
+        static bool hdr                = false;
+        ImGui::Checkbox("With Alpha Preview", &alpha_preview);
+        ImGui::Checkbox("With Half Alpha Preview", &alpha_half_preview);
+        ImGui::Checkbox("With Drag and Drop", &drag_and_drop);
+        ImGui::Checkbox("With Options Menu", &options_menu);
+        ImGui::SameLine();
+        HelpMarker("Right-click on the individual color widget to show options.");
+        ImGui::Checkbox("With HDR", &hdr);
+        ImGui::SameLine();
+        HelpMarker("Currently all this does is to lift the 0..1 limits on dragging widgets.");
+        int misc_flags =
+            (hdr ? ImGuiColorEditFlags_HDR : 0) |
+            (drag_and_drop ? 0 : ImGuiColorEditFlags_NoDragDrop) |
+            (alpha_half_preview ? ImGuiColorEditFlags_AlphaPreviewHalf
+                                : (alpha_preview ? ImGuiColorEditFlags_AlphaPreview : 0)) |
+            (options_menu ? 0 : ImGuiColorEditFlags_NoOptions);
+
+        ImGui::Text("Color widget:");
+        ImGui::SameLine();
+        HelpMarker(
+            "Click on the colored square to open a color picker.\nCTRL+click on individual "
+            "component to input value.\n");
+        ImGui::ColorEdit3("MyColor##1", (float *)&color, misc_flags);
+
+        ImGui::Text("Color widget HSV with Alpha:");
+        ImGui::ColorEdit4("MyColor##2", (float *)&color,
+                          ImGuiColorEditFlags_DisplayHSV | misc_flags);
+
+        ImGui::Text("Color widget with Float Display:");
+        ImGui::ColorEdit4("MyColor##2f", (float *)&color, ImGuiColorEditFlags_Float | misc_flags);
+
+        ImGui::Text("Color button with Picker:");
+        ImGui::SameLine();
+        HelpMarker(
+            "With the ImGuiColorEditFlags_NoInputs flag you can hide all the slider/text "
+            "inputs.\nWith the ImGuiColorEditFlags_NoLabel flag you can pass a non-empty label "
+            "which will only be used for the tooltip and picker popup.");
+        ImGui::ColorEdit4("MyColor##3", (float *)&color,
+                          ImGuiColorEditFlags_NoInputs | ImGuiColorEditFlags_NoLabel | misc_flags);
+
+        ImGui::Text("Color button with Custom Picker Popup:");
+
+        // Generate a dummy default palette. The palette will persist and can be edited.
+        static bool saved_palette_init  = true;
+        static ImVec4 saved_palette[32] = {};
+        if (saved_palette_init)
+        {
+            for (int n = 0; n < IM_ARRAYSIZE(saved_palette); n++)
+            {
+                ImGui::ColorConvertHSVtoRGB(n / 31.0f, 0.8f, 0.8f, saved_palette[n].x,
+                                            saved_palette[n].y, saved_palette[n].z);
+                saved_palette[n].w = 1.0f;  // Alpha
+            }
+            saved_palette_init = false;
+        }
+
+        static ImVec4 backup_color;
+        bool open_popup = ImGui::ColorButton("MyColor##3b", color, misc_flags);
+        ImGui::SameLine();
+        open_popup |= ImGui::Button("Palette");
+        if (open_popup)
+        {
+            ImGui::OpenPopup("mypicker");
+            backup_color = color;
+        }
+        if (ImGui::BeginPopup("mypicker"))
+        {
+            ImGui::Text("MY CUSTOM COLOR PICKER WITH AN AMAZING PALETTE!");
+            ImGui::Separator();
+            ImGui::ColorPicker4("##picker", (float *)&color,
+                                misc_flags | ImGuiColorEditFlags_NoSidePreview |
+                                    ImGuiColorEditFlags_NoSmallPreview);
+            ImGui::SameLine();
+
+            ImGui::BeginGroup();  // Lock X position
+            ImGui::Text("Current");
+            ImGui::ColorButton("##current", color,
+                               ImGuiColorEditFlags_NoPicker | ImGuiColorEditFlags_AlphaPreviewHalf,
+                               ImVec2(60, 40));
+            ImGui::Text("Previous");
+            if (ImGui::ColorButton(
+                    "##previous", backup_color,
+                    ImGuiColorEditFlags_NoPicker | ImGuiColorEditFlags_AlphaPreviewHalf,
+                    ImVec2(60, 40)))
+                color = backup_color;
+            ImGui::Separator();
+            ImGui::Text("Palette");
+            for (int n = 0; n < IM_ARRAYSIZE(saved_palette); n++)
+            {
+                ImGui::PushID(n);
+                if ((n % 8) != 0)
+                    ImGui::SameLine(0.0f, ImGui::GetStyle().ItemSpacing.y);
+                if (ImGui::ColorButton("##palette", saved_palette[n],
+                                       ImGuiColorEditFlags_NoAlpha | ImGuiColorEditFlags_NoPicker |
+                                           ImGuiColorEditFlags_NoTooltip,
+                                       ImVec2(20, 20)))
+                    color = ImVec4(saved_palette[n].x, saved_palette[n].y, saved_palette[n].z,
+                                   color.w);  // Preserve alpha!
+
+                // Allow user to drop colors into each palette entry
+                // (Note that ColorButton is already a drag source by default, unless using
+                // ImGuiColorEditFlags_NoDragDrop)
+                if (ImGui::BeginDragDropTarget())
+                {
+                    if (const ImGuiPayload *payload =
+                            ImGui::AcceptDragDropPayload(IMGUI_PAYLOAD_TYPE_COLOR_3F))
+                        memcpy((float *)&saved_palette[n], payload->Data, sizeof(float) * 3);
+                    if (const ImGuiPayload *payload =
+                            ImGui::AcceptDragDropPayload(IMGUI_PAYLOAD_TYPE_COLOR_4F))
+                        memcpy((float *)&saved_palette[n], payload->Data, sizeof(float) * 4);
+                    ImGui::EndDragDropTarget();
+                }
+
+                ImGui::PopID();
+            }
+            ImGui::EndGroup();
+            ImGui::EndPopup();
+        }
+
+        ImGui::Text("Color button only:");
+        ImGui::ColorButton("MyColor##3c", *(ImVec4 *)&color, misc_flags, ImVec2(80, 80));
+
+        ImGui::Text("Color picker:");
+        static bool alpha        = true;
+        static bool alpha_bar    = true;
+        static bool side_preview = true;
+        static bool ref_color    = false;
+        static ImVec4 ref_color_v(1.0f, 0.0f, 1.0f, 0.5f);
+        static int display_mode = 0;
+        static int picker_mode  = 0;
+        ImGui::Checkbox("With Alpha", &alpha);
+        ImGui::Checkbox("With Alpha Bar", &alpha_bar);
+        ImGui::Checkbox("With Side Preview", &side_preview);
+        if (side_preview)
+        {
+            ImGui::SameLine();
+            ImGui::Checkbox("With Ref Color", &ref_color);
+            if (ref_color)
+            {
+                ImGui::SameLine();
+                ImGui::ColorEdit4("##RefColor", &ref_color_v.x,
+                                  ImGuiColorEditFlags_NoInputs | misc_flags);
+            }
+        }
+        ImGui::Combo("Display Mode", &display_mode,
+                     "Auto/Current\0None\0RGB Only\0HSV Only\0Hex Only\0");
+        ImGui::SameLine();
+        HelpMarker(
+            "ColorEdit defaults to displaying RGB inputs if you don't specify a display mode, but "
+            "the user can change it with a right-click.\n\nColorPicker defaults to displaying "
+            "RGB+HSV+Hex if you don't specify a display mode.\n\nYou can change the defaults using "
+            "SetColorEditOptions().");
+        ImGui::Combo("Picker Mode", &picker_mode,
+                     "Auto/Current\0Hue bar + SV rect\0Hue wheel + SV triangle\0");
+        ImGui::SameLine();
+        HelpMarker("User can right-click the picker to change mode.");
+        ImGuiColorEditFlags flags = misc_flags;
+        if (!alpha)
+            flags |= ImGuiColorEditFlags_NoAlpha;  // This is by default if you call ColorPicker3()
+                                                   // instead of ColorPicker4()
+        if (alpha_bar)
+            flags |= ImGuiColorEditFlags_AlphaBar;
+        if (!side_preview)
+            flags |= ImGuiColorEditFlags_NoSidePreview;
+        if (picker_mode == 1)
+            flags |= ImGuiColorEditFlags_PickerHueBar;
+        if (picker_mode == 2)
+            flags |= ImGuiColorEditFlags_PickerHueWheel;
+        if (display_mode == 1)
+            flags |= ImGuiColorEditFlags_NoInputs;  // Disable all RGB/HSV/Hex displays
+        if (display_mode == 2)
+            flags |= ImGuiColorEditFlags_DisplayRGB;  // Override display mode
+        if (display_mode == 3)
+            flags |= ImGuiColorEditFlags_DisplayHSV;
+        if (display_mode == 4)
+            flags |= ImGuiColorEditFlags_DisplayHex;
+        ImGui::ColorPicker4("MyColor##4", (float *)&color, flags,
+                            ref_color ? &ref_color_v.x : NULL);
+
+        ImGui::Text("Programmatically set defaults:");
+        ImGui::SameLine();
+        HelpMarker(
+            "SetColorEditOptions() is designed to allow you to set boot-time default.\nWe don't "
+            "have Push/Pop functions because you can force options on a per-widget basis if "
+            "needed, and the user can change non-forced ones with the options menu.\nWe don't have "
+            "a getter to avoid encouraging you to persistently save values that aren't "
+            "forward-compatible.");
+        if (ImGui::Button("Default: Uint8 + HSV + Hue Bar"))
+            ImGui::SetColorEditOptions(ImGuiColorEditFlags_Uint8 | ImGuiColorEditFlags_DisplayHSV |
+                                       ImGuiColorEditFlags_PickerHueBar);
+        if (ImGui::Button("Default: Float + HDR + Hue Wheel"))
+            ImGui::SetColorEditOptions(ImGuiColorEditFlags_Float | ImGuiColorEditFlags_HDR |
+                                       ImGuiColorEditFlags_PickerHueWheel);
+
+        // HSV encoded support (to avoid RGB<>HSV round trips and singularities when S==0 or V==0)
+        static ImVec4 color_stored_as_hsv(0.23f, 1.0f, 1.0f, 1.0f);
+        ImGui::Spacing();
+        ImGui::Text("HSV encoded colors");
+        ImGui::SameLine();
+        HelpMarker(
+            "By default, colors are given to ColorEdit and ColorPicker in RGB, but "
+            "ImGuiColorEditFlags_InputHSV allows you to store colors as HSV and pass them to "
+            "ColorEdit and ColorPicker as HSV. This comes with the added benefit that you can "
+            "manipulate hue values with the picker even when saturation or value are zero.");
+        ImGui::Text("Color widget with InputHSV:");
+        ImGui::ColorEdit4("HSV shown as RGB##1", (float *)&color_stored_as_hsv,
+                          ImGuiColorEditFlags_DisplayRGB | ImGuiColorEditFlags_InputHSV |
+                              ImGuiColorEditFlags_Float);
+        ImGui::ColorEdit4("HSV shown as HSV##1", (float *)&color_stored_as_hsv,
+                          ImGuiColorEditFlags_DisplayHSV | ImGuiColorEditFlags_InputHSV |
+                              ImGuiColorEditFlags_Float);
+        ImGui::DragFloat4("Raw HSV values", (float *)&color_stored_as_hsv, 0.01f, 0.0f, 1.0f);
+
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Range Widgets"))
+    {
+        static float begin = 10, end = 90;
+        static int begin_i = 100, end_i = 1000;
+        ImGui::DragFloatRange2("range", &begin, &end, 0.25f, 0.0f, 100.0f, "Min: %.1f %%",
+                               "Max: %.1f %%");
+        ImGui::DragIntRange2("range int (no bounds)", &begin_i, &end_i, 5, 0, 0, "Min: %d units",
+                             "Max: %d units");
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Data Types"))
+    {
+// The DragScalar/InputScalar/SliderScalar functions allow various data types: signed/unsigned
+// int/long long and float/double To avoid polluting the public API with all possible combinations,
+// we use the ImGuiDataType enum to pass the type, and passing all arguments by address. This is the
+// reason the test code below creates local variables to hold "zero" "one" etc. for each types. In
+// practice, if you frequently use a given type that is not covered by the normal API entry points,
+// you can wrap it yourself inside a 1 line function which can take typed argument as value instead
+// of void*, and then pass their address to the generic function. For example:
+//   bool MySliderU64(const char *label, u64* value, u64 min = 0, u64 max = 0, const char* format =
+//   "%lld")
+//   {
+//      return SliderScalar(label, ImGuiDataType_U64, value, &min, &max, format);
+//   }
+
+// Limits (as helper variables that we can take the address of)
+// Note that the SliderScalar function has a maximum usable range of half the natural type maximum,
+// hence the /2 below.
+#ifndef LLONG_MIN
+        ImS64 LLONG_MIN  = -9223372036854775807LL - 1;
+        ImS64 LLONG_MAX  = 9223372036854775807LL;
+        ImU64 ULLONG_MAX = (2ULL * 9223372036854775807LL + 1);
+#endif
+        const char s8_zero = 0, s8_one = 1, s8_fifty = 50, s8_min = -128, s8_max = 127;
+        const ImU8 u8_zero = 0, u8_one = 1, u8_fifty = 50, u8_min = 0, u8_max = 255;
+        const short s16_zero = 0, s16_one = 1, s16_fifty = 50, s16_min = -32768, s16_max = 32767;
+        const ImU16 u16_zero = 0, u16_one = 1, u16_fifty = 50, u16_min = 0, u16_max = 65535;
+        const ImS32 s32_zero = 0, s32_one = 1, s32_fifty = 50, s32_min = INT_MIN / 2,
+                    s32_max = INT_MAX / 2, s32_hi_a = INT_MAX / 2 - 100, s32_hi_b = INT_MAX / 2;
+        const ImU32 u32_zero = 0, u32_one = 1, u32_fifty = 50, u32_min = 0, u32_max = UINT_MAX / 2,
+                    u32_hi_a = UINT_MAX / 2 - 100, u32_hi_b = UINT_MAX / 2;
+        const ImS64 s64_zero = 0, s64_one = 1, s64_fifty = 50, s64_min = LLONG_MIN / 2,
+                    s64_max = LLONG_MAX / 2, s64_hi_a = LLONG_MAX / 2 - 100,
+                    s64_hi_b = LLONG_MAX / 2;
+        const ImU64 u64_zero = 0, u64_one = 1, u64_fifty = 50, u64_min = 0,
+                    u64_max = ULLONG_MAX / 2, u64_hi_a = ULLONG_MAX / 2 - 100,
+                    u64_hi_b = ULLONG_MAX / 2;
+        const float f32_zero = 0.f, f32_one = 1.f, f32_lo_a = -10000000000.0f,
+                    f32_hi_a  = +10000000000.0f;
+        const double f64_zero = 0., f64_one = 1., f64_lo_a = -1000000000000000.0,
+                     f64_hi_a = +1000000000000000.0;
+
+        // State
+        static char s8_v    = 127;
+        static ImU8 u8_v    = 255;
+        static short s16_v  = 32767;
+        static ImU16 u16_v  = 65535;
+        static ImS32 s32_v  = -1;
+        static ImU32 u32_v  = (ImU32)-1;
+        static ImS64 s64_v  = -1;
+        static ImU64 u64_v  = (ImU64)-1;
+        static float f32_v  = 0.123f;
+        static double f64_v = 90000.01234567890123456789;
+
+        const float drag_speed = 0.2f;
+        static bool drag_clamp = false;
+        ImGui::Text("Drags:");
+        ImGui::Checkbox("Clamp integers to 0..50", &drag_clamp);
+        ImGui::SameLine();
+        HelpMarker(
+            "As with every widgets in dear imgui, we never modify values unless there is a user "
+            "interaction.\nYou can override the clamping limits by using CTRL+Click to input a "
+            "value.");
+        ImGui::DragScalar("drag s8", ImGuiDataType_S8, &s8_v, drag_speed,
+                          drag_clamp ? &s8_zero : NULL, drag_clamp ? &s8_fifty : NULL);
+        ImGui::DragScalar("drag u8", ImGuiDataType_U8, &u8_v, drag_speed,
+                          drag_clamp ? &u8_zero : NULL, drag_clamp ? &u8_fifty : NULL, "%u ms");
+        ImGui::DragScalar("drag s16", ImGuiDataType_S16, &s16_v, drag_speed,
+                          drag_clamp ? &s16_zero : NULL, drag_clamp ? &s16_fifty : NULL);
+        ImGui::DragScalar("drag u16", ImGuiDataType_U16, &u16_v, drag_speed,
+                          drag_clamp ? &u16_zero : NULL, drag_clamp ? &u16_fifty : NULL, "%u ms");
+        ImGui::DragScalar("drag s32", ImGuiDataType_S32, &s32_v, drag_speed,
+                          drag_clamp ? &s32_zero : NULL, drag_clamp ? &s32_fifty : NULL);
+        ImGui::DragScalar("drag u32", ImGuiDataType_U32, &u32_v, drag_speed,
+                          drag_clamp ? &u32_zero : NULL, drag_clamp ? &u32_fifty : NULL, "%u ms");
+        ImGui::DragScalar("drag s64", ImGuiDataType_S64, &s64_v, drag_speed,
+                          drag_clamp ? &s64_zero : NULL, drag_clamp ? &s64_fifty : NULL);
+        ImGui::DragScalar("drag u64", ImGuiDataType_U64, &u64_v, drag_speed,
+                          drag_clamp ? &u64_zero : NULL, drag_clamp ? &u64_fifty : NULL);
+        ImGui::DragScalar("drag float", ImGuiDataType_Float, &f32_v, 0.005f, &f32_zero, &f32_one,
+                          "%f", 1.0f);
+        ImGui::DragScalar("drag float ^2", ImGuiDataType_Float, &f32_v, 0.005f, &f32_zero, &f32_one,
+                          "%f", 2.0f);
+        ImGui::SameLine();
+        HelpMarker(
+            "You can use the 'power' parameter to increase tweaking precision on one side of the "
+            "range.");
+        ImGui::DragScalar("drag double", ImGuiDataType_Double, &f64_v, 0.0005f, &f64_zero, NULL,
+                          "%.10f grams", 1.0f);
+        ImGui::DragScalar("drag double ^2", ImGuiDataType_Double, &f64_v, 0.0005f, &f64_zero,
+                          &f64_one, "0 < %.10f < 1", 2.0f);
+
+        ImGui::Text("Sliders");
+        ImGui::SliderScalar("slider s8 full", ImGuiDataType_S8, &s8_v, &s8_min, &s8_max, "%d");
+        ImGui::SliderScalar("slider u8 full", ImGuiDataType_U8, &u8_v, &u8_min, &u8_max, "%u");
+        ImGui::SliderScalar("slider s16 full", ImGuiDataType_S16, &s16_v, &s16_min, &s16_max, "%d");
+        ImGui::SliderScalar("slider u16 full", ImGuiDataType_U16, &u16_v, &u16_min, &u16_max, "%u");
+        ImGui::SliderScalar("slider s32 low", ImGuiDataType_S32, &s32_v, &s32_zero, &s32_fifty,
+                            "%d");
+        ImGui::SliderScalar("slider s32 high", ImGuiDataType_S32, &s32_v, &s32_hi_a, &s32_hi_b,
+                            "%d");
+        ImGui::SliderScalar("slider s32 full", ImGuiDataType_S32, &s32_v, &s32_min, &s32_max, "%d");
+        ImGui::SliderScalar("slider u32 low", ImGuiDataType_U32, &u32_v, &u32_zero, &u32_fifty,
+                            "%u");
+        ImGui::SliderScalar("slider u32 high", ImGuiDataType_U32, &u32_v, &u32_hi_a, &u32_hi_b,
+                            "%u");
+        ImGui::SliderScalar("slider u32 full", ImGuiDataType_U32, &u32_v, &u32_min, &u32_max, "%u");
+        ImGui::SliderScalar("slider s64 low", ImGuiDataType_S64, &s64_v, &s64_zero, &s64_fifty,
+                            "%I64d");
+        ImGui::SliderScalar("slider s64 high", ImGuiDataType_S64, &s64_v, &s64_hi_a, &s64_hi_b,
+                            "%I64d");
+        ImGui::SliderScalar("slider s64 full", ImGuiDataType_S64, &s64_v, &s64_min, &s64_max,
+                            "%I64d");
+        ImGui::SliderScalar("slider u64 low", ImGuiDataType_U64, &u64_v, &u64_zero, &u64_fifty,
+                            "%I64u ms");
+        ImGui::SliderScalar("slider u64 high", ImGuiDataType_U64, &u64_v, &u64_hi_a, &u64_hi_b,
+                            "%I64u ms");
+        ImGui::SliderScalar("slider u64 full", ImGuiDataType_U64, &u64_v, &u64_min, &u64_max,
+                            "%I64u ms");
+        ImGui::SliderScalar("slider float low", ImGuiDataType_Float, &f32_v, &f32_zero, &f32_one);
+        ImGui::SliderScalar("slider float low^2", ImGuiDataType_Float, &f32_v, &f32_zero, &f32_one,
+                            "%.10f", 2.0f);
+        ImGui::SliderScalar("slider float high", ImGuiDataType_Float, &f32_v, &f32_lo_a, &f32_hi_a,
+                            "%e");
+        ImGui::SliderScalar("slider double low", ImGuiDataType_Double, &f64_v, &f64_zero, &f64_one,
+                            "%.10f grams", 1.0f);
+        ImGui::SliderScalar("slider double low^2", ImGuiDataType_Double, &f64_v, &f64_zero,
+                            &f64_one, "%.10f", 2.0f);
+        ImGui::SliderScalar("slider double high", ImGuiDataType_Double, &f64_v, &f64_lo_a,
+                            &f64_hi_a, "%e grams", 1.0f);
+
+        static bool inputs_step = true;
+        ImGui::Text("Inputs");
+        ImGui::Checkbox("Show step buttons", &inputs_step);
+        ImGui::InputScalar("input s8", ImGuiDataType_S8, &s8_v, inputs_step ? &s8_one : NULL, NULL,
+                           "%d");
+        ImGui::InputScalar("input u8", ImGuiDataType_U8, &u8_v, inputs_step ? &u8_one : NULL, NULL,
+                           "%u");
+        ImGui::InputScalar("input s16", ImGuiDataType_S16, &s16_v, inputs_step ? &s16_one : NULL,
+                           NULL, "%d");
+        ImGui::InputScalar("input u16", ImGuiDataType_U16, &u16_v, inputs_step ? &u16_one : NULL,
+                           NULL, "%u");
+        ImGui::InputScalar("input s32", ImGuiDataType_S32, &s32_v, inputs_step ? &s32_one : NULL,
+                           NULL, "%d");
+        ImGui::InputScalar("input s32 hex", ImGuiDataType_S32, &s32_v,
+                           inputs_step ? &s32_one : NULL, NULL, "%08X",
+                           ImGuiInputTextFlags_CharsHexadecimal);
+        ImGui::InputScalar("input u32", ImGuiDataType_U32, &u32_v, inputs_step ? &u32_one : NULL,
+                           NULL, "%u");
+        ImGui::InputScalar("input u32 hex", ImGuiDataType_U32, &u32_v,
+                           inputs_step ? &u32_one : NULL, NULL, "%08X",
+                           ImGuiInputTextFlags_CharsHexadecimal);
+        ImGui::InputScalar("input s64", ImGuiDataType_S64, &s64_v, inputs_step ? &s64_one : NULL);
+        ImGui::InputScalar("input u64", ImGuiDataType_U64, &u64_v, inputs_step ? &u64_one : NULL);
+        ImGui::InputScalar("input float", ImGuiDataType_Float, &f32_v,
+                           inputs_step ? &f32_one : NULL);
+        ImGui::InputScalar("input double", ImGuiDataType_Double, &f64_v,
+                           inputs_step ? &f64_one : NULL);
+
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Multi-component Widgets"))
+    {
+        static float vec4f[4] = {0.10f, 0.20f, 0.30f, 0.44f};
+        static int vec4i[4]   = {1, 5, 100, 255};
+
+        ImGui::InputFloat2("input float2", vec4f);
+        ImGui::DragFloat2("drag float2", vec4f, 0.01f, 0.0f, 1.0f);
+        ImGui::SliderFloat2("slider float2", vec4f, 0.0f, 1.0f);
+        ImGui::InputInt2("input int2", vec4i);
+        ImGui::DragInt2("drag int2", vec4i, 1, 0, 255);
+        ImGui::SliderInt2("slider int2", vec4i, 0, 255);
+        ImGui::Spacing();
+
+        ImGui::InputFloat3("input float3", vec4f);
+        ImGui::DragFloat3("drag float3", vec4f, 0.01f, 0.0f, 1.0f);
+        ImGui::SliderFloat3("slider float3", vec4f, 0.0f, 1.0f);
+        ImGui::InputInt3("input int3", vec4i);
+        ImGui::DragInt3("drag int3", vec4i, 1, 0, 255);
+        ImGui::SliderInt3("slider int3", vec4i, 0, 255);
+        ImGui::Spacing();
+
+        ImGui::InputFloat4("input float4", vec4f);
+        ImGui::DragFloat4("drag float4", vec4f, 0.01f, 0.0f, 1.0f);
+        ImGui::SliderFloat4("slider float4", vec4f, 0.0f, 1.0f);
+        ImGui::InputInt4("input int4", vec4i);
+        ImGui::DragInt4("drag int4", vec4i, 1, 0, 255);
+        ImGui::SliderInt4("slider int4", vec4i, 0, 255);
+
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Vertical Sliders"))
+    {
+        const float spacing = 4;
+        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(spacing, spacing));
+
+        static int int_value = 0;
+        ImGui::VSliderInt("##int", ImVec2(18, 160), &int_value, 0, 5);
+        ImGui::SameLine();
+
+        static float values[7] = {0.0f, 0.60f, 0.35f, 0.9f, 0.70f, 0.20f, 0.0f};
+        ImGui::PushID("set1");
+        for (int i = 0; i < 7; i++)
+        {
+            if (i > 0)
+                ImGui::SameLine();
+            ImGui::PushID(i);
+            ImGui::PushStyleColor(ImGuiCol_FrameBg, (ImVec4)ImColor::HSV(i / 7.0f, 0.5f, 0.5f));
+            ImGui::PushStyleColor(ImGuiCol_FrameBgHovered,
+                                  (ImVec4)ImColor::HSV(i / 7.0f, 0.6f, 0.5f));
+            ImGui::PushStyleColor(ImGuiCol_FrameBgActive,
+                                  (ImVec4)ImColor::HSV(i / 7.0f, 0.7f, 0.5f));
+            ImGui::PushStyleColor(ImGuiCol_SliderGrab, (ImVec4)ImColor::HSV(i / 7.0f, 0.9f, 0.9f));
+            ImGui::VSliderFloat("##v", ImVec2(18, 160), &values[i], 0.0f, 1.0f, "");
+            if (ImGui::IsItemActive() || ImGui::IsItemHovered())
+                ImGui::SetTooltip("%.3f", values[i]);
+            ImGui::PopStyleColor(4);
+            ImGui::PopID();
+        }
+        ImGui::PopID();
+
+        ImGui::SameLine();
+        ImGui::PushID("set2");
+        static float values2[4] = {0.20f, 0.80f, 0.40f, 0.25f};
+        const int rows          = 3;
+        const ImVec2 small_slider_size(18, (160.0f - (rows - 1) * spacing) / rows);
+        for (int nx = 0; nx < 4; nx++)
+        {
+            if (nx > 0)
+                ImGui::SameLine();
+            ImGui::BeginGroup();
+            for (int ny = 0; ny < rows; ny++)
+            {
+                ImGui::PushID(nx * rows + ny);
+                ImGui::VSliderFloat("##v", small_slider_size, &values2[nx], 0.0f, 1.0f, "");
+                if (ImGui::IsItemActive() || ImGui::IsItemHovered())
+                    ImGui::SetTooltip("%.3f", values2[nx]);
+                ImGui::PopID();
+            }
+            ImGui::EndGroup();
+        }
+        ImGui::PopID();
+
+        ImGui::SameLine();
+        ImGui::PushID("set3");
+        for (int i = 0; i < 4; i++)
+        {
+            if (i > 0)
+                ImGui::SameLine();
+            ImGui::PushID(i);
+            ImGui::PushStyleVar(ImGuiStyleVar_GrabMinSize, 40);
+            ImGui::VSliderFloat("##v", ImVec2(40, 160), &values[i], 0.0f, 1.0f, "%.2f\nsec");
+            ImGui::PopStyleVar();
+            ImGui::PopID();
+        }
+        ImGui::PopID();
+        ImGui::PopStyleVar();
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Drag and Drop"))
+    {
+        {
+            // ColorEdit widgets automatically act as drag source and drag target.
+            // They are using standardized payload strings IMGUI_PAYLOAD_TYPE_COLOR_3F and
+            // IMGUI_PAYLOAD_TYPE_COLOR_4F to allow your own widgets to use colors in their drag and
+            // drop interaction. Also see the demo in Color Picker -> Palette demo.
+            ImGui::BulletText("Drag and drop in standard widgets");
+            ImGui::Indent();
+            static float col1[3] = {1.0f, 0.0f, 0.2f};
+            static float col2[4] = {0.4f, 0.7f, 0.0f, 0.5f};
+            ImGui::ColorEdit3("color 1", col1);
+            ImGui::ColorEdit4("color 2", col2);
+            ImGui::Unindent();
+        }
+
+        {
+            ImGui::BulletText("Drag and drop to copy/swap items");
+            ImGui::Indent();
+            enum Mode
+            {
+                Mode_Copy,
+                Mode_Move,
+                Mode_Swap
+            };
+            static int mode = 0;
+            if (ImGui::RadioButton("Copy", mode == Mode_Copy))
+            {
+                mode = Mode_Copy;
+            }
+            ImGui::SameLine();
+            if (ImGui::RadioButton("Move", mode == Mode_Move))
+            {
+                mode = Mode_Move;
+            }
+            ImGui::SameLine();
+            if (ImGui::RadioButton("Swap", mode == Mode_Swap))
+            {
+                mode = Mode_Swap;
+            }
+            static const char *names[9] = {"Bobby",   "Beatrice", "Betty",  "Brianna", "Barry",
+                                           "Bernard", "Bibi",     "Blaine", "Bryn"};
+            for (int n = 0; n < IM_ARRAYSIZE(names); n++)
+            {
+                ImGui::PushID(n);
+                if ((n % 3) != 0)
+                    ImGui::SameLine();
+                ImGui::Button(names[n], ImVec2(60, 60));
+
+                // Our buttons are both drag sources and drag targets here!
+                if (ImGui::BeginDragDropSource(ImGuiDragDropFlags_None))
+                {
+                    ImGui::SetDragDropPayload("DND_DEMO_CELL", &n,
+                                              sizeof(int));  // Set payload to carry the index of
+                                                             // our item (could be anything)
+                    if (mode == Mode_Copy)
+                    {
+                        ImGui::Text("Copy %s", names[n]);
+                    }  // Display preview (could be anything, e.g. when dragging an image we could
+                       // decide to display the filename and a small preview of the image, etc.)
+                    if (mode == Mode_Move)
+                    {
+                        ImGui::Text("Move %s", names[n]);
+                    }
+                    if (mode == Mode_Swap)
+                    {
+                        ImGui::Text("Swap %s", names[n]);
+                    }
+                    ImGui::EndDragDropSource();
+                }
+                if (ImGui::BeginDragDropTarget())
+                {
+                    if (const ImGuiPayload *payload = ImGui::AcceptDragDropPayload("DND_DEMO_CELL"))
+                    {
+                        IM_ASSERT(payload->DataSize == sizeof(int));
+                        int payload_n = *(const int *)payload->Data;
+                        if (mode == Mode_Copy)
+                        {
+                            names[n] = names[payload_n];
+                        }
+                        if (mode == Mode_Move)
+                        {
+                            names[n]         = names[payload_n];
+                            names[payload_n] = "";
+                        }
+                        if (mode == Mode_Swap)
+                        {
+                            const char *tmp  = names[n];
+                            names[n]         = names[payload_n];
+                            names[payload_n] = tmp;
+                        }
+                    }
+                    ImGui::EndDragDropTarget();
+                }
+                ImGui::PopID();
+            }
+            ImGui::Unindent();
+        }
+
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Querying Status (Active/Focused/Hovered etc.)"))
+    {
+        // Display the value of IsItemHovered() and other common item state functions. Note that the
+        // flags can be combined. (because BulletText is an item itself and that would affect the
+        // output of IsItemHovered() we pass all state in a single call to simplify the code).
+        static int item_type  = 1;
+        static bool b         = false;
+        static float col4f[4] = {1.0f, 0.5, 0.0f, 1.0f};
+        static char str[16]   = {};
+        ImGui::RadioButton("Text", &item_type, 0);
+        ImGui::RadioButton("Button", &item_type, 1);
+        ImGui::RadioButton("Checkbox", &item_type, 2);
+        ImGui::RadioButton("SliderFloat", &item_type, 3);
+        ImGui::RadioButton("InputText", &item_type, 4);
+        ImGui::RadioButton("InputFloat3", &item_type, 5);
+        ImGui::RadioButton("ColorEdit4", &item_type, 6);
+        ImGui::RadioButton("MenuItem", &item_type, 7);
+        ImGui::RadioButton("TreeNode (w/ double-click)", &item_type, 8);
+        ImGui::RadioButton("ListBox", &item_type, 9);
+        ImGui::Separator();
+        bool ret = false;
+        if (item_type == 0)
+        {
+            ImGui::Text("ITEM: Text");
+        }  // Testing text items with no identifier/interaction
+        if (item_type == 1)
+        {
+            ret = ImGui::Button("ITEM: Button");
+        }  // Testing button
+        if (item_type == 2)
+        {
+            ret = ImGui::Checkbox("ITEM: Checkbox", &b);
+        }  // Testing checkbox
+        if (item_type == 3)
+        {
+            ret = ImGui::SliderFloat("ITEM: SliderFloat", &col4f[0], 0.0f, 1.0f);
+        }  // Testing basic item
+        if (item_type == 4)
+        {
+            ret = ImGui::InputText("ITEM: InputText", &str[0], IM_ARRAYSIZE(str));
+        }  // Testing input text (which handles tabbing)
+        if (item_type == 5)
+        {
+            ret = ImGui::InputFloat3("ITEM: InputFloat3", col4f);
+        }  // Testing multi-component items (IsItemXXX flags are reported merged)
+        if (item_type == 6)
+        {
+            ret = ImGui::ColorEdit4("ITEM: ColorEdit4", col4f);
+        }  // Testing multi-component items (IsItemXXX flags are reported merged)
+        if (item_type == 7)
+        {
+            ret = ImGui::MenuItem("ITEM: MenuItem");
+        }  // Testing menu item (they use ImGuiButtonFlags_PressedOnRelease button policy)
+        if (item_type == 8)
+        {
+            ret = ImGui::TreeNodeEx(
+                "ITEM: TreeNode w/ ImGuiTreeNodeFlags_OpenOnDoubleClick",
+                ImGuiTreeNodeFlags_OpenOnDoubleClick | ImGuiTreeNodeFlags_NoTreePushOnOpen);
+        }  // Testing tree node with ImGuiButtonFlags_PressedOnDoubleClick button policy.
+        if (item_type == 9)
+        {
+            const char *items[] = {"Apple", "Banana", "Cherry", "Kiwi"};
+            static int current  = 1;
+            ret = ImGui::ListBox("ITEM: ListBox", &current, items, IM_ARRAYSIZE(items),
+                                 IM_ARRAYSIZE(items));
+        }
+        ImGui::BulletText(
+            "Return value = %d\n"
+            "IsItemFocused() = %d\n"
+            "IsItemHovered() = %d\n"
+            "IsItemHovered(_AllowWhenBlockedByPopup) = %d\n"
+            "IsItemHovered(_AllowWhenBlockedByActiveItem) = %d\n"
+            "IsItemHovered(_AllowWhenOverlapped) = %d\n"
+            "IsItemHovered(_RectOnly) = %d\n"
+            "IsItemActive() = %d\n"
+            "IsItemEdited() = %d\n"
+            "IsItemActivated() = %d\n"
+            "IsItemDeactivated() = %d\n"
+            "IsItemDeactivatedAfterEdit() = %d\n"
+            "IsItemVisible() = %d\n"
+            "IsItemClicked() = %d\n"
+            "GetItemRectMin() = (%.1f, %.1f)\n"
+            "GetItemRectMax() = (%.1f, %.1f)\n"
+            "GetItemRectSize() = (%.1f, %.1f)",
+            ret, ImGui::IsItemFocused(), ImGui::IsItemHovered(),
+            ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup),
+            ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByActiveItem),
+            ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenOverlapped),
+            ImGui::IsItemHovered(ImGuiHoveredFlags_RectOnly), ImGui::IsItemActive(),
+            ImGui::IsItemEdited(), ImGui::IsItemActivated(), ImGui::IsItemDeactivated(),
+            ImGui::IsItemDeactivatedAfterEdit(), ImGui::IsItemVisible(), ImGui::IsItemClicked(),
+            ImGui::GetItemRectMin().x, ImGui::GetItemRectMin().y, ImGui::GetItemRectMax().x,
+            ImGui::GetItemRectMax().y, ImGui::GetItemRectSize().x, ImGui::GetItemRectSize().y);
+
+        static bool embed_all_inside_a_child_window = false;
+        ImGui::Checkbox("Embed everything inside a child window (for additional testing)",
+                        &embed_all_inside_a_child_window);
+        if (embed_all_inside_a_child_window)
+            ImGui::BeginChild("outer_child", ImVec2(0, ImGui::GetFontSize() * 20), true);
+
+        // Testing IsWindowFocused() function with its various flags. Note that the flags can be
+        // combined.
+        ImGui::BulletText(
+            "IsWindowFocused() = %d\n"
+            "IsWindowFocused(_ChildWindows) = %d\n"
+            "IsWindowFocused(_ChildWindows|_RootWindow) = %d\n"
+            "IsWindowFocused(_RootWindow) = %d\n"
+            "IsWindowFocused(_AnyWindow) = %d\n",
+            ImGui::IsWindowFocused(), ImGui::IsWindowFocused(ImGuiFocusedFlags_ChildWindows),
+            ImGui::IsWindowFocused(ImGuiFocusedFlags_ChildWindows | ImGuiFocusedFlags_RootWindow),
+            ImGui::IsWindowFocused(ImGuiFocusedFlags_RootWindow),
+            ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow));
+
+        // Testing IsWindowHovered() function with its various flags. Note that the flags can be
+        // combined.
+        ImGui::BulletText(
+            "IsWindowHovered() = %d\n"
+            "IsWindowHovered(_AllowWhenBlockedByPopup) = %d\n"
+            "IsWindowHovered(_AllowWhenBlockedByActiveItem) = %d\n"
+            "IsWindowHovered(_ChildWindows) = %d\n"
+            "IsWindowHovered(_ChildWindows|_RootWindow) = %d\n"
+            "IsWindowHovered(_ChildWindows|_AllowWhenBlockedByPopup) = %d\n"
+            "IsWindowHovered(_RootWindow) = %d\n"
+            "IsWindowHovered(_AnyWindow) = %d\n",
+            ImGui::IsWindowHovered(),
+            ImGui::IsWindowHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup),
+            ImGui::IsWindowHovered(ImGuiHoveredFlags_AllowWhenBlockedByActiveItem),
+            ImGui::IsWindowHovered(ImGuiHoveredFlags_ChildWindows),
+            ImGui::IsWindowHovered(ImGuiHoveredFlags_ChildWindows | ImGuiHoveredFlags_RootWindow),
+            ImGui::IsWindowHovered(ImGuiHoveredFlags_ChildWindows |
+                                   ImGuiHoveredFlags_AllowWhenBlockedByPopup),
+            ImGui::IsWindowHovered(ImGuiHoveredFlags_RootWindow),
+            ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow));
+
+        ImGui::BeginChild("child", ImVec2(0, 50), true);
+        ImGui::Text("This is another child window for testing the _ChildWindows flag.");
+        ImGui::EndChild();
+        if (embed_all_inside_a_child_window)
+            ImGui::EndChild();
+
+        static char dummy_str[] =
+            "This is a dummy field to be able to tab-out of the widgets above.";
+        ImGui::InputText("dummy", dummy_str, IM_ARRAYSIZE(dummy_str), ImGuiInputTextFlags_ReadOnly);
+
+        // Calling IsItemHovered() after begin returns the hovered status of the title bar.
+        // This is useful in particular if you want to create a context menu (with
+        // BeginPopupContextItem) associated to the title bar of a window.
+        static bool test_window = false;
+        ImGui::Checkbox("Hovered/Active tests after Begin() for title bar testing", &test_window);
+        if (test_window)
+        {
+            ImGui::Begin("Title bar Hovered/Active tests", &test_window);
+            if (ImGui::BeginPopupContextItem())  // <-- This is using IsItemHovered()
+            {
+                if (ImGui::MenuItem("Close"))
+                {
+                    test_window = false;
+                }
+                ImGui::EndPopup();
+            }
+            ImGui::Text(
+                "IsItemHovered() after begin = %d (== is title bar hovered)\n"
+                "IsItemActive() after begin = %d (== is window being clicked/moved)\n",
+                ImGui::IsItemHovered(), ImGui::IsItemActive());
+            ImGui::End();
+        }
+
+        ImGui::TreePop();
+    }
+}
+
+static void ShowDemoWindowLayout()
+{
+    if (!ImGui::CollapsingHeader("Layout"))
+        return;
+
+    if (ImGui::TreeNode("Child windows"))
+    {
+        HelpMarker(
+            "Use child windows to begin into a self-contained independent scrolling/clipping "
+            "regions within a host window.");
+        static bool disable_mouse_wheel = false;
+        static bool disable_menu        = false;
+        ImGui::Checkbox("Disable Mouse Wheel", &disable_mouse_wheel);
+        ImGui::Checkbox("Disable Menu", &disable_menu);
+
+        static int line = 50;
+        bool goto_line  = ImGui::Button("Goto");
+        ImGui::SameLine();
+        ImGui::SetNextItemWidth(100);
+        goto_line |= ImGui::InputInt("##Line", &line, 0, 0, ImGuiInputTextFlags_EnterReturnsTrue);
+
+        // Child 1: no border, enable horizontal scrollbar
+        {
+            ImGuiWindowFlags window_flags =
+                ImGuiWindowFlags_HorizontalScrollbar |
+                (disable_mouse_wheel ? ImGuiWindowFlags_NoScrollWithMouse : 0);
+            ImGui::BeginChild("Child1", ImVec2(ImGui::GetWindowContentRegionWidth() * 0.5f, 260),
+                              false, window_flags);
+            for (int i = 0; i < 100; i++)
+            {
+                ImGui::Text("%04d: scrollable region", i);
+                if (goto_line && line == i)
+                    ImGui::SetScrollHereY();
+            }
+            if (goto_line && line >= 100)
+                ImGui::SetScrollHereY();
+            ImGui::EndChild();
+        }
+
+        ImGui::SameLine();
+
+        // Child 2: rounded border
+        {
+            ImGuiWindowFlags window_flags =
+                (disable_mouse_wheel ? ImGuiWindowFlags_NoScrollWithMouse : 0) |
+                (disable_menu ? 0 : ImGuiWindowFlags_MenuBar);
+            ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 5.0f);
+            ImGui::BeginChild("Child2", ImVec2(0, 260), true, window_flags);
+            if (!disable_menu && ImGui::BeginMenuBar())
+            {
+                if (ImGui::BeginMenu("Menu"))
+                {
+                    ShowExampleMenuFile();
+                    ImGui::EndMenu();
+                }
+                ImGui::EndMenuBar();
+            }
+            ImGui::Columns(2);
+            for (int i = 0; i < 100; i++)
+            {
+                char buf[32];
+                sprintf(buf, "%03d", i);
+                ImGui::Button(buf, ImVec2(-FLT_MIN, 0.0f));
+                ImGui::NextColumn();
+            }
+            ImGui::EndChild();
+            ImGui::PopStyleVar();
+        }
+
+        ImGui::Separator();
+
+        // Demonstrate a few extra things
+        // - Changing ImGuiCol_ChildBg (which is transparent black in default styles)
+        // - Using SetCursorPos() to position the child window (because the child window is an item
+        // from the POV of the parent window)
+        //   You can also call SetNextWindowPos() to position the child window. The parent window
+        //   will effectively layout from this position.
+        // - Using ImGui::GetItemRectMin/Max() to query the "item" state (because the child window
+        // is an item from the POV of the parent window)
+        //   See "Widgets" -> "Querying Status (Active/Focused/Hovered etc.)" section for more
+        //   details about this.
+        {
+            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + 10);
+            ImGui::PushStyleColor(ImGuiCol_ChildBg, IM_COL32(255, 0, 0, 100));
+            ImGui::BeginChild("blah", ImVec2(200, 100), true, ImGuiWindowFlags_None);
+            for (int n = 0; n < 50; n++)
+                ImGui::Text("Some test %d", n);
+            ImGui::EndChild();
+            ImVec2 child_rect_min = ImGui::GetItemRectMin();
+            ImVec2 child_rect_max = ImGui::GetItemRectMax();
+            ImGui::PopStyleColor();
+            ImGui::Text("Rect of child window is: (%.0f,%.0f) (%.0f,%.0f)", child_rect_min.x,
+                        child_rect_min.y, child_rect_max.x, child_rect_max.y);
+        }
+
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Widgets Width"))
+    {
+        // Use SetNextItemWidth() to set the width of a single upcoming item.
+        // Use PushItemWidth()/PopItemWidth() to set the width of a group of items.
+        static float f = 0.0f;
+        ImGui::Text("SetNextItemWidth/PushItemWidth(100)");
+        ImGui::SameLine();
+        HelpMarker("Fixed width.");
+        ImGui::SetNextItemWidth(100);
+        ImGui::DragFloat("float##1", &f);
+
+        ImGui::Text("SetNextItemWidth/PushItemWidth(GetWindowWidth() * 0.5f)");
+        ImGui::SameLine();
+        HelpMarker("Half of window width.");
+        ImGui::SetNextItemWidth(ImGui::GetWindowWidth() * 0.5f);
+        ImGui::DragFloat("float##2", &f);
+
+        ImGui::Text("SetNextItemWidth/PushItemWidth(GetContentRegionAvail().x * 0.5f)");
+        ImGui::SameLine();
+        HelpMarker("Half of available width.\n(~ right-cursor_pos)\n(works within a column set)");
+        ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x * 0.5f);
+        ImGui::DragFloat("float##3", &f);
+
+        ImGui::Text("SetNextItemWidth/PushItemWidth(-100)");
+        ImGui::SameLine();
+        HelpMarker("Align to right edge minus 100");
+        ImGui::SetNextItemWidth(-100);
+        ImGui::DragFloat("float##4", &f);
+
+        // Demonstrate using PushItemWidth to surround three items. Calling SetNextItemWidth()
+        // before each of them would have the same effect.
+        ImGui::Text("SetNextItemWidth/PushItemWidth(-1)");
+        ImGui::SameLine();
+        HelpMarker("Align to right edge");
+        ImGui::PushItemWidth(-1);
+        ImGui::DragFloat("float##5a", &f);
+        ImGui::DragFloat("float##5b", &f);
+        ImGui::DragFloat("float##5c", &f);
+        ImGui::PopItemWidth();
+
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Basic Horizontal Layout"))
+    {
+        ImGui::TextWrapped(
+            "(Use ImGui::SameLine() to keep adding items to the right of the preceding item)");
+
+        // Text
+        ImGui::Text("Two items: Hello");
+        ImGui::SameLine();
+        ImGui::TextColored(ImVec4(1, 1, 0, 1), "Sailor");
+
+        // Adjust spacing
+        ImGui::Text("More spacing: Hello");
+        ImGui::SameLine(0, 20);
+        ImGui::TextColored(ImVec4(1, 1, 0, 1), "Sailor");
+
+        // Button
+        ImGui::AlignTextToFramePadding();
+        ImGui::Text("Normal buttons");
+        ImGui::SameLine();
+        ImGui::Button("Banana");
+        ImGui::SameLine();
+        ImGui::Button("Apple");
+        ImGui::SameLine();
+        ImGui::Button("Corniflower");
+
+        // Button
+        ImGui::Text("Small buttons");
+        ImGui::SameLine();
+        ImGui::SmallButton("Like this one");
+        ImGui::SameLine();
+        ImGui::Text("can fit within a text block.");
+
+        // Aligned to arbitrary position. Easy/cheap column.
+        ImGui::Text("Aligned");
+        ImGui::SameLine(150);
+        ImGui::Text("x=150");
+        ImGui::SameLine(300);
+        ImGui::Text("x=300");
+        ImGui::Text("Aligned");
+        ImGui::SameLine(150);
+        ImGui::SmallButton("x=150");
+        ImGui::SameLine(300);
+        ImGui::SmallButton("x=300");
+
+        // Checkbox
+        static bool c1 = false, c2 = false, c3 = false, c4 = false;
+        ImGui::Checkbox("My", &c1);
+        ImGui::SameLine();
+        ImGui::Checkbox("Tailor", &c2);
+        ImGui::SameLine();
+        ImGui::Checkbox("Is", &c3);
+        ImGui::SameLine();
+        ImGui::Checkbox("Rich", &c4);
+
+        // Various
+        static float f0 = 1.0f, f1 = 2.0f, f2 = 3.0f;
+        ImGui::PushItemWidth(80);
+        const char *items[] = {"AAAA", "BBBB", "CCCC", "DDDD"};
+        static int item     = -1;
+        ImGui::Combo("Combo", &item, items, IM_ARRAYSIZE(items));
+        ImGui::SameLine();
+        ImGui::SliderFloat("X", &f0, 0.0f, 5.0f);
+        ImGui::SameLine();
+        ImGui::SliderFloat("Y", &f1, 0.0f, 5.0f);
+        ImGui::SameLine();
+        ImGui::SliderFloat("Z", &f2, 0.0f, 5.0f);
+        ImGui::PopItemWidth();
+
+        ImGui::PushItemWidth(80);
+        ImGui::Text("Lists:");
+        static int selection[4] = {0, 1, 2, 3};
+        for (int i = 0; i < 4; i++)
+        {
+            if (i > 0)
+                ImGui::SameLine();
+            ImGui::PushID(i);
+            ImGui::ListBox("", &selection[i], items, IM_ARRAYSIZE(items));
+            ImGui::PopID();
+            // if (ImGui::IsItemHovered()) ImGui::SetTooltip("ListBox %d hovered", i);
+        }
+        ImGui::PopItemWidth();
+
+        // Dummy
+        ImVec2 button_sz(40, 40);
+        ImGui::Button("A", button_sz);
+        ImGui::SameLine();
+        ImGui::Dummy(button_sz);
+        ImGui::SameLine();
+        ImGui::Button("B", button_sz);
+
+        // Manually wrapping (we should eventually provide this as an automatic layout feature, but
+        // for now you can do it manually)
+        ImGui::Text("Manually wrapping:");
+        ImGuiStyle &style       = ImGui::GetStyle();
+        int buttons_count       = 20;
+        float window_visible_x2 = ImGui::GetWindowPos().x + ImGui::GetWindowContentRegionMax().x;
+        for (int n = 0; n < buttons_count; n++)
+        {
+            ImGui::PushID(n);
+            ImGui::Button("Box", button_sz);
+            float last_button_x2 = ImGui::GetItemRectMax().x;
+            float next_button_x2 =
+                last_button_x2 + style.ItemSpacing.x +
+                button_sz.x;  // Expected position if next button was on same line
+            if (n + 1 < buttons_count && next_button_x2 < window_visible_x2)
+                ImGui::SameLine();
+            ImGui::PopID();
+        }
+
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Tabs"))
+    {
+        if (ImGui::TreeNode("Basic"))
+        {
+            ImGuiTabBarFlags tab_bar_flags = ImGuiTabBarFlags_None;
+            if (ImGui::BeginTabBar("MyTabBar", tab_bar_flags))
+            {
+                if (ImGui::BeginTabItem("Avocado"))
+                {
+                    ImGui::Text("This is the Avocado tab!\nblah blah blah blah blah");
+                    ImGui::EndTabItem();
+                }
+                if (ImGui::BeginTabItem("Broccoli"))
+                {
+                    ImGui::Text("This is the Broccoli tab!\nblah blah blah blah blah");
+                    ImGui::EndTabItem();
+                }
+                if (ImGui::BeginTabItem("Cucumber"))
+                {
+                    ImGui::Text("This is the Cucumber tab!\nblah blah blah blah blah");
+                    ImGui::EndTabItem();
+                }
+                ImGui::EndTabBar();
+            }
+            ImGui::Separator();
+            ImGui::TreePop();
+        }
+
+        if (ImGui::TreeNode("Advanced & Close Button"))
+        {
+            // Expose a couple of the available flags. In most cases you may just call BeginTabBar()
+            // with no flags (0).
+            static ImGuiTabBarFlags tab_bar_flags = ImGuiTabBarFlags_Reorderable;
+            ImGui::CheckboxFlags("ImGuiTabBarFlags_Reorderable", (unsigned int *)&tab_bar_flags,
+                                 ImGuiTabBarFlags_Reorderable);
+            ImGui::CheckboxFlags("ImGuiTabBarFlags_AutoSelectNewTabs",
+                                 (unsigned int *)&tab_bar_flags,
+                                 ImGuiTabBarFlags_AutoSelectNewTabs);
+            ImGui::CheckboxFlags("ImGuiTabBarFlags_TabListPopupButton",
+                                 (unsigned int *)&tab_bar_flags,
+                                 ImGuiTabBarFlags_TabListPopupButton);
+            ImGui::CheckboxFlags("ImGuiTabBarFlags_NoCloseWithMiddleMouseButton",
+                                 (unsigned int *)&tab_bar_flags,
+                                 ImGuiTabBarFlags_NoCloseWithMiddleMouseButton);
+            if ((tab_bar_flags & ImGuiTabBarFlags_FittingPolicyMask_) == 0)
+                tab_bar_flags |= ImGuiTabBarFlags_FittingPolicyDefault_;
+            if (ImGui::CheckboxFlags("ImGuiTabBarFlags_FittingPolicyResizeDown",
+                                     (unsigned int *)&tab_bar_flags,
+                                     ImGuiTabBarFlags_FittingPolicyResizeDown))
+                tab_bar_flags &= ~(ImGuiTabBarFlags_FittingPolicyMask_ ^
+                                   ImGuiTabBarFlags_FittingPolicyResizeDown);
+            if (ImGui::CheckboxFlags("ImGuiTabBarFlags_FittingPolicyScroll",
+                                     (unsigned int *)&tab_bar_flags,
+                                     ImGuiTabBarFlags_FittingPolicyScroll))
+                tab_bar_flags &=
+                    ~(ImGuiTabBarFlags_FittingPolicyMask_ ^ ImGuiTabBarFlags_FittingPolicyScroll);
+
+            // Tab Bar
+            const char *names[4]  = {"Artichoke", "Beetroot", "Celery", "Daikon"};
+            static bool opened[4] = {true, true, true, true};  // Persistent user state
+            for (int n = 0; n < IM_ARRAYSIZE(opened); n++)
+            {
+                if (n > 0)
+                {
+                    ImGui::SameLine();
+                }
+                ImGui::Checkbox(names[n], &opened[n]);
+            }
+
+            // Passing a bool* to BeginTabItem() is similar to passing one to Begin(): the
+            // underlying bool will be set to false when the tab is closed.
+            if (ImGui::BeginTabBar("MyTabBar", tab_bar_flags))
+            {
+                for (int n = 0; n < IM_ARRAYSIZE(opened); n++)
+                    if (opened[n] && ImGui::BeginTabItem(names[n], &opened[n]))
+                    {
+                        ImGui::Text("This is the %s tab!", names[n]);
+                        if (n & 1)
+                            ImGui::Text("I am an odd tab.");
+                        ImGui::EndTabItem();
+                    }
+                ImGui::EndTabBar();
+            }
+            ImGui::Separator();
+            ImGui::TreePop();
+        }
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Groups"))
+    {
+        HelpMarker(
+            "BeginGroup() basically locks the horizontal position for new line. EndGroup() bundles "
+            "the whole group so that you can use \"item\" functions such as "
+            "IsItemHovered()/IsItemActive() or SameLine() etc. on the whole group.");
+        ImGui::BeginGroup();
+        {
+            ImGui::BeginGroup();
+            ImGui::Button("AAA");
+            ImGui::SameLine();
+            ImGui::Button("BBB");
+            ImGui::SameLine();
+            ImGui::BeginGroup();
+            ImGui::Button("CCC");
+            ImGui::Button("DDD");
+            ImGui::EndGroup();
+            ImGui::SameLine();
+            ImGui::Button("EEE");
+            ImGui::EndGroup();
+            if (ImGui::IsItemHovered())
+                ImGui::SetTooltip("First group hovered");
+        }
+        // Capture the group size and create widgets using the same size
+        ImVec2 size           = ImGui::GetItemRectSize();
+        const float values[5] = {0.5f, 0.20f, 0.80f, 0.60f, 0.25f};
+        ImGui::PlotHistogram("##values", values, IM_ARRAYSIZE(values), 0, NULL, 0.0f, 1.0f, size);
+
+        ImGui::Button("ACTION", ImVec2((size.x - ImGui::GetStyle().ItemSpacing.x) * 0.5f, size.y));
+        ImGui::SameLine();
+        ImGui::Button("REACTION",
+                      ImVec2((size.x - ImGui::GetStyle().ItemSpacing.x) * 0.5f, size.y));
+        ImGui::EndGroup();
+        ImGui::SameLine();
+
+        ImGui::Button("LEVERAGE\nBUZZWORD", size);
+        ImGui::SameLine();
+
+        if (ImGui::ListBoxHeader("List", size))
+        {
+            ImGui::Selectable("Selected", true);
+            ImGui::Selectable("Not Selected", false);
+            ImGui::ListBoxFooter();
+        }
+
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Text Baseline Alignment"))
+    {
+        HelpMarker(
+            "This is testing the vertical alignment that gets applied on text to keep it aligned "
+            "with widgets. Lines only composed of text or \"small\" widgets fit in less vertical "
+            "spaces than lines with normal widgets.");
+
+        ImGui::Text("One\nTwo\nThree");
+        ImGui::SameLine();
+        ImGui::Text("Hello\nWorld");
+        ImGui::SameLine();
+        ImGui::Text("Banana");
+
+        ImGui::Text("Banana");
+        ImGui::SameLine();
+        ImGui::Text("Hello\nWorld");
+        ImGui::SameLine();
+        ImGui::Text("One\nTwo\nThree");
+
+        ImGui::Button("HOP##1");
+        ImGui::SameLine();
+        ImGui::Text("Banana");
+        ImGui::SameLine();
+        ImGui::Text("Hello\nWorld");
+        ImGui::SameLine();
+        ImGui::Text("Banana");
+
+        ImGui::Button("HOP##2");
+        ImGui::SameLine();
+        ImGui::Text("Hello\nWorld");
+        ImGui::SameLine();
+        ImGui::Text("Banana");
+
+        ImGui::Button("TEST##1");
+        ImGui::SameLine();
+        ImGui::Text("TEST");
+        ImGui::SameLine();
+        ImGui::SmallButton("TEST##2");
+
+        ImGui::AlignTextToFramePadding();  // If your line starts with text, call this to align it
+                                           // to upcoming widgets.
+        ImGui::Text("Text aligned to Widget");
+        ImGui::SameLine();
+        ImGui::Button("Widget##1");
+        ImGui::SameLine();
+        ImGui::Text("Widget");
+        ImGui::SameLine();
+        ImGui::SmallButton("Widget##2");
+        ImGui::SameLine();
+        ImGui::Button("Widget##3");
+
+        // Tree
+        const float spacing = ImGui::GetStyle().ItemInnerSpacing.x;
+        ImGui::Button("Button##1");
+        ImGui::SameLine(0.0f, spacing);
+        if (ImGui::TreeNode("Node##1"))
+        {
+            for (int i = 0; i < 6; i++)
+                ImGui::BulletText("Item %d..", i);
+            ImGui::TreePop();
+        }  // Dummy tree data
+
+        ImGui::AlignTextToFramePadding();  // Vertically align text node a bit lower so it'll be
+                                           // vertically centered with upcoming widget. Otherwise
+                                           // you can use SmallButton (smaller fit).
+        bool node_open =
+            ImGui::TreeNode("Node##2");  // Common mistake to avoid: if we want to SameLine after
+                                         // TreeNode we need to do it before we add child content.
+        ImGui::SameLine(0.0f, spacing);
+        ImGui::Button("Button##2");
+        if (node_open)
+        {
+            for (int i = 0; i < 6; i++)
+                ImGui::BulletText("Item %d..", i);
+            ImGui::TreePop();
+        }  // Dummy tree data
+
+        // Bullet
+        ImGui::Button("Button##3");
+        ImGui::SameLine(0.0f, spacing);
+        ImGui::BulletText("Bullet text");
+
+        ImGui::AlignTextToFramePadding();
+        ImGui::BulletText("Node");
+        ImGui::SameLine(0.0f, spacing);
+        ImGui::Button("Button##4");
+
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Scrolling"))
+    {
+        // Vertical scroll functions
+        HelpMarker(
+            "Use SetScrollHereY() or SetScrollFromPosY() to scroll to a given vertical position.");
+
+        static bool track             = true;
+        static int track_item         = 50;
+        static float scroll_to_off_px = 0.0f;
+        static float scroll_to_pos_px = 200.0f;
+        ImGui::Checkbox("Track", &track);
+        ImGui::PushItemWidth(100);
+        ImGui::SameLine(140);
+        track |= ImGui::DragInt("##item", &track_item, 0.25f, 0, 99, "Item = %d");
+
+        bool scroll_to_off = ImGui::Button("Scroll Offset");
+        ImGui::SameLine(140);
+        scroll_to_off |= ImGui::DragFloat("##off", &scroll_to_off_px, 1.00f, 0, 9999, "+%.0f px");
+
+        bool scroll_to_pos = ImGui::Button("Scroll To Pos");
+        ImGui::SameLine(140);
+        scroll_to_pos |=
+            ImGui::DragFloat("##pos", &scroll_to_pos_px, 1.00f, 0, 9999, "X/Y = %.0f px");
+
+        ImGui::PopItemWidth();
+        if (scroll_to_off || scroll_to_pos)
+            track = false;
+
+        ImGuiStyle &style = ImGui::GetStyle();
+        float child_w     = (ImGui::GetContentRegionAvail().x - 4 * style.ItemSpacing.x) / 5;
+        if (child_w < 1.0f)
+            child_w = 1.0f;
+        ImGui::PushID("##VerticalScrolling");
+        for (int i = 0; i < 5; i++)
+        {
+            if (i > 0)
+                ImGui::SameLine();
+            ImGui::BeginGroup();
+            const char *names[] = {"Top", "25%", "Center", "75%", "Bottom"};
+            ImGui::TextUnformatted(names[i]);
+
+            ImGui::BeginChild(ImGui::GetID((void *)(intptr_t)i), ImVec2(child_w, 200.0f), true,
+                              ImGuiWindowFlags_None);
+            if (scroll_to_off)
+                ImGui::SetScrollY(scroll_to_off_px);
+            if (scroll_to_pos)
+                ImGui::SetScrollFromPosY(ImGui::GetCursorStartPos().y + scroll_to_pos_px,
+                                         i * 0.25f);
+            for (int item = 0; item < 100; item++)
+            {
+                if (track && item == track_item)
+                {
+                    ImGui::TextColored(ImVec4(1, 1, 0, 1), "Item %d", item);
+                    ImGui::SetScrollHereY(i * 0.25f);  // 0.0f:top, 0.5f:center, 1.0f:bottom
+                }
+                else
+                {
+                    ImGui::Text("Item %d", item);
+                }
+            }
+            float scroll_y     = ImGui::GetScrollY();
+            float scroll_max_y = ImGui::GetScrollMaxY();
+            ImGui::EndChild();
+            ImGui::Text("%.0f/%.0f", scroll_y, scroll_max_y);
+            ImGui::EndGroup();
+        }
+        ImGui::PopID();
+
+        // Horizontal scroll functions
+        ImGui::Spacing();
+        HelpMarker(
+            "Use SetScrollHereX() or SetScrollFromPosX() to scroll to a given horizontal "
+            "position.\n\nUsing the \"Scroll To Pos\" button above will make the discontinuity at "
+            "edges visible: scrolling to the top/bottom/left/right-most item will add an "
+            "additional WindowPadding to reflect on reaching the edge of the list.\n\nBecause the "
+            "clipping rectangle of most window hides half worth of WindowPadding on the "
+            "left/right, using SetScrollFromPosX(+1) will usually result in clipped text whereas "
+            "the equivalent SetScrollFromPosY(+1) wouldn't.");
+        ImGui::PushID("##HorizontalScrolling");
+        for (int i = 0; i < 5; i++)
+        {
+            float child_height =
+                ImGui::GetTextLineHeight() + style.ScrollbarSize + style.WindowPadding.y * 2.0f;
+            ImGui::BeginChild(ImGui::GetID((void *)(intptr_t)i), ImVec2(-100, child_height), true,
+                              ImGuiWindowFlags_HorizontalScrollbar);
+            if (scroll_to_off)
+                ImGui::SetScrollX(scroll_to_off_px);
+            if (scroll_to_pos)
+                ImGui::SetScrollFromPosX(ImGui::GetCursorStartPos().x + scroll_to_pos_px,
+                                         i * 0.25f);
+            for (int item = 0; item < 100; item++)
+            {
+                if (track && item == track_item)
+                {
+                    ImGui::TextColored(ImVec4(1, 1, 0, 1), "Item %d", item);
+                    ImGui::SetScrollHereX(i * 0.25f);  // 0.0f:left, 0.5f:center, 1.0f:right
+                }
+                else
+                {
+                    ImGui::Text("Item %d", item);
+                }
+                ImGui::SameLine();
+            }
+            float scroll_x     = ImGui::GetScrollX();
+            float scroll_max_x = ImGui::GetScrollMaxX();
+            ImGui::EndChild();
+            ImGui::SameLine();
+            const char *names[] = {"Left", "25%", "Center", "75%", "Right"};
+            ImGui::Text("%s\n%.0f/%.0f", names[i], scroll_x, scroll_max_x);
+            ImGui::Spacing();
+        }
+        ImGui::PopID();
+
+        // Miscellaneous Horizontal Scrolling Demo
+        HelpMarker(
+            "Horizontal scrolling for a window has to be enabled explicitly via the "
+            "ImGuiWindowFlags_HorizontalScrollbar flag.\n\nYou may want to explicitly specify "
+            "content width by calling SetNextWindowContentWidth() before Begin().");
+        static int lines = 7;
+        ImGui::SliderInt("Lines", &lines, 1, 15);
+        ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 3.0f);
+        ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(2.0f, 1.0f));
+        ImGui::BeginChild("scrolling", ImVec2(0, ImGui::GetFrameHeightWithSpacing() * 7 + 30), true,
+                          ImGuiWindowFlags_HorizontalScrollbar);
+        for (int line = 0; line < lines; line++)
+        {
+            // Display random stuff (for the sake of this trivial demo we are using basic
+            // Button+SameLine. If you want to create your own time line for a real application you
+            // may be better off manipulating the cursor position yourself, aka using
+            // SetCursorPos/SetCursorScreenPos to position the widgets yourself. You may also want
+            // to use the lower-level ImDrawList API)
+            int num_buttons = 10 + ((line & 1) ? line * 9 : line * 3);
+            for (int n = 0; n < num_buttons; n++)
+            {
+                if (n > 0)
+                    ImGui::SameLine();
+                ImGui::PushID(n + line * 1000);
+                char num_buf[16];
+                sprintf(num_buf, "%d", n);
+                const char *label =
+                    (!(n % 15)) ? "FizzBuzz" : (!(n % 3)) ? "Fizz" : (!(n % 5)) ? "Buzz" : num_buf;
+                float hue = n * 0.05f;
+                ImGui::PushStyleColor(ImGuiCol_Button, (ImVec4)ImColor::HSV(hue, 0.6f, 0.6f));
+                ImGui::PushStyleColor(ImGuiCol_ButtonHovered,
+                                      (ImVec4)ImColor::HSV(hue, 0.7f, 0.7f));
+                ImGui::PushStyleColor(ImGuiCol_ButtonActive, (ImVec4)ImColor::HSV(hue, 0.8f, 0.8f));
+                ImGui::Button(label, ImVec2(40.0f + sinf((float)(line + n)) * 20.0f, 0.0f));
+                ImGui::PopStyleColor(3);
+                ImGui::PopID();
+            }
+        }
+        float scroll_x     = ImGui::GetScrollX();
+        float scroll_max_x = ImGui::GetScrollMaxX();
+        ImGui::EndChild();
+        ImGui::PopStyleVar(2);
+        float scroll_x_delta = 0.0f;
+        ImGui::SmallButton("<<");
+        if (ImGui::IsItemActive())
+        {
+            scroll_x_delta = -ImGui::GetIO().DeltaTime * 1000.0f;
+        }
+        ImGui::SameLine();
+        ImGui::Text("Scroll from code");
+        ImGui::SameLine();
+        ImGui::SmallButton(">>");
+        if (ImGui::IsItemActive())
+        {
+            scroll_x_delta = +ImGui::GetIO().DeltaTime * 1000.0f;
+        }
+        ImGui::SameLine();
+        ImGui::Text("%.0f/%.0f", scroll_x, scroll_max_x);
+        if (scroll_x_delta != 0.0f)
+        {
+            ImGui::BeginChild("scrolling");  // Demonstrate a trick: you can use Begin to set
+                                             // yourself in the context of another window (here we
+                                             // are already out of your child window)
+            ImGui::SetScrollX(ImGui::GetScrollX() + scroll_x_delta);
+            ImGui::EndChild();
+        }
+        ImGui::Spacing();
+
+        static bool show_horizontal_contents_size_demo_window = false;
+        ImGui::Checkbox("Show Horizontal contents size demo window",
+                        &show_horizontal_contents_size_demo_window);
+
+        if (show_horizontal_contents_size_demo_window)
+        {
+            static bool show_h_scrollbar      = true;
+            static bool show_button           = true;
+            static bool show_tree_nodes       = true;
+            static bool show_text_wrapped     = false;
+            static bool show_columns          = true;
+            static bool show_tab_bar          = true;
+            static bool show_child            = false;
+            static bool explicit_content_size = false;
+            static float contents_size_x      = 300.0f;
+            if (explicit_content_size)
+                ImGui::SetNextWindowContentSize(ImVec2(contents_size_x, 0.0f));
+            ImGui::Begin("Horizontal contents size demo window",
+                         &show_horizontal_contents_size_demo_window,
+                         show_h_scrollbar ? ImGuiWindowFlags_HorizontalScrollbar : 0);
+            ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(2, 0));
+            ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(2, 0));
+            HelpMarker(
+                "Test of different widgets react and impact the work rectangle growing when "
+                "horizontal scrolling is enabled.\n\nUse 'Metrics->Tools->Show windows rectangles' "
+                "to visualize rectangles.");
+            ImGui::Checkbox("H-scrollbar", &show_h_scrollbar);
+            ImGui::Checkbox(
+                "Button", &show_button);  // Will grow contents size (unless explicitly overwritten)
+            ImGui::Checkbox(
+                "Tree nodes",
+                &show_tree_nodes);  // Will grow contents size and display highlight over full width
+            ImGui::Checkbox("Text wrapped", &show_text_wrapped);  // Will grow and use contents size
+            ImGui::Checkbox("Columns", &show_columns);            // Will use contents size
+            ImGui::Checkbox("Tab bar", &show_tab_bar);            // Will use contents size
+            ImGui::Checkbox("Child", &show_child);                // Will grow and use contents size
+            ImGui::Checkbox("Explicit content size", &explicit_content_size);
+            ImGui::Text("Scroll %.1f/%.1f %.1f/%.1f", ImGui::GetScrollX(), ImGui::GetScrollMaxX(),
+                        ImGui::GetScrollY(), ImGui::GetScrollMaxY());
+            if (explicit_content_size)
+            {
+                ImGui::SameLine();
+                ImGui::SetNextItemWidth(100);
+                ImGui::DragFloat("##csx", &contents_size_x);
+                ImVec2 p = ImGui::GetCursorScreenPos();
+                ImGui::GetWindowDrawList()->AddRectFilled(p, ImVec2(p.x + 10, p.y + 10),
+                                                          IM_COL32_WHITE);
+                ImGui::GetWindowDrawList()->AddRectFilled(ImVec2(p.x + contents_size_x - 10, p.y),
+                                                          ImVec2(p.x + contents_size_x, p.y + 10),
+                                                          IM_COL32_WHITE);
+                ImGui::Dummy(ImVec2(0, 10));
+            }
+            ImGui::PopStyleVar(2);
+            ImGui::Separator();
+            if (show_button)
+            {
+                ImGui::Button("this is a 300-wide button", ImVec2(300, 0));
+            }
+            if (show_tree_nodes)
+            {
+                bool open = true;
+                if (ImGui::TreeNode("this is a tree node"))
+                {
+                    if (ImGui::TreeNode("another one of those tree node..."))
+                    {
+                        ImGui::Text("Some tree contents");
+                        ImGui::TreePop();
+                    }
+                    ImGui::TreePop();
+                }
+                ImGui::CollapsingHeader("CollapsingHeader", &open);
+            }
+            if (show_text_wrapped)
+            {
+                ImGui::TextWrapped(
+                    "This text should automatically wrap on the edge of the work rectangle.");
+            }
+            if (show_columns)
+            {
+                ImGui::Columns(4);
+                for (int n = 0; n < 4; n++)
+                {
+                    ImGui::Text("Width %.2f", ImGui::GetColumnWidth());
+                    ImGui::NextColumn();
+                }
+                ImGui::Columns(1);
+            }
+            if (show_tab_bar && ImGui::BeginTabBar("Hello"))
+            {
+                if (ImGui::BeginTabItem("OneOneOne"))
+                {
+                    ImGui::EndTabItem();
+                }
+                if (ImGui::BeginTabItem("TwoTwoTwo"))
+                {
+                    ImGui::EndTabItem();
+                }
+                if (ImGui::BeginTabItem("ThreeThreeThree"))
+                {
+                    ImGui::EndTabItem();
+                }
+                if (ImGui::BeginTabItem("FourFourFour"))
+                {
+                    ImGui::EndTabItem();
+                }
+                ImGui::EndTabBar();
+            }
+            if (show_child)
+            {
+                ImGui::BeginChild("child", ImVec2(0, 0), true);
+                ImGui::EndChild();
+            }
+            ImGui::End();
+        }
+
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Clipping"))
+    {
+        static ImVec2 size(100, 100), offset(50, 20);
+        ImGui::TextWrapped(
+            "On a per-widget basis we are occasionally clipping text CPU-side if it won't fit in "
+            "its frame. Otherwise we are doing coarser clipping + passing a scissor rectangle to "
+            "the renderer. The system is designed to try minimizing both execution and CPU/GPU "
+            "rendering cost.");
+        ImGui::DragFloat2("size", (float *)&size, 0.5f, 1.0f, 200.0f, "%.0f");
+        ImGui::TextWrapped("(Click and drag)");
+        ImVec2 pos = ImGui::GetCursorScreenPos();
+        ImVec4 clip_rect(pos.x, pos.y, pos.x + size.x, pos.y + size.y);
+        ImGui::InvisibleButton("##dummy", size);
+        if (ImGui::IsItemActive() && ImGui::IsMouseDragging())
+        {
+            offset.x += ImGui::GetIO().MouseDelta.x;
+            offset.y += ImGui::GetIO().MouseDelta.y;
+        }
+        ImGui::GetWindowDrawList()->AddRectFilled(pos, ImVec2(pos.x + size.x, pos.y + size.y),
+                                                  IM_COL32(90, 90, 120, 255));
+        ImGui::GetWindowDrawList()->AddText(
+            ImGui::GetFont(), ImGui::GetFontSize() * 2.0f,
+            ImVec2(pos.x + offset.x, pos.y + offset.y), IM_COL32(255, 255, 255, 255),
+            "Line 1 hello\nLine 2 clip me!", NULL, 0.0f, &clip_rect);
+        ImGui::TreePop();
+    }
+}
+
+static void ShowDemoWindowPopups()
+{
+    if (!ImGui::CollapsingHeader("Popups & Modal windows"))
+        return;
+
+    // The properties of popups windows are:
+    // - They block normal mouse hovering detection outside them. (*)
+    // - Unless modal, they can be closed by clicking anywhere outside them, or by pressing ESCAPE.
+    // - Their visibility state (~bool) is held internally by Dear ImGui instead of being held by
+    // the programmer as we are used to with regular Begin() calls.
+    //   User can manipulate the visibility state by calling OpenPopup().
+    // (*) One can use IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup) to bypass it and
+    // detect hovering even when normally blocked by a popup. Those three properties are connected.
+    // The library needs to hold their visibility state because it can close popups at any time.
+
+    // Typical use for regular windows:
+    //   bool my_tool_is_active = false; if (ImGui::Button("Open")) my_tool_is_active = true; [...]
+    //   if (my_tool_is_active) Begin("My Tool", &my_tool_is_active) { [...] } End();
+    // Typical use for popups:
+    //   if (ImGui::Button("Open")) ImGui::OpenPopup("MyPopup"); if (ImGui::BeginPopup("MyPopup") {
+    //   [...] EndPopup(); }
+
+    // With popups we have to go through a library call (here OpenPopup) to manipulate the
+    // visibility state. This may be a bit confusing at first but it should quickly make sense.
+    // Follow on the examples below.
+
+    if (ImGui::TreeNode("Popups"))
+    {
+        ImGui::TextWrapped(
+            "When a popup is active, it inhibits interacting with windows that are behind the "
+            "popup. Clicking outside the popup closes it.");
+
+        static int selected_fish = -1;
+        const char *names[]      = {"Bream", "Haddock", "Mackerel", "Pollock", "Tilefish"};
+        static bool toggles[]    = {true, false, false, false, false};
+
+        // Simple selection popup
+        // (If you want to show the current selection inside the Button itself, you may want to
+        // build a string using the "###" operator to preserve a constant ID with a variable label)
+        if (ImGui::Button("Select.."))
+            ImGui::OpenPopup("my_select_popup");
+        ImGui::SameLine();
+        ImGui::TextUnformatted(selected_fish == -1 ? "<None>" : names[selected_fish]);
+        if (ImGui::BeginPopup("my_select_popup"))
+        {
+            ImGui::Text("Aquarium");
+            ImGui::Separator();
+            for (int i = 0; i < IM_ARRAYSIZE(names); i++)
+                if (ImGui::Selectable(names[i]))
+                    selected_fish = i;
+            ImGui::EndPopup();
+        }
+
+        // Showing a menu with toggles
+        if (ImGui::Button("Toggle.."))
+            ImGui::OpenPopup("my_toggle_popup");
+        if (ImGui::BeginPopup("my_toggle_popup"))
+        {
+            for (int i = 0; i < IM_ARRAYSIZE(names); i++)
+                ImGui::MenuItem(names[i], "", &toggles[i]);
+            if (ImGui::BeginMenu("Sub-menu"))
+            {
+                ImGui::MenuItem("Click me");
+                ImGui::EndMenu();
+            }
+
+            ImGui::Separator();
+            ImGui::Text("Tooltip here");
+            if (ImGui::IsItemHovered())
+                ImGui::SetTooltip("I am a tooltip over a popup");
+
+            if (ImGui::Button("Stacked Popup"))
+                ImGui::OpenPopup("another popup");
+            if (ImGui::BeginPopup("another popup"))
+            {
+                for (int i = 0; i < IM_ARRAYSIZE(names); i++)
+                    ImGui::MenuItem(names[i], "", &toggles[i]);
+                if (ImGui::BeginMenu("Sub-menu"))
+                {
+                    ImGui::MenuItem("Click me");
+                    if (ImGui::Button("Stacked Popup"))
+                        ImGui::OpenPopup("another popup");
+                    if (ImGui::BeginPopup("another popup"))
+                    {
+                        ImGui::Text("I am the last one here.");
+                        ImGui::EndPopup();
+                    }
+                    ImGui::EndMenu();
+                }
+                ImGui::EndPopup();
+            }
+            ImGui::EndPopup();
+        }
+
+        // Call the more complete ShowExampleMenuFile which we use in various places of this demo
+        if (ImGui::Button("File Menu.."))
+            ImGui::OpenPopup("my_file_popup");
+        if (ImGui::BeginPopup("my_file_popup"))
+        {
+            ShowExampleMenuFile();
+            ImGui::EndPopup();
+        }
+
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Context menus"))
+    {
+        // BeginPopupContextItem() is a helper to provide common/simple popup behavior of
+        // essentially doing:
+        //    if (IsItemHovered() && IsMouseReleased(0))
+        //       OpenPopup(id);
+        //    return BeginPopup(id);
+        // For more advanced uses you may want to replicate and cuztomize this code. This the
+        // comments inside BeginPopupContextItem() implementation.
+        static float value = 0.5f;
+        ImGui::Text("Value = %.3f (<-- right-click here)", value);
+        if (ImGui::BeginPopupContextItem("item context menu"))
+        {
+            if (ImGui::Selectable("Set to zero"))
+                value = 0.0f;
+            if (ImGui::Selectable("Set to PI"))
+                value = 3.1415f;
+            ImGui::SetNextItemWidth(-1);
+            ImGui::DragFloat("##Value", &value, 0.1f, 0.0f, 0.0f);
+            ImGui::EndPopup();
+        }
+
+        // We can also use OpenPopupOnItemClick() which is the same as BeginPopupContextItem() but
+        // without the Begin call. So here we will make it that clicking on the text field with the
+        // right mouse button (1) will toggle the visibility of the popup above.
+        ImGui::Text("(You can also right-click me to open the same popup as above.)");
+        ImGui::OpenPopupOnItemClick("item context menu", 1);
+
+        // When used after an item that has an ID (here the Button), we can skip providing an ID to
+        // BeginPopupContextItem(). BeginPopupContextItem() will use the last item ID as the popup
+        // ID. In addition here, we want to include your editable label inside the button label. We
+        // use the ### operator to override the ID (read FAQ about ID for details)
+        static char name[32] = "Label1";
+        char buf[64];
+        sprintf(buf, "Button: %s###Button",
+                name);  // ### operator override ID ignoring the preceding label
+        ImGui::Button(buf);
+        if (ImGui::BeginPopupContextItem())
+        {
+            ImGui::Text("Edit name:");
+            ImGui::InputText("##edit", name, IM_ARRAYSIZE(name));
+            if (ImGui::Button("Close"))
+                ImGui::CloseCurrentPopup();
+            ImGui::EndPopup();
+        }
+        ImGui::SameLine();
+        ImGui::Text("(<-- right-click here)");
+
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Modals"))
+    {
+        ImGui::TextWrapped(
+            "Modal windows are like popups but the user cannot close them by clicking outside the "
+            "window.");
+
+        if (ImGui::Button("Delete.."))
+            ImGui::OpenPopup("Delete?");
+
+        if (ImGui::BeginPopupModal("Delete?", NULL, ImGuiWindowFlags_AlwaysAutoResize))
+        {
+            ImGui::Text(
+                "All those beautiful files will be deleted.\nThis operation cannot be undone!\n\n");
+            ImGui::Separator();
+
+            // static int dummy_i = 0;
+            // ImGui::Combo("Combo", &dummy_i, "Delete\0Delete harder\0");
+
+            static bool dont_ask_me_next_time = false;
+            ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
+            ImGui::Checkbox("Don't ask me next time", &dont_ask_me_next_time);
+            ImGui::PopStyleVar();
+
+            if (ImGui::Button("OK", ImVec2(120, 0)))
+            {
+                ImGui::CloseCurrentPopup();
+            }
+            ImGui::SetItemDefaultFocus();
+            ImGui::SameLine();
+            if (ImGui::Button("Cancel", ImVec2(120, 0)))
+            {
+                ImGui::CloseCurrentPopup();
+            }
+            ImGui::EndPopup();
+        }
+
+        if (ImGui::Button("Stacked modals.."))
+            ImGui::OpenPopup("Stacked 1");
+        if (ImGui::BeginPopupModal("Stacked 1", NULL, ImGuiWindowFlags_MenuBar))
+        {
+            if (ImGui::BeginMenuBar())
+            {
+                if (ImGui::BeginMenu("File"))
+                {
+                    if (ImGui::MenuItem("Dummy menu item"))
+                    {
+                    }
+                    ImGui::EndMenu();
+                }
+                ImGui::EndMenuBar();
+            }
+            ImGui::Text(
+                "Hello from Stacked The First\nUsing style.Colors[ImGuiCol_ModalWindowDimBg] "
+                "behind it.");
+
+            // Testing behavior of widgets stacking their own regular popups over the modal.
+            static int item       = 1;
+            static float color[4] = {0.4f, 0.7f, 0.0f, 0.5f};
+            ImGui::Combo("Combo", &item, "aaaa\0bbbb\0cccc\0dddd\0eeee\0\0");
+            ImGui::ColorEdit4("color", color);
+
+            if (ImGui::Button("Add another modal.."))
+                ImGui::OpenPopup("Stacked 2");
+
+            // Also demonstrate passing a bool* to BeginPopupModal(), this will create a regular
+            // close button which will close the popup. Note that the visibility state of popups is
+            // owned by imgui, so the input value of the bool actually doesn't matter here.
+            bool dummy_open = true;
+            if (ImGui::BeginPopupModal("Stacked 2", &dummy_open))
+            {
+                ImGui::Text("Hello from Stacked The Second!");
+                if (ImGui::Button("Close"))
+                    ImGui::CloseCurrentPopup();
+                ImGui::EndPopup();
+            }
+
+            if (ImGui::Button("Close"))
+                ImGui::CloseCurrentPopup();
+            ImGui::EndPopup();
+        }
+
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Menus inside a regular window"))
+    {
+        ImGui::TextWrapped(
+            "Below we are testing adding menu items to a regular window. It's rather unusual but "
+            "should work!");
+        ImGui::Separator();
+        // NB: As a quirk in this very specific example, we want to differentiate the parent of this
+        // menu from the parent of the various popup menus above. To do so we are encloding the
+        // items in a PushID()/PopID() block to make them two different menusets. If we don't,
+        // opening any popup above and hovering our menu here would open it. This is because once a
+        // menu is active, we allow to switch to a sibling menu by just hovering on it, which is the
+        // desired behavior for regular menus.
+        ImGui::PushID("foo");
+        ImGui::MenuItem("Menu item", "CTRL+M");
+        if (ImGui::BeginMenu("Menu inside a regular window"))
+        {
+            ShowExampleMenuFile();
+            ImGui::EndMenu();
+        }
+        ImGui::PopID();
+        ImGui::Separator();
+        ImGui::TreePop();
+    }
+}
+
+static void ShowDemoWindowColumns()
+{
+    if (!ImGui::CollapsingHeader("Columns"))
+        return;
+
+    ImGui::PushID("Columns");
+
+    static bool disable_indent = false;
+    ImGui::Checkbox("Disable tree indentation", &disable_indent);
+    ImGui::SameLine();
+    HelpMarker(
+        "Disable the indenting of tree nodes so demo columns can use the full window width.");
+    if (disable_indent)
+        ImGui::PushStyleVar(ImGuiStyleVar_IndentSpacing, 0.0f);
+
+    // Basic columns
+    if (ImGui::TreeNode("Basic"))
+    {
+        ImGui::Text("Without border:");
+        ImGui::Columns(3, "mycolumns3", false);  // 3-ways, no border
+        ImGui::Separator();
+        for (int n = 0; n < 14; n++)
+        {
+            char label[32];
+            sprintf(label, "Item %d", n);
+            if (ImGui::Selectable(label))
+            {
+            }
+            // if (ImGui::Button(label, ImVec2(-FLT_MIN,0.0f))) {}
+            ImGui::NextColumn();
+        }
+        ImGui::Columns(1);
+        ImGui::Separator();
+
+        ImGui::Text("With border:");
+        ImGui::Columns(4, "mycolumns");  // 4-ways, with border
+        ImGui::Separator();
+        ImGui::Text("ID");
+        ImGui::NextColumn();
+        ImGui::Text("Name");
+        ImGui::NextColumn();
+        ImGui::Text("Path");
+        ImGui::NextColumn();
+        ImGui::Text("Hovered");
+        ImGui::NextColumn();
+        ImGui::Separator();
+        const char *names[3] = {"One", "Two", "Three"};
+        const char *paths[3] = {"/path/one", "/path/two", "/path/three"};
+        static int selected  = -1;
+        for (int i = 0; i < 3; i++)
+        {
+            char label[32];
+            sprintf(label, "%04d", i);
+            if (ImGui::Selectable(label, selected == i, ImGuiSelectableFlags_SpanAllColumns))
+                selected = i;
+            bool hovered = ImGui::IsItemHovered();
+            ImGui::NextColumn();
+            ImGui::Text(names[i]);
+            ImGui::NextColumn();
+            ImGui::Text(paths[i]);
+            ImGui::NextColumn();
+            ImGui::Text("%d", hovered);
+            ImGui::NextColumn();
+        }
+        ImGui::Columns(1);
+        ImGui::Separator();
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Borders"))
+    {
+        // NB: Future columns API should allow automatic horizontal borders.
+        static bool h_borders = true;
+        static bool v_borders = true;
+        ImGui::Checkbox("horizontal", &h_borders);
+        ImGui::SameLine();
+        ImGui::Checkbox("vertical", &v_borders);
+        ImGui::Columns(4, NULL, v_borders);
+        for (int i = 0; i < 4 * 3; i++)
+        {
+            if (h_borders && ImGui::GetColumnIndex() == 0)
+                ImGui::Separator();
+            ImGui::Text("%c%c%c", 'a' + i, 'a' + i, 'a' + i);
+            ImGui::Text("Width %.2f", ImGui::GetColumnWidth());
+            ImGui::Text("Offset %.2f", ImGui::GetColumnOffset());
+            ImGui::Text("Long text that is likely to clip");
+            ImGui::Button("Button", ImVec2(-FLT_MIN, 0.0f));
+            ImGui::NextColumn();
+        }
+        ImGui::Columns(1);
+        if (h_borders)
+            ImGui::Separator();
+        ImGui::TreePop();
+    }
+
+    // Create multiple items in a same cell before switching to next column
+    if (ImGui::TreeNode("Mixed items"))
+    {
+        ImGui::Columns(3, "mixed");
+        ImGui::Separator();
+
+        ImGui::Text("Hello");
+        ImGui::Button("Banana");
+        ImGui::NextColumn();
+
+        ImGui::Text("ImGui");
+        ImGui::Button("Apple");
+        static float foo = 1.0f;
+        ImGui::InputFloat("red", &foo, 0.05f, 0, "%.3f");
+        ImGui::Text("An extra line here.");
+        ImGui::NextColumn();
+
+        ImGui::Text("Sailor");
+        ImGui::Button("Corniflower");
+        static float bar = 1.0f;
+        ImGui::InputFloat("blue", &bar, 0.05f, 0, "%.3f");
+        ImGui::NextColumn();
+
+        if (ImGui::CollapsingHeader("Category A"))
+        {
+            ImGui::Text("Blah blah blah");
+        }
+        ImGui::NextColumn();
+        if (ImGui::CollapsingHeader("Category B"))
+        {
+            ImGui::Text("Blah blah blah");
+        }
+        ImGui::NextColumn();
+        if (ImGui::CollapsingHeader("Category C"))
+        {
+            ImGui::Text("Blah blah blah");
+        }
+        ImGui::NextColumn();
+        ImGui::Columns(1);
+        ImGui::Separator();
+        ImGui::TreePop();
+    }
+
+    // Word wrapping
+    if (ImGui::TreeNode("Word-wrapping"))
+    {
+        ImGui::Columns(2, "word-wrapping");
+        ImGui::Separator();
+        ImGui::TextWrapped("The quick brown fox jumps over the lazy dog.");
+        ImGui::TextWrapped("Hello Left");
+        ImGui::NextColumn();
+        ImGui::TextWrapped("The quick brown fox jumps over the lazy dog.");
+        ImGui::TextWrapped("Hello Right");
+        ImGui::Columns(1);
+        ImGui::Separator();
+        ImGui::TreePop();
+    }
+
+    // Scrolling columns
+    /*
+    if (ImGui::TreeNode("Vertical Scrolling"))
+    {
+        ImGui::BeginChild("##header", ImVec2(0,
+    ImGui::GetTextLineHeightWithSpacing()+ImGui::GetStyle().ItemSpacing.y)); ImGui::Columns(3);
+        ImGui::Text("ID"); ImGui::NextColumn();
+        ImGui::Text("Name"); ImGui::NextColumn();
+        ImGui::Text("Path"); ImGui::NextColumn();
+        ImGui::Columns(1);
+        ImGui::Separator();
+        ImGui::EndChild();
+        ImGui::BeginChild("##scrollingregion", ImVec2(0, 60));
+        ImGui::Columns(3);
+        for (int i = 0; i < 10; i++)
+        {
+            ImGui::Text("%04d", i); ImGui::NextColumn();
+            ImGui::Text("Foobar"); ImGui::NextColumn();
+            ImGui::Text("/path/foobar/%04d/", i); ImGui::NextColumn();
+        }
+        ImGui::Columns(1);
+        ImGui::EndChild();
+        ImGui::TreePop();
+    }
+    */
+
+    if (ImGui::TreeNode("Horizontal Scrolling"))
+    {
+        ImGui::SetNextWindowContentSize(ImVec2(1500.0f, 0.0f));
+        ImGui::BeginChild("##ScrollingRegion", ImVec2(0, ImGui::GetFontSize() * 20), false,
+                          ImGuiWindowFlags_HorizontalScrollbar);
+        ImGui::Columns(10);
+        int ITEMS_COUNT = 2000;
+        ImGuiListClipper clipper(ITEMS_COUNT);  // Also demonstrate using the clipper for large list
+        while (clipper.Step())
+        {
+            for (int i = clipper.DisplayStart; i < clipper.DisplayEnd; i++)
+                for (int j = 0; j < 10; j++)
+                {
+                    ImGui::Text("Line %d Column %d...", i, j);
+                    ImGui::NextColumn();
+                }
+        }
+        ImGui::Columns(1);
+        ImGui::EndChild();
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Tree"))
+    {
+        ImGui::Columns(2, "tree", true);
+        for (int x = 0; x < 3; x++)
+        {
+            bool open1 = ImGui::TreeNode((void *)(intptr_t)x, "Node%d", x);
+            ImGui::NextColumn();
+            ImGui::Text("Node contents");
+            ImGui::NextColumn();
+            if (open1)
+            {
+                for (int y = 0; y < 3; y++)
+                {
+                    bool open2 = ImGui::TreeNode((void *)(intptr_t)y, "Node%d.%d", x, y);
+                    ImGui::NextColumn();
+                    ImGui::Text("Node contents");
+                    if (open2)
+                    {
+                        ImGui::Text("Even more contents");
+                        if (ImGui::TreeNode("Tree in column"))
+                        {
+                            ImGui::Text("The quick brown fox jumps over the lazy dog");
+                            ImGui::TreePop();
+                        }
+                    }
+                    ImGui::NextColumn();
+                    if (open2)
+                        ImGui::TreePop();
+                }
+                ImGui::TreePop();
+            }
+        }
+        ImGui::Columns(1);
+        ImGui::TreePop();
+    }
+
+    if (disable_indent)
+        ImGui::PopStyleVar();
+    ImGui::PopID();
+}
+
+static void ShowDemoWindowMisc()
+{
+    if (ImGui::CollapsingHeader("Filtering"))
+    {
+        static ImGuiTextFilter filter;
+        ImGui::Text(
+            "Filter usage:\n"
+            "  \"\"         display all lines\n"
+            "  \"xxx\"      display lines containing \"xxx\"\n"
+            "  \"xxx,yyy\"  display lines containing \"xxx\" or \"yyy\"\n"
+            "  \"-xxx\"     hide lines containing \"xxx\"");
+        filter.Draw();
+        const char *lines[] = {"aaa1.c",   "bbb1.c",   "ccc1.c", "aaa2.cpp",
+                               "bbb2.cpp", "ccc2.cpp", "abc.h",  "hello, world"};
+        for (int i = 0; i < IM_ARRAYSIZE(lines); i++)
+            if (filter.PassFilter(lines[i]))
+                ImGui::BulletText("%s", lines[i]);
+    }
+
+    if (ImGui::CollapsingHeader("Inputs, Navigation & Focus"))
+    {
+        ImGuiIO &io = ImGui::GetIO();
+
+        ImGui::Text("WantCaptureMouse: %d", io.WantCaptureMouse);
+        ImGui::Text("WantCaptureKeyboard: %d", io.WantCaptureKeyboard);
+        ImGui::Text("WantTextInput: %d", io.WantTextInput);
+        ImGui::Text("WantSetMousePos: %d", io.WantSetMousePos);
+        ImGui::Text("NavActive: %d, NavVisible: %d", io.NavActive, io.NavVisible);
+
+        if (ImGui::TreeNode("Keyboard, Mouse & Navigation State"))
+        {
+            if (ImGui::IsMousePosValid())
+                ImGui::Text("Mouse pos: (%g, %g)", io.MousePos.x, io.MousePos.y);
+            else
+                ImGui::Text("Mouse pos: <INVALID>");
+            ImGui::Text("Mouse delta: (%g, %g)", io.MouseDelta.x, io.MouseDelta.y);
+            ImGui::Text("Mouse down:");
+            for (int i = 0; i < IM_ARRAYSIZE(io.MouseDown); i++)
+                if (io.MouseDownDuration[i] >= 0.0f)
+                {
+                    ImGui::SameLine();
+                    ImGui::Text("b%d (%.02f secs)", i, io.MouseDownDuration[i]);
+                }
+            ImGui::Text("Mouse clicked:");
+            for (int i = 0; i < IM_ARRAYSIZE(io.MouseDown); i++)
+                if (ImGui::IsMouseClicked(i))
+                {
+                    ImGui::SameLine();
+                    ImGui::Text("b%d", i);
+                }
+            ImGui::Text("Mouse dbl-clicked:");
+            for (int i = 0; i < IM_ARRAYSIZE(io.MouseDown); i++)
+                if (ImGui::IsMouseDoubleClicked(i))
+                {
+                    ImGui::SameLine();
+                    ImGui::Text("b%d", i);
+                }
+            ImGui::Text("Mouse released:");
+            for (int i = 0; i < IM_ARRAYSIZE(io.MouseDown); i++)
+                if (ImGui::IsMouseReleased(i))
+                {
+                    ImGui::SameLine();
+                    ImGui::Text("b%d", i);
+                }
+            ImGui::Text("Mouse wheel: %.1f", io.MouseWheel);
+
+            ImGui::Text("Keys down:");
+            for (int i = 0; i < IM_ARRAYSIZE(io.KeysDown); i++)
+                if (io.KeysDownDuration[i] >= 0.0f)
+                {
+                    ImGui::SameLine();
+                    ImGui::Text("%d (0x%X) (%.02f secs)", i, i, io.KeysDownDuration[i]);
+                }
+            ImGui::Text("Keys pressed:");
+            for (int i = 0; i < IM_ARRAYSIZE(io.KeysDown); i++)
+                if (ImGui::IsKeyPressed(i))
+                {
+                    ImGui::SameLine();
+                    ImGui::Text("%d (0x%X)", i, i);
+                }
+            ImGui::Text("Keys release:");
+            for (int i = 0; i < IM_ARRAYSIZE(io.KeysDown); i++)
+                if (ImGui::IsKeyReleased(i))
+                {
+                    ImGui::SameLine();
+                    ImGui::Text("%d (0x%X)", i, i);
+                }
+            ImGui::Text("Keys mods: %s%s%s%s", io.KeyCtrl ? "CTRL " : "",
+                        io.KeyShift ? "SHIFT " : "", io.KeyAlt ? "ALT " : "",
+                        io.KeySuper ? "SUPER " : "");
+            ImGui::Text("Chars queue:");
+            for (int i = 0; i < io.InputQueueCharacters.Size; i++)
+            {
+                ImWchar c = io.InputQueueCharacters[i];
+                ImGui::SameLine();
+                ImGui::Text("\'%c\' (0x%04X)", (c > ' ' && c <= 255) ? (char)c : '?', c);
+            }  // FIXME: We should convert 'c' to UTF-8 here but the functions are not public.
+
+            ImGui::Text("NavInputs down:");
+            for (int i = 0; i < IM_ARRAYSIZE(io.NavInputs); i++)
+                if (io.NavInputs[i] > 0.0f)
+                {
+                    ImGui::SameLine();
+                    ImGui::Text("[%d] %.2f", i, io.NavInputs[i]);
+                }
+            ImGui::Text("NavInputs pressed:");
+            for (int i = 0; i < IM_ARRAYSIZE(io.NavInputs); i++)
+                if (io.NavInputsDownDuration[i] == 0.0f)
+                {
+                    ImGui::SameLine();
+                    ImGui::Text("[%d]", i);
+                }
+            ImGui::Text("NavInputs duration:");
+            for (int i = 0; i < IM_ARRAYSIZE(io.NavInputs); i++)
+                if (io.NavInputsDownDuration[i] >= 0.0f)
+                {
+                    ImGui::SameLine();
+                    ImGui::Text("[%d] %.2f", i, io.NavInputsDownDuration[i]);
+                }
+
+            ImGui::Button("Hovering me sets the\nkeyboard capture flag");
+            if (ImGui::IsItemHovered())
+                ImGui::CaptureKeyboardFromApp(true);
+            ImGui::SameLine();
+            ImGui::Button("Holding me clears the\nthe keyboard capture flag");
+            if (ImGui::IsItemActive())
+                ImGui::CaptureKeyboardFromApp(false);
+
+            ImGui::TreePop();
+        }
+
+        if (ImGui::TreeNode("Tabbing"))
+        {
+            ImGui::Text("Use TAB/SHIFT+TAB to cycle through keyboard editable fields.");
+            static char buf[32] = "dummy";
+            ImGui::InputText("1", buf, IM_ARRAYSIZE(buf));
+            ImGui::InputText("2", buf, IM_ARRAYSIZE(buf));
+            ImGui::InputText("3", buf, IM_ARRAYSIZE(buf));
+            ImGui::PushAllowKeyboardFocus(false);
+            ImGui::InputText("4 (tab skip)", buf, IM_ARRAYSIZE(buf));
+            // ImGui::SameLine(); HelpMarker("Use ImGui::PushAllowKeyboardFocus(bool)\nto disable
+            // tabbing through certain widgets.");
+            ImGui::PopAllowKeyboardFocus();
+            ImGui::InputText("5", buf, IM_ARRAYSIZE(buf));
+            ImGui::TreePop();
+        }
+
+        if (ImGui::TreeNode("Focus from code"))
+        {
+            bool focus_1 = ImGui::Button("Focus on 1");
+            ImGui::SameLine();
+            bool focus_2 = ImGui::Button("Focus on 2");
+            ImGui::SameLine();
+            bool focus_3         = ImGui::Button("Focus on 3");
+            int has_focus        = 0;
+            static char buf[128] = "click on a button to set focus";
+
+            if (focus_1)
+                ImGui::SetKeyboardFocusHere();
+            ImGui::InputText("1", buf, IM_ARRAYSIZE(buf));
+            if (ImGui::IsItemActive())
+                has_focus = 1;
+
+            if (focus_2)
+                ImGui::SetKeyboardFocusHere();
+            ImGui::InputText("2", buf, IM_ARRAYSIZE(buf));
+            if (ImGui::IsItemActive())
+                has_focus = 2;
+
+            ImGui::PushAllowKeyboardFocus(false);
+            if (focus_3)
+                ImGui::SetKeyboardFocusHere();
+            ImGui::InputText("3 (tab skip)", buf, IM_ARRAYSIZE(buf));
+            if (ImGui::IsItemActive())
+                has_focus = 3;
+            ImGui::PopAllowKeyboardFocus();
+
+            if (has_focus)
+                ImGui::Text("Item with focus: %d", has_focus);
+            else
+                ImGui::Text("Item with focus: <none>");
+
+            // Use >= 0 parameter to SetKeyboardFocusHere() to focus an upcoming item
+            static float f3[3] = {0.0f, 0.0f, 0.0f};
+            int focus_ahead    = -1;
+            if (ImGui::Button("Focus on X"))
+            {
+                focus_ahead = 0;
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Focus on Y"))
+            {
+                focus_ahead = 1;
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Focus on Z"))
+            {
+                focus_ahead = 2;
+            }
+            if (focus_ahead != -1)
+                ImGui::SetKeyboardFocusHere(focus_ahead);
+            ImGui::SliderFloat3("Float3", &f3[0], 0.0f, 1.0f);
+
+            ImGui::TextWrapped(
+                "NB: Cursor & selection are preserved when refocusing last used item in code.");
+            ImGui::TreePop();
+        }
+
+        if (ImGui::TreeNode("Dragging"))
+        {
+            ImGui::TextWrapped(
+                "You can use ImGui::GetMouseDragDelta(0) to query for the dragged amount on any "
+                "widget.");
+            for (int button = 0; button < 3; button++)
+                ImGui::Text(
+                    "IsMouseDragging(%d):\n  w/ default threshold: %d,\n  w/ zero threshold: %d\n  "
+                    "w/ large threshold: %d",
+                    button, ImGui::IsMouseDragging(button), ImGui::IsMouseDragging(button, 0.0f),
+                    ImGui::IsMouseDragging(button, 20.0f));
+
+            ImGui::Button("Drag Me");
+            if (ImGui::IsItemActive())
+                ImGui::GetForegroundDrawList()->AddLine(
+                    io.MouseClickedPos[0], io.MousePos, ImGui::GetColorU32(ImGuiCol_Button),
+                    4.0f);  // Draw a line between the button and the mouse cursor
+
+            // Drag operations gets "unlocked" when the mouse has moved past a certain threshold
+            // (the default threshold is stored in io.MouseDragThreshold) You can request a lower or
+            // higher threshold using the second parameter of IsMouseDragging() and
+            // GetMouseDragDelta()
+            ImVec2 value_raw                 = ImGui::GetMouseDragDelta(0, 0.0f);
+            ImVec2 value_with_lock_threshold = ImGui::GetMouseDragDelta(0);
+            ImVec2 mouse_delta               = io.MouseDelta;
+            ImGui::Text(
+                "GetMouseDragDelta(0):\n  w/ default threshold: (%.1f, %.1f),\n  w/ zero "
+                "threshold: (%.1f, %.1f)\nMouseDelta: (%.1f, %.1f)",
+                value_with_lock_threshold.x, value_with_lock_threshold.y, value_raw.x, value_raw.y,
+                mouse_delta.x, mouse_delta.y);
+            ImGui::TreePop();
+        }
+
+        if (ImGui::TreeNode("Mouse cursors"))
+        {
+            const char *mouse_cursors_names[] = {"Arrow",    "TextInput",  "Move",       "ResizeNS",
+                                                 "ResizeEW", "ResizeNESW", "ResizeNWSE", "Hand"};
+            IM_ASSERT(IM_ARRAYSIZE(mouse_cursors_names) == ImGuiMouseCursor_COUNT);
+
+            ImGui::Text("Current mouse cursor = %d: %s", ImGui::GetMouseCursor(),
+                        mouse_cursors_names[ImGui::GetMouseCursor()]);
+            ImGui::Text("Hover to see mouse cursors:");
+            ImGui::SameLine();
+            HelpMarker(
+                "Your application can render a different mouse cursor based on what "
+                "ImGui::GetMouseCursor() returns. If software cursor rendering "
+                "(io.MouseDrawCursor) is set ImGui will draw the right cursor for you, otherwise "
+                "your backend needs to handle it.");
+            for (int i = 0; i < ImGuiMouseCursor_COUNT; i++)
+            {
+                char label[32];
+                sprintf(label, "Mouse cursor %d: %s", i, mouse_cursors_names[i]);
+                ImGui::Bullet();
+                ImGui::Selectable(label, false);
+                if (ImGui::IsItemHovered() || ImGui::IsItemFocused())
+                    ImGui::SetMouseCursor(i);
+            }
+            ImGui::TreePop();
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] About Window / ShowAboutWindow()
+// Access from Dear ImGui Demo -> Help -> About
+//-----------------------------------------------------------------------------
+
+void ImGui::ShowAboutWindow(bool *p_open)
+{
+    if (!ImGui::Begin("About Dear ImGui", p_open, ImGuiWindowFlags_AlwaysAutoResize))
+    {
+        ImGui::End();
+        return;
+    }
+    ImGui::Text("Dear ImGui %s", ImGui::GetVersion());
+    ImGui::Separator();
+    ImGui::Text("By Omar Cornut and all dear imgui contributors.");
+    ImGui::Text("Dear ImGui is licensed under the MIT License, see LICENSE for more information.");
+
+    static bool show_config_info = false;
+    ImGui::Checkbox("Config/Build Information", &show_config_info);
+    if (show_config_info)
+    {
+        ImGuiIO &io       = ImGui::GetIO();
+        ImGuiStyle &style = ImGui::GetStyle();
+
+        bool copy_to_clipboard = ImGui::Button("Copy to clipboard");
+        ImGui::BeginChildFrame(ImGui::GetID("cfginfos"),
+                               ImVec2(0, ImGui::GetTextLineHeightWithSpacing() * 18),
+                               ImGuiWindowFlags_NoMove);
+        if (copy_to_clipboard)
+            ImGui::LogToClipboard();
+
+        ImGui::Text("Dear ImGui %s (%d)", IMGUI_VERSION, IMGUI_VERSION_NUM);
+        ImGui::Separator();
+        ImGui::Text("sizeof(size_t): %d, sizeof(ImDrawIdx): %d, sizeof(ImDrawVert): %d",
+                    (int)sizeof(size_t), (int)sizeof(ImDrawIdx), (int)sizeof(ImDrawVert));
+        ImGui::Text("define: __cplusplus=%d", (int)__cplusplus);
+#ifdef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+        ImGui::Text("define: IMGUI_DISABLE_OBSOLETE_FUNCTIONS");
+#endif
+#ifdef IMGUI_DISABLE_WIN32_DEFAULT_CLIPBOARD_FUNCTIONS
+        ImGui::Text("define: IMGUI_DISABLE_WIN32_DEFAULT_CLIPBOARD_FUNCTIONS");
+#endif
+#ifdef IMGUI_DISABLE_WIN32_DEFAULT_IME_FUNCTIONS
+        ImGui::Text("define: IMGUI_DISABLE_WIN32_DEFAULT_IME_FUNCTIONS");
+#endif
+#ifdef IMGUI_DISABLE_WIN32_FUNCTIONS
+        ImGui::Text("define: IMGUI_DISABLE_WIN32_FUNCTIONS");
+#endif
+#ifdef IMGUI_DISABLE_FORMAT_STRING_FUNCTIONS
+        ImGui::Text("define: IMGUI_DISABLE_FORMAT_STRING_FUNCTIONS");
+#endif
+#ifdef IMGUI_DISABLE_MATH_FUNCTIONS
+        ImGui::Text("define: IMGUI_DISABLE_MATH_FUNCTIONS");
+#endif
+#ifdef IMGUI_DISABLE_DEFAULT_ALLOCATORS
+        ImGui::Text("define: IMGUI_DISABLE_DEFAULT_ALLOCATORS");
+#endif
+#ifdef IMGUI_USE_BGRA_PACKED_COLOR
+        ImGui::Text("define: IMGUI_USE_BGRA_PACKED_COLOR");
+#endif
+#ifdef _WIN32
+        ImGui::Text("define: _WIN32");
+#endif
+#ifdef _WIN64
+        ImGui::Text("define: _WIN64");
+#endif
+#ifdef __linux__
+        ImGui::Text("define: __linux__");
+#endif
+#ifdef __APPLE__
+        ImGui::Text("define: __APPLE__");
+#endif
+#ifdef _MSC_VER
+        ImGui::Text("define: _MSC_VER=%d", _MSC_VER);
+#endif
+#ifdef __MINGW32__
+        ImGui::Text("define: __MINGW32__");
+#endif
+#ifdef __MINGW64__
+        ImGui::Text("define: __MINGW64__");
+#endif
+#ifdef __GNUC__
+        ImGui::Text("define: __GNUC__=%d", (int)__GNUC__);
+#endif
+#ifdef __clang_version__
+        ImGui::Text("define: __clang_version__=%s", __clang_version__);
+#endif
+        ImGui::Separator();
+        ImGui::Text("io.BackendPlatformName: %s",
+                    io.BackendPlatformName ? io.BackendPlatformName : "NULL");
+        ImGui::Text("io.BackendRendererName: %s",
+                    io.BackendRendererName ? io.BackendRendererName : "NULL");
+        ImGui::Text("io.ConfigFlags: 0x%08X", io.ConfigFlags);
+        if (io.ConfigFlags & ImGuiConfigFlags_NavEnableKeyboard)
+            ImGui::Text(" NavEnableKeyboard");
+        if (io.ConfigFlags & ImGuiConfigFlags_NavEnableGamepad)
+            ImGui::Text(" NavEnableGamepad");
+        if (io.ConfigFlags & ImGuiConfigFlags_NavEnableSetMousePos)
+            ImGui::Text(" NavEnableSetMousePos");
+        if (io.ConfigFlags & ImGuiConfigFlags_NavNoCaptureKeyboard)
+            ImGui::Text(" NavNoCaptureKeyboard");
+        if (io.ConfigFlags & ImGuiConfigFlags_NoMouse)
+            ImGui::Text(" NoMouse");
+        if (io.ConfigFlags & ImGuiConfigFlags_NoMouseCursorChange)
+            ImGui::Text(" NoMouseCursorChange");
+        if (io.MouseDrawCursor)
+            ImGui::Text("io.MouseDrawCursor");
+        if (io.ConfigMacOSXBehaviors)
+            ImGui::Text("io.ConfigMacOSXBehaviors");
+        if (io.ConfigInputTextCursorBlink)
+            ImGui::Text("io.ConfigInputTextCursorBlink");
+        if (io.ConfigWindowsResizeFromEdges)
+            ImGui::Text("io.ConfigWindowsResizeFromEdges");
+        if (io.ConfigWindowsMoveFromTitleBarOnly)
+            ImGui::Text("io.ConfigWindowsMoveFromTitleBarOnly");
+        ImGui::Text("io.BackendFlags: 0x%08X", io.BackendFlags);
+        if (io.BackendFlags & ImGuiBackendFlags_HasGamepad)
+            ImGui::Text(" HasGamepad");
+        if (io.BackendFlags & ImGuiBackendFlags_HasMouseCursors)
+            ImGui::Text(" HasMouseCursors");
+        if (io.BackendFlags & ImGuiBackendFlags_HasSetMousePos)
+            ImGui::Text(" HasSetMousePos");
+        if (io.BackendFlags & ImGuiBackendFlags_RendererHasVtxOffset)
+            ImGui::Text(" RendererHasVtxOffset");
+        ImGui::Separator();
+        ImGui::Text("io.Fonts: %d fonts, Flags: 0x%08X, TexSize: %d,%d", io.Fonts->Fonts.Size,
+                    io.Fonts->Flags, io.Fonts->TexWidth, io.Fonts->TexHeight);
+        ImGui::Text("io.DisplaySize: %.2f,%.2f", io.DisplaySize.x, io.DisplaySize.y);
+        ImGui::Text("io.DisplayFramebufferScale: %.2f,%.2f", io.DisplayFramebufferScale.x,
+                    io.DisplayFramebufferScale.y);
+        ImGui::Separator();
+        ImGui::Text("style.WindowPadding: %.2f,%.2f", style.WindowPadding.x, style.WindowPadding.y);
+        ImGui::Text("style.WindowBorderSize: %.2f", style.WindowBorderSize);
+        ImGui::Text("style.FramePadding: %.2f,%.2f", style.FramePadding.x, style.FramePadding.y);
+        ImGui::Text("style.FrameRounding: %.2f", style.FrameRounding);
+        ImGui::Text("style.FrameBorderSize: %.2f", style.FrameBorderSize);
+        ImGui::Text("style.ItemSpacing: %.2f,%.2f", style.ItemSpacing.x, style.ItemSpacing.y);
+        ImGui::Text("style.ItemInnerSpacing: %.2f,%.2f", style.ItemInnerSpacing.x,
+                    style.ItemInnerSpacing.y);
+
+        if (copy_to_clipboard)
+            ImGui::LogFinish();
+        ImGui::EndChildFrame();
+    }
+    ImGui::End();
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Style Editor / ShowStyleEditor()
+//-----------------------------------------------------------------------------
+
+// Demo helper function to select among default colors. See ShowStyleEditor() for more advanced
+// options. Here we use the simplified Combo() api that packs items into a single literal string.
+// Useful for quick combo boxes where the choices are known locally.
+bool ImGui::ShowStyleSelector(const char *label)
+{
+    static int style_idx = -1;
+    if (ImGui::Combo(label, &style_idx, "Classic\0Dark\0Light\0"))
+    {
+        switch (style_idx)
+        {
+            case 0:
+                ImGui::StyleColorsClassic();
+                break;
+            case 1:
+                ImGui::StyleColorsDark();
+                break;
+            case 2:
+                ImGui::StyleColorsLight();
+                break;
+        }
+        return true;
+    }
+    return false;
+}
+
+// Demo helper function to select among loaded fonts.
+// Here we use the regular BeginCombo()/EndCombo() api which is more the more flexible one.
+void ImGui::ShowFontSelector(const char *label)
+{
+    ImGuiIO &io          = ImGui::GetIO();
+    ImFont *font_current = ImGui::GetFont();
+    if (ImGui::BeginCombo(label, font_current->GetDebugName()))
+    {
+        for (int n = 0; n < io.Fonts->Fonts.Size; n++)
+        {
+            ImFont *font = io.Fonts->Fonts[n];
+            ImGui::PushID((void *)font);
+            if (ImGui::Selectable(font->GetDebugName(), font == font_current))
+                io.FontDefault = font;
+            ImGui::PopID();
+        }
+        ImGui::EndCombo();
+    }
+    ImGui::SameLine();
+    HelpMarker(
+        "- Load additional fonts with io.Fonts->AddFontFromFileTTF().\n"
+        "- The font atlas is built when calling io.Fonts->GetTexDataAsXXXX() or "
+        "io.Fonts->Build().\n"
+        "- Read FAQ and documentation in misc/fonts/ for more details.\n"
+        "- If you need to add/remove fonts at runtime (e.g. for DPI change), do it before calling "
+        "NewFrame().");
+}
+
+void ImGui::ShowStyleEditor(ImGuiStyle *ref)
+{
+    // You can pass in a reference ImGuiStyle structure to compare to, revert to and save to (else
+    // it compares to an internally stored reference)
+    ImGuiStyle &style = ImGui::GetStyle();
+    static ImGuiStyle ref_saved_style;
+
+    // Default to using internal storage as reference
+    static bool init = true;
+    if (init && ref == NULL)
+        ref_saved_style = style;
+    init = false;
+    if (ref == NULL)
+        ref = &ref_saved_style;
+
+    ImGui::PushItemWidth(ImGui::GetWindowWidth() * 0.50f);
+
+    if (ImGui::ShowStyleSelector("Colors##Selector"))
+        ref_saved_style = style;
+    ImGui::ShowFontSelector("Fonts##Selector");
+
+    // Simplified Settings
+    if (ImGui::SliderFloat("FrameRounding", &style.FrameRounding, 0.0f, 12.0f, "%.0f"))
+        style.GrabRounding =
+            style.FrameRounding;  // Make GrabRounding always the same value as FrameRounding
+    {
+        bool window_border = (style.WindowBorderSize > 0.0f);
+        if (ImGui::Checkbox("WindowBorder", &window_border))
+            style.WindowBorderSize = window_border ? 1.0f : 0.0f;
+    }
+    ImGui::SameLine();
+    {
+        bool frame_border = (style.FrameBorderSize > 0.0f);
+        if (ImGui::Checkbox("FrameBorder", &frame_border))
+            style.FrameBorderSize = frame_border ? 1.0f : 0.0f;
+    }
+    ImGui::SameLine();
+    {
+        bool popup_border = (style.PopupBorderSize > 0.0f);
+        if (ImGui::Checkbox("PopupBorder", &popup_border))
+            style.PopupBorderSize = popup_border ? 1.0f : 0.0f;
+    }
+
+    // Save/Revert button
+    if (ImGui::Button("Save Ref"))
+        *ref = ref_saved_style = style;
+    ImGui::SameLine();
+    if (ImGui::Button("Revert Ref"))
+        style = *ref;
+    ImGui::SameLine();
+    HelpMarker(
+        "Save/Revert in local non-persistent storage. Default Colors definition are not affected. "
+        "Use \"Export Colors\" below to save them somewhere.");
+
+    ImGui::Separator();
+
+    if (ImGui::BeginTabBar("##tabs", ImGuiTabBarFlags_None))
+    {
+        if (ImGui::BeginTabItem("Sizes"))
+        {
+            ImGui::Text("Main");
+            ImGui::SliderFloat2("WindowPadding", (float *)&style.WindowPadding, 0.0f, 20.0f,
+                                "%.0f");
+            ImGui::SliderFloat2("FramePadding", (float *)&style.FramePadding, 0.0f, 20.0f, "%.0f");
+            ImGui::SliderFloat2("ItemSpacing", (float *)&style.ItemSpacing, 0.0f, 20.0f, "%.0f");
+            ImGui::SliderFloat2("ItemInnerSpacing", (float *)&style.ItemInnerSpacing, 0.0f, 20.0f,
+                                "%.0f");
+            ImGui::SliderFloat2("TouchExtraPadding", (float *)&style.TouchExtraPadding, 0.0f, 10.0f,
+                                "%.0f");
+            ImGui::SliderFloat("IndentSpacing", &style.IndentSpacing, 0.0f, 30.0f, "%.0f");
+            ImGui::SliderFloat("ScrollbarSize", &style.ScrollbarSize, 1.0f, 20.0f, "%.0f");
+            ImGui::SliderFloat("GrabMinSize", &style.GrabMinSize, 1.0f, 20.0f, "%.0f");
+            ImGui::Text("Borders");
+            ImGui::SliderFloat("WindowBorderSize", &style.WindowBorderSize, 0.0f, 1.0f, "%.0f");
+            ImGui::SliderFloat("ChildBorderSize", &style.ChildBorderSize, 0.0f, 1.0f, "%.0f");
+            ImGui::SliderFloat("PopupBorderSize", &style.PopupBorderSize, 0.0f, 1.0f, "%.0f");
+            ImGui::SliderFloat("FrameBorderSize", &style.FrameBorderSize, 0.0f, 1.0f, "%.0f");
+            ImGui::SliderFloat("TabBorderSize", &style.TabBorderSize, 0.0f, 1.0f, "%.0f");
+            ImGui::Text("Rounding");
+            ImGui::SliderFloat("WindowRounding", &style.WindowRounding, 0.0f, 12.0f, "%.0f");
+            ImGui::SliderFloat("ChildRounding", &style.ChildRounding, 0.0f, 12.0f, "%.0f");
+            ImGui::SliderFloat("FrameRounding", &style.FrameRounding, 0.0f, 12.0f, "%.0f");
+            ImGui::SliderFloat("PopupRounding", &style.PopupRounding, 0.0f, 12.0f, "%.0f");
+            ImGui::SliderFloat("ScrollbarRounding", &style.ScrollbarRounding, 0.0f, 12.0f, "%.0f");
+            ImGui::SliderFloat("GrabRounding", &style.GrabRounding, 0.0f, 12.0f, "%.0f");
+            ImGui::SliderFloat("TabRounding", &style.TabRounding, 0.0f, 12.0f, "%.0f");
+            ImGui::Text("Alignment");
+            ImGui::SliderFloat2("WindowTitleAlign", (float *)&style.WindowTitleAlign, 0.0f, 1.0f,
+                                "%.2f");
+            ImGui::Combo("WindowMenuButtonPosition", (int *)&style.WindowMenuButtonPosition,
+                         "Left\0Right\0");
+            ImGui::SliderFloat2("ButtonTextAlign", (float *)&style.ButtonTextAlign, 0.0f, 1.0f,
+                                "%.2f");
+            ImGui::SameLine();
+            HelpMarker("Alignment applies when a button is larger than its text content.");
+            ImGui::SliderFloat2("SelectableTextAlign", (float *)&style.SelectableTextAlign, 0.0f,
+                                1.0f, "%.2f");
+            ImGui::SameLine();
+            HelpMarker("Alignment applies when a selectable is larger than its text content.");
+            ImGui::Text("Safe Area Padding");
+            ImGui::SameLine();
+            HelpMarker(
+                "Adjust if you cannot see the edges of your screen (e.g. on a TV where scaling has "
+                "not been configured).");
+            ImGui::SliderFloat2("DisplaySafeAreaPadding", (float *)&style.DisplaySafeAreaPadding,
+                                0.0f, 30.0f, "%.0f");
+            ImGui::EndTabItem();
+        }
+
+        if (ImGui::BeginTabItem("Colors"))
+        {
+            static int output_dest           = 0;
+            static bool output_only_modified = true;
+            if (ImGui::Button("Export Unsaved"))
+            {
+                if (output_dest == 0)
+                    ImGui::LogToClipboard();
+                else
+                    ImGui::LogToTTY();
+                ImGui::LogText("ImVec4* colors = ImGui::GetStyle().Colors;" IM_NEWLINE);
+                for (int i = 0; i < ImGuiCol_COUNT; i++)
+                {
+                    const ImVec4 &col = style.Colors[i];
+                    const char *name  = ImGui::GetStyleColorName(i);
+                    if (!output_only_modified || memcmp(&col, &ref->Colors[i], sizeof(ImVec4)) != 0)
+                        ImGui::LogText(
+                            "colors[ImGuiCol_%s]%*s= ImVec4(%.2ff, %.2ff, %.2ff, "
+                            "%.2ff);" IM_NEWLINE,
+                            name, 23 - (int)strlen(name), "", col.x, col.y, col.z, col.w);
+                }
+                ImGui::LogFinish();
+            }
+            ImGui::SameLine();
+            ImGui::SetNextItemWidth(120);
+            ImGui::Combo("##output_type", &output_dest, "To Clipboard\0To TTY\0");
+            ImGui::SameLine();
+            ImGui::Checkbox("Only Modified Colors", &output_only_modified);
+
+            static ImGuiTextFilter filter;
+            filter.Draw("Filter colors", ImGui::GetFontSize() * 16);
+
+            static ImGuiColorEditFlags alpha_flags = 0;
+            ImGui::RadioButton("Opaque", &alpha_flags, 0);
+            ImGui::SameLine();
+            ImGui::RadioButton("Alpha", &alpha_flags, ImGuiColorEditFlags_AlphaPreview);
+            ImGui::SameLine();
+            ImGui::RadioButton("Both", &alpha_flags, ImGuiColorEditFlags_AlphaPreviewHalf);
+            ImGui::SameLine();
+            HelpMarker(
+                "In the color list:\nLeft-click on colored square to open color "
+                "picker,\nRight-click to open edit options menu.");
+
+            ImGui::BeginChild("##colors", ImVec2(0, 0), true,
+                              ImGuiWindowFlags_AlwaysVerticalScrollbar |
+                                  ImGuiWindowFlags_AlwaysHorizontalScrollbar |
+                                  ImGuiWindowFlags_NavFlattened);
+            ImGui::PushItemWidth(-160);
+            for (int i = 0; i < ImGuiCol_COUNT; i++)
+            {
+                const char *name = ImGui::GetStyleColorName(i);
+                if (!filter.PassFilter(name))
+                    continue;
+                ImGui::PushID(i);
+                ImGui::ColorEdit4("##color", (float *)&style.Colors[i],
+                                  ImGuiColorEditFlags_AlphaBar | alpha_flags);
+                if (memcmp(&style.Colors[i], &ref->Colors[i], sizeof(ImVec4)) != 0)
+                {
+                    // Tips: in a real user application, you may want to merge and use an icon font
+                    // into the main font, so instead of "Save"/"Revert" you'd use icons. Read the
+                    // FAQ and misc/fonts/README.txt about using icon fonts. It's really easy and
+                    // super convenient!
+                    ImGui::SameLine(0.0f, style.ItemInnerSpacing.x);
+                    if (ImGui::Button("Save"))
+                        ref->Colors[i] = style.Colors[i];
+                    ImGui::SameLine(0.0f, style.ItemInnerSpacing.x);
+                    if (ImGui::Button("Revert"))
+                        style.Colors[i] = ref->Colors[i];
+                }
+                ImGui::SameLine(0.0f, style.ItemInnerSpacing.x);
+                ImGui::TextUnformatted(name);
+                ImGui::PopID();
+            }
+            ImGui::PopItemWidth();
+            ImGui::EndChild();
+
+            ImGui::EndTabItem();
+        }
+
+        if (ImGui::BeginTabItem("Fonts"))
+        {
+            ImGuiIO &io        = ImGui::GetIO();
+            ImFontAtlas *atlas = io.Fonts;
+            HelpMarker("Read FAQ and misc/fonts/README.txt for details on font loading.");
+            ImGui::PushItemWidth(120);
+            for (int i = 0; i < atlas->Fonts.Size; i++)
+            {
+                ImFont *font = atlas->Fonts[i];
+                ImGui::PushID(font);
+                bool font_details_opened =
+                    ImGui::TreeNode(font, "Font %d: \"%s\"\n%.2f px, %d glyphs, %d file(s)", i,
+                                    font->ConfigData ? font->ConfigData[0].Name : "",
+                                    font->FontSize, font->Glyphs.Size, font->ConfigDataCount);
+                ImGui::SameLine();
+                if (ImGui::SmallButton("Set as default"))
+                {
+                    io.FontDefault = font;
+                }
+                if (font_details_opened)
+                {
+                    ImGui::PushFont(font);
+                    ImGui::Text("The quick brown fox jumps over the lazy dog");
+                    ImGui::PopFont();
+                    ImGui::DragFloat("Font scale", &font->Scale, 0.005f, 0.3f, 2.0f,
+                                     "%.1f");  // Scale only this font
+                    ImGui::SameLine();
+                    HelpMarker(
+                        "Note than the default embedded font is NOT meant to be scaled.\n\nFont "
+                        "are currently rendered into bitmaps at a given size at the time of "
+                        "building the atlas. You may oversample them to get some flexibility with "
+                        "scaling. You can also render at multiple sizes and select which one to "
+                        "use at runtime.\n\n(Glimmer of hope: the atlas system should hopefully be "
+                        "rewritten in the future to make scaling more natural and automatic.)");
+                    ImGui::InputFloat("Font offset", &font->DisplayOffset.y, 1, 1, "%.0f");
+                    ImGui::Text("Ascent: %f, Descent: %f, Height: %f", font->Ascent, font->Descent,
+                                font->Ascent - font->Descent);
+                    ImGui::Text("Fallback character: '%c' (%d)", font->FallbackChar,
+                                font->FallbackChar);
+                    const float surface_sqrt = sqrtf((float)font->MetricsTotalSurface);
+                    ImGui::Text("Texture surface: %d pixels (approx) ~ %dx%d",
+                                font->MetricsTotalSurface, (int)surface_sqrt, (int)surface_sqrt);
+                    for (int config_i = 0; config_i < font->ConfigDataCount; config_i++)
+                        if (const ImFontConfig *cfg = &font->ConfigData[config_i])
+                            ImGui::BulletText(
+                                "Input %d: \'%s\', Oversample: (%d,%d), PixelSnapH: %d", config_i,
+                                cfg->Name, cfg->OversampleH, cfg->OversampleV, cfg->PixelSnapH);
+                    if (ImGui::TreeNode("Glyphs", "Glyphs (%d)", font->Glyphs.Size))
+                    {
+                        // Display all glyphs of the fonts in separate pages of 256 characters
+                        for (int base = 0; base < 0x10000; base += 256)
+                        {
+                            int count = 0;
+                            for (int n = 0; n < 256; n++)
+                                count += font->FindGlyphNoFallback((ImWchar)(base + n)) ? 1 : 0;
+                            if (count > 0 &&
+                                ImGui::TreeNode((void *)(intptr_t)base, "U+%04X..U+%04X (%d %s)",
+                                                base, base + 255, count,
+                                                count > 1 ? "glyphs" : "glyph"))
+                            {
+                                float cell_size       = font->FontSize * 1;
+                                float cell_spacing    = style.ItemSpacing.y;
+                                ImVec2 base_pos       = ImGui::GetCursorScreenPos();
+                                ImDrawList *draw_list = ImGui::GetWindowDrawList();
+                                for (int n = 0; n < 256; n++)
+                                {
+                                    ImVec2 cell_p1(
+                                        base_pos.x + (n % 16) * (cell_size + cell_spacing),
+                                        base_pos.y + (n / 16) * (cell_size + cell_spacing));
+                                    ImVec2 cell_p2(cell_p1.x + cell_size, cell_p1.y + cell_size);
+                                    const ImFontGlyph *glyph =
+                                        font->FindGlyphNoFallback((ImWchar)(base + n));
+                                    draw_list->AddRect(cell_p1, cell_p2,
+                                                       glyph ? IM_COL32(255, 255, 255, 100)
+                                                             : IM_COL32(255, 255, 255, 50));
+                                    if (glyph)
+                                        font->RenderChar(
+                                            draw_list, cell_size, cell_p1,
+                                            ImGui::GetColorU32(ImGuiCol_Text),
+                                            (ImWchar)(
+                                                base +
+                                                n));  // We use ImFont::RenderChar as a shortcut
+                                                      // because we don't have UTF-8 conversion
+                                                      // functions available to generate a string.
+                                    if (glyph && ImGui::IsMouseHoveringRect(cell_p1, cell_p2))
+                                    {
+                                        ImGui::BeginTooltip();
+                                        ImGui::Text("Codepoint: U+%04X", base + n);
+                                        ImGui::Separator();
+                                        ImGui::Text("AdvanceX: %.1f", glyph->AdvanceX);
+                                        ImGui::Text("Pos: (%.2f,%.2f)->(%.2f,%.2f)", glyph->X0,
+                                                    glyph->Y0, glyph->X1, glyph->Y1);
+                                        ImGui::Text("UV: (%.3f,%.3f)->(%.3f,%.3f)", glyph->U0,
+                                                    glyph->V0, glyph->U1, glyph->V1);
+                                        ImGui::EndTooltip();
+                                    }
+                                }
+                                ImGui::Dummy(ImVec2((cell_size + cell_spacing) * 16,
+                                                    (cell_size + cell_spacing) * 16));
+                                ImGui::TreePop();
+                            }
+                        }
+                        ImGui::TreePop();
+                    }
+                    ImGui::TreePop();
+                }
+                ImGui::PopID();
+            }
+            if (ImGui::TreeNode("Atlas texture", "Atlas texture (%dx%d pixels)", atlas->TexWidth,
+                                atlas->TexHeight))
+            {
+                ImVec4 tint_col   = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
+                ImVec4 border_col = ImVec4(1.0f, 1.0f, 1.0f, 0.5f);
+                ImGui::Image(atlas->TexID, ImVec2((float)atlas->TexWidth, (float)atlas->TexHeight),
+                             ImVec2(0, 0), ImVec2(1, 1), tint_col, border_col);
+                ImGui::TreePop();
+            }
+
+            static float window_scale = 1.0f;
+            if (ImGui::DragFloat("this window scale", &window_scale, 0.005f, 0.3f, 2.0f,
+                                 "%.2f"))  // scale only this window
+                ImGui::SetWindowFontScale(window_scale);
+            ImGui::DragFloat("global scale", &io.FontGlobalScale, 0.005f, 0.3f, 2.0f,
+                             "%.2f");  // scale everything
+            ImGui::PopItemWidth();
+
+            ImGui::EndTabItem();
+        }
+
+        if (ImGui::BeginTabItem("Rendering"))
+        {
+            ImGui::Checkbox("Anti-aliased lines", &style.AntiAliasedLines);
+            ImGui::SameLine();
+            HelpMarker(
+                "When disabling anti-aliasing lines, you'll probably want to disable borders in "
+                "your style as well.");
+            ImGui::Checkbox("Anti-aliased fill", &style.AntiAliasedFill);
+            ImGui::PushItemWidth(100);
+            ImGui::DragFloat("Curve Tessellation Tolerance", &style.CurveTessellationTol, 0.02f,
+                             0.10f, FLT_MAX, "%.2f", 2.0f);
+            if (style.CurveTessellationTol < 0.10f)
+                style.CurveTessellationTol = 0.10f;
+            ImGui::DragFloat("Global Alpha", &style.Alpha, 0.005f, 0.20f, 1.0f,
+                             "%.2f");  // Not exposing zero here so user doesn't "lose" the UI (zero
+                                       // alpha clips all widgets). But application code could have
+                                       // a toggle to switch between zero and non-zero.
+            ImGui::PopItemWidth();
+
+            ImGui::EndTabItem();
+        }
+
+        ImGui::EndTabBar();
+    }
+
+    ImGui::PopItemWidth();
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Example App: Main Menu Bar / ShowExampleAppMainMenuBar()
+//-----------------------------------------------------------------------------
+
+// Demonstrate creating a "main" fullscreen menu bar and populating it.
+// Note the difference between BeginMainMenuBar() and BeginMenuBar():
+// - BeginMenuBar() = menu-bar inside current window we Begin()-ed into (the window needs the
+// ImGuiWindowFlags_MenuBar flag)
+// - BeginMainMenuBar() = helper to create menu-bar-sized window at the top of the main viewport +
+// call BeginMenuBar() into it.
+static void ShowExampleAppMainMenuBar()
+{
+    if (ImGui::BeginMainMenuBar())
+    {
+        if (ImGui::BeginMenu("File"))
+        {
+            ShowExampleMenuFile();
+            ImGui::EndMenu();
+        }
+        if (ImGui::BeginMenu("Edit"))
+        {
+            if (ImGui::MenuItem("Undo", "CTRL+Z"))
+            {
+            }
+            if (ImGui::MenuItem("Redo", "CTRL+Y", false, false))
+            {
+            }  // Disabled item
+            ImGui::Separator();
+            if (ImGui::MenuItem("Cut", "CTRL+X"))
+            {
+            }
+            if (ImGui::MenuItem("Copy", "CTRL+C"))
+            {
+            }
+            if (ImGui::MenuItem("Paste", "CTRL+V"))
+            {
+            }
+            ImGui::EndMenu();
+        }
+        ImGui::EndMainMenuBar();
+    }
+}
+
+// Note that shortcuts are currently provided for display only (future version will add flags to
+// BeginMenu to process shortcuts)
+static void ShowExampleMenuFile()
+{
+    ImGui::MenuItem("(dummy menu)", NULL, false, false);
+    if (ImGui::MenuItem("New"))
+    {
+    }
+    if (ImGui::MenuItem("Open", "Ctrl+O"))
+    {
+    }
+    if (ImGui::BeginMenu("Open Recent"))
+    {
+        ImGui::MenuItem("fish_hat.c");
+        ImGui::MenuItem("fish_hat.inl");
+        ImGui::MenuItem("fish_hat.h");
+        if (ImGui::BeginMenu("More.."))
+        {
+            ImGui::MenuItem("Hello");
+            ImGui::MenuItem("Sailor");
+            if (ImGui::BeginMenu("Recurse.."))
+            {
+                ShowExampleMenuFile();
+                ImGui::EndMenu();
+            }
+            ImGui::EndMenu();
+        }
+        ImGui::EndMenu();
+    }
+    if (ImGui::MenuItem("Save", "Ctrl+S"))
+    {
+    }
+    if (ImGui::MenuItem("Save As.."))
+    {
+    }
+    ImGui::Separator();
+    if (ImGui::BeginMenu("Options"))
+    {
+        static bool enabled = true;
+        ImGui::MenuItem("Enabled", "", &enabled);
+        ImGui::BeginChild("child", ImVec2(0, 60), true);
+        for (int i = 0; i < 10; i++)
+            ImGui::Text("Scrolling Text %d", i);
+        ImGui::EndChild();
+        static float f = 0.5f;
+        static int n   = 0;
+        static bool b  = true;
+        ImGui::SliderFloat("Value", &f, 0.0f, 1.0f);
+        ImGui::InputFloat("Input", &f, 0.1f);
+        ImGui::Combo("Combo", &n, "Yes\0No\0Maybe\0\0");
+        ImGui::Checkbox("Check", &b);
+        ImGui::EndMenu();
+    }
+    if (ImGui::BeginMenu("Colors"))
+    {
+        float sz = ImGui::GetTextLineHeight();
+        for (int i = 0; i < ImGuiCol_COUNT; i++)
+        {
+            const char *name = ImGui::GetStyleColorName((ImGuiCol)i);
+            ImVec2 p         = ImGui::GetCursorScreenPos();
+            ImGui::GetWindowDrawList()->AddRectFilled(p, ImVec2(p.x + sz, p.y + sz),
+                                                      ImGui::GetColorU32((ImGuiCol)i));
+            ImGui::Dummy(ImVec2(sz, sz));
+            ImGui::SameLine();
+            ImGui::MenuItem(name);
+        }
+        ImGui::EndMenu();
+    }
+    if (ImGui::BeginMenu("Disabled", false))  // Disabled
+    {
+        IM_ASSERT(0);
+    }
+    if (ImGui::MenuItem("Checked", NULL, true))
+    {
+    }
+    if (ImGui::MenuItem("Quit", "Alt+F4"))
+    {
+    }
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Example App: Debug Console / ShowExampleAppConsole()
+//-----------------------------------------------------------------------------
+
+// Demonstrate creating a simple console window, with scrolling, filtering, completion and history.
+// For the console example, here we are using a more C++ like approach of declaring a class to hold
+// the data and the functions.
+struct ExampleAppConsole
+{
+    char InputBuf[256];
+    ImVector<char *> Items;
+    ImVector<const char *> Commands;
+    ImVector<char *> History;
+    int HistoryPos;  // -1: new line, 0..History.Size-1 browsing history.
+    ImGuiTextFilter Filter;
+    bool AutoScroll;
+    bool ScrollToBottom;
+
+    ExampleAppConsole()
+    {
+        ClearLog();
+        memset(InputBuf, 0, sizeof(InputBuf));
+        HistoryPos = -1;
+        Commands.push_back("HELP");
+        Commands.push_back("HISTORY");
+        Commands.push_back("CLEAR");
+        Commands.push_back("CLASSIFY");  // "classify" is only here to provide an example of
+                                         // "C"+[tab] completing to "CL" and displaying matches.
+        AutoScroll     = true;
+        ScrollToBottom = true;
+        AddLog("Welcome to Dear ImGui!");
+    }
+    ~ExampleAppConsole()
+    {
+        ClearLog();
+        for (int i = 0; i < History.Size; i++)
+            free(History[i]);
+    }
+
+    // Portable helpers
+    static int Stricmp(const char *str1, const char *str2)
+    {
+        int d;
+        while ((d = toupper(*str2) - toupper(*str1)) == 0 && *str1)
+        {
+            str1++;
+            str2++;
+        }
+        return d;
+    }
+    static int Strnicmp(const char *str1, const char *str2, int n)
+    {
+        int d = 0;
+        while (n > 0 && (d = toupper(*str2) - toupper(*str1)) == 0 && *str1)
+        {
+            str1++;
+            str2++;
+            n--;
+        }
+        return d;
+    }
+    static char *Strdup(const char *str)
+    {
+        size_t len = strlen(str) + 1;
+        void *buf  = malloc(len);
+        IM_ASSERT(buf);
+        return (char *)memcpy(buf, (const void *)str, len);
+    }
+    static void Strtrim(char *str)
+    {
+        char *str_end = str + strlen(str);
+        while (str_end > str && str_end[-1] == ' ')
+            str_end--;
+        *str_end = 0;
+    }
+
+    void ClearLog()
+    {
+        for (int i = 0; i < Items.Size; i++)
+            free(Items[i]);
+        Items.clear();
+        ScrollToBottom = true;
+    }
+
+    void AddLog(const char *fmt, ...) IM_FMTARGS(2)
+    {
+        // FIXME-OPT
+        char buf[1024];
+        va_list args;
+        va_start(args, fmt);
+        vsnprintf(buf, IM_ARRAYSIZE(buf), fmt, args);
+        buf[IM_ARRAYSIZE(buf) - 1] = 0;
+        va_end(args);
+        Items.push_back(Strdup(buf));
+        if (AutoScroll)
+            ScrollToBottom = true;
+    }
+
+    void Draw(const char *title, bool *p_open)
+    {
+        ImGui::SetNextWindowSize(ImVec2(520, 600), ImGuiCond_FirstUseEver);
+        if (!ImGui::Begin(title, p_open))
+        {
+            ImGui::End();
+            return;
+        }
+
+        // As a specific feature guaranteed by the library, after calling Begin() the last Item
+        // represent the title bar. So e.g. IsItemHovered() will return true when hovering the title
+        // bar. Here we create a context menu only available from the title bar.
+        if (ImGui::BeginPopupContextItem())
+        {
+            if (ImGui::MenuItem("Close Console"))
+                *p_open = false;
+            ImGui::EndPopup();
+        }
+
+        ImGui::TextWrapped(
+            "This example implements a console with basic coloring, completion and history. A more "
+            "elaborate implementation may want to store entries along with extra data such as "
+            "timestamp, emitter, etc.");
+        ImGui::TextWrapped("Enter 'HELP' for help, press TAB to use text completion.");
+
+        // TODO: display items starting from the bottom
+
+        if (ImGui::SmallButton("Add Dummy Text"))
+        {
+            AddLog("%d some text", Items.Size);
+            AddLog("some more text");
+            AddLog("display very important message here!");
+        }
+        ImGui::SameLine();
+        if (ImGui::SmallButton("Add Dummy Error"))
+        {
+            AddLog("[error] something went wrong");
+        }
+        ImGui::SameLine();
+        if (ImGui::SmallButton("Clear"))
+        {
+            ClearLog();
+        }
+        ImGui::SameLine();
+        bool copy_to_clipboard = ImGui::SmallButton("Copy");
+        ImGui::SameLine();
+        if (ImGui::SmallButton("Scroll to bottom"))
+            ScrollToBottom = true;
+        // static float t = 0.0f; if (ImGui::GetTime() - t > 0.02f) { t = ImGui::GetTime();
+        // AddLog("Spam %f", t); }
+
+        ImGui::Separator();
+
+        // Options menu
+        if (ImGui::BeginPopup("Options"))
+        {
+            if (ImGui::Checkbox("Auto-scroll", &AutoScroll))
+                if (AutoScroll)
+                    ScrollToBottom = true;
+            ImGui::EndPopup();
+        }
+
+        // Options, Filter
+        if (ImGui::Button("Options"))
+            ImGui::OpenPopup("Options");
+        ImGui::SameLine();
+        Filter.Draw("Filter (\"incl,-excl\") (\"error\")", 180);
+        ImGui::Separator();
+
+        const float footer_height_to_reserve =
+            ImGui::GetStyle().ItemSpacing.y +
+            ImGui::GetFrameHeightWithSpacing();  // 1 separator, 1 input text
+        ImGui::BeginChild(
+            "ScrollingRegion", ImVec2(0, -footer_height_to_reserve), false,
+            ImGuiWindowFlags_HorizontalScrollbar);  // Leave room for 1 separator + 1 InputText
+        if (ImGui::BeginPopupContextWindow())
+        {
+            if (ImGui::Selectable("Clear"))
+                ClearLog();
+            ImGui::EndPopup();
+        }
+
+        // Display every line as a separate entry so we can change their color or add custom
+        // widgets. If you only want raw text you can use ImGui::TextUnformatted(log.begin(),
+        // log.end()); NB- if you have thousands of entries this approach may be too inefficient and
+        // may require user-side clipping to only process visible items. You can seek and display
+        // only the lines that are visible using the ImGuiListClipper helper, if your elements are
+        // evenly spaced and you have cheap random access to the elements. To use the clipper we
+        // could replace the 'for (int i = 0; i < Items.Size; i++)' loop with:
+        //     ImGuiListClipper clipper(Items.Size);
+        //     while (clipper.Step())
+        //         for (int i = clipper.DisplayStart; i < clipper.DisplayEnd; i++)
+        // However, note that you can not use this code as is if a filter is active because it
+        // breaks the 'cheap random-access' property. We would need random-access on the
+        // post-filtered list. A typical application wanting coarse clipping and filtering may want
+        // to pre-compute an array of indices that passed the filtering test, recomputing this array
+        // when user changes the filter, and appending newly elements as they are inserted. This is
+        // left as a task to the user until we can manage to improve this example code! If your
+        // items are of variable size you may want to implement code similar to what
+        // ImGuiListClipper does. Or split your data into fixed height items to allow random-seeking
+        // into your list.
+        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(4, 1));  // Tighten spacing
+        if (copy_to_clipboard)
+            ImGui::LogToClipboard();
+        for (int i = 0; i < Items.Size; i++)
+        {
+            const char *item = Items[i];
+            if (!Filter.PassFilter(item))
+                continue;
+
+            // Normally you would store more information in your item (e.g. make Items[] an array of
+            // structure, store color/type etc.)
+            bool pop_color = false;
+            if (strstr(item, "[error]"))
+            {
+                ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.4f, 0.4f, 1.0f));
+                pop_color = true;
+            }
+            else if (strncmp(item, "# ", 2) == 0)
+            {
+                ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.8f, 0.6f, 1.0f));
+                pop_color = true;
+            }
+            ImGui::TextUnformatted(item);
+            if (pop_color)
+                ImGui::PopStyleColor();
+        }
+        if (copy_to_clipboard)
+            ImGui::LogFinish();
+        if (ScrollToBottom)
+            ImGui::SetScrollHereY(1.0f);
+        ScrollToBottom = false;
+        ImGui::PopStyleVar();
+        ImGui::EndChild();
+        ImGui::Separator();
+
+        // Command-line
+        bool reclaim_focus = false;
+        if (ImGui::InputText("Input", InputBuf, IM_ARRAYSIZE(InputBuf),
+                             ImGuiInputTextFlags_EnterReturnsTrue |
+                                 ImGuiInputTextFlags_CallbackCompletion |
+                                 ImGuiInputTextFlags_CallbackHistory,
+                             &TextEditCallbackStub, (void *)this))
+        {
+            char *s = InputBuf;
+            Strtrim(s);
+            if (s[0])
+                ExecCommand(s);
+            strcpy(s, "");
+            reclaim_focus = true;
+        }
+
+        // Auto-focus on window apparition
+        ImGui::SetItemDefaultFocus();
+        if (reclaim_focus)
+            ImGui::SetKeyboardFocusHere(-1);  // Auto focus previous widget
+
+        ImGui::End();
+    }
+
+    void ExecCommand(const char *command_line)
+    {
+        AddLog("# %s\n", command_line);
+
+        // Insert into history. First find match and delete it so it can be pushed to the back. This
+        // isn't trying to be smart or optimal.
+        HistoryPos = -1;
+        for (int i = History.Size - 1; i >= 0; i--)
+            if (Stricmp(History[i], command_line) == 0)
+            {
+                free(History[i]);
+                History.erase(History.begin() + i);
+                break;
+            }
+        History.push_back(Strdup(command_line));
+
+        // Process command
+        if (Stricmp(command_line, "CLEAR") == 0)
+        {
+            ClearLog();
+        }
+        else if (Stricmp(command_line, "HELP") == 0)
+        {
+            AddLog("Commands:");
+            for (int i = 0; i < Commands.Size; i++)
+                AddLog("- %s", Commands[i]);
+        }
+        else if (Stricmp(command_line, "HISTORY") == 0)
+        {
+            int first = History.Size - 10;
+            for (int i = first > 0 ? first : 0; i < History.Size; i++)
+                AddLog("%3d: %s\n", i, History[i]);
+        }
+        else
+        {
+            AddLog("Unknown command: '%s'\n", command_line);
+        }
+
+        // On commad input, we scroll to bottom even if AutoScroll==false
+        ScrollToBottom = true;
+    }
+
+    static int TextEditCallbackStub(
+        ImGuiInputTextCallbackData *data)  // In C++11 you are better off using lambdas for this
+                                           // sort of forwarding callbacks
+    {
+        ExampleAppConsole *console = (ExampleAppConsole *)data->UserData;
+        return console->TextEditCallback(data);
+    }
+
+    int TextEditCallback(ImGuiInputTextCallbackData *data)
+    {
+        // AddLog("cursor: %d, selection: %d-%d", data->CursorPos, data->SelectionStart,
+        // data->SelectionEnd);
+        switch (data->EventFlag)
+        {
+            case ImGuiInputTextFlags_CallbackCompletion:
+            {
+                // Example of TEXT COMPLETION
+
+                // Locate beginning of current word
+                const char *word_end   = data->Buf + data->CursorPos;
+                const char *word_start = word_end;
+                while (word_start > data->Buf)
+                {
+                    const char c = word_start[-1];
+                    if (c == ' ' || c == '\t' || c == ',' || c == ';')
+                        break;
+                    word_start--;
+                }
+
+                // Build a list of candidates
+                ImVector<const char *> candidates;
+                for (int i = 0; i < Commands.Size; i++)
+                    if (Strnicmp(Commands[i], word_start, (int)(word_end - word_start)) == 0)
+                        candidates.push_back(Commands[i]);
+
+                if (candidates.Size == 0)
+                {
+                    // No match
+                    AddLog("No match for \"%.*s\"!\n", (int)(word_end - word_start), word_start);
+                }
+                else if (candidates.Size == 1)
+                {
+                    // Single match. Delete the beginning of the word and replace it entirely so
+                    // we've got nice casing
+                    data->DeleteChars((int)(word_start - data->Buf), (int)(word_end - word_start));
+                    data->InsertChars(data->CursorPos, candidates[0]);
+                    data->InsertChars(data->CursorPos, " ");
+                }
+                else
+                {
+                    // Multiple matches. Complete as much as we can, so inputing "C" will complete
+                    // to "CL" and display "CLEAR" and "CLASSIFY"
+                    int match_len = (int)(word_end - word_start);
+                    for (;;)
+                    {
+                        int c                       = 0;
+                        bool all_candidates_matches = true;
+                        for (int i = 0; i < candidates.Size && all_candidates_matches; i++)
+                            if (i == 0)
+                                c = toupper(candidates[i][match_len]);
+                            else if (c == 0 || c != toupper(candidates[i][match_len]))
+                                all_candidates_matches = false;
+                        if (!all_candidates_matches)
+                            break;
+                        match_len++;
+                    }
+
+                    if (match_len > 0)
+                    {
+                        data->DeleteChars((int)(word_start - data->Buf),
+                                          (int)(word_end - word_start));
+                        data->InsertChars(data->CursorPos, candidates[0],
+                                          candidates[0] + match_len);
+                    }
+
+                    // List matches
+                    AddLog("Possible matches:\n");
+                    for (int i = 0; i < candidates.Size; i++)
+                        AddLog("- %s\n", candidates[i]);
+                }
+
+                break;
+            }
+            case ImGuiInputTextFlags_CallbackHistory:
+            {
+                // Example of HISTORY
+                const int prev_history_pos = HistoryPos;
+                if (data->EventKey == ImGuiKey_UpArrow)
+                {
+                    if (HistoryPos == -1)
+                        HistoryPos = History.Size - 1;
+                    else if (HistoryPos > 0)
+                        HistoryPos--;
+                }
+                else if (data->EventKey == ImGuiKey_DownArrow)
+                {
+                    if (HistoryPos != -1)
+                        if (++HistoryPos >= History.Size)
+                            HistoryPos = -1;
+                }
+
+                // A better implementation would preserve the data on the current input line along
+                // with cursor position.
+                if (prev_history_pos != HistoryPos)
+                {
+                    const char *history_str = (HistoryPos >= 0) ? History[HistoryPos] : "";
+                    data->DeleteChars(0, data->BufTextLen);
+                    data->InsertChars(0, history_str);
+                }
+            }
+        }
+        return 0;
+    }
+};
+
+static void ShowExampleAppConsole(bool *p_open)
+{
+    static ExampleAppConsole console;
+    console.Draw("Example: Console", p_open);
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Example App: Debug Log / ShowExampleAppLog()
+//-----------------------------------------------------------------------------
+
+// Usage:
+//  static ExampleAppLog my_log;
+//  my_log.AddLog("Hello %d world\n", 123);
+//  my_log.Draw("title");
+struct ExampleAppLog
+{
+    ImGuiTextBuffer Buf;
+    ImGuiTextFilter Filter;
+    ImVector<int> LineOffsets;  // Index to lines offset. We maintain this with AddLog() calls,
+                                // allowing us to have a random access on lines
+    bool AutoScroll;
+    bool ScrollToBottom;
+
+    ExampleAppLog()
+    {
+        AutoScroll     = true;
+        ScrollToBottom = false;
+        Clear();
+    }
+
+    void Clear()
+    {
+        Buf.clear();
+        LineOffsets.clear();
+        LineOffsets.push_back(0);
+    }
+
+    void AddLog(const char *fmt, ...) IM_FMTARGS(2)
+    {
+        int old_size = Buf.size();
+        va_list args;
+        va_start(args, fmt);
+        Buf.appendfv(fmt, args);
+        va_end(args);
+        for (int new_size = Buf.size(); old_size < new_size; old_size++)
+            if (Buf[old_size] == '\n')
+                LineOffsets.push_back(old_size + 1);
+        if (AutoScroll)
+            ScrollToBottom = true;
+    }
+
+    void Draw(const char *title, bool *p_open = NULL)
+    {
+        if (!ImGui::Begin(title, p_open))
+        {
+            ImGui::End();
+            return;
+        }
+
+        // Options menu
+        if (ImGui::BeginPopup("Options"))
+        {
+            if (ImGui::Checkbox("Auto-scroll", &AutoScroll))
+                if (AutoScroll)
+                    ScrollToBottom = true;
+            ImGui::EndPopup();
+        }
+
+        // Main window
+        if (ImGui::Button("Options"))
+            ImGui::OpenPopup("Options");
+        ImGui::SameLine();
+        bool clear = ImGui::Button("Clear");
+        ImGui::SameLine();
+        bool copy = ImGui::Button("Copy");
+        ImGui::SameLine();
+        Filter.Draw("Filter", -100.0f);
+
+        ImGui::Separator();
+        ImGui::BeginChild("scrolling", ImVec2(0, 0), false, ImGuiWindowFlags_HorizontalScrollbar);
+
+        if (clear)
+            Clear();
+        if (copy)
+            ImGui::LogToClipboard();
+
+        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
+        const char *buf     = Buf.begin();
+        const char *buf_end = Buf.end();
+        if (Filter.IsActive())
+        {
+            // In this example we don't use the clipper when Filter is enabled.
+            // This is because we don't have a random access on the result on our filter.
+            // A real application processing logs with ten of thousands of entries may want to store
+            // the result of search/filter. especially if the filtering function is not trivial
+            // (e.g. reg-exp).
+            for (int line_no = 0; line_no < LineOffsets.Size; line_no++)
+            {
+                const char *line_start = buf + LineOffsets[line_no];
+                const char *line_end   = (line_no + 1 < LineOffsets.Size)
+                                           ? (buf + LineOffsets[line_no + 1] - 1)
+                                           : buf_end;
+                if (Filter.PassFilter(line_start, line_end))
+                    ImGui::TextUnformatted(line_start, line_end);
+            }
+        }
+        else
+        {
+            // The simplest and easy way to display the entire buffer:
+            //   ImGui::TextUnformatted(buf_begin, buf_end);
+            // And it'll just work. TextUnformatted() has specialization for large blob of text and
+            // will fast-forward to skip non-visible lines. Here we instead demonstrate using the
+            // clipper to only process lines that are within the visible area. If you have tens of
+            // thousands of items and their processing cost is non-negligible, coarse clipping them
+            // on your side is recommended. Using ImGuiListClipper requires A) random access into
+            // your data, and B) items all being the  same height, both of which we can handle since
+            // we an array pointing to the beginning of each line of text. When using the filter (in
+            // the block of code above) we don't have random access into the data to display
+            // anymore, which is why we don't use the clipper. Storing or skimming through the
+            // search result would make it possible (and would be recommended if you want to search
+            // through tens of thousands of entries)
+            ImGuiListClipper clipper;
+            clipper.Begin(LineOffsets.Size);
+            while (clipper.Step())
+            {
+                for (int line_no = clipper.DisplayStart; line_no < clipper.DisplayEnd; line_no++)
+                {
+                    const char *line_start = buf + LineOffsets[line_no];
+                    const char *line_end   = (line_no + 1 < LineOffsets.Size)
+                                               ? (buf + LineOffsets[line_no + 1] - 1)
+                                               : buf_end;
+                    ImGui::TextUnformatted(line_start, line_end);
+                }
+            }
+            clipper.End();
+        }
+        ImGui::PopStyleVar();
+
+        if (ScrollToBottom)
+            ImGui::SetScrollHereY(1.0f);
+        ScrollToBottom = false;
+        ImGui::EndChild();
+        ImGui::End();
+    }
+};
+
+// Demonstrate creating a simple log window with basic filtering.
+static void ShowExampleAppLog(bool *p_open)
+{
+    static ExampleAppLog log;
+
+    // For the demo: add a debug button _BEFORE_ the normal log window contents
+    // We take advantage of a rarely used feature: multiple calls to Begin()/End() are appending to
+    // the _same_ window. Most of the contents of the window will be added by the log.Draw() call.
+    ImGui::SetNextWindowSize(ImVec2(500, 400), ImGuiCond_FirstUseEver);
+    ImGui::Begin("Example: Log", p_open);
+    if (ImGui::SmallButton("[Debug] Add 5 entries"))
+    {
+        static int counter = 0;
+        for (int n = 0; n < 5; n++)
+        {
+            const char *categories[3] = {"info", "warn", "error"};
+            const char *words[] = {"Bumfuzzled",   "Cattywampus", "Snickersnee", "Abibliophobia",
+                                   "Absquatulate", "Nincompoop",  "Pauciloquent"};
+            log.AddLog("[%05d] [%s] Hello, current time is %.1f, here's a word: '%s'\n",
+                       ImGui::GetFrameCount(), categories[counter % IM_ARRAYSIZE(categories)],
+                       ImGui::GetTime(), words[counter % IM_ARRAYSIZE(words)]);
+            counter++;
+        }
+    }
+    ImGui::End();
+
+    // Actually call in the regular Log helper (which will Begin() into the same window as we just
+    // did)
+    log.Draw("Example: Log", p_open);
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Example App: Simple Layout / ShowExampleAppLayout()
+//-----------------------------------------------------------------------------
+
+// Demonstrate create a window with multiple child windows.
+static void ShowExampleAppLayout(bool *p_open)
+{
+    ImGui::SetNextWindowSize(ImVec2(500, 440), ImGuiCond_FirstUseEver);
+    if (ImGui::Begin("Example: Simple layout", p_open, ImGuiWindowFlags_MenuBar))
+    {
+        if (ImGui::BeginMenuBar())
+        {
+            if (ImGui::BeginMenu("File"))
+            {
+                if (ImGui::MenuItem("Close"))
+                    *p_open = false;
+                ImGui::EndMenu();
+            }
+            ImGui::EndMenuBar();
+        }
+
+        // left
+        static int selected = 0;
+        ImGui::BeginChild("left pane", ImVec2(150, 0), true);
+        for (int i = 0; i < 100; i++)
+        {
+            char label[128];
+            sprintf(label, "MyObject %d", i);
+            if (ImGui::Selectable(label, selected == i))
+                selected = i;
+        }
+        ImGui::EndChild();
+        ImGui::SameLine();
+
+        // right
+        ImGui::BeginGroup();
+        ImGui::BeginChild(
+            "item view",
+            ImVec2(0, -ImGui::GetFrameHeightWithSpacing()));  // Leave room for 1 line below us
+        ImGui::Text("MyObject: %d", selected);
+        ImGui::Separator();
+        if (ImGui::BeginTabBar("##Tabs", ImGuiTabBarFlags_None))
+        {
+            if (ImGui::BeginTabItem("Description"))
+            {
+                ImGui::TextWrapped(
+                    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod "
+                    "tempor incididunt ut labore et dolore magna aliqua. ");
+                ImGui::EndTabItem();
+            }
+            if (ImGui::BeginTabItem("Details"))
+            {
+                ImGui::Text("ID: 0123456789");
+                ImGui::EndTabItem();
+            }
+            ImGui::EndTabBar();
+        }
+        ImGui::EndChild();
+        if (ImGui::Button("Revert"))
+        {
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Save"))
+        {
+        }
+        ImGui::EndGroup();
+    }
+    ImGui::End();
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Example App: Property Editor / ShowExampleAppPropertyEditor()
+//-----------------------------------------------------------------------------
+
+// Demonstrate create a simple property editor.
+static void ShowExampleAppPropertyEditor(bool *p_open)
+{
+    ImGui::SetNextWindowSize(ImVec2(430, 450), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin("Example: Property editor", p_open))
+    {
+        ImGui::End();
+        return;
+    }
+
+    HelpMarker(
+        "This example shows how you may implement a property editor using two columns.\nAll "
+        "objects/fields data are dummies here.\nRemember that in many simple cases, you can use "
+        "ImGui::SameLine(xxx) to position\nyour cursor horizontally instead of using the Columns() "
+        "API.");
+
+    ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(2, 2));
+    ImGui::Columns(2);
+    ImGui::Separator();
+
+    struct funcs
+    {
+        static void ShowDummyObject(const char *prefix, int uid)
+        {
+            ImGui::PushID(uid);  // Use object uid as identifier. Most commonly you could also use
+                                 // the object pointer as a base ID.
+            ImGui::AlignTextToFramePadding();  // Text and Tree nodes are less high than regular
+                                               // widgets, here we add vertical spacing to make the
+                                               // tree lines equal high.
+            bool node_open = ImGui::TreeNode("Object", "%s_%u", prefix, uid);
+            ImGui::NextColumn();
+            ImGui::AlignTextToFramePadding();
+            ImGui::Text("my sailor is rich");
+            ImGui::NextColumn();
+            if (node_open)
+            {
+                static float dummy_members[8] = {0.0f, 0.0f, 1.0f, 3.1416f, 100.0f, 999.0f};
+                for (int i = 0; i < 8; i++)
+                {
+                    ImGui::PushID(i);  // Use field index as identifier.
+                    if (i < 2)
+                    {
+                        ShowDummyObject("Child", 424242);
+                    }
+                    else
+                    {
+                        // Here we use a TreeNode to highlight on hover (we could use e.g.
+                        // Selectable as well)
+                        ImGui::AlignTextToFramePadding();
+                        ImGui::TreeNodeEx("Field",
+                                          ImGuiTreeNodeFlags_Leaf |
+                                              ImGuiTreeNodeFlags_NoTreePushOnOpen |
+                                              ImGuiTreeNodeFlags_Bullet,
+                                          "Field_%d", i);
+                        ImGui::NextColumn();
+                        ImGui::SetNextItemWidth(-1);
+                        if (i >= 5)
+                            ImGui::InputFloat("##value", &dummy_members[i], 1.0f);
+                        else
+                            ImGui::DragFloat("##value", &dummy_members[i], 0.01f);
+                        ImGui::NextColumn();
+                    }
+                    ImGui::PopID();
+                }
+                ImGui::TreePop();
+            }
+            ImGui::PopID();
+        }
+    };
+
+    // Iterate dummy objects with dummy members (all the same data)
+    for (int obj_i = 0; obj_i < 3; obj_i++)
+        funcs::ShowDummyObject("Object", obj_i);
+
+    ImGui::Columns(1);
+    ImGui::Separator();
+    ImGui::PopStyleVar();
+    ImGui::End();
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Example App: Long Text / ShowExampleAppLongText()
+//-----------------------------------------------------------------------------
+
+// Demonstrate/test rendering huge amount of text, and the incidence of clipping.
+static void ShowExampleAppLongText(bool *p_open)
+{
+    ImGui::SetNextWindowSize(ImVec2(520, 600), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin("Example: Long text display", p_open))
+    {
+        ImGui::End();
+        return;
+    }
+
+    static int test_type = 0;
+    static ImGuiTextBuffer log;
+    static int lines = 0;
+    ImGui::Text("Printing unusually long amount of text.");
+    ImGui::Combo("Test type", &test_type,
+                 "Single call to TextUnformatted()\0Multiple calls to Text(), clipped\0Multiple "
+                 "calls to Text(), not clipped (slow)\0");
+    ImGui::Text("Buffer contents: %d lines, %d bytes", lines, log.size());
+    if (ImGui::Button("Clear"))
+    {
+        log.clear();
+        lines = 0;
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Add 1000 lines"))
+    {
+        for (int i = 0; i < 1000; i++)
+            log.appendf("%i The quick brown fox jumps over the lazy dog\n", lines + i);
+        lines += 1000;
+    }
+    ImGui::BeginChild("Log");
+    switch (test_type)
+    {
+        case 0:
+            // Single call to TextUnformatted() with a big buffer
+            ImGui::TextUnformatted(log.begin(), log.end());
+            break;
+        case 1:
+        {
+            // Multiple calls to Text(), manually coarsely clipped - demonstrate how to use the
+            // ImGuiListClipper helper.
+            ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
+            ImGuiListClipper clipper(lines);
+            while (clipper.Step())
+                for (int i = clipper.DisplayStart; i < clipper.DisplayEnd; i++)
+                    ImGui::Text("%i The quick brown fox jumps over the lazy dog", i);
+            ImGui::PopStyleVar();
+            break;
+        }
+        case 2:
+            // Multiple calls to Text(), not clipped (slow)
+            ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
+            for (int i = 0; i < lines; i++)
+                ImGui::Text("%i The quick brown fox jumps over the lazy dog", i);
+            ImGui::PopStyleVar();
+            break;
+    }
+    ImGui::EndChild();
+    ImGui::End();
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Example App: Auto Resize / ShowExampleAppAutoResize()
+//-----------------------------------------------------------------------------
+
+// Demonstrate creating a window which gets auto-resized according to its content.
+static void ShowExampleAppAutoResize(bool *p_open)
+{
+    if (!ImGui::Begin("Example: Auto-resizing window", p_open, ImGuiWindowFlags_AlwaysAutoResize))
+    {
+        ImGui::End();
+        return;
+    }
+
+    static int lines = 10;
+    ImGui::Text(
+        "Window will resize every-frame to the size of its content.\nNote that you probably don't "
+        "want to query the window size to\noutput your content because that would create a "
+        "feedback loop.");
+    ImGui::SliderInt("Number of lines", &lines, 1, 20);
+    for (int i = 0; i < lines; i++)
+        ImGui::Text("%*sThis is line %d", i * 4, "",
+                    i);  // Pad with space to extend size horizontally
+    ImGui::End();
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Example App: Constrained Resize / ShowExampleAppConstrainedResize()
+//-----------------------------------------------------------------------------
+
+// Demonstrate creating a window with custom resize constraints.
+static void ShowExampleAppConstrainedResize(bool *p_open)
+{
+    struct CustomConstraints  // Helper functions to demonstrate programmatic constraints
+    {
+        static void Square(ImGuiSizeCallbackData *data)
+        {
+            data->DesiredSize = ImVec2(IM_MAX(data->DesiredSize.x, data->DesiredSize.y),
+                                       IM_MAX(data->DesiredSize.x, data->DesiredSize.y));
+        }
+        static void Step(ImGuiSizeCallbackData *data)
+        {
+            float step        = (float)(int)(intptr_t)data->UserData;
+            data->DesiredSize = ImVec2((int)(data->DesiredSize.x / step + 0.5f) * step,
+                                       (int)(data->DesiredSize.y / step + 0.5f) * step);
+        }
+    };
+
+    static bool auto_resize  = false;
+    static int type          = 0;
+    static int display_lines = 10;
+    if (type == 0)
+        ImGui::SetNextWindowSizeConstraints(ImVec2(-1, 0), ImVec2(-1, FLT_MAX));  // Vertical only
+    if (type == 1)
+        ImGui::SetNextWindowSizeConstraints(ImVec2(0, -1), ImVec2(FLT_MAX, -1));  // Horizontal only
+    if (type == 2)
+        ImGui::SetNextWindowSizeConstraints(ImVec2(100, 100),
+                                            ImVec2(FLT_MAX, FLT_MAX));  // Width > 100, Height > 100
+    if (type == 3)
+        ImGui::SetNextWindowSizeConstraints(ImVec2(400, -1), ImVec2(500, -1));  // Width 400-500
+    if (type == 4)
+        ImGui::SetNextWindowSizeConstraints(ImVec2(-1, 400), ImVec2(-1, 500));  // Height 400-500
+    if (type == 5)
+        ImGui::SetNextWindowSizeConstraints(ImVec2(0, 0), ImVec2(FLT_MAX, FLT_MAX),
+                                            CustomConstraints::Square);  // Always Square
+    if (type == 6)
+        ImGui::SetNextWindowSizeConstraints(ImVec2(0, 0), ImVec2(FLT_MAX, FLT_MAX),
+                                            CustomConstraints::Step,
+                                            (void *)(intptr_t)100);  // Fixed Step
+
+    ImGuiWindowFlags flags = auto_resize ? ImGuiWindowFlags_AlwaysAutoResize : 0;
+    if (ImGui::Begin("Example: Constrained Resize", p_open, flags))
+    {
+        const char *desc[] = {
+            "Resize vertical only",
+            "Resize horizontal only",
+            "Width > 100, Height > 100",
+            "Width 400-500",
+            "Height 400-500",
+            "Custom: Always Square",
+            "Custom: Fixed Steps (100)",
+        };
+        if (ImGui::Button("200x200"))
+        {
+            ImGui::SetWindowSize(ImVec2(200, 200));
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("500x500"))
+        {
+            ImGui::SetWindowSize(ImVec2(500, 500));
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("800x200"))
+        {
+            ImGui::SetWindowSize(ImVec2(800, 200));
+        }
+        ImGui::SetNextItemWidth(200);
+        ImGui::Combo("Constraint", &type, desc, IM_ARRAYSIZE(desc));
+        ImGui::SetNextItemWidth(200);
+        ImGui::DragInt("Lines", &display_lines, 0.2f, 1, 100);
+        ImGui::Checkbox("Auto-resize", &auto_resize);
+        for (int i = 0; i < display_lines; i++)
+            ImGui::Text("%*sHello, sailor! Making this line long enough for the example.", i * 4,
+                        "");
+    }
+    ImGui::End();
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Example App: Simple Overlay / ShowExampleAppSimpleOverlay()
+//-----------------------------------------------------------------------------
+
+// Demonstrate creating a simple static window with no decoration + a context-menu to choose which
+// corner of the screen to use.
+static void ShowExampleAppSimpleOverlay(bool *p_open)
+{
+    const float DISTANCE = 10.0f;
+    static int corner    = 0;
+    ImGuiIO &io          = ImGui::GetIO();
+    if (corner != -1)
+    {
+        ImVec2 window_pos       = ImVec2((corner & 1) ? io.DisplaySize.x - DISTANCE : DISTANCE,
+                                   (corner & 2) ? io.DisplaySize.y - DISTANCE : DISTANCE);
+        ImVec2 window_pos_pivot = ImVec2((corner & 1) ? 1.0f : 0.0f, (corner & 2) ? 1.0f : 0.0f);
+        ImGui::SetNextWindowPos(window_pos, ImGuiCond_Always, window_pos_pivot);
+    }
+    ImGui::SetNextWindowBgAlpha(0.35f);  // Transparent background
+    if (ImGui::Begin("Example: Simple overlay", p_open,
+                     (corner != -1 ? ImGuiWindowFlags_NoMove : 0) | ImGuiWindowFlags_NoDecoration |
+                         ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings |
+                         ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav))
+    {
+        ImGui::Text(
+            "Simple overlay\n"
+            "in the corner of the screen.\n"
+            "(right-click to change position)");
+        ImGui::Separator();
+        if (ImGui::IsMousePosValid())
+            ImGui::Text("Mouse Position: (%.1f,%.1f)", io.MousePos.x, io.MousePos.y);
+        else
+            ImGui::Text("Mouse Position: <invalid>");
+        if (ImGui::BeginPopupContextWindow())
+        {
+            if (ImGui::MenuItem("Custom", NULL, corner == -1))
+                corner = -1;
+            if (ImGui::MenuItem("Top-left", NULL, corner == 0))
+                corner = 0;
+            if (ImGui::MenuItem("Top-right", NULL, corner == 1))
+                corner = 1;
+            if (ImGui::MenuItem("Bottom-left", NULL, corner == 2))
+                corner = 2;
+            if (ImGui::MenuItem("Bottom-right", NULL, corner == 3))
+                corner = 3;
+            if (p_open && ImGui::MenuItem("Close"))
+                *p_open = false;
+            ImGui::EndPopup();
+        }
+    }
+    ImGui::End();
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Example App: Manipulating Window Titles / ShowExampleAppWindowTitles()
+//-----------------------------------------------------------------------------
+
+// Demonstrate using "##" and "###" in identifiers to manipulate ID generation.
+// This apply to all regular items as well. Read FAQ section "How can I have multiple widgets with
+// the same label? Can I have widget without a label? (Yes). A primer on the purpose of labels/IDs."
+// for details.
+static void ShowExampleAppWindowTitles(bool *)
+{
+    // By default, Windows are uniquely identified by their title.
+    // You can use the "##" and "###" markers to manipulate the display/ID.
+
+    // Using "##" to display same title but have unique identifier.
+    ImGui::SetNextWindowPos(ImVec2(100, 100), ImGuiCond_FirstUseEver);
+    ImGui::Begin("Same title as another window##1");
+    ImGui::Text(
+        "This is window 1.\nMy title is the same as window 2, but my identifier is unique.");
+    ImGui::End();
+
+    ImGui::SetNextWindowPos(ImVec2(100, 200), ImGuiCond_FirstUseEver);
+    ImGui::Begin("Same title as another window##2");
+    ImGui::Text(
+        "This is window 2.\nMy title is the same as window 1, but my identifier is unique.");
+    ImGui::End();
+
+    // Using "###" to display a changing title but keep a static identifier "AnimatedTitle"
+    char buf[128];
+    sprintf(buf, "Animated title %c %d###AnimatedTitle",
+            "|/-\\"[(int)(ImGui::GetTime() / 0.25f) & 3], ImGui::GetFrameCount());
+    ImGui::SetNextWindowPos(ImVec2(100, 300), ImGuiCond_FirstUseEver);
+    ImGui::Begin(buf);
+    ImGui::Text("This window has a changing title.");
+    ImGui::End();
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Example App: Custom Rendering using ImDrawList API / ShowExampleAppCustomRendering()
+//-----------------------------------------------------------------------------
+
+// Demonstrate using the low-level ImDrawList to draw custom shapes.
+static void ShowExampleAppCustomRendering(bool *p_open)
+{
+    ImGui::SetNextWindowSize(ImVec2(350, 560), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin("Example: Custom rendering", p_open))
+    {
+        ImGui::End();
+        return;
+    }
+
+    // Tip: If you do a lot of custom rendering, you probably want to use your own geometrical types
+    // and benefit of overloaded operators, etc. Define IM_VEC2_CLASS_EXTRA in imconfig.h to create
+    // implicit conversions between your types and ImVec2/ImVec4. ImGui defines overloaded operators
+    // but they are internal to imgui.cpp and not exposed outside (to avoid messing with your types)
+    // In this example we are not using the maths operators!
+    ImDrawList *draw_list = ImGui::GetWindowDrawList();
+
+    if (ImGui::BeginTabBar("##TabBar"))
+    {
+        // Primitives
+        if (ImGui::BeginTabItem("Primitives"))
+        {
+            static float sz        = 36.0f;
+            static float thickness = 3.0f;
+            static ImVec4 colf     = ImVec4(1.0f, 1.0f, 0.4f, 1.0f);
+            ImGui::DragFloat("Size", &sz, 0.2f, 2.0f, 72.0f, "%.0f");
+            ImGui::DragFloat("Thickness", &thickness, 0.05f, 1.0f, 8.0f, "%.02f");
+            ImGui::ColorEdit4("Color", &colf.x);
+            const ImVec2 p  = ImGui::GetCursorScreenPos();
+            const ImU32 col = ImColor(colf);
+            float x = p.x + 4.0f, y = p.y + 4.0f;
+            float spacing                  = 10.0f;
+            ImDrawCornerFlags corners_none = 0;
+            ImDrawCornerFlags corners_all  = ImDrawCornerFlags_All;
+            ImDrawCornerFlags corners_tl_br =
+                ImDrawCornerFlags_TopLeft | ImDrawCornerFlags_BotRight;
+            for (int n = 0; n < 2; n++)
+            {
+                // First line uses a thickness of 1.0f, second line uses the configurable thickness
+                float th = (n == 0) ? 1.0f : thickness;
+                draw_list->AddCircle(ImVec2(x + sz * 0.5f, y + sz * 0.5f), sz * 0.5f, col, 6, th);
+                x += sz + spacing;  // Hexagon
+                draw_list->AddCircle(ImVec2(x + sz * 0.5f, y + sz * 0.5f), sz * 0.5f, col, 20, th);
+                x += sz + spacing;  // Circle
+                draw_list->AddRect(ImVec2(x, y), ImVec2(x + sz, y + sz), col, 0.0f, corners_none,
+                                   th);
+                x += sz + spacing;  // Square
+                draw_list->AddRect(ImVec2(x, y), ImVec2(x + sz, y + sz), col, 10.0f, corners_all,
+                                   th);
+                x += sz + spacing;  // Square with all rounded corners
+                draw_list->AddRect(ImVec2(x, y), ImVec2(x + sz, y + sz), col, 10.0f, corners_tl_br,
+                                   th);
+                x += sz + spacing;  // Square with two rounded corners
+                draw_list->AddTriangle(ImVec2(x + sz * 0.5f, y), ImVec2(x + sz, y + sz - 0.5f),
+                                       ImVec2(x, y + sz - 0.5f), col, th);
+                x += sz + spacing;  // Triangle
+                draw_list->AddTriangle(ImVec2(x + sz * 0.2f, y), ImVec2(x, y + sz - 0.5f),
+                                       ImVec2(x + sz * 0.4f, y + sz - 0.5f), col, th);
+                x += sz * 0.4f + spacing;  // Thin triangle
+                draw_list->AddLine(ImVec2(x, y), ImVec2(x + sz, y), col, th);
+                x += sz +
+                     spacing;  // Horizontal line (note: drawing a filled rectangle will be faster!)
+                draw_list->AddLine(ImVec2(x, y), ImVec2(x, y + sz), col, th);
+                x += spacing;  // Vertical line (note: drawing a filled rectangle will be faster!)
+                draw_list->AddLine(ImVec2(x, y), ImVec2(x + sz, y + sz), col, th);
+                x += sz + spacing;  // Diagonal line
+                draw_list->AddBezierCurve(ImVec2(x, y), ImVec2(x + sz * 1.3f, y + sz * 0.3f),
+                                          ImVec2(x + sz - sz * 1.3f, y + sz - sz * 0.3f),
+                                          ImVec2(x + sz, y + sz), col, th);
+                x = p.x + 4;
+                y += sz + spacing;
+            }
+            draw_list->AddCircleFilled(ImVec2(x + sz * 0.5f, y + sz * 0.5f), sz * 0.5f, col, 6);
+            x += sz + spacing;  // Hexagon
+            draw_list->AddCircleFilled(ImVec2(x + sz * 0.5f, y + sz * 0.5f), sz * 0.5f, col, 32);
+            x += sz + spacing;  // Circle
+            draw_list->AddRectFilled(ImVec2(x, y), ImVec2(x + sz, y + sz), col);
+            x += sz + spacing;  // Square
+            draw_list->AddRectFilled(ImVec2(x, y), ImVec2(x + sz, y + sz), col, 10.0f);
+            x += sz + spacing;  // Square with all rounded corners
+            draw_list->AddRectFilled(ImVec2(x, y), ImVec2(x + sz, y + sz), col, 10.0f,
+                                     corners_tl_br);
+            x += sz + spacing;  // Square with two rounded corners
+            draw_list->AddTriangleFilled(ImVec2(x + sz * 0.5f, y), ImVec2(x + sz, y + sz - 0.5f),
+                                         ImVec2(x, y + sz - 0.5f), col);
+            x += sz + spacing;  // Triangle
+            draw_list->AddTriangleFilled(ImVec2(x + sz * 0.2f, y), ImVec2(x, y + sz - 0.5f),
+                                         ImVec2(x + sz * 0.4f, y + sz - 0.5f), col);
+            x += sz * 0.4f + spacing;  // Thin triangle
+            draw_list->AddRectFilled(ImVec2(x, y), ImVec2(x + sz, y + thickness), col);
+            x += sz + spacing;  // Horizontal line (faster than AddLine, but only handle integer
+                                // thickness)
+            draw_list->AddRectFilled(ImVec2(x, y), ImVec2(x + thickness, y + sz), col);
+            x += spacing *
+                 2.0f;  // Vertical line (faster than AddLine, but only handle integer thickness)
+            draw_list->AddRectFilled(ImVec2(x, y), ImVec2(x + 1, y + 1), col);
+            x += sz;  // Pixel (faster than AddLine)
+            draw_list->AddRectFilledMultiColor(
+                ImVec2(x, y), ImVec2(x + sz, y + sz), IM_COL32(0, 0, 0, 255),
+                IM_COL32(255, 0, 0, 255), IM_COL32(255, 255, 0, 255), IM_COL32(0, 255, 0, 255));
+            ImGui::Dummy(ImVec2((sz + spacing) * 9.8f, (sz + spacing) * 3));
+            ImGui::EndTabItem();
+        }
+
+        if (ImGui::BeginTabItem("Canvas"))
+        {
+            static ImVector<ImVec2> points;
+            static bool adding_line = false;
+            if (ImGui::Button("Clear"))
+                points.clear();
+            if (points.Size >= 2)
+            {
+                ImGui::SameLine();
+                if (ImGui::Button("Undo"))
+                {
+                    points.pop_back();
+                    points.pop_back();
+                }
+            }
+            ImGui::Text("Left-click and drag to add lines,\nRight-click to undo");
+
+            // Here we are using InvisibleButton() as a convenience to 1) advance the cursor and 2)
+            // allows us to use IsItemHovered() But you can also draw directly and poll
+            // mouse/keyboard by yourself. You can manipulate the cursor using GetCursorPos() and
+            // SetCursorPos(). If you only use the ImDrawList API, you can notify the owner window
+            // of its extends by using SetCursorPos(max).
+            ImVec2 canvas_pos =
+                ImGui::GetCursorScreenPos();  // ImDrawList API uses screen coordinates!
+            ImVec2 canvas_size =
+                ImGui::GetContentRegionAvail();  // Resize canvas to what's available
+            if (canvas_size.x < 50.0f)
+                canvas_size.x = 50.0f;
+            if (canvas_size.y < 50.0f)
+                canvas_size.y = 50.0f;
+            draw_list->AddRectFilledMultiColor(
+                canvas_pos, ImVec2(canvas_pos.x + canvas_size.x, canvas_pos.y + canvas_size.y),
+                IM_COL32(50, 50, 50, 255), IM_COL32(50, 50, 60, 255), IM_COL32(60, 60, 70, 255),
+                IM_COL32(50, 50, 60, 255));
+            draw_list->AddRect(canvas_pos,
+                               ImVec2(canvas_pos.x + canvas_size.x, canvas_pos.y + canvas_size.y),
+                               IM_COL32(255, 255, 255, 255));
+
+            bool adding_preview = false;
+            ImGui::InvisibleButton("canvas", canvas_size);
+            ImVec2 mouse_pos_in_canvas = ImVec2(ImGui::GetIO().MousePos.x - canvas_pos.x,
+                                                ImGui::GetIO().MousePos.y - canvas_pos.y);
+            if (adding_line)
+            {
+                adding_preview = true;
+                points.push_back(mouse_pos_in_canvas);
+                if (!ImGui::IsMouseDown(0))
+                    adding_line = adding_preview = false;
+            }
+            if (ImGui::IsItemHovered())
+            {
+                if (!adding_line && ImGui::IsMouseClicked(0))
+                {
+                    points.push_back(mouse_pos_in_canvas);
+                    adding_line = true;
+                }
+                if (ImGui::IsMouseClicked(1) && !points.empty())
+                {
+                    adding_line = adding_preview = false;
+                    points.pop_back();
+                    points.pop_back();
+                }
+            }
+            draw_list->PushClipRect(
+                canvas_pos, ImVec2(canvas_pos.x + canvas_size.x, canvas_pos.y + canvas_size.y),
+                true);  // clip lines within the canvas (if we resize it, etc.)
+            for (int i = 0; i < points.Size - 1; i += 2)
+                draw_list->AddLine(
+                    ImVec2(canvas_pos.x + points[i].x, canvas_pos.y + points[i].y),
+                    ImVec2(canvas_pos.x + points[i + 1].x, canvas_pos.y + points[i + 1].y),
+                    IM_COL32(255, 255, 0, 255), 2.0f);
+            draw_list->PopClipRect();
+            if (adding_preview)
+                points.pop_back();
+            ImGui::EndTabItem();
+        }
+
+        if (ImGui::BeginTabItem("BG/FG draw lists"))
+        {
+            static bool draw_bg = true;
+            static bool draw_fg = true;
+            ImGui::Checkbox("Draw in Background draw list", &draw_bg);
+            ImGui::Checkbox("Draw in Foreground draw list", &draw_fg);
+            ImVec2 window_pos  = ImGui::GetWindowPos();
+            ImVec2 window_size = ImGui::GetWindowSize();
+            ImVec2 window_center =
+                ImVec2(window_pos.x + window_size.x * 0.5f, window_pos.y + window_size.y * 0.5f);
+            if (draw_bg)
+                ImGui::GetBackgroundDrawList()->AddCircle(window_center, window_size.x * 0.6f,
+                                                          IM_COL32(255, 0, 0, 200), 32, 10 + 4);
+            if (draw_fg)
+                ImGui::GetForegroundDrawList()->AddCircle(window_center, window_size.y * 0.6f,
+                                                          IM_COL32(0, 255, 0, 200), 32, 10);
+            ImGui::EndTabItem();
+        }
+
+        ImGui::EndTabBar();
+    }
+
+    ImGui::End();
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Example App: Documents Handling / ShowExampleAppDocuments()
+//-----------------------------------------------------------------------------
+
+// Simplified structure to mimic a Document model
+struct MyDocument
+{
+    const char *Name;  // Document title
+    bool Open;  // Set when the document is open (in this demo, we keep an array of all available
+                // documents to simplify the demo)
+    bool OpenPrev;   // Copy of Open from last update.
+    bool Dirty;      // Set when the document has been modified
+    bool WantClose;  // Set when the document
+    ImVec4 Color;    // An arbitrary variable associated to the document
+
+    MyDocument(const char *name,
+               bool open           = true,
+               const ImVec4 &color = ImVec4(1.0f, 1.0f, 1.0f, 1.0f))
+    {
+        Name = name;
+        Open = OpenPrev = open;
+        Dirty           = false;
+        WantClose       = false;
+        Color           = color;
+    }
+    void DoOpen() { Open = true; }
+    void DoQueueClose() { WantClose = true; }
+    void DoForceClose()
+    {
+        Open  = false;
+        Dirty = false;
+    }
+    void DoSave() { Dirty = false; }
+
+    // Display dummy contents for the Document
+    static void DisplayContents(MyDocument *doc)
+    {
+        ImGui::PushID(doc);
+        ImGui::Text("Document \"%s\"", doc->Name);
+        ImGui::PushStyleColor(ImGuiCol_Text, doc->Color);
+        ImGui::TextWrapped(
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor "
+            "incididunt ut labore et dolore magna aliqua.");
+        ImGui::PopStyleColor();
+        if (ImGui::Button("Modify", ImVec2(100, 0)))
+            doc->Dirty = true;
+        ImGui::SameLine();
+        if (ImGui::Button("Save", ImVec2(100, 0)))
+            doc->DoSave();
+        ImGui::ColorEdit3(
+            "color",
+            &doc->Color.x);  // Useful to test drag and drop and hold-dragged-to-open-tab behavior.
+        ImGui::PopID();
+    }
+
+    // Display context menu for the Document
+    static void DisplayContextMenu(MyDocument *doc)
+    {
+        if (!ImGui::BeginPopupContextItem())
+            return;
+
+        char buf[256];
+        sprintf(buf, "Save %s", doc->Name);
+        if (ImGui::MenuItem(buf, "CTRL+S", false, doc->Open))
+            doc->DoSave();
+        if (ImGui::MenuItem("Close", "CTRL+W", false, doc->Open))
+            doc->DoQueueClose();
+        ImGui::EndPopup();
+    }
+};
+
+struct ExampleAppDocuments
+{
+    ImVector<MyDocument> Documents;
+
+    ExampleAppDocuments()
+    {
+        Documents.push_back(MyDocument("Lettuce", true, ImVec4(0.4f, 0.8f, 0.4f, 1.0f)));
+        Documents.push_back(MyDocument("Eggplant", true, ImVec4(0.8f, 0.5f, 1.0f, 1.0f)));
+        Documents.push_back(MyDocument("Carrot", true, ImVec4(1.0f, 0.8f, 0.5f, 1.0f)));
+        Documents.push_back(MyDocument("Tomato", false, ImVec4(1.0f, 0.3f, 0.4f, 1.0f)));
+        Documents.push_back(MyDocument("A Rather Long Title", false));
+        Documents.push_back(MyDocument("Some Document", false));
+    }
+};
+
+// [Optional] Notify the system of Tabs/Windows closure that happened outside the regular tab
+// interface. If a tab has been closed programmatically (aka closed from another source such as the
+// Checkbox() in the demo, as opposed to clicking on the regular tab closing button) and stops being
+// submitted, it will take a frame for the tab bar to notice its absence. During this frame there
+// will be a gap in the tab bar, and if the tab that has disappeared was the selected one, the tab
+// bar will report no selected tab during the frame. This will effectively give the impression of a
+// flicker for one frame. We call SetTabItemClosed() to manually notify the Tab Bar or Docking
+// system of removed tabs to avoid this glitch. Note that this completely optional, and only affect
+// tab bars with the ImGuiTabBarFlags_Reorderable flag.
+static void NotifyOfDocumentsClosedElsewhere(ExampleAppDocuments &app)
+{
+    for (int doc_n = 0; doc_n < app.Documents.Size; doc_n++)
+    {
+        MyDocument *doc = &app.Documents[doc_n];
+        if (!doc->Open && doc->OpenPrev)
+            ImGui::SetTabItemClosed(doc->Name);
+        doc->OpenPrev = doc->Open;
+    }
+}
+
+void ShowExampleAppDocuments(bool *p_open)
+{
+    static ExampleAppDocuments app;
+
+    // Options
+    static bool opt_reorderable               = true;
+    static ImGuiTabBarFlags opt_fitting_flags = ImGuiTabBarFlags_FittingPolicyDefault_;
+
+    if (!ImGui::Begin("Example: Documents", p_open, ImGuiWindowFlags_MenuBar))
+    {
+        ImGui::End();
+        return;
+    }
+
+    // Menu
+    if (ImGui::BeginMenuBar())
+    {
+        if (ImGui::BeginMenu("File"))
+        {
+            int open_count = 0;
+            for (int doc_n = 0; doc_n < app.Documents.Size; doc_n++)
+                open_count += app.Documents[doc_n].Open ? 1 : 0;
+
+            if (ImGui::BeginMenu("Open", open_count < app.Documents.Size))
+            {
+                for (int doc_n = 0; doc_n < app.Documents.Size; doc_n++)
+                {
+                    MyDocument *doc = &app.Documents[doc_n];
+                    if (!doc->Open)
+                        if (ImGui::MenuItem(doc->Name))
+                            doc->DoOpen();
+                }
+                ImGui::EndMenu();
+            }
+            if (ImGui::MenuItem("Close All Documents", NULL, false, open_count > 0))
+                for (int doc_n = 0; doc_n < app.Documents.Size; doc_n++)
+                    app.Documents[doc_n].DoQueueClose();
+            if (ImGui::MenuItem("Exit", "Alt+F4"))
+            {
+            }
+            ImGui::EndMenu();
+        }
+        ImGui::EndMenuBar();
+    }
+
+    // [Debug] List documents with one checkbox for each
+    for (int doc_n = 0; doc_n < app.Documents.Size; doc_n++)
+    {
+        MyDocument *doc = &app.Documents[doc_n];
+        if (doc_n > 0)
+            ImGui::SameLine();
+        ImGui::PushID(doc);
+        if (ImGui::Checkbox(doc->Name, &doc->Open))
+            if (!doc->Open)
+                doc->DoForceClose();
+        ImGui::PopID();
+    }
+
+    ImGui::Separator();
+
+    // Submit Tab Bar and Tabs
+    {
+        ImGuiTabBarFlags tab_bar_flags =
+            (opt_fitting_flags) | (opt_reorderable ? ImGuiTabBarFlags_Reorderable : 0);
+        if (ImGui::BeginTabBar("##tabs", tab_bar_flags))
+        {
+            if (opt_reorderable)
+                NotifyOfDocumentsClosedElsewhere(app);
+
+            // [DEBUG] Stress tests
+            // if ((ImGui::GetFrameCount() % 30) == 0) docs[1].Open ^= 1;            // [DEBUG]
+            // Automatically show/hide a tab. Test various interactions e.g. dragging with this on.
+            // if (ImGui::GetIO().KeyCtrl) ImGui::SetTabItemSelected(docs[1].Name);  // [DEBUG] Test
+            // SetTabItemSelected(), probably not very useful as-is anyway..
+
+            // Submit Tabs
+            for (int doc_n = 0; doc_n < app.Documents.Size; doc_n++)
+            {
+                MyDocument *doc = &app.Documents[doc_n];
+                if (!doc->Open)
+                    continue;
+
+                ImGuiTabItemFlags tab_flags = (doc->Dirty ? ImGuiTabItemFlags_UnsavedDocument : 0);
+                bool visible                = ImGui::BeginTabItem(doc->Name, &doc->Open, tab_flags);
+
+                // Cancel attempt to close when unsaved add to save queue so we can display a popup.
+                if (!doc->Open && doc->Dirty)
+                {
+                    doc->Open = true;
+                    doc->DoQueueClose();
+                }
+
+                MyDocument::DisplayContextMenu(doc);
+                if (visible)
+                {
+                    MyDocument::DisplayContents(doc);
+                    ImGui::EndTabItem();
+                }
+            }
+
+            ImGui::EndTabBar();
+        }
+    }
+
+    // Update closing queue
+    static ImVector<MyDocument *> close_queue;
+    if (close_queue.empty())
+    {
+        // Close queue is locked once we started a popup
+        for (int doc_n = 0; doc_n < app.Documents.Size; doc_n++)
+        {
+            MyDocument *doc = &app.Documents[doc_n];
+            if (doc->WantClose)
+            {
+                doc->WantClose = false;
+                close_queue.push_back(doc);
+            }
+        }
+    }
+
+    // Display closing confirmation UI
+    if (!close_queue.empty())
+    {
+        int close_queue_unsaved_documents = 0;
+        for (int n = 0; n < close_queue.Size; n++)
+            if (close_queue[n]->Dirty)
+                close_queue_unsaved_documents++;
+
+        if (close_queue_unsaved_documents == 0)
+        {
+            // Close documents when all are unsaved
+            for (int n = 0; n < close_queue.Size; n++)
+                close_queue[n]->DoForceClose();
+            close_queue.clear();
+        }
+        else
+        {
+            if (!ImGui::IsPopupOpen("Save?"))
+                ImGui::OpenPopup("Save?");
+            if (ImGui::BeginPopupModal("Save?"))
+            {
+                ImGui::Text("Save change to the following items?");
+                ImGui::SetNextItemWidth(-1.0f);
+                if (ImGui::ListBoxHeader("##", close_queue_unsaved_documents, 6))
+                {
+                    for (int n = 0; n < close_queue.Size; n++)
+                        if (close_queue[n]->Dirty)
+                            ImGui::Text("%s", close_queue[n]->Name);
+                    ImGui::ListBoxFooter();
+                }
+
+                if (ImGui::Button("Yes", ImVec2(80, 0)))
+                {
+                    for (int n = 0; n < close_queue.Size; n++)
+                    {
+                        if (close_queue[n]->Dirty)
+                            close_queue[n]->DoSave();
+                        close_queue[n]->DoForceClose();
+                    }
+                    close_queue.clear();
+                    ImGui::CloseCurrentPopup();
+                }
+                ImGui::SameLine();
+                if (ImGui::Button("No", ImVec2(80, 0)))
+                {
+                    for (int n = 0; n < close_queue.Size; n++)
+                        close_queue[n]->DoForceClose();
+                    close_queue.clear();
+                    ImGui::CloseCurrentPopup();
+                }
+                ImGui::SameLine();
+                if (ImGui::Button("Cancel", ImVec2(80, 0)))
+                {
+                    close_queue.clear();
+                    ImGui::CloseCurrentPopup();
+                }
+                ImGui::EndPopup();
+            }
+        }
+    }
+
+    ImGui::End();
+}
+
+// End of Demo code
+#else
+
+void ImGui::ShowAboutWindow(bool *) {}
+void ImGui::ShowDemoWindow(bool *) {}
+void ImGui::ShowUserGuide() {}
+void ImGui::ShowStyleEditor(ImGuiStyle *) {}
+
+#endif

--- a/third_party/imgui/imgui_draw.cpp
+++ b/third_party/imgui/imgui_draw.cpp
@@ -1,0 +1,4340 @@
+// dear imgui, v1.72 WIP
+// (drawing and font code)
+
+/*
+
+Index of this file:
+
+// [SECTION] STB libraries implementation
+// [SECTION] Style functions
+// [SECTION] ImDrawList
+// [SECTION] ImDrawListSplitter
+// [SECTION] ImDrawData
+// [SECTION] Helpers ShadeVertsXXX functions
+// [SECTION] ImFontConfig
+// [SECTION] ImFontAtlas
+// [SECTION] ImFontAtlas glyph ranges helpers
+// [SECTION] ImFontGlyphRangesBuilder
+// [SECTION] ImFont
+// [SECTION] Internal Render Helpers
+// [SECTION] Decompression code
+// [SECTION] Default font data (ProggyClean.ttf)
+
+*/
+
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#include "imgui.h"
+#ifndef IMGUI_DEFINE_MATH_OPERATORS
+#define IMGUI_DEFINE_MATH_OPERATORS
+#endif
+#include "imgui_internal.h"
+
+#include <stdio.h>  // vsnprintf, sscanf, printf
+#if !defined(alloca)
+#if defined(__GLIBC__) || defined(__sun) || defined(__CYGWIN__) || defined(__APPLE__) || \
+    defined(__SWITCH__)
+#include <alloca.h>  // alloca (glibc uses <alloca.h>. Note that Cygwin may have _WIN32 defined, so the order matters here)
+#elif defined(_WIN32)
+#include <malloc.h>  // alloca
+#if !defined(alloca)
+#define alloca _alloca  // for clang with MS Codegen
+#endif
+#else
+#include <stdlib.h>  // alloca
+#endif
+#endif
+
+// Visual Studio warnings
+#ifdef _MSC_VER
+#pragma warning(disable : 4127)  // condition expression is constant
+#pragma warning(disable : 4505)  // unreferenced local function has been removed (stb stuff)
+#pragma warning(disable : 4996)  // 'This function or variable may be unsafe': strcpy, strdup,
+                                 // sprintf, vsnprintf, sscanf, fopen
+#endif
+
+// Clang/GCC warnings with -Weverything
+#if defined(__clang__)
+#pragma clang diagnostic ignored "-Wold-style-cast"  // warning : use of old-style cast // yes, they
+                                                     // are more terse.
+#pragma clang diagnostic ignored \
+    "-Wfloat-equal"  // warning : comparing floating point with == or != is unsafe   // storing and
+                     // comparing against same constants ok.
+#pragma clang diagnostic ignored \
+    "-Wglobal-constructors"  // warning : declaration requires a global destructor           //
+                             // similar to above, not sure what the exact difference is.
+#pragma clang diagnostic ignored \
+    "-Wsign-conversion"  // warning : implicit conversion changes signedness             //
+#if __has_warning("-Wzero-as-null-pointer-constant")
+#pragma clang diagnostic ignored \
+    "-Wzero-as-null-pointer-constant"  // warning : zero as null pointer constant              //
+                                       // some standard header variations use #define NULL 0
+#endif
+#if __has_warning("-Wcomma")
+#pragma clang diagnostic ignored "-Wcomma"  // warning : possible misuse of comma operator here //
+#endif
+#if __has_warning("-Wreserved-id-macro")
+#pragma clang diagnostic ignored \
+    "-Wreserved-id-macro"  // warning : macro name is a reserved identifier                //
+#endif
+#if __has_warning("-Wdouble-promotion")
+#pragma clang diagnostic ignored \
+    "-Wdouble-promotion"  // warning: implicit conversion from 'float' to 'double' when passing
+                          // argument to function  // using printf() is a misery with this as C++
+                          // va_arg ellipsis changes float to double.
+#endif
+#elif defined(__GNUC__)
+#pragma GCC diagnostic ignored \
+    "-Wpragmas"  // warning: unknown option after '#pragma GCC diagnostic' kind
+#pragma GCC diagnostic ignored "-Wunused-function"   // warning: 'xxxx' defined but not used
+#pragma GCC diagnostic ignored "-Wdouble-promotion"  // warning: implicit conversion from 'float' to
+                                                     // 'double' when passing argument to function
+#pragma GCC diagnostic ignored \
+    "-Wconversion"  // warning: conversion to 'xxxx' from 'xxxx' may alter its value
+#pragma GCC diagnostic ignored "-Wstack-protector"  // warning: stack protector not protecting local
+                                                    // variables: variable length buffer
+#pragma GCC diagnostic ignored \
+    "-Wclass-memaccess"  // [__GNUC__ >= 8] warning: 'memset/memcpy' clearing/writing an object of
+                         // type 'xxxx' with no trivial copy-assignment; use assignment or
+                         // value-initialization instead
+#endif
+
+//-------------------------------------------------------------------------
+// [SECTION] STB libraries implementation
+//-------------------------------------------------------------------------
+
+// Compile time options:
+//#define IMGUI_STB_NAMESPACE           ImStb
+//#define IMGUI_STB_TRUETYPE_FILENAME   "my_folder/stb_truetype.h"
+//#define IMGUI_STB_RECT_PACK_FILENAME  "my_folder/stb_rect_pack.h"
+//#define IMGUI_DISABLE_STB_TRUETYPE_IMPLEMENTATION
+//#define IMGUI_DISABLE_STB_RECT_PACK_IMPLEMENTATION
+
+#ifdef IMGUI_STB_NAMESPACE
+namespace IMGUI_STB_NAMESPACE
+{
+#endif
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4456)  // declaration of 'xx' hides previous local declaration
+#endif
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wimplicit-fallthrough"
+#pragma clang diagnostic ignored \
+    "-Wcast-qual"  // warning : cast from 'const xxxx *' to 'xxx *' drops const qualifier //
+#endif
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtype-limits"  // warning: comparison is always true due to limited
+                                                // range of data type [-Wtype-limits]
+#pragma GCC diagnostic ignored "-Wcast-qual"    // warning: cast from type 'const xxxx *' to type
+                                                // 'xxxx *' casts away qualifiers
+#endif
+
+#ifndef STB_RECT_PACK_IMPLEMENTATION  // in case the user already have an implementation in the
+                                      // _same_ compilation unit (e.g. unity builds)
+#ifndef IMGUI_DISABLE_STB_RECT_PACK_IMPLEMENTATION
+#define STBRP_STATIC
+#define STBRP_ASSERT(x) IM_ASSERT(x)
+#define STBRP_SORT ImQsort
+#define STB_RECT_PACK_IMPLEMENTATION
+#endif
+#ifdef IMGUI_STB_RECT_PACK_FILENAME
+#include IMGUI_STB_RECT_PACK_FILENAME
+#else
+#include "imstb_rectpack.h"
+#endif
+#endif
+
+#ifndef STB_TRUETYPE_IMPLEMENTATION  // in case the user already have an implementation in the
+                                     // _same_ compilation unit (e.g. unity builds)
+#ifndef IMGUI_DISABLE_STB_TRUETYPE_IMPLEMENTATION
+#define STBTT_malloc(x, u) ((void)(u), IM_ALLOC(x))
+#define STBTT_free(x, u) ((void)(u), IM_FREE(x))
+#define STBTT_assert(x) IM_ASSERT(x)
+#define STBTT_fmod(x, y) ImFmod(x, y)
+#define STBTT_sqrt(x) ImSqrt(x)
+#define STBTT_pow(x, y) ImPow(x, y)
+#define STBTT_fabs(x) ImFabs(x)
+#define STBTT_ifloor(x) ((int)ImFloorStd(x))
+#define STBTT_iceil(x) ((int)ImCeil(x))
+#define STBTT_STATIC
+#define STB_TRUETYPE_IMPLEMENTATION
+#else
+#define STBTT_DEF extern
+#endif
+#ifdef IMGUI_STB_TRUETYPE_FILENAME
+#include IMGUI_STB_TRUETYPE_FILENAME
+#else
+#include "imstb_truetype.h"
+#endif
+#endif
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+#ifdef IMGUI_STB_NAMESPACE
+}  // namespace ImStb
+using namespace IMGUI_STB_NAMESPACE;
+#endif
+
+//-----------------------------------------------------------------------------
+// [SECTION] Style functions
+//-----------------------------------------------------------------------------
+
+void ImGui::StyleColorsDark(ImGuiStyle *dst)
+{
+    ImGuiStyle *style = dst ? dst : &ImGui::GetStyle();
+    ImVec4 *colors    = style->Colors;
+
+    colors[ImGuiCol_Text]                 = ImVec4(1.00f, 1.00f, 1.00f, 1.00f);
+    colors[ImGuiCol_TextDisabled]         = ImVec4(0.50f, 0.50f, 0.50f, 1.00f);
+    colors[ImGuiCol_WindowBg]             = ImVec4(0.06f, 0.06f, 0.06f, 0.94f);
+    colors[ImGuiCol_ChildBg]              = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
+    colors[ImGuiCol_PopupBg]              = ImVec4(0.08f, 0.08f, 0.08f, 0.94f);
+    colors[ImGuiCol_Border]               = ImVec4(0.43f, 0.43f, 0.50f, 0.50f);
+    colors[ImGuiCol_BorderShadow]         = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
+    colors[ImGuiCol_FrameBg]              = ImVec4(0.16f, 0.29f, 0.48f, 0.54f);
+    colors[ImGuiCol_FrameBgHovered]       = ImVec4(0.26f, 0.59f, 0.98f, 0.40f);
+    colors[ImGuiCol_FrameBgActive]        = ImVec4(0.26f, 0.59f, 0.98f, 0.67f);
+    colors[ImGuiCol_TitleBg]              = ImVec4(0.04f, 0.04f, 0.04f, 1.00f);
+    colors[ImGuiCol_TitleBgActive]        = ImVec4(0.16f, 0.29f, 0.48f, 1.00f);
+    colors[ImGuiCol_TitleBgCollapsed]     = ImVec4(0.00f, 0.00f, 0.00f, 0.51f);
+    colors[ImGuiCol_MenuBarBg]            = ImVec4(0.14f, 0.14f, 0.14f, 1.00f);
+    colors[ImGuiCol_ScrollbarBg]          = ImVec4(0.02f, 0.02f, 0.02f, 0.53f);
+    colors[ImGuiCol_ScrollbarGrab]        = ImVec4(0.31f, 0.31f, 0.31f, 1.00f);
+    colors[ImGuiCol_ScrollbarGrabHovered] = ImVec4(0.41f, 0.41f, 0.41f, 1.00f);
+    colors[ImGuiCol_ScrollbarGrabActive]  = ImVec4(0.51f, 0.51f, 0.51f, 1.00f);
+    colors[ImGuiCol_CheckMark]            = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
+    colors[ImGuiCol_SliderGrab]           = ImVec4(0.24f, 0.52f, 0.88f, 1.00f);
+    colors[ImGuiCol_SliderGrabActive]     = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
+    colors[ImGuiCol_Button]               = ImVec4(0.26f, 0.59f, 0.98f, 0.40f);
+    colors[ImGuiCol_ButtonHovered]        = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
+    colors[ImGuiCol_ButtonActive]         = ImVec4(0.06f, 0.53f, 0.98f, 1.00f);
+    colors[ImGuiCol_Header]               = ImVec4(0.26f, 0.59f, 0.98f, 0.31f);
+    colors[ImGuiCol_HeaderHovered]        = ImVec4(0.26f, 0.59f, 0.98f, 0.80f);
+    colors[ImGuiCol_HeaderActive]         = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
+    colors[ImGuiCol_Separator]            = colors[ImGuiCol_Border];
+    colors[ImGuiCol_SeparatorHovered]     = ImVec4(0.10f, 0.40f, 0.75f, 0.78f);
+    colors[ImGuiCol_SeparatorActive]      = ImVec4(0.10f, 0.40f, 0.75f, 1.00f);
+    colors[ImGuiCol_ResizeGrip]           = ImVec4(0.26f, 0.59f, 0.98f, 0.25f);
+    colors[ImGuiCol_ResizeGripHovered]    = ImVec4(0.26f, 0.59f, 0.98f, 0.67f);
+    colors[ImGuiCol_ResizeGripActive]     = ImVec4(0.26f, 0.59f, 0.98f, 0.95f);
+    colors[ImGuiCol_Tab] = ImLerp(colors[ImGuiCol_Header], colors[ImGuiCol_TitleBgActive], 0.80f);
+    colors[ImGuiCol_TabHovered] = colors[ImGuiCol_HeaderHovered];
+    colors[ImGuiCol_TabActive] =
+        ImLerp(colors[ImGuiCol_HeaderActive], colors[ImGuiCol_TitleBgActive], 0.60f);
+    colors[ImGuiCol_TabUnfocused] = ImLerp(colors[ImGuiCol_Tab], colors[ImGuiCol_TitleBg], 0.80f);
+    colors[ImGuiCol_TabUnfocusedActive] =
+        ImLerp(colors[ImGuiCol_TabActive], colors[ImGuiCol_TitleBg], 0.40f);
+    colors[ImGuiCol_PlotLines]             = ImVec4(0.61f, 0.61f, 0.61f, 1.00f);
+    colors[ImGuiCol_PlotLinesHovered]      = ImVec4(1.00f, 0.43f, 0.35f, 1.00f);
+    colors[ImGuiCol_PlotHistogram]         = ImVec4(0.90f, 0.70f, 0.00f, 1.00f);
+    colors[ImGuiCol_PlotHistogramHovered]  = ImVec4(1.00f, 0.60f, 0.00f, 1.00f);
+    colors[ImGuiCol_TextSelectedBg]        = ImVec4(0.26f, 0.59f, 0.98f, 0.35f);
+    colors[ImGuiCol_DragDropTarget]        = ImVec4(1.00f, 1.00f, 0.00f, 0.90f);
+    colors[ImGuiCol_NavHighlight]          = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
+    colors[ImGuiCol_NavWindowingHighlight] = ImVec4(1.00f, 1.00f, 1.00f, 0.70f);
+    colors[ImGuiCol_NavWindowingDimBg]     = ImVec4(0.80f, 0.80f, 0.80f, 0.20f);
+    colors[ImGuiCol_ModalWindowDimBg]      = ImVec4(0.80f, 0.80f, 0.80f, 0.35f);
+}
+
+void ImGui::StyleColorsClassic(ImGuiStyle *dst)
+{
+    ImGuiStyle *style = dst ? dst : &ImGui::GetStyle();
+    ImVec4 *colors    = style->Colors;
+
+    colors[ImGuiCol_Text]                 = ImVec4(0.90f, 0.90f, 0.90f, 1.00f);
+    colors[ImGuiCol_TextDisabled]         = ImVec4(0.60f, 0.60f, 0.60f, 1.00f);
+    colors[ImGuiCol_WindowBg]             = ImVec4(0.00f, 0.00f, 0.00f, 0.70f);
+    colors[ImGuiCol_ChildBg]              = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
+    colors[ImGuiCol_PopupBg]              = ImVec4(0.11f, 0.11f, 0.14f, 0.92f);
+    colors[ImGuiCol_Border]               = ImVec4(0.50f, 0.50f, 0.50f, 0.50f);
+    colors[ImGuiCol_BorderShadow]         = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
+    colors[ImGuiCol_FrameBg]              = ImVec4(0.43f, 0.43f, 0.43f, 0.39f);
+    colors[ImGuiCol_FrameBgHovered]       = ImVec4(0.47f, 0.47f, 0.69f, 0.40f);
+    colors[ImGuiCol_FrameBgActive]        = ImVec4(0.42f, 0.41f, 0.64f, 0.69f);
+    colors[ImGuiCol_TitleBg]              = ImVec4(0.27f, 0.27f, 0.54f, 0.83f);
+    colors[ImGuiCol_TitleBgActive]        = ImVec4(0.32f, 0.32f, 0.63f, 0.87f);
+    colors[ImGuiCol_TitleBgCollapsed]     = ImVec4(0.40f, 0.40f, 0.80f, 0.20f);
+    colors[ImGuiCol_MenuBarBg]            = ImVec4(0.40f, 0.40f, 0.55f, 0.80f);
+    colors[ImGuiCol_ScrollbarBg]          = ImVec4(0.20f, 0.25f, 0.30f, 0.60f);
+    colors[ImGuiCol_ScrollbarGrab]        = ImVec4(0.40f, 0.40f, 0.80f, 0.30f);
+    colors[ImGuiCol_ScrollbarGrabHovered] = ImVec4(0.40f, 0.40f, 0.80f, 0.40f);
+    colors[ImGuiCol_ScrollbarGrabActive]  = ImVec4(0.41f, 0.39f, 0.80f, 0.60f);
+    colors[ImGuiCol_CheckMark]            = ImVec4(0.90f, 0.90f, 0.90f, 0.50f);
+    colors[ImGuiCol_SliderGrab]           = ImVec4(1.00f, 1.00f, 1.00f, 0.30f);
+    colors[ImGuiCol_SliderGrabActive]     = ImVec4(0.41f, 0.39f, 0.80f, 0.60f);
+    colors[ImGuiCol_Button]               = ImVec4(0.35f, 0.40f, 0.61f, 0.62f);
+    colors[ImGuiCol_ButtonHovered]        = ImVec4(0.40f, 0.48f, 0.71f, 0.79f);
+    colors[ImGuiCol_ButtonActive]         = ImVec4(0.46f, 0.54f, 0.80f, 1.00f);
+    colors[ImGuiCol_Header]               = ImVec4(0.40f, 0.40f, 0.90f, 0.45f);
+    colors[ImGuiCol_HeaderHovered]        = ImVec4(0.45f, 0.45f, 0.90f, 0.80f);
+    colors[ImGuiCol_HeaderActive]         = ImVec4(0.53f, 0.53f, 0.87f, 0.80f);
+    colors[ImGuiCol_Separator]            = ImVec4(0.50f, 0.50f, 0.50f, 0.60f);
+    colors[ImGuiCol_SeparatorHovered]     = ImVec4(0.60f, 0.60f, 0.70f, 1.00f);
+    colors[ImGuiCol_SeparatorActive]      = ImVec4(0.70f, 0.70f, 0.90f, 1.00f);
+    colors[ImGuiCol_ResizeGrip]           = ImVec4(1.00f, 1.00f, 1.00f, 0.16f);
+    colors[ImGuiCol_ResizeGripHovered]    = ImVec4(0.78f, 0.82f, 1.00f, 0.60f);
+    colors[ImGuiCol_ResizeGripActive]     = ImVec4(0.78f, 0.82f, 1.00f, 0.90f);
+    colors[ImGuiCol_Tab] = ImLerp(colors[ImGuiCol_Header], colors[ImGuiCol_TitleBgActive], 0.80f);
+    colors[ImGuiCol_TabHovered] = colors[ImGuiCol_HeaderHovered];
+    colors[ImGuiCol_TabActive] =
+        ImLerp(colors[ImGuiCol_HeaderActive], colors[ImGuiCol_TitleBgActive], 0.60f);
+    colors[ImGuiCol_TabUnfocused] = ImLerp(colors[ImGuiCol_Tab], colors[ImGuiCol_TitleBg], 0.80f);
+    colors[ImGuiCol_TabUnfocusedActive] =
+        ImLerp(colors[ImGuiCol_TabActive], colors[ImGuiCol_TitleBg], 0.40f);
+    colors[ImGuiCol_PlotLines]             = ImVec4(1.00f, 1.00f, 1.00f, 1.00f);
+    colors[ImGuiCol_PlotLinesHovered]      = ImVec4(0.90f, 0.70f, 0.00f, 1.00f);
+    colors[ImGuiCol_PlotHistogram]         = ImVec4(0.90f, 0.70f, 0.00f, 1.00f);
+    colors[ImGuiCol_PlotHistogramHovered]  = ImVec4(1.00f, 0.60f, 0.00f, 1.00f);
+    colors[ImGuiCol_TextSelectedBg]        = ImVec4(0.00f, 0.00f, 1.00f, 0.35f);
+    colors[ImGuiCol_DragDropTarget]        = ImVec4(1.00f, 1.00f, 0.00f, 0.90f);
+    colors[ImGuiCol_NavHighlight]          = colors[ImGuiCol_HeaderHovered];
+    colors[ImGuiCol_NavWindowingHighlight] = ImVec4(1.00f, 1.00f, 1.00f, 0.70f);
+    colors[ImGuiCol_NavWindowingDimBg]     = ImVec4(0.80f, 0.80f, 0.80f, 0.20f);
+    colors[ImGuiCol_ModalWindowDimBg]      = ImVec4(0.20f, 0.20f, 0.20f, 0.35f);
+}
+
+// Those light colors are better suited with a thicker font than the default one + FrameBorder
+void ImGui::StyleColorsLight(ImGuiStyle *dst)
+{
+    ImGuiStyle *style = dst ? dst : &ImGui::GetStyle();
+    ImVec4 *colors    = style->Colors;
+
+    colors[ImGuiCol_Text]                 = ImVec4(0.00f, 0.00f, 0.00f, 1.00f);
+    colors[ImGuiCol_TextDisabled]         = ImVec4(0.60f, 0.60f, 0.60f, 1.00f);
+    colors[ImGuiCol_WindowBg]             = ImVec4(0.94f, 0.94f, 0.94f, 1.00f);
+    colors[ImGuiCol_ChildBg]              = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
+    colors[ImGuiCol_PopupBg]              = ImVec4(1.00f, 1.00f, 1.00f, 0.98f);
+    colors[ImGuiCol_Border]               = ImVec4(0.00f, 0.00f, 0.00f, 0.30f);
+    colors[ImGuiCol_BorderShadow]         = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
+    colors[ImGuiCol_FrameBg]              = ImVec4(1.00f, 1.00f, 1.00f, 1.00f);
+    colors[ImGuiCol_FrameBgHovered]       = ImVec4(0.26f, 0.59f, 0.98f, 0.40f);
+    colors[ImGuiCol_FrameBgActive]        = ImVec4(0.26f, 0.59f, 0.98f, 0.67f);
+    colors[ImGuiCol_TitleBg]              = ImVec4(0.96f, 0.96f, 0.96f, 1.00f);
+    colors[ImGuiCol_TitleBgActive]        = ImVec4(0.82f, 0.82f, 0.82f, 1.00f);
+    colors[ImGuiCol_TitleBgCollapsed]     = ImVec4(1.00f, 1.00f, 1.00f, 0.51f);
+    colors[ImGuiCol_MenuBarBg]            = ImVec4(0.86f, 0.86f, 0.86f, 1.00f);
+    colors[ImGuiCol_ScrollbarBg]          = ImVec4(0.98f, 0.98f, 0.98f, 0.53f);
+    colors[ImGuiCol_ScrollbarGrab]        = ImVec4(0.69f, 0.69f, 0.69f, 0.80f);
+    colors[ImGuiCol_ScrollbarGrabHovered] = ImVec4(0.49f, 0.49f, 0.49f, 0.80f);
+    colors[ImGuiCol_ScrollbarGrabActive]  = ImVec4(0.49f, 0.49f, 0.49f, 1.00f);
+    colors[ImGuiCol_CheckMark]            = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
+    colors[ImGuiCol_SliderGrab]           = ImVec4(0.26f, 0.59f, 0.98f, 0.78f);
+    colors[ImGuiCol_SliderGrabActive]     = ImVec4(0.46f, 0.54f, 0.80f, 0.60f);
+    colors[ImGuiCol_Button]               = ImVec4(0.26f, 0.59f, 0.98f, 0.40f);
+    colors[ImGuiCol_ButtonHovered]        = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
+    colors[ImGuiCol_ButtonActive]         = ImVec4(0.06f, 0.53f, 0.98f, 1.00f);
+    colors[ImGuiCol_Header]               = ImVec4(0.26f, 0.59f, 0.98f, 0.31f);
+    colors[ImGuiCol_HeaderHovered]        = ImVec4(0.26f, 0.59f, 0.98f, 0.80f);
+    colors[ImGuiCol_HeaderActive]         = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
+    colors[ImGuiCol_Separator]            = ImVec4(0.39f, 0.39f, 0.39f, 0.62f);
+    colors[ImGuiCol_SeparatorHovered]     = ImVec4(0.14f, 0.44f, 0.80f, 0.78f);
+    colors[ImGuiCol_SeparatorActive]      = ImVec4(0.14f, 0.44f, 0.80f, 1.00f);
+    colors[ImGuiCol_ResizeGrip]           = ImVec4(0.80f, 0.80f, 0.80f, 0.56f);
+    colors[ImGuiCol_ResizeGripHovered]    = ImVec4(0.26f, 0.59f, 0.98f, 0.67f);
+    colors[ImGuiCol_ResizeGripActive]     = ImVec4(0.26f, 0.59f, 0.98f, 0.95f);
+    colors[ImGuiCol_Tab] = ImLerp(colors[ImGuiCol_Header], colors[ImGuiCol_TitleBgActive], 0.90f);
+    colors[ImGuiCol_TabHovered] = colors[ImGuiCol_HeaderHovered];
+    colors[ImGuiCol_TabActive] =
+        ImLerp(colors[ImGuiCol_HeaderActive], colors[ImGuiCol_TitleBgActive], 0.60f);
+    colors[ImGuiCol_TabUnfocused] = ImLerp(colors[ImGuiCol_Tab], colors[ImGuiCol_TitleBg], 0.80f);
+    colors[ImGuiCol_TabUnfocusedActive] =
+        ImLerp(colors[ImGuiCol_TabActive], colors[ImGuiCol_TitleBg], 0.40f);
+    colors[ImGuiCol_PlotLines]             = ImVec4(0.39f, 0.39f, 0.39f, 1.00f);
+    colors[ImGuiCol_PlotLinesHovered]      = ImVec4(1.00f, 0.43f, 0.35f, 1.00f);
+    colors[ImGuiCol_PlotHistogram]         = ImVec4(0.90f, 0.70f, 0.00f, 1.00f);
+    colors[ImGuiCol_PlotHistogramHovered]  = ImVec4(1.00f, 0.45f, 0.00f, 1.00f);
+    colors[ImGuiCol_TextSelectedBg]        = ImVec4(0.26f, 0.59f, 0.98f, 0.35f);
+    colors[ImGuiCol_DragDropTarget]        = ImVec4(0.26f, 0.59f, 0.98f, 0.95f);
+    colors[ImGuiCol_NavHighlight]          = colors[ImGuiCol_HeaderHovered];
+    colors[ImGuiCol_NavWindowingHighlight] = ImVec4(0.70f, 0.70f, 0.70f, 0.70f);
+    colors[ImGuiCol_NavWindowingDimBg]     = ImVec4(0.20f, 0.20f, 0.20f, 0.20f);
+    colors[ImGuiCol_ModalWindowDimBg]      = ImVec4(0.20f, 0.20f, 0.20f, 0.35f);
+}
+
+//-----------------------------------------------------------------------------
+// ImDrawList
+//-----------------------------------------------------------------------------
+
+ImDrawListSharedData::ImDrawListSharedData()
+{
+    Font                 = NULL;
+    FontSize             = 0.0f;
+    CurveTessellationTol = 0.0f;
+    ClipRectFullscreen   = ImVec4(-8192.0f, -8192.0f, +8192.0f, +8192.0f);
+    InitialFlags         = ImDrawListFlags_None;
+
+    // Const data
+    for (int i = 0; i < IM_ARRAYSIZE(CircleVtx12); i++)
+    {
+        const float a  = ((float)i * 2 * IM_PI) / (float)IM_ARRAYSIZE(CircleVtx12);
+        CircleVtx12[i] = ImVec2(ImCos(a), ImSin(a));
+    }
+}
+
+void ImDrawList::Clear()
+{
+    CmdBuffer.resize(0);
+    IdxBuffer.resize(0);
+    VtxBuffer.resize(0);
+    Flags             = _Data ? _Data->InitialFlags : ImDrawListFlags_None;
+    _VtxCurrentOffset = 0;
+    _VtxCurrentIdx    = 0;
+    _VtxWritePtr      = NULL;
+    _IdxWritePtr      = NULL;
+    _ClipRectStack.resize(0);
+    _TextureIdStack.resize(0);
+    _Path.resize(0);
+    _Splitter.Clear();
+}
+
+void ImDrawList::ClearFreeMemory()
+{
+    CmdBuffer.clear();
+    IdxBuffer.clear();
+    VtxBuffer.clear();
+    _VtxCurrentIdx = 0;
+    _VtxWritePtr   = NULL;
+    _IdxWritePtr   = NULL;
+    _ClipRectStack.clear();
+    _TextureIdStack.clear();
+    _Path.clear();
+    _Splitter.ClearFreeMemory();
+}
+
+ImDrawList *ImDrawList::CloneOutput() const
+{
+    ImDrawList *dst = IM_NEW(ImDrawList(_Data));
+    dst->CmdBuffer  = CmdBuffer;
+    dst->IdxBuffer  = IdxBuffer;
+    dst->VtxBuffer  = VtxBuffer;
+    dst->Flags      = Flags;
+    return dst;
+}
+
+// Using macros because C++ is a terrible language, we want guaranteed inline, no code in header,
+// and no overhead in Debug builds
+#define GetCurrentClipRect() \
+    (_ClipRectStack.Size ? _ClipRectStack.Data[_ClipRectStack.Size - 1] : _Data->ClipRectFullscreen)
+#define GetCurrentTextureId() \
+    (_TextureIdStack.Size ? _TextureIdStack.Data[_TextureIdStack.Size - 1] : (ImTextureID)NULL)
+
+void ImDrawList::AddDrawCmd()
+{
+    ImDrawCmd draw_cmd;
+    draw_cmd.ClipRect  = GetCurrentClipRect();
+    draw_cmd.TextureId = GetCurrentTextureId();
+    draw_cmd.VtxOffset = _VtxCurrentOffset;
+    draw_cmd.IdxOffset = IdxBuffer.Size;
+
+    IM_ASSERT(draw_cmd.ClipRect.x <= draw_cmd.ClipRect.z &&
+              draw_cmd.ClipRect.y <= draw_cmd.ClipRect.w);
+    CmdBuffer.push_back(draw_cmd);
+}
+
+void ImDrawList::AddCallback(ImDrawCallback callback, void *callback_data)
+{
+    ImDrawCmd *current_cmd = CmdBuffer.Size ? &CmdBuffer.back() : NULL;
+    if (!current_cmd || current_cmd->ElemCount != 0 || current_cmd->UserCallback != NULL)
+    {
+        AddDrawCmd();
+        current_cmd = &CmdBuffer.back();
+    }
+    current_cmd->UserCallback     = callback;
+    current_cmd->UserCallbackData = callback_data;
+
+    AddDrawCmd();  // Force a new command after us (see comment below)
+}
+
+// Our scheme may appears a bit unusual, basically we want the most-common calls AddLine AddRect
+// etc. to not have to perform any check so we always have a command ready in the stack. The cost of
+// figuring out if a new command has to be added or if we can merge is paid in those Update**
+// functions only.
+void ImDrawList::UpdateClipRect()
+{
+    // If current command is used with different settings we need to add a new command
+    const ImVec4 curr_clip_rect = GetCurrentClipRect();
+    ImDrawCmd *curr_cmd         = CmdBuffer.Size > 0 ? &CmdBuffer.Data[CmdBuffer.Size - 1] : NULL;
+    if (!curr_cmd ||
+        (curr_cmd->ElemCount != 0 &&
+         memcmp(&curr_cmd->ClipRect, &curr_clip_rect, sizeof(ImVec4)) != 0) ||
+        curr_cmd->UserCallback != NULL)
+    {
+        AddDrawCmd();
+        return;
+    }
+
+    // Try to merge with previous command if it matches, else use current command
+    ImDrawCmd *prev_cmd = CmdBuffer.Size > 1 ? curr_cmd - 1 : NULL;
+    if (curr_cmd->ElemCount == 0 && prev_cmd &&
+        memcmp(&prev_cmd->ClipRect, &curr_clip_rect, sizeof(ImVec4)) == 0 &&
+        prev_cmd->TextureId == GetCurrentTextureId() && prev_cmd->UserCallback == NULL)
+        CmdBuffer.pop_back();
+    else
+        curr_cmd->ClipRect = curr_clip_rect;
+}
+
+void ImDrawList::UpdateTextureID()
+{
+    // If current command is used with different settings we need to add a new command
+    const ImTextureID curr_texture_id = GetCurrentTextureId();
+    ImDrawCmd *curr_cmd               = CmdBuffer.Size ? &CmdBuffer.back() : NULL;
+    if (!curr_cmd || (curr_cmd->ElemCount != 0 && curr_cmd->TextureId != curr_texture_id) ||
+        curr_cmd->UserCallback != NULL)
+    {
+        AddDrawCmd();
+        return;
+    }
+
+    // Try to merge with previous command if it matches, else use current command
+    ImDrawCmd *prev_cmd = CmdBuffer.Size > 1 ? curr_cmd - 1 : NULL;
+    if (curr_cmd->ElemCount == 0 && prev_cmd && prev_cmd->TextureId == curr_texture_id &&
+        memcmp(&prev_cmd->ClipRect, &GetCurrentClipRect(), sizeof(ImVec4)) == 0 &&
+        prev_cmd->UserCallback == NULL)
+        CmdBuffer.pop_back();
+    else
+        curr_cmd->TextureId = curr_texture_id;
+}
+
+#undef GetCurrentClipRect
+#undef GetCurrentTextureId
+
+// Render-level scissoring. This is passed down to your render function but not used for CPU-side
+// coarse clipping. Prefer using higher-level ImGui::PushClipRect() to affect logic (hit-testing and
+// widget culling)
+void ImDrawList::PushClipRect(ImVec2 cr_min, ImVec2 cr_max, bool intersect_with_current_clip_rect)
+{
+    ImVec4 cr(cr_min.x, cr_min.y, cr_max.x, cr_max.y);
+    if (intersect_with_current_clip_rect && _ClipRectStack.Size)
+    {
+        ImVec4 current = _ClipRectStack.Data[_ClipRectStack.Size - 1];
+        if (cr.x < current.x)
+            cr.x = current.x;
+        if (cr.y < current.y)
+            cr.y = current.y;
+        if (cr.z > current.z)
+            cr.z = current.z;
+        if (cr.w > current.w)
+            cr.w = current.w;
+    }
+    cr.z = ImMax(cr.x, cr.z);
+    cr.w = ImMax(cr.y, cr.w);
+
+    _ClipRectStack.push_back(cr);
+    UpdateClipRect();
+}
+
+void ImDrawList::PushClipRectFullScreen()
+{
+    PushClipRect(ImVec2(_Data->ClipRectFullscreen.x, _Data->ClipRectFullscreen.y),
+                 ImVec2(_Data->ClipRectFullscreen.z, _Data->ClipRectFullscreen.w));
+}
+
+void ImDrawList::PopClipRect()
+{
+    IM_ASSERT(_ClipRectStack.Size > 0);
+    _ClipRectStack.pop_back();
+    UpdateClipRect();
+}
+
+void ImDrawList::PushTextureID(ImTextureID texture_id)
+{
+    _TextureIdStack.push_back(texture_id);
+    UpdateTextureID();
+}
+
+void ImDrawList::PopTextureID()
+{
+    IM_ASSERT(_TextureIdStack.Size > 0);
+    _TextureIdStack.pop_back();
+    UpdateTextureID();
+}
+
+// NB: this can be called with negative count for removing primitives (as long as the result does
+// not underflow)
+void ImDrawList::PrimReserve(int idx_count, int vtx_count)
+{
+    // Large mesh support (when enabled)
+    if (sizeof(ImDrawIdx) == 2 && (_VtxCurrentIdx + vtx_count >= (1 << 16)) &&
+        (Flags & ImDrawListFlags_AllowVtxOffset))
+    {
+        _VtxCurrentOffset = VtxBuffer.Size;
+        _VtxCurrentIdx    = 0;
+        AddDrawCmd();
+    }
+
+    ImDrawCmd &draw_cmd = CmdBuffer.Data[CmdBuffer.Size - 1];
+    draw_cmd.ElemCount += idx_count;
+
+    int vtx_buffer_old_size = VtxBuffer.Size;
+    VtxBuffer.resize(vtx_buffer_old_size + vtx_count);
+    _VtxWritePtr = VtxBuffer.Data + vtx_buffer_old_size;
+
+    int idx_buffer_old_size = IdxBuffer.Size;
+    IdxBuffer.resize(idx_buffer_old_size + idx_count);
+    _IdxWritePtr = IdxBuffer.Data + idx_buffer_old_size;
+}
+
+// Fully unrolled with inline call to keep our debug builds decently fast.
+void ImDrawList::PrimRect(const ImVec2 &a, const ImVec2 &c, ImU32 col)
+{
+    ImVec2 b(c.x, a.y), d(a.x, c.y), uv(_Data->TexUvWhitePixel);
+    ImDrawIdx idx       = (ImDrawIdx)_VtxCurrentIdx;
+    _IdxWritePtr[0]     = idx;
+    _IdxWritePtr[1]     = (ImDrawIdx)(idx + 1);
+    _IdxWritePtr[2]     = (ImDrawIdx)(idx + 2);
+    _IdxWritePtr[3]     = idx;
+    _IdxWritePtr[4]     = (ImDrawIdx)(idx + 2);
+    _IdxWritePtr[5]     = (ImDrawIdx)(idx + 3);
+    _VtxWritePtr[0].pos = a;
+    _VtxWritePtr[0].uv  = uv;
+    _VtxWritePtr[0].col = col;
+    _VtxWritePtr[1].pos = b;
+    _VtxWritePtr[1].uv  = uv;
+    _VtxWritePtr[1].col = col;
+    _VtxWritePtr[2].pos = c;
+    _VtxWritePtr[2].uv  = uv;
+    _VtxWritePtr[2].col = col;
+    _VtxWritePtr[3].pos = d;
+    _VtxWritePtr[3].uv  = uv;
+    _VtxWritePtr[3].col = col;
+    _VtxWritePtr += 4;
+    _VtxCurrentIdx += 4;
+    _IdxWritePtr += 6;
+}
+
+void ImDrawList::PrimRectUV(const ImVec2 &a,
+                            const ImVec2 &c,
+                            const ImVec2 &uv_a,
+                            const ImVec2 &uv_c,
+                            ImU32 col)
+{
+    ImVec2 b(c.x, a.y), d(a.x, c.y), uv_b(uv_c.x, uv_a.y), uv_d(uv_a.x, uv_c.y);
+    ImDrawIdx idx       = (ImDrawIdx)_VtxCurrentIdx;
+    _IdxWritePtr[0]     = idx;
+    _IdxWritePtr[1]     = (ImDrawIdx)(idx + 1);
+    _IdxWritePtr[2]     = (ImDrawIdx)(idx + 2);
+    _IdxWritePtr[3]     = idx;
+    _IdxWritePtr[4]     = (ImDrawIdx)(idx + 2);
+    _IdxWritePtr[5]     = (ImDrawIdx)(idx + 3);
+    _VtxWritePtr[0].pos = a;
+    _VtxWritePtr[0].uv  = uv_a;
+    _VtxWritePtr[0].col = col;
+    _VtxWritePtr[1].pos = b;
+    _VtxWritePtr[1].uv  = uv_b;
+    _VtxWritePtr[1].col = col;
+    _VtxWritePtr[2].pos = c;
+    _VtxWritePtr[2].uv  = uv_c;
+    _VtxWritePtr[2].col = col;
+    _VtxWritePtr[3].pos = d;
+    _VtxWritePtr[3].uv  = uv_d;
+    _VtxWritePtr[3].col = col;
+    _VtxWritePtr += 4;
+    _VtxCurrentIdx += 4;
+    _IdxWritePtr += 6;
+}
+
+void ImDrawList::PrimQuadUV(const ImVec2 &a,
+                            const ImVec2 &b,
+                            const ImVec2 &c,
+                            const ImVec2 &d,
+                            const ImVec2 &uv_a,
+                            const ImVec2 &uv_b,
+                            const ImVec2 &uv_c,
+                            const ImVec2 &uv_d,
+                            ImU32 col)
+{
+    ImDrawIdx idx       = (ImDrawIdx)_VtxCurrentIdx;
+    _IdxWritePtr[0]     = idx;
+    _IdxWritePtr[1]     = (ImDrawIdx)(idx + 1);
+    _IdxWritePtr[2]     = (ImDrawIdx)(idx + 2);
+    _IdxWritePtr[3]     = idx;
+    _IdxWritePtr[4]     = (ImDrawIdx)(idx + 2);
+    _IdxWritePtr[5]     = (ImDrawIdx)(idx + 3);
+    _VtxWritePtr[0].pos = a;
+    _VtxWritePtr[0].uv  = uv_a;
+    _VtxWritePtr[0].col = col;
+    _VtxWritePtr[1].pos = b;
+    _VtxWritePtr[1].uv  = uv_b;
+    _VtxWritePtr[1].col = col;
+    _VtxWritePtr[2].pos = c;
+    _VtxWritePtr[2].uv  = uv_c;
+    _VtxWritePtr[2].col = col;
+    _VtxWritePtr[3].pos = d;
+    _VtxWritePtr[3].uv  = uv_d;
+    _VtxWritePtr[3].col = col;
+    _VtxWritePtr += 4;
+    _VtxCurrentIdx += 4;
+    _IdxWritePtr += 6;
+}
+
+// On AddPolyline() and AddConvexPolyFilled() we intentionally avoid using ImVec2 and superflous
+// function calls to optimize debug/non-inlined builds. Those macros expects l-values.
+#define IM_NORMALIZE2F_OVER_ZERO(VX, VY)       \
+    {                                          \
+        float d2 = VX * VX + VY * VY;          \
+        if (d2 > 0.0f)                         \
+        {                                      \
+            float inv_len = 1.0f / ImSqrt(d2); \
+            VX *= inv_len;                     \
+            VY *= inv_len;                     \
+        }                                      \
+    }
+#define IM_FIXNORMAL2F(VX, VY)        \
+    {                                 \
+        float d2 = VX * VX + VY * VY; \
+        if (d2 < 0.5f)                \
+            d2 = 0.5f;                \
+        float inv_lensq = 1.0f / d2;  \
+        VX *= inv_lensq;              \
+        VY *= inv_lensq;              \
+    }
+
+// TODO: Thickness anti-aliased lines cap are missing their AA fringe.
+// We avoid using the ImVec2 math operators here to reduce cost to a minimum for debug/non-inlined
+// builds.
+void ImDrawList::AddPolyline(const ImVec2 *points,
+                             const int points_count,
+                             ImU32 col,
+                             bool closed,
+                             float thickness)
+{
+    if (points_count < 2)
+        return;
+
+    const ImVec2 uv = _Data->TexUvWhitePixel;
+
+    int count = points_count;
+    if (!closed)
+        count = points_count - 1;
+
+    const bool thick_line = thickness > 1.0f;
+    if (Flags & ImDrawListFlags_AntiAliasedLines)
+    {
+        // Anti-aliased stroke
+        const float AA_SIZE   = 1.0f;
+        const ImU32 col_trans = col & ~IM_COL32_A_MASK;
+
+        const int idx_count = thick_line ? count * 18 : count * 12;
+        const int vtx_count = thick_line ? points_count * 4 : points_count * 3;
+        PrimReserve(idx_count, vtx_count);
+
+        // Temporary buffer
+        ImVec2 *temp_normals =
+            (ImVec2 *)alloca(points_count * (thick_line ? 5 : 3) * sizeof(ImVec2));  //-V630
+        ImVec2 *temp_points = temp_normals + points_count;
+
+        for (int i1 = 0; i1 < count; i1++)
+        {
+            const int i2 = (i1 + 1) == points_count ? 0 : i1 + 1;
+            float dx     = points[i2].x - points[i1].x;
+            float dy     = points[i2].y - points[i1].y;
+            IM_NORMALIZE2F_OVER_ZERO(dx, dy);
+            temp_normals[i1].x = dy;
+            temp_normals[i1].y = -dx;
+        }
+        if (!closed)
+            temp_normals[points_count - 1] = temp_normals[points_count - 2];
+
+        if (!thick_line)
+        {
+            if (!closed)
+            {
+                temp_points[0] = points[0] + temp_normals[0] * AA_SIZE;
+                temp_points[1] = points[0] - temp_normals[0] * AA_SIZE;
+                temp_points[(points_count - 1) * 2 + 0] =
+                    points[points_count - 1] + temp_normals[points_count - 1] * AA_SIZE;
+                temp_points[(points_count - 1) * 2 + 1] =
+                    points[points_count - 1] - temp_normals[points_count - 1] * AA_SIZE;
+            }
+
+            // FIXME-OPT: Merge the different loops, possibly remove the temporary buffer.
+            unsigned int idx1 = _VtxCurrentIdx;
+            for (int i1 = 0; i1 < count; i1++)
+            {
+                const int i2      = (i1 + 1) == points_count ? 0 : i1 + 1;
+                unsigned int idx2 = (i1 + 1) == points_count ? _VtxCurrentIdx : idx1 + 3;
+
+                // Average normals
+                float dm_x = (temp_normals[i1].x + temp_normals[i2].x) * 0.5f;
+                float dm_y = (temp_normals[i1].y + temp_normals[i2].y) * 0.5f;
+                IM_FIXNORMAL2F(dm_x, dm_y)
+                dm_x *= AA_SIZE;
+                dm_y *= AA_SIZE;
+
+                // Add temporary vertexes
+                ImVec2 *out_vtx = &temp_points[i2 * 2];
+                out_vtx[0].x    = points[i2].x + dm_x;
+                out_vtx[0].y    = points[i2].y + dm_y;
+                out_vtx[1].x    = points[i2].x - dm_x;
+                out_vtx[1].y    = points[i2].y - dm_y;
+
+                // Add indexes
+                _IdxWritePtr[0]  = (ImDrawIdx)(idx2 + 0);
+                _IdxWritePtr[1]  = (ImDrawIdx)(idx1 + 0);
+                _IdxWritePtr[2]  = (ImDrawIdx)(idx1 + 2);
+                _IdxWritePtr[3]  = (ImDrawIdx)(idx1 + 2);
+                _IdxWritePtr[4]  = (ImDrawIdx)(idx2 + 2);
+                _IdxWritePtr[5]  = (ImDrawIdx)(idx2 + 0);
+                _IdxWritePtr[6]  = (ImDrawIdx)(idx2 + 1);
+                _IdxWritePtr[7]  = (ImDrawIdx)(idx1 + 1);
+                _IdxWritePtr[8]  = (ImDrawIdx)(idx1 + 0);
+                _IdxWritePtr[9]  = (ImDrawIdx)(idx1 + 0);
+                _IdxWritePtr[10] = (ImDrawIdx)(idx2 + 0);
+                _IdxWritePtr[11] = (ImDrawIdx)(idx2 + 1);
+                _IdxWritePtr += 12;
+
+                idx1 = idx2;
+            }
+
+            // Add vertexes
+            for (int i = 0; i < points_count; i++)
+            {
+                _VtxWritePtr[0].pos = points[i];
+                _VtxWritePtr[0].uv  = uv;
+                _VtxWritePtr[0].col = col;
+                _VtxWritePtr[1].pos = temp_points[i * 2 + 0];
+                _VtxWritePtr[1].uv  = uv;
+                _VtxWritePtr[1].col = col_trans;
+                _VtxWritePtr[2].pos = temp_points[i * 2 + 1];
+                _VtxWritePtr[2].uv  = uv;
+                _VtxWritePtr[2].col = col_trans;
+                _VtxWritePtr += 3;
+            }
+        }
+        else
+        {
+            const float half_inner_thickness = (thickness - AA_SIZE) * 0.5f;
+            if (!closed)
+            {
+                temp_points[0] = points[0] + temp_normals[0] * (half_inner_thickness + AA_SIZE);
+                temp_points[1] = points[0] + temp_normals[0] * (half_inner_thickness);
+                temp_points[2] = points[0] - temp_normals[0] * (half_inner_thickness);
+                temp_points[3] = points[0] - temp_normals[0] * (half_inner_thickness + AA_SIZE);
+                temp_points[(points_count - 1) * 4 + 0] =
+                    points[points_count - 1] +
+                    temp_normals[points_count - 1] * (half_inner_thickness + AA_SIZE);
+                temp_points[(points_count - 1) * 4 + 1] =
+                    points[points_count - 1] +
+                    temp_normals[points_count - 1] * (half_inner_thickness);
+                temp_points[(points_count - 1) * 4 + 2] =
+                    points[points_count - 1] -
+                    temp_normals[points_count - 1] * (half_inner_thickness);
+                temp_points[(points_count - 1) * 4 + 3] =
+                    points[points_count - 1] -
+                    temp_normals[points_count - 1] * (half_inner_thickness + AA_SIZE);
+            }
+
+            // FIXME-OPT: Merge the different loops, possibly remove the temporary buffer.
+            unsigned int idx1 = _VtxCurrentIdx;
+            for (int i1 = 0; i1 < count; i1++)
+            {
+                const int i2      = (i1 + 1) == points_count ? 0 : i1 + 1;
+                unsigned int idx2 = (i1 + 1) == points_count ? _VtxCurrentIdx : idx1 + 4;
+
+                // Average normals
+                float dm_x = (temp_normals[i1].x + temp_normals[i2].x) * 0.5f;
+                float dm_y = (temp_normals[i1].y + temp_normals[i2].y) * 0.5f;
+                IM_FIXNORMAL2F(dm_x, dm_y);
+                float dm_out_x = dm_x * (half_inner_thickness + AA_SIZE);
+                float dm_out_y = dm_y * (half_inner_thickness + AA_SIZE);
+                float dm_in_x  = dm_x * half_inner_thickness;
+                float dm_in_y  = dm_y * half_inner_thickness;
+
+                // Add temporary vertexes
+                ImVec2 *out_vtx = &temp_points[i2 * 4];
+                out_vtx[0].x    = points[i2].x + dm_out_x;
+                out_vtx[0].y    = points[i2].y + dm_out_y;
+                out_vtx[1].x    = points[i2].x + dm_in_x;
+                out_vtx[1].y    = points[i2].y + dm_in_y;
+                out_vtx[2].x    = points[i2].x - dm_in_x;
+                out_vtx[2].y    = points[i2].y - dm_in_y;
+                out_vtx[3].x    = points[i2].x - dm_out_x;
+                out_vtx[3].y    = points[i2].y - dm_out_y;
+
+                // Add indexes
+                _IdxWritePtr[0]  = (ImDrawIdx)(idx2 + 1);
+                _IdxWritePtr[1]  = (ImDrawIdx)(idx1 + 1);
+                _IdxWritePtr[2]  = (ImDrawIdx)(idx1 + 2);
+                _IdxWritePtr[3]  = (ImDrawIdx)(idx1 + 2);
+                _IdxWritePtr[4]  = (ImDrawIdx)(idx2 + 2);
+                _IdxWritePtr[5]  = (ImDrawIdx)(idx2 + 1);
+                _IdxWritePtr[6]  = (ImDrawIdx)(idx2 + 1);
+                _IdxWritePtr[7]  = (ImDrawIdx)(idx1 + 1);
+                _IdxWritePtr[8]  = (ImDrawIdx)(idx1 + 0);
+                _IdxWritePtr[9]  = (ImDrawIdx)(idx1 + 0);
+                _IdxWritePtr[10] = (ImDrawIdx)(idx2 + 0);
+                _IdxWritePtr[11] = (ImDrawIdx)(idx2 + 1);
+                _IdxWritePtr[12] = (ImDrawIdx)(idx2 + 2);
+                _IdxWritePtr[13] = (ImDrawIdx)(idx1 + 2);
+                _IdxWritePtr[14] = (ImDrawIdx)(idx1 + 3);
+                _IdxWritePtr[15] = (ImDrawIdx)(idx1 + 3);
+                _IdxWritePtr[16] = (ImDrawIdx)(idx2 + 3);
+                _IdxWritePtr[17] = (ImDrawIdx)(idx2 + 2);
+                _IdxWritePtr += 18;
+
+                idx1 = idx2;
+            }
+
+            // Add vertexes
+            for (int i = 0; i < points_count; i++)
+            {
+                _VtxWritePtr[0].pos = temp_points[i * 4 + 0];
+                _VtxWritePtr[0].uv  = uv;
+                _VtxWritePtr[0].col = col_trans;
+                _VtxWritePtr[1].pos = temp_points[i * 4 + 1];
+                _VtxWritePtr[1].uv  = uv;
+                _VtxWritePtr[1].col = col;
+                _VtxWritePtr[2].pos = temp_points[i * 4 + 2];
+                _VtxWritePtr[2].uv  = uv;
+                _VtxWritePtr[2].col = col;
+                _VtxWritePtr[3].pos = temp_points[i * 4 + 3];
+                _VtxWritePtr[3].uv  = uv;
+                _VtxWritePtr[3].col = col_trans;
+                _VtxWritePtr += 4;
+            }
+        }
+        _VtxCurrentIdx += (ImDrawIdx)vtx_count;
+    }
+    else
+    {
+        // Non Anti-aliased Stroke
+        const int idx_count = count * 6;
+        const int vtx_count = count * 4;  // FIXME-OPT: Not sharing edges
+        PrimReserve(idx_count, vtx_count);
+
+        for (int i1 = 0; i1 < count; i1++)
+        {
+            const int i2     = (i1 + 1) == points_count ? 0 : i1 + 1;
+            const ImVec2 &p1 = points[i1];
+            const ImVec2 &p2 = points[i2];
+
+            float dx = p2.x - p1.x;
+            float dy = p2.y - p1.y;
+            IM_NORMALIZE2F_OVER_ZERO(dx, dy);
+            dx *= (thickness * 0.5f);
+            dy *= (thickness * 0.5f);
+
+            _VtxWritePtr[0].pos.x = p1.x + dy;
+            _VtxWritePtr[0].pos.y = p1.y - dx;
+            _VtxWritePtr[0].uv    = uv;
+            _VtxWritePtr[0].col   = col;
+            _VtxWritePtr[1].pos.x = p2.x + dy;
+            _VtxWritePtr[1].pos.y = p2.y - dx;
+            _VtxWritePtr[1].uv    = uv;
+            _VtxWritePtr[1].col   = col;
+            _VtxWritePtr[2].pos.x = p2.x - dy;
+            _VtxWritePtr[2].pos.y = p2.y + dx;
+            _VtxWritePtr[2].uv    = uv;
+            _VtxWritePtr[2].col   = col;
+            _VtxWritePtr[3].pos.x = p1.x - dy;
+            _VtxWritePtr[3].pos.y = p1.y + dx;
+            _VtxWritePtr[3].uv    = uv;
+            _VtxWritePtr[3].col   = col;
+            _VtxWritePtr += 4;
+
+            _IdxWritePtr[0] = (ImDrawIdx)(_VtxCurrentIdx);
+            _IdxWritePtr[1] = (ImDrawIdx)(_VtxCurrentIdx + 1);
+            _IdxWritePtr[2] = (ImDrawIdx)(_VtxCurrentIdx + 2);
+            _IdxWritePtr[3] = (ImDrawIdx)(_VtxCurrentIdx);
+            _IdxWritePtr[4] = (ImDrawIdx)(_VtxCurrentIdx + 2);
+            _IdxWritePtr[5] = (ImDrawIdx)(_VtxCurrentIdx + 3);
+            _IdxWritePtr += 6;
+            _VtxCurrentIdx += 4;
+        }
+    }
+}
+
+// We intentionally avoid using ImVec2 and its math operators here to reduce cost to a minimum for
+// debug/non-inlined builds.
+void ImDrawList::AddConvexPolyFilled(const ImVec2 *points, const int points_count, ImU32 col)
+{
+    if (points_count < 3)
+        return;
+
+    const ImVec2 uv = _Data->TexUvWhitePixel;
+
+    if (Flags & ImDrawListFlags_AntiAliasedFill)
+    {
+        // Anti-aliased Fill
+        const float AA_SIZE   = 1.0f;
+        const ImU32 col_trans = col & ~IM_COL32_A_MASK;
+        const int idx_count   = (points_count - 2) * 3 + points_count * 6;
+        const int vtx_count   = (points_count * 2);
+        PrimReserve(idx_count, vtx_count);
+
+        // Add indexes for fill
+        unsigned int vtx_inner_idx = _VtxCurrentIdx;
+        unsigned int vtx_outer_idx = _VtxCurrentIdx + 1;
+        for (int i = 2; i < points_count; i++)
+        {
+            _IdxWritePtr[0] = (ImDrawIdx)(vtx_inner_idx);
+            _IdxWritePtr[1] = (ImDrawIdx)(vtx_inner_idx + ((i - 1) << 1));
+            _IdxWritePtr[2] = (ImDrawIdx)(vtx_inner_idx + (i << 1));
+            _IdxWritePtr += 3;
+        }
+
+        // Compute normals
+        ImVec2 *temp_normals = (ImVec2 *)alloca(points_count * sizeof(ImVec2));  //-V630
+        for (int i0 = points_count - 1, i1 = 0; i1 < points_count; i0 = i1++)
+        {
+            const ImVec2 &p0 = points[i0];
+            const ImVec2 &p1 = points[i1];
+            float dx         = p1.x - p0.x;
+            float dy         = p1.y - p0.y;
+            IM_NORMALIZE2F_OVER_ZERO(dx, dy);
+            temp_normals[i0].x = dy;
+            temp_normals[i0].y = -dx;
+        }
+
+        for (int i0 = points_count - 1, i1 = 0; i1 < points_count; i0 = i1++)
+        {
+            // Average normals
+            const ImVec2 &n0 = temp_normals[i0];
+            const ImVec2 &n1 = temp_normals[i1];
+            float dm_x       = (n0.x + n1.x) * 0.5f;
+            float dm_y       = (n0.y + n1.y) * 0.5f;
+            IM_FIXNORMAL2F(dm_x, dm_y);
+            dm_x *= AA_SIZE * 0.5f;
+            dm_y *= AA_SIZE * 0.5f;
+
+            // Add vertices
+            _VtxWritePtr[0].pos.x = (points[i1].x - dm_x);
+            _VtxWritePtr[0].pos.y = (points[i1].y - dm_y);
+            _VtxWritePtr[0].uv    = uv;
+            _VtxWritePtr[0].col   = col;  // Inner
+            _VtxWritePtr[1].pos.x = (points[i1].x + dm_x);
+            _VtxWritePtr[1].pos.y = (points[i1].y + dm_y);
+            _VtxWritePtr[1].uv    = uv;
+            _VtxWritePtr[1].col   = col_trans;  // Outer
+            _VtxWritePtr += 2;
+
+            // Add indexes for fringes
+            _IdxWritePtr[0] = (ImDrawIdx)(vtx_inner_idx + (i1 << 1));
+            _IdxWritePtr[1] = (ImDrawIdx)(vtx_inner_idx + (i0 << 1));
+            _IdxWritePtr[2] = (ImDrawIdx)(vtx_outer_idx + (i0 << 1));
+            _IdxWritePtr[3] = (ImDrawIdx)(vtx_outer_idx + (i0 << 1));
+            _IdxWritePtr[4] = (ImDrawIdx)(vtx_outer_idx + (i1 << 1));
+            _IdxWritePtr[5] = (ImDrawIdx)(vtx_inner_idx + (i1 << 1));
+            _IdxWritePtr += 6;
+        }
+        _VtxCurrentIdx += (ImDrawIdx)vtx_count;
+    }
+    else
+    {
+        // Non Anti-aliased Fill
+        const int idx_count = (points_count - 2) * 3;
+        const int vtx_count = points_count;
+        PrimReserve(idx_count, vtx_count);
+        for (int i = 0; i < vtx_count; i++)
+        {
+            _VtxWritePtr[0].pos = points[i];
+            _VtxWritePtr[0].uv  = uv;
+            _VtxWritePtr[0].col = col;
+            _VtxWritePtr++;
+        }
+        for (int i = 2; i < points_count; i++)
+        {
+            _IdxWritePtr[0] = (ImDrawIdx)(_VtxCurrentIdx);
+            _IdxWritePtr[1] = (ImDrawIdx)(_VtxCurrentIdx + i - 1);
+            _IdxWritePtr[2] = (ImDrawIdx)(_VtxCurrentIdx + i);
+            _IdxWritePtr += 3;
+        }
+        _VtxCurrentIdx += (ImDrawIdx)vtx_count;
+    }
+}
+
+void ImDrawList::PathArcToFast(const ImVec2 &centre, float radius, int a_min_of_12, int a_max_of_12)
+{
+    if (radius == 0.0f || a_min_of_12 > a_max_of_12)
+    {
+        _Path.push_back(centre);
+        return;
+    }
+    _Path.reserve(_Path.Size + (a_max_of_12 - a_min_of_12 + 1));
+    for (int a = a_min_of_12; a <= a_max_of_12; a++)
+    {
+        const ImVec2 &c = _Data->CircleVtx12[a % IM_ARRAYSIZE(_Data->CircleVtx12)];
+        _Path.push_back(ImVec2(centre.x + c.x * radius, centre.y + c.y * radius));
+    }
+}
+
+void ImDrawList::PathArcTo(const ImVec2 &centre,
+                           float radius,
+                           float a_min,
+                           float a_max,
+                           int num_segments)
+{
+    if (radius == 0.0f)
+    {
+        _Path.push_back(centre);
+        return;
+    }
+
+    // Note that we are adding a point at both a_min and a_max.
+    // If you are trying to draw a full closed circle you don't want the overlapping points!
+    _Path.reserve(_Path.Size + (num_segments + 1));
+    for (int i = 0; i <= num_segments; i++)
+    {
+        const float a = a_min + ((float)i / (float)num_segments) * (a_max - a_min);
+        _Path.push_back(ImVec2(centre.x + ImCos(a) * radius, centre.y + ImSin(a) * radius));
+    }
+}
+
+static void PathBezierToCasteljau(ImVector<ImVec2> *path,
+                                  float x1,
+                                  float y1,
+                                  float x2,
+                                  float y2,
+                                  float x3,
+                                  float y3,
+                                  float x4,
+                                  float y4,
+                                  float tess_tol,
+                                  int level)
+{
+    float dx = x4 - x1;
+    float dy = y4 - y1;
+    float d2 = ((x2 - x4) * dy - (y2 - y4) * dx);
+    float d3 = ((x3 - x4) * dy - (y3 - y4) * dx);
+    d2       = (d2 >= 0) ? d2 : -d2;
+    d3       = (d3 >= 0) ? d3 : -d3;
+    if ((d2 + d3) * (d2 + d3) < tess_tol * (dx * dx + dy * dy))
+    {
+        path->push_back(ImVec2(x4, y4));
+    }
+    else if (level < 10)
+    {
+        float x12 = (x1 + x2) * 0.5f, y12 = (y1 + y2) * 0.5f;
+        float x23 = (x2 + x3) * 0.5f, y23 = (y2 + y3) * 0.5f;
+        float x34 = (x3 + x4) * 0.5f, y34 = (y3 + y4) * 0.5f;
+        float x123 = (x12 + x23) * 0.5f, y123 = (y12 + y23) * 0.5f;
+        float x234 = (x23 + x34) * 0.5f, y234 = (y23 + y34) * 0.5f;
+        float x1234 = (x123 + x234) * 0.5f, y1234 = (y123 + y234) * 0.5f;
+
+        PathBezierToCasteljau(path, x1, y1, x12, y12, x123, y123, x1234, y1234, tess_tol,
+                              level + 1);
+        PathBezierToCasteljau(path, x1234, y1234, x234, y234, x34, y34, x4, y4, tess_tol,
+                              level + 1);
+    }
+}
+
+void ImDrawList::PathBezierCurveTo(const ImVec2 &p2,
+                                   const ImVec2 &p3,
+                                   const ImVec2 &p4,
+                                   int num_segments)
+{
+    ImVec2 p1 = _Path.back();
+    if (num_segments == 0)
+    {
+        // Auto-tessellated
+        PathBezierToCasteljau(&_Path, p1.x, p1.y, p2.x, p2.y, p3.x, p3.y, p4.x, p4.y,
+                              _Data->CurveTessellationTol, 0);
+    }
+    else
+    {
+        float t_step = 1.0f / (float)num_segments;
+        for (int i_step = 1; i_step <= num_segments; i_step++)
+        {
+            float t  = t_step * i_step;
+            float u  = 1.0f - t;
+            float w1 = u * u * u;
+            float w2 = 3 * u * u * t;
+            float w3 = 3 * u * t * t;
+            float w4 = t * t * t;
+            _Path.push_back(ImVec2(w1 * p1.x + w2 * p2.x + w3 * p3.x + w4 * p4.x,
+                                   w1 * p1.y + w2 * p2.y + w3 * p3.y + w4 * p4.y));
+        }
+    }
+}
+
+void ImDrawList::PathRect(const ImVec2 &a, const ImVec2 &b, float rounding, int rounding_corners)
+{
+    rounding =
+        ImMin(rounding,
+              ImFabs(b.x - a.x) *
+                      (((rounding_corners & ImDrawCornerFlags_Top) == ImDrawCornerFlags_Top) ||
+                               ((rounding_corners & ImDrawCornerFlags_Bot) == ImDrawCornerFlags_Bot)
+                           ? 0.5f
+                           : 1.0f) -
+                  1.0f);
+    rounding = ImMin(
+        rounding,
+        ImFabs(b.y - a.y) *
+                (((rounding_corners & ImDrawCornerFlags_Left) == ImDrawCornerFlags_Left) ||
+                         ((rounding_corners & ImDrawCornerFlags_Right) == ImDrawCornerFlags_Right)
+                     ? 0.5f
+                     : 1.0f) -
+            1.0f);
+
+    if (rounding <= 0.0f || rounding_corners == 0)
+    {
+        PathLineTo(a);
+        PathLineTo(ImVec2(b.x, a.y));
+        PathLineTo(b);
+        PathLineTo(ImVec2(a.x, b.y));
+    }
+    else
+    {
+        const float rounding_tl = (rounding_corners & ImDrawCornerFlags_TopLeft) ? rounding : 0.0f;
+        const float rounding_tr = (rounding_corners & ImDrawCornerFlags_TopRight) ? rounding : 0.0f;
+        const float rounding_br = (rounding_corners & ImDrawCornerFlags_BotRight) ? rounding : 0.0f;
+        const float rounding_bl = (rounding_corners & ImDrawCornerFlags_BotLeft) ? rounding : 0.0f;
+        PathArcToFast(ImVec2(a.x + rounding_tl, a.y + rounding_tl), rounding_tl, 6, 9);
+        PathArcToFast(ImVec2(b.x - rounding_tr, a.y + rounding_tr), rounding_tr, 9, 12);
+        PathArcToFast(ImVec2(b.x - rounding_br, b.y - rounding_br), rounding_br, 0, 3);
+        PathArcToFast(ImVec2(a.x + rounding_bl, b.y - rounding_bl), rounding_bl, 3, 6);
+    }
+}
+
+void ImDrawList::AddLine(const ImVec2 &a, const ImVec2 &b, ImU32 col, float thickness)
+{
+    if ((col & IM_COL32_A_MASK) == 0)
+        return;
+    PathLineTo(a + ImVec2(0.5f, 0.5f));
+    PathLineTo(b + ImVec2(0.5f, 0.5f));
+    PathStroke(col, false, thickness);
+}
+
+// a: upper-left, b: lower-right. we don't render 1 px sized rectangles properly.
+void ImDrawList::AddRect(const ImVec2 &a,
+                         const ImVec2 &b,
+                         ImU32 col,
+                         float rounding,
+                         int rounding_corners_flags,
+                         float thickness)
+{
+    if ((col & IM_COL32_A_MASK) == 0)
+        return;
+    if (Flags & ImDrawListFlags_AntiAliasedLines)
+        PathRect(a + ImVec2(0.5f, 0.5f), b - ImVec2(0.50f, 0.50f), rounding,
+                 rounding_corners_flags);
+    else
+        PathRect(a + ImVec2(0.5f, 0.5f), b - ImVec2(0.49f, 0.49f), rounding,
+                 rounding_corners_flags);  // Better looking lower-right corner and rounded non-AA
+                                           // shapes.
+    PathStroke(col, true, thickness);
+}
+
+void ImDrawList::AddRectFilled(const ImVec2 &a,
+                               const ImVec2 &b,
+                               ImU32 col,
+                               float rounding,
+                               int rounding_corners_flags)
+{
+    if ((col & IM_COL32_A_MASK) == 0)
+        return;
+    if (rounding > 0.0f)
+    {
+        PathRect(a, b, rounding, rounding_corners_flags);
+        PathFillConvex(col);
+    }
+    else
+    {
+        PrimReserve(6, 4);
+        PrimRect(a, b, col);
+    }
+}
+
+void ImDrawList::AddRectFilledMultiColor(const ImVec2 &a,
+                                         const ImVec2 &c,
+                                         ImU32 col_upr_left,
+                                         ImU32 col_upr_right,
+                                         ImU32 col_bot_right,
+                                         ImU32 col_bot_left)
+{
+    if (((col_upr_left | col_upr_right | col_bot_right | col_bot_left) & IM_COL32_A_MASK) == 0)
+        return;
+
+    const ImVec2 uv = _Data->TexUvWhitePixel;
+    PrimReserve(6, 4);
+    PrimWriteIdx((ImDrawIdx)(_VtxCurrentIdx));
+    PrimWriteIdx((ImDrawIdx)(_VtxCurrentIdx + 1));
+    PrimWriteIdx((ImDrawIdx)(_VtxCurrentIdx + 2));
+    PrimWriteIdx((ImDrawIdx)(_VtxCurrentIdx));
+    PrimWriteIdx((ImDrawIdx)(_VtxCurrentIdx + 2));
+    PrimWriteIdx((ImDrawIdx)(_VtxCurrentIdx + 3));
+    PrimWriteVtx(a, uv, col_upr_left);
+    PrimWriteVtx(ImVec2(c.x, a.y), uv, col_upr_right);
+    PrimWriteVtx(c, uv, col_bot_right);
+    PrimWriteVtx(ImVec2(a.x, c.y), uv, col_bot_left);
+}
+
+void ImDrawList::AddQuad(const ImVec2 &a,
+                         const ImVec2 &b,
+                         const ImVec2 &c,
+                         const ImVec2 &d,
+                         ImU32 col,
+                         float thickness)
+{
+    if ((col & IM_COL32_A_MASK) == 0)
+        return;
+
+    PathLineTo(a);
+    PathLineTo(b);
+    PathLineTo(c);
+    PathLineTo(d);
+    PathStroke(col, true, thickness);
+}
+
+void ImDrawList::AddQuadFilled(const ImVec2 &a,
+                               const ImVec2 &b,
+                               const ImVec2 &c,
+                               const ImVec2 &d,
+                               ImU32 col)
+{
+    if ((col & IM_COL32_A_MASK) == 0)
+        return;
+
+    PathLineTo(a);
+    PathLineTo(b);
+    PathLineTo(c);
+    PathLineTo(d);
+    PathFillConvex(col);
+}
+
+void ImDrawList::AddTriangle(const ImVec2 &a,
+                             const ImVec2 &b,
+                             const ImVec2 &c,
+                             ImU32 col,
+                             float thickness)
+{
+    if ((col & IM_COL32_A_MASK) == 0)
+        return;
+
+    PathLineTo(a);
+    PathLineTo(b);
+    PathLineTo(c);
+    PathStroke(col, true, thickness);
+}
+
+void ImDrawList::AddTriangleFilled(const ImVec2 &a, const ImVec2 &b, const ImVec2 &c, ImU32 col)
+{
+    if ((col & IM_COL32_A_MASK) == 0)
+        return;
+
+    PathLineTo(a);
+    PathLineTo(b);
+    PathLineTo(c);
+    PathFillConvex(col);
+}
+
+void ImDrawList::AddCircle(const ImVec2 &centre,
+                           float radius,
+                           ImU32 col,
+                           int num_segments,
+                           float thickness)
+{
+    if ((col & IM_COL32_A_MASK) == 0 || num_segments <= 2)
+        return;
+
+    // Because we are filling a closed shape we remove 1 from the count of segments/points
+    const float a_max = IM_PI * 2.0f * ((float)num_segments - 1.0f) / (float)num_segments;
+    PathArcTo(centre, radius - 0.5f, 0.0f, a_max, num_segments - 1);
+    PathStroke(col, true, thickness);
+}
+
+void ImDrawList::AddCircleFilled(const ImVec2 &centre, float radius, ImU32 col, int num_segments)
+{
+    if ((col & IM_COL32_A_MASK) == 0 || num_segments <= 2)
+        return;
+
+    // Because we are filling a closed shape we remove 1 from the count of segments/points
+    const float a_max = IM_PI * 2.0f * ((float)num_segments - 1.0f) / (float)num_segments;
+    PathArcTo(centre, radius, 0.0f, a_max, num_segments - 1);
+    PathFillConvex(col);
+}
+
+void ImDrawList::AddBezierCurve(const ImVec2 &pos0,
+                                const ImVec2 &cp0,
+                                const ImVec2 &cp1,
+                                const ImVec2 &pos1,
+                                ImU32 col,
+                                float thickness,
+                                int num_segments)
+{
+    if ((col & IM_COL32_A_MASK) == 0)
+        return;
+
+    PathLineTo(pos0);
+    PathBezierCurveTo(cp0, cp1, pos1, num_segments);
+    PathStroke(col, false, thickness);
+}
+
+void ImDrawList::AddText(const ImFont *font,
+                         float font_size,
+                         const ImVec2 &pos,
+                         ImU32 col,
+                         const char *text_begin,
+                         const char *text_end,
+                         float wrap_width,
+                         const ImVec4 *cpu_fine_clip_rect)
+{
+    if ((col & IM_COL32_A_MASK) == 0)
+        return;
+
+    if (text_end == NULL)
+        text_end = text_begin + strlen(text_begin);
+    if (text_begin == text_end)
+        return;
+
+    // Pull default font/size from the shared ImDrawListSharedData instance
+    if (font == NULL)
+        font = _Data->Font;
+    if (font_size == 0.0f)
+        font_size = _Data->FontSize;
+
+    IM_ASSERT(font->ContainerAtlas->TexID ==
+              _TextureIdStack.back());  // Use high-level ImGui::PushFont() or low-level
+                                        // ImDrawList::PushTextureId() to change font.
+
+    ImVec4 clip_rect = _ClipRectStack.back();
+    if (cpu_fine_clip_rect)
+    {
+        clip_rect.x = ImMax(clip_rect.x, cpu_fine_clip_rect->x);
+        clip_rect.y = ImMax(clip_rect.y, cpu_fine_clip_rect->y);
+        clip_rect.z = ImMin(clip_rect.z, cpu_fine_clip_rect->z);
+        clip_rect.w = ImMin(clip_rect.w, cpu_fine_clip_rect->w);
+    }
+    font->RenderText(this, font_size, pos, col, clip_rect, text_begin, text_end, wrap_width,
+                     cpu_fine_clip_rect != NULL);
+}
+
+void ImDrawList::AddText(const ImVec2 &pos, ImU32 col, const char *text_begin, const char *text_end)
+{
+    AddText(NULL, 0.0f, pos, col, text_begin, text_end);
+}
+
+void ImDrawList::AddImage(ImTextureID user_texture_id,
+                          const ImVec2 &a,
+                          const ImVec2 &b,
+                          const ImVec2 &uv_a,
+                          const ImVec2 &uv_b,
+                          ImU32 col)
+{
+    if ((col & IM_COL32_A_MASK) == 0)
+        return;
+
+    const bool push_texture_id =
+        _TextureIdStack.empty() || user_texture_id != _TextureIdStack.back();
+    if (push_texture_id)
+        PushTextureID(user_texture_id);
+
+    PrimReserve(6, 4);
+    PrimRectUV(a, b, uv_a, uv_b, col);
+
+    if (push_texture_id)
+        PopTextureID();
+}
+
+void ImDrawList::AddImageQuad(ImTextureID user_texture_id,
+                              const ImVec2 &a,
+                              const ImVec2 &b,
+                              const ImVec2 &c,
+                              const ImVec2 &d,
+                              const ImVec2 &uv_a,
+                              const ImVec2 &uv_b,
+                              const ImVec2 &uv_c,
+                              const ImVec2 &uv_d,
+                              ImU32 col)
+{
+    if ((col & IM_COL32_A_MASK) == 0)
+        return;
+
+    const bool push_texture_id =
+        _TextureIdStack.empty() || user_texture_id != _TextureIdStack.back();
+    if (push_texture_id)
+        PushTextureID(user_texture_id);
+
+    PrimReserve(6, 4);
+    PrimQuadUV(a, b, c, d, uv_a, uv_b, uv_c, uv_d, col);
+
+    if (push_texture_id)
+        PopTextureID();
+}
+
+void ImDrawList::AddImageRounded(ImTextureID user_texture_id,
+                                 const ImVec2 &a,
+                                 const ImVec2 &b,
+                                 const ImVec2 &uv_a,
+                                 const ImVec2 &uv_b,
+                                 ImU32 col,
+                                 float rounding,
+                                 int rounding_corners)
+{
+    if ((col & IM_COL32_A_MASK) == 0)
+        return;
+
+    if (rounding <= 0.0f || (rounding_corners & ImDrawCornerFlags_All) == 0)
+    {
+        AddImage(user_texture_id, a, b, uv_a, uv_b, col);
+        return;
+    }
+
+    const bool push_texture_id =
+        _TextureIdStack.empty() || user_texture_id != _TextureIdStack.back();
+    if (push_texture_id)
+        PushTextureID(user_texture_id);
+
+    int vert_start_idx = VtxBuffer.Size;
+    PathRect(a, b, rounding, rounding_corners);
+    PathFillConvex(col);
+    int vert_end_idx = VtxBuffer.Size;
+    ImGui::ShadeVertsLinearUV(this, vert_start_idx, vert_end_idx, a, b, uv_a, uv_b, true);
+
+    if (push_texture_id)
+        PopTextureID();
+}
+
+//-----------------------------------------------------------------------------
+// ImDrawListSplitter
+//-----------------------------------------------------------------------------
+// FIXME: This may be a little confusing, trying to be a little too low-level/optimal instead of
+// just doing vector swap..
+//-----------------------------------------------------------------------------
+
+void ImDrawListSplitter::ClearFreeMemory()
+{
+    for (int i = 0; i < _Channels.Size; i++)
+    {
+        if (i == _Current)
+            memset(&_Channels[i], 0,
+                   sizeof(_Channels[i]));  // Current channel is a copy of CmdBuffer/IdxBuffer,
+                                           // don't destruct again
+        _Channels[i]._CmdBuffer.clear();
+        _Channels[i]._IdxBuffer.clear();
+    }
+    _Current = 0;
+    _Count   = 1;
+    _Channels.clear();
+}
+
+void ImDrawListSplitter::Split(ImDrawList *draw_list, int channels_count)
+{
+    IM_ASSERT(_Current == 0 && _Count <= 1);
+    int old_channels_count = _Channels.Size;
+    if (old_channels_count < channels_count)
+        _Channels.resize(channels_count);
+    _Count = channels_count;
+
+    // Channels[] (24/32 bytes each) hold storage that we'll swap with
+    // draw_list->_CmdBuffer/_IdxBuffer The content of Channels[0] at this point doesn't matter. We
+    // clear it to make state tidy in a debugger but we don't strictly need to. When we switch to
+    // the next channel, we'll copy draw_list->_CmdBuffer/_IdxBuffer into Channels[0] and then
+    // Channels[1] into draw_list->CmdBuffer/_IdxBuffer
+    memset(&_Channels[0], 0, sizeof(ImDrawChannel));
+    for (int i = 1; i < channels_count; i++)
+    {
+        if (i >= old_channels_count)
+        {
+            IM_PLACEMENT_NEW(&_Channels[i]) ImDrawChannel();
+        }
+        else
+        {
+            _Channels[i]._CmdBuffer.resize(0);
+            _Channels[i]._IdxBuffer.resize(0);
+        }
+        if (_Channels[i]._CmdBuffer.Size == 0)
+        {
+            ImDrawCmd draw_cmd;
+            draw_cmd.ClipRect  = draw_list->_ClipRectStack.back();
+            draw_cmd.TextureId = draw_list->_TextureIdStack.back();
+            _Channels[i]._CmdBuffer.push_back(draw_cmd);
+        }
+    }
+}
+
+static inline bool CanMergeDrawCommands(ImDrawCmd *a, ImDrawCmd *b)
+{
+    return memcmp(&a->ClipRect, &b->ClipRect, sizeof(a->ClipRect)) == 0 &&
+           a->TextureId == b->TextureId && a->VtxOffset == b->VtxOffset && !a->UserCallback &&
+           !b->UserCallback;
+}
+
+void ImDrawListSplitter::Merge(ImDrawList *draw_list)
+{
+    // Note that we never use or rely on channels.Size because it is merely a buffer that we never
+    // shrink back to 0 to keep all sub-buffers ready for use.
+    if (_Count <= 1)
+        return;
+
+    SetCurrentChannel(draw_list, 0);
+    if (draw_list->CmdBuffer.Size != 0 && draw_list->CmdBuffer.back().ElemCount == 0)
+        draw_list->CmdBuffer.pop_back();
+
+    // Calculate our final buffer sizes. Also fix the incorrect IdxOffset values in each command.
+    int new_cmd_buffer_count = 0;
+    int new_idx_buffer_count = 0;
+    ImDrawCmd *last_cmd =
+        (_Count > 0 && draw_list->CmdBuffer.Size > 0) ? &draw_list->CmdBuffer.back() : NULL;
+    int idx_offset = last_cmd ? last_cmd->IdxOffset + last_cmd->ElemCount : 0;
+    for (int i = 1; i < _Count; i++)
+    {
+        ImDrawChannel &ch = _Channels[i];
+        if (ch._CmdBuffer.Size > 0 && ch._CmdBuffer.back().ElemCount == 0)
+            ch._CmdBuffer.pop_back();
+        if (ch._CmdBuffer.Size > 0 && last_cmd != NULL &&
+            CanMergeDrawCommands(last_cmd, &ch._CmdBuffer[0]))
+        {
+            // Merge previous channel last draw command with current channel first draw command if
+            // matching.
+            last_cmd->ElemCount += ch._CmdBuffer[0].ElemCount;
+            idx_offset += ch._CmdBuffer[0].ElemCount;
+            ch._CmdBuffer.erase(ch._CmdBuffer.Data);
+        }
+        if (ch._CmdBuffer.Size > 0)
+            last_cmd = &ch._CmdBuffer.back();
+        new_cmd_buffer_count += ch._CmdBuffer.Size;
+        new_idx_buffer_count += ch._IdxBuffer.Size;
+        for (int cmd_n = 0; cmd_n < ch._CmdBuffer.Size; cmd_n++)
+        {
+            ch._CmdBuffer.Data[cmd_n].IdxOffset = idx_offset;
+            idx_offset += ch._CmdBuffer.Data[cmd_n].ElemCount;
+        }
+    }
+    draw_list->CmdBuffer.resize(draw_list->CmdBuffer.Size + new_cmd_buffer_count);
+    draw_list->IdxBuffer.resize(draw_list->IdxBuffer.Size + new_idx_buffer_count);
+
+    // Write commands and indices in order (they are fairly small structures, we don't copy vertices
+    // only indices)
+    ImDrawCmd *cmd_write =
+        draw_list->CmdBuffer.Data + draw_list->CmdBuffer.Size - new_cmd_buffer_count;
+    ImDrawIdx *idx_write =
+        draw_list->IdxBuffer.Data + draw_list->IdxBuffer.Size - new_idx_buffer_count;
+    for (int i = 1; i < _Count; i++)
+    {
+        ImDrawChannel &ch = _Channels[i];
+        if (int sz = ch._CmdBuffer.Size)
+        {
+            memcpy(cmd_write, ch._CmdBuffer.Data, sz * sizeof(ImDrawCmd));
+            cmd_write += sz;
+        }
+        if (int sz = ch._IdxBuffer.Size)
+        {
+            memcpy(idx_write, ch._IdxBuffer.Data, sz * sizeof(ImDrawIdx));
+            idx_write += sz;
+        }
+    }
+    draw_list->_IdxWritePtr = idx_write;
+    draw_list->UpdateClipRect();  // We call this instead of AddDrawCmd(), so that empty channels
+                                  // won't produce an extra draw call.
+    _Count = 1;
+}
+
+void ImDrawListSplitter::SetCurrentChannel(ImDrawList *draw_list, int idx)
+{
+    IM_ASSERT(idx >= 0 && idx < _Count);
+    if (_Current == idx)
+        return;
+    // Overwrite ImVector (12/16 bytes), four times. This is merely a silly optimization instead of
+    // doing .swap()
+    memcpy(&_Channels.Data[_Current]._CmdBuffer, &draw_list->CmdBuffer,
+           sizeof(draw_list->CmdBuffer));
+    memcpy(&_Channels.Data[_Current]._IdxBuffer, &draw_list->IdxBuffer,
+           sizeof(draw_list->IdxBuffer));
+    _Current = idx;
+    memcpy(&draw_list->CmdBuffer, &_Channels.Data[idx]._CmdBuffer, sizeof(draw_list->CmdBuffer));
+    memcpy(&draw_list->IdxBuffer, &_Channels.Data[idx]._IdxBuffer, sizeof(draw_list->IdxBuffer));
+    draw_list->_IdxWritePtr = draw_list->IdxBuffer.Data + draw_list->IdxBuffer.Size;
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] ImDrawData
+//-----------------------------------------------------------------------------
+
+// For backward compatibility: convert all buffers from indexed to de-indexed, in case you cannot
+// render indexed. Note: this is slow and most likely a waste of resources. Always prefer indexed
+// rendering!
+void ImDrawData::DeIndexAllBuffers()
+{
+    ImVector<ImDrawVert> new_vtx_buffer;
+    TotalVtxCount = TotalIdxCount = 0;
+    for (int i = 0; i < CmdListsCount; i++)
+    {
+        ImDrawList *cmd_list = CmdLists[i];
+        if (cmd_list->IdxBuffer.empty())
+            continue;
+        new_vtx_buffer.resize(cmd_list->IdxBuffer.Size);
+        for (int j = 0; j < cmd_list->IdxBuffer.Size; j++)
+            new_vtx_buffer[j] = cmd_list->VtxBuffer[cmd_list->IdxBuffer[j]];
+        cmd_list->VtxBuffer.swap(new_vtx_buffer);
+        cmd_list->IdxBuffer.resize(0);
+        TotalVtxCount += cmd_list->VtxBuffer.Size;
+    }
+}
+
+// Helper to scale the ClipRect field of each ImDrawCmd.
+// Use if your final output buffer is at a different scale than draw_data->DisplaySize,
+// or if there is a difference between your window resolution and framebuffer resolution.
+void ImDrawData::ScaleClipRects(const ImVec2 &fb_scale)
+{
+    for (int i = 0; i < CmdListsCount; i++)
+    {
+        ImDrawList *cmd_list = CmdLists[i];
+        for (int cmd_i = 0; cmd_i < cmd_list->CmdBuffer.Size; cmd_i++)
+        {
+            ImDrawCmd *cmd = &cmd_list->CmdBuffer[cmd_i];
+            cmd->ClipRect  = ImVec4(cmd->ClipRect.x * fb_scale.x, cmd->ClipRect.y * fb_scale.y,
+                                   cmd->ClipRect.z * fb_scale.x, cmd->ClipRect.w * fb_scale.y);
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Helpers ShadeVertsXXX functions
+//-----------------------------------------------------------------------------
+
+// Generic linear color gradient, write to RGB fields, leave A untouched.
+void ImGui::ShadeVertsLinearColorGradientKeepAlpha(ImDrawList *draw_list,
+                                                   int vert_start_idx,
+                                                   int vert_end_idx,
+                                                   ImVec2 gradient_p0,
+                                                   ImVec2 gradient_p1,
+                                                   ImU32 col0,
+                                                   ImU32 col1)
+{
+    ImVec2 gradient_extent     = gradient_p1 - gradient_p0;
+    float gradient_inv_length2 = 1.0f / ImLengthSqr(gradient_extent);
+    ImDrawVert *vert_start     = draw_list->VtxBuffer.Data + vert_start_idx;
+    ImDrawVert *vert_end       = draw_list->VtxBuffer.Data + vert_end_idx;
+    for (ImDrawVert *vert = vert_start; vert < vert_end; vert++)
+    {
+        float d   = ImDot(vert->pos - gradient_p0, gradient_extent);
+        float t   = ImClamp(d * gradient_inv_length2, 0.0f, 1.0f);
+        int r     = ImLerp((int)(col0 >> IM_COL32_R_SHIFT) & 0xFF,
+                       (int)(col1 >> IM_COL32_R_SHIFT) & 0xFF, t);
+        int g     = ImLerp((int)(col0 >> IM_COL32_G_SHIFT) & 0xFF,
+                       (int)(col1 >> IM_COL32_G_SHIFT) & 0xFF, t);
+        int b     = ImLerp((int)(col0 >> IM_COL32_B_SHIFT) & 0xFF,
+                       (int)(col1 >> IM_COL32_B_SHIFT) & 0xFF, t);
+        vert->col = (r << IM_COL32_R_SHIFT) | (g << IM_COL32_G_SHIFT) | (b << IM_COL32_B_SHIFT) |
+                    (vert->col & IM_COL32_A_MASK);
+    }
+}
+
+// Distribute UV over (a, b) rectangle
+void ImGui::ShadeVertsLinearUV(ImDrawList *draw_list,
+                               int vert_start_idx,
+                               int vert_end_idx,
+                               const ImVec2 &a,
+                               const ImVec2 &b,
+                               const ImVec2 &uv_a,
+                               const ImVec2 &uv_b,
+                               bool clamp)
+{
+    const ImVec2 size    = b - a;
+    const ImVec2 uv_size = uv_b - uv_a;
+    const ImVec2 scale   = ImVec2(size.x != 0.0f ? (uv_size.x / size.x) : 0.0f,
+                                size.y != 0.0f ? (uv_size.y / size.y) : 0.0f);
+
+    ImDrawVert *vert_start = draw_list->VtxBuffer.Data + vert_start_idx;
+    ImDrawVert *vert_end   = draw_list->VtxBuffer.Data + vert_end_idx;
+    if (clamp)
+    {
+        const ImVec2 min = ImMin(uv_a, uv_b);
+        const ImVec2 max = ImMax(uv_a, uv_b);
+        for (ImDrawVert *vertex = vert_start; vertex < vert_end; ++vertex)
+            vertex->uv =
+                ImClamp(uv_a + ImMul(ImVec2(vertex->pos.x, vertex->pos.y) - a, scale), min, max);
+    }
+    else
+    {
+        for (ImDrawVert *vertex = vert_start; vertex < vert_end; ++vertex)
+            vertex->uv = uv_a + ImMul(ImVec2(vertex->pos.x, vertex->pos.y) - a, scale);
+    }
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] ImFontConfig
+//-----------------------------------------------------------------------------
+
+ImFontConfig::ImFontConfig()
+{
+    FontData             = NULL;
+    FontDataSize         = 0;
+    FontDataOwnedByAtlas = true;
+    FontNo               = 0;
+    SizePixels           = 0.0f;
+    OversampleH          = 3;  // FIXME: 2 may be a better default?
+    OversampleV          = 1;
+    PixelSnapH           = false;
+    GlyphExtraSpacing    = ImVec2(0.0f, 0.0f);
+    GlyphOffset          = ImVec2(0.0f, 0.0f);
+    GlyphRanges          = NULL;
+    GlyphMinAdvanceX     = 0.0f;
+    GlyphMaxAdvanceX     = FLT_MAX;
+    MergeMode            = false;
+    RasterizerFlags      = 0x00;
+    RasterizerMultiply   = 1.0f;
+    memset(Name, 0, sizeof(Name));
+    DstFont = NULL;
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] ImFontAtlas
+//-----------------------------------------------------------------------------
+
+// A work of art lies ahead! (. = white layer, X = black layer, others are blank)
+// The white texels on the top left are the ones we'll use everywhere in Dear ImGui to render filled
+// shapes.
+const int FONT_ATLAS_DEFAULT_TEX_DATA_W_HALF            = 108;
+const int FONT_ATLAS_DEFAULT_TEX_DATA_H                 = 27;
+const unsigned int FONT_ATLAS_DEFAULT_TEX_DATA_ID       = 0x80000000;
+static const char FONT_ATLAS_DEFAULT_TEX_DATA_PIXELS[FONT_ATLAS_DEFAULT_TEX_DATA_W_HALF *
+                                                         FONT_ATLAS_DEFAULT_TEX_DATA_H +
+                                                     1] = {
+    "..-         -XXXXXXX-    X    -           X           -XXXXXXX          -          XXXXXXX-   "
+    "  XX          "
+    "..-         -X.....X-   X.X   -          X.X          -X.....X          -          X.....X-   "
+    " X..X         "
+    "---         -XXX.XXX-  X...X  -         X...X         -X....X           -           X....X-   "
+    " X..X         "
+    "X           -  X.X  - X.....X -        X.....X        -X...X            -            X...X-   "
+    " X..X         "
+    "XX          -  X.X  -X.......X-       X.......X       -X..X.X           -           X.X..X-   "
+    " X..X         "
+    "X.X         -  X.X  -XXXX.XXXX-       XXXX.XXXX       -X.X X.X          -          X.X X.X-   "
+    " X..XXX       "
+    "X..X        -  X.X  -   X.X   -          X.X          -XX   X.X         -         X.X   XX-   "
+    " X..X..XXX    "
+    "X...X       -  X.X  -   X.X   -    XX    X.X    XX    -      X.X        -        X.X      -   "
+    " X..X..X..XX  "
+    "X....X      -  X.X  -   X.X   -   X.X    X.X    X.X   -       X.X       -       X.X       -   "
+    " X..X..X..X.X "
+    "X.....X     -  X.X  -   X.X   -  X..X    X.X    X..X  -        X.X      -      X.X        "
+    "-XXX X..X..X..X..X"
+    "X......X    -  X.X  -   X.X   - X...XXXXXX.XXXXXX...X -         X.X   XX-XX   X.X         "
+    "-X..XX........X..X"
+    "X.......X   -  X.X  -   X.X   -X.....................X-          X.X X.X-X.X X.X          "
+    "-X...X...........X"
+    "X........X  -  X.X  -   X.X   - X...XXXXXX.XXXXXX...X -           X.X..X-X..X.X           - "
+    "X..............X"
+    "X.........X -XXX.XXX-   X.X   -  X..X    X.X    X..X  -            X...X-X...X            -  "
+    "X.............X"
+    "X..........X-X.....X-   X.X   -   X.X    X.X    X.X   -           X....X-X....X           -  "
+    "X.............X"
+    "X......XXXXX-XXXXXXX-   X.X   -    XX    X.X    XX    -          X.....X-X.....X          -   "
+    "X............X"
+    "X...X..X    ---------   X.X   -          X.X          -          XXXXXXX-XXXXXXX          -   "
+    "X...........X "
+    "X..X X..X   -       -XXXX.XXXX-       XXXX.XXXX       -------------------------------------   "
+    " X..........X "
+    "X.X  X..X   -       -X.......X-       X.......X       -    XX           XX    -           -   "
+    " X..........X "
+    "XX    X..X  -       - X.....X -        X.....X        -   X.X           X.X   -           -   "
+    "  X........X  "
+    "      X..X          -  X...X  -         X...X         -  X..X           X..X  -           -   "
+    "  X........X  "
+    "       XX           -   X.X   -          X.X          - X...XXXXXXXXXXXXX...X -           -   "
+    "  XXXXXXXXXX  "
+    "------------        -    X    -           X           -X.....................X-           "
+    "------------------"
+    "                    ----------------------------------- X...XXXXXXXXXXXXX...X -               "
+    "              "
+    "                                                      -  X..X           X..X  -               "
+    "              "
+    "                                                      -   X.X           X.X   -               "
+    "              "
+    "                                                      -    XX           XX    -               "
+    "              "};
+
+static const ImVec2 FONT_ATLAS_DEFAULT_TEX_CURSOR_DATA[ImGuiMouseCursor_COUNT][3] = {
+    // Pos ........ Size ......... Offset ......
+    {ImVec2(0, 3), ImVec2(12, 19), ImVec2(0, 0)},     // ImGuiMouseCursor_Arrow
+    {ImVec2(13, 0), ImVec2(7, 16), ImVec2(1, 8)},     // ImGuiMouseCursor_TextInput
+    {ImVec2(31, 0), ImVec2(23, 23), ImVec2(11, 11)},  // ImGuiMouseCursor_ResizeAll
+    {ImVec2(21, 0), ImVec2(9, 23), ImVec2(4, 11)},    // ImGuiMouseCursor_ResizeNS
+    {ImVec2(55, 18), ImVec2(23, 9), ImVec2(11, 4)},   // ImGuiMouseCursor_ResizeEW
+    {ImVec2(73, 0), ImVec2(17, 17), ImVec2(8, 8)},    // ImGuiMouseCursor_ResizeNESW
+    {ImVec2(55, 0), ImVec2(17, 17), ImVec2(8, 8)},    // ImGuiMouseCursor_ResizeNWSE
+    {ImVec2(91, 0), ImVec2(17, 22), ImVec2(5, 0)},    // ImGuiMouseCursor_Hand
+};
+
+ImFontAtlas::ImFontAtlas()
+{
+    Locked          = false;
+    Flags           = ImFontAtlasFlags_None;
+    TexID           = (ImTextureID)NULL;
+    TexDesiredWidth = 0;
+    TexGlyphPadding = 1;
+
+    TexPixelsAlpha8 = NULL;
+    TexPixelsRGBA32 = NULL;
+    TexWidth = TexHeight = 0;
+    TexUvScale           = ImVec2(0.0f, 0.0f);
+    TexUvWhitePixel      = ImVec2(0.0f, 0.0f);
+    for (int n = 0; n < IM_ARRAYSIZE(CustomRectIds); n++)
+        CustomRectIds[n] = -1;
+}
+
+ImFontAtlas::~ImFontAtlas()
+{
+    IM_ASSERT(!Locked &&
+              "Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!");
+    Clear();
+}
+
+void ImFontAtlas::ClearInputData()
+{
+    IM_ASSERT(!Locked &&
+              "Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!");
+    for (int i = 0; i < ConfigData.Size; i++)
+        if (ConfigData[i].FontData && ConfigData[i].FontDataOwnedByAtlas)
+        {
+            IM_FREE(ConfigData[i].FontData);
+            ConfigData[i].FontData = NULL;
+        }
+
+    // When clearing this we lose access to the font name and other information used to build the
+    // font.
+    for (int i = 0; i < Fonts.Size; i++)
+        if (Fonts[i]->ConfigData >= ConfigData.Data &&
+            Fonts[i]->ConfigData < ConfigData.Data + ConfigData.Size)
+        {
+            Fonts[i]->ConfigData      = NULL;
+            Fonts[i]->ConfigDataCount = 0;
+        }
+    ConfigData.clear();
+    CustomRects.clear();
+    for (int n = 0; n < IM_ARRAYSIZE(CustomRectIds); n++)
+        CustomRectIds[n] = -1;
+}
+
+void ImFontAtlas::ClearTexData()
+{
+    IM_ASSERT(!Locked &&
+              "Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!");
+    if (TexPixelsAlpha8)
+        IM_FREE(TexPixelsAlpha8);
+    if (TexPixelsRGBA32)
+        IM_FREE(TexPixelsRGBA32);
+    TexPixelsAlpha8 = NULL;
+    TexPixelsRGBA32 = NULL;
+}
+
+void ImFontAtlas::ClearFonts()
+{
+    IM_ASSERT(!Locked &&
+              "Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!");
+    for (int i = 0; i < Fonts.Size; i++)
+        IM_DELETE(Fonts[i]);
+    Fonts.clear();
+}
+
+void ImFontAtlas::Clear()
+{
+    ClearInputData();
+    ClearTexData();
+    ClearFonts();
+}
+
+void ImFontAtlas::GetTexDataAsAlpha8(unsigned char **out_pixels,
+                                     int *out_width,
+                                     int *out_height,
+                                     int *out_bytes_per_pixel)
+{
+    // Build atlas on demand
+    if (TexPixelsAlpha8 == NULL)
+    {
+        if (ConfigData.empty())
+            AddFontDefault();
+        Build();
+    }
+
+    *out_pixels = TexPixelsAlpha8;
+    if (out_width)
+        *out_width = TexWidth;
+    if (out_height)
+        *out_height = TexHeight;
+    if (out_bytes_per_pixel)
+        *out_bytes_per_pixel = 1;
+}
+
+void ImFontAtlas::GetTexDataAsRGBA32(unsigned char **out_pixels,
+                                     int *out_width,
+                                     int *out_height,
+                                     bool enableAlphaBlending,
+                                     int *out_bytes_per_pixel)
+{
+    // Convert to RGBA32 format on demand
+    // Although it is likely to be the most commonly used format, our font rendering is 1 channel /
+    // 8 bpp
+    if (!TexPixelsRGBA32)
+    {
+        unsigned char *pixels = NULL;
+        GetTexDataAsAlpha8(&pixels, NULL, NULL);
+        if (pixels)
+        {
+            TexPixelsRGBA32 = (unsigned int *)IM_ALLOC((size_t)TexWidth * (size_t)TexHeight * 4);
+            const unsigned char *src = pixels;
+            unsigned int *dst        = TexPixelsRGBA32;
+            if (!enableAlphaBlending)
+            {
+                for (int n = TexWidth * TexHeight; n > 0; n--)
+                    if ((unsigned int)(*src++) == 255)
+                    {
+                        *dst++ = IM_COL32(255, 255, 255, 255);
+                    }
+                    else
+                    {
+                        *dst++ = IM_COL32(0, 0, 0, 255);
+                    }
+            }
+            else
+            {
+                for (int n = TexWidth * TexHeight; n > 0; n--)
+                {
+                    *dst++ = IM_COL32(255, 255, 255, (unsigned int)(*src++));
+                }
+            }
+        }
+    }
+
+    *out_pixels = (unsigned char *)TexPixelsRGBA32;
+    if (out_width)
+        *out_width = TexWidth;
+    if (out_height)
+        *out_height = TexHeight;
+    if (out_bytes_per_pixel)
+        *out_bytes_per_pixel = 4;
+}
+
+ImFont *ImFontAtlas::AddFont(const ImFontConfig *font_cfg)
+{
+    IM_ASSERT(!Locked &&
+              "Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!");
+    IM_ASSERT(font_cfg->FontData != NULL && font_cfg->FontDataSize > 0);
+    IM_ASSERT(font_cfg->SizePixels > 0.0f);
+
+    // Create new font
+    if (!font_cfg->MergeMode)
+        Fonts.push_back(IM_NEW(ImFont));
+    else
+        IM_ASSERT(
+            !Fonts.empty() &&
+            "Cannot use MergeMode for the first font");  // When using MergeMode make sure
+                                                         // that a font has already been added
+                                                         // before. You can use
+                                                         // ImGui::GetIO().Fonts->AddFontDefault()
+                                                         // to add the default imgui font.
+
+    ConfigData.push_back(*font_cfg);
+    ImFontConfig &new_font_cfg = ConfigData.back();
+    if (new_font_cfg.DstFont == NULL)
+        new_font_cfg.DstFont = Fonts.back();
+    if (!new_font_cfg.FontDataOwnedByAtlas)
+    {
+        new_font_cfg.FontData             = IM_ALLOC(new_font_cfg.FontDataSize);
+        new_font_cfg.FontDataOwnedByAtlas = true;
+        memcpy(new_font_cfg.FontData, font_cfg->FontData, (size_t)new_font_cfg.FontDataSize);
+    }
+
+    // Invalidate texture
+    ClearTexData();
+    return new_font_cfg.DstFont;
+}
+
+// Default font TTF is compressed with stb_compress then base85 encoded (see
+// misc/fonts/binary_to_compressed_c.cpp for encoder)
+static unsigned int stb_decompress_length(const unsigned char *input);
+static unsigned int stb_decompress(unsigned char *output,
+                                   const unsigned char *input,
+                                   unsigned int length);
+static const char *GetDefaultCompressedFontDataTTFBase85();
+static unsigned int Decode85Byte(char c)
+{
+    return c >= '\\' ? c - 36 : c - 35;
+}
+static void Decode85(const unsigned char *src, unsigned char *dst)
+{
+    while (*src)
+    {
+        unsigned int tmp = Decode85Byte(src[0]) +
+                           85 * (Decode85Byte(src[1]) +
+                                 85 * (Decode85Byte(src[2]) +
+                                       85 * (Decode85Byte(src[3]) + 85 * Decode85Byte(src[4]))));
+        dst[0] = ((tmp >> 0) & 0xFF);
+        dst[1] = ((tmp >> 8) & 0xFF);
+        dst[2] = ((tmp >> 16) & 0xFF);
+        dst[3] = ((tmp >> 24) & 0xFF);  // We can't assume little-endianness.
+        src += 5;
+        dst += 4;
+    }
+}
+
+// Load embedded ProggyClean.ttf at size 13, disable oversampling
+ImFont *ImFontAtlas::AddFontDefault(const ImFontConfig *font_cfg_template)
+{
+    ImFontConfig font_cfg = font_cfg_template ? *font_cfg_template : ImFontConfig();
+    if (!font_cfg_template)
+    {
+        font_cfg.OversampleH = font_cfg.OversampleV = 1;
+        font_cfg.PixelSnapH                         = true;
+    }
+    if (font_cfg.SizePixels <= 0.0f)
+        font_cfg.SizePixels = 13.0f * 1.0f;
+    if (font_cfg.Name[0] == '\0')
+        ImFormatString(font_cfg.Name, IM_ARRAYSIZE(font_cfg.Name), "ProggyClean.ttf, %dpx",
+                       (int)font_cfg.SizePixels);
+
+    const char *ttf_compressed_base85 = GetDefaultCompressedFontDataTTFBase85();
+    const ImWchar *glyph_ranges =
+        font_cfg.GlyphRanges != NULL ? font_cfg.GlyphRanges : GetGlyphRangesDefault();
+    ImFont *font = AddFontFromMemoryCompressedBase85TTF(ttf_compressed_base85, font_cfg.SizePixels,
+                                                        &font_cfg, glyph_ranges);
+    font->DisplayOffset.y = 1.0f;
+    return font;
+}
+
+ImFont *ImFontAtlas::AddFontFromFileTTF(const char *filename,
+                                        float size_pixels,
+                                        const ImFontConfig *font_cfg_template,
+                                        const ImWchar *glyph_ranges)
+{
+    IM_ASSERT(!Locked &&
+              "Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!");
+    size_t data_size = 0;
+    void *data       = ImFileLoadToMemory(filename, "rb", &data_size, 0);
+    if (!data)
+    {
+        IM_ASSERT(0);  // Could not load file.
+        return NULL;
+    }
+    ImFontConfig font_cfg = font_cfg_template ? *font_cfg_template : ImFontConfig();
+    if (font_cfg.Name[0] == '\0')
+    {
+        // Store a short copy of filename into into the font name for convenience
+        const char *p;
+        for (p = filename + strlen(filename); p > filename && p[-1] != '/' && p[-1] != '\\'; p--)
+        {
+        }
+        ImFormatString(font_cfg.Name, IM_ARRAYSIZE(font_cfg.Name), "%s, %.0fpx", p, size_pixels);
+    }
+    return AddFontFromMemoryTTF(data, (int)data_size, size_pixels, &font_cfg, glyph_ranges);
+}
+
+// NB: Transfer ownership of 'ttf_data' to ImFontAtlas, unless
+// font_cfg_template->FontDataOwnedByAtlas == false. Owned TTF buffer will be deleted after Build().
+ImFont *ImFontAtlas::AddFontFromMemoryTTF(void *ttf_data,
+                                          int ttf_size,
+                                          float size_pixels,
+                                          const ImFontConfig *font_cfg_template,
+                                          const ImWchar *glyph_ranges)
+{
+    IM_ASSERT(!Locked &&
+              "Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!");
+    ImFontConfig font_cfg = font_cfg_template ? *font_cfg_template : ImFontConfig();
+    IM_ASSERT(font_cfg.FontData == NULL);
+    font_cfg.FontData     = ttf_data;
+    font_cfg.FontDataSize = ttf_size;
+    font_cfg.SizePixels   = size_pixels;
+    if (glyph_ranges)
+        font_cfg.GlyphRanges = glyph_ranges;
+    return AddFont(&font_cfg);
+}
+
+ImFont *ImFontAtlas::AddFontFromMemoryCompressedTTF(const void *compressed_ttf_data,
+                                                    int compressed_ttf_size,
+                                                    float size_pixels,
+                                                    const ImFontConfig *font_cfg_template,
+                                                    const ImWchar *glyph_ranges)
+{
+    const unsigned int buf_decompressed_size =
+        stb_decompress_length((const unsigned char *)compressed_ttf_data);
+    unsigned char *buf_decompressed_data = (unsigned char *)IM_ALLOC(buf_decompressed_size);
+    stb_decompress(buf_decompressed_data, (const unsigned char *)compressed_ttf_data,
+                   (unsigned int)compressed_ttf_size);
+
+    ImFontConfig font_cfg = font_cfg_template ? *font_cfg_template : ImFontConfig();
+    IM_ASSERT(font_cfg.FontData == NULL);
+    font_cfg.FontDataOwnedByAtlas = true;
+    return AddFontFromMemoryTTF(buf_decompressed_data, (int)buf_decompressed_size, size_pixels,
+                                &font_cfg, glyph_ranges);
+}
+
+ImFont *ImFontAtlas::AddFontFromMemoryCompressedBase85TTF(const char *compressed_ttf_data_base85,
+                                                          float size_pixels,
+                                                          const ImFontConfig *font_cfg,
+                                                          const ImWchar *glyph_ranges)
+{
+    int compressed_ttf_size = (((int)strlen(compressed_ttf_data_base85) + 4) / 5) * 4;
+    void *compressed_ttf    = IM_ALLOC((size_t)compressed_ttf_size);
+    Decode85((const unsigned char *)compressed_ttf_data_base85, (unsigned char *)compressed_ttf);
+    ImFont *font = AddFontFromMemoryCompressedTTF(compressed_ttf, compressed_ttf_size, size_pixels,
+                                                  font_cfg, glyph_ranges);
+    IM_FREE(compressed_ttf);
+    return font;
+}
+
+int ImFontAtlas::AddCustomRectRegular(unsigned int id, int width, int height)
+{
+    IM_ASSERT(id >= 0x10000);
+    IM_ASSERT(width > 0 && width <= 0xFFFF);
+    IM_ASSERT(height > 0 && height <= 0xFFFF);
+    CustomRect r;
+    r.ID     = id;
+    r.Width  = (unsigned short)width;
+    r.Height = (unsigned short)height;
+    CustomRects.push_back(r);
+    return CustomRects.Size - 1;  // Return index
+}
+
+int ImFontAtlas::AddCustomRectFontGlyph(ImFont *font,
+                                        ImWchar id,
+                                        int width,
+                                        int height,
+                                        float advance_x,
+                                        const ImVec2 &offset)
+{
+    IM_ASSERT(font != NULL);
+    IM_ASSERT(width > 0 && width <= 0xFFFF);
+    IM_ASSERT(height > 0 && height <= 0xFFFF);
+    CustomRect r;
+    r.ID            = id;
+    r.Width         = (unsigned short)width;
+    r.Height        = (unsigned short)height;
+    r.GlyphAdvanceX = advance_x;
+    r.GlyphOffset   = offset;
+    r.Font          = font;
+    CustomRects.push_back(r);
+    return CustomRects.Size - 1;  // Return index
+}
+
+void ImFontAtlas::CalcCustomRectUV(const CustomRect *rect, ImVec2 *out_uv_min, ImVec2 *out_uv_max)
+{
+    IM_ASSERT(TexWidth > 0 &&
+              TexHeight >
+                  0);  // Font atlas needs to be built before we can calculate UV coordinates
+    IM_ASSERT(rect->IsPacked());  // Make sure the rectangle has been packed
+    *out_uv_min = ImVec2((float)rect->X * TexUvScale.x, (float)rect->Y * TexUvScale.y);
+    *out_uv_max = ImVec2((float)(rect->X + rect->Width) * TexUvScale.x,
+                         (float)(rect->Y + rect->Height) * TexUvScale.y);
+}
+
+bool ImFontAtlas::GetMouseCursorTexData(ImGuiMouseCursor cursor_type,
+                                        ImVec2 *out_offset,
+                                        ImVec2 *out_size,
+                                        ImVec2 out_uv_border[2],
+                                        ImVec2 out_uv_fill[2])
+{
+    if (cursor_type <= ImGuiMouseCursor_None || cursor_type >= ImGuiMouseCursor_COUNT)
+        return false;
+    if (Flags & ImFontAtlasFlags_NoMouseCursors)
+        return false;
+
+    IM_ASSERT(CustomRectIds[0] != -1);
+    ImFontAtlas::CustomRect &r = CustomRects[CustomRectIds[0]];
+    IM_ASSERT(r.ID == FONT_ATLAS_DEFAULT_TEX_DATA_ID);
+    ImVec2 pos =
+        FONT_ATLAS_DEFAULT_TEX_CURSOR_DATA[cursor_type][0] + ImVec2((float)r.X, (float)r.Y);
+    ImVec2 size      = FONT_ATLAS_DEFAULT_TEX_CURSOR_DATA[cursor_type][1];
+    *out_size        = size;
+    *out_offset      = FONT_ATLAS_DEFAULT_TEX_CURSOR_DATA[cursor_type][2];
+    out_uv_border[0] = (pos)*TexUvScale;
+    out_uv_border[1] = (pos + size) * TexUvScale;
+    pos.x += FONT_ATLAS_DEFAULT_TEX_DATA_W_HALF + 1;
+    out_uv_fill[0] = (pos)*TexUvScale;
+    out_uv_fill[1] = (pos + size) * TexUvScale;
+    return true;
+}
+
+bool ImFontAtlas::Build()
+{
+    IM_ASSERT(!Locked &&
+              "Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!");
+    return ImFontAtlasBuildWithStbTruetype(this);
+}
+
+void ImFontAtlasBuildMultiplyCalcLookupTable(unsigned char out_table[256], float in_brighten_factor)
+{
+    for (unsigned int i = 0; i < 256; i++)
+    {
+        unsigned int value = (unsigned int)(i * in_brighten_factor);
+        out_table[i]       = value > 255 ? 255 : (value & 0xFF);
+    }
+}
+
+void ImFontAtlasBuildMultiplyRectAlpha8(const unsigned char table[256],
+                                        unsigned char *pixels,
+                                        int x,
+                                        int y,
+                                        int w,
+                                        int h,
+                                        int stride)
+{
+    unsigned char *data = pixels + x + y * stride;
+    for (int j = h; j > 0; j--, data += stride)
+        for (int i = 0; i < w; i++)
+            data[i] = table[data[i]];
+}
+
+// Temporary data for one source font (multiple source fonts can be merged into one destination
+// ImFont) (C++03 doesn't allow instancing ImVector<> with function-local types so we declare the
+// type here.)
+struct ImFontBuildSrcData
+{
+    stbtt_fontinfo FontInfo;
+    stbtt_pack_range
+        PackRange;  // Hold the list of codepoints to pack (essentially points to Codepoints.Data)
+    stbrp_rect *Rects;  // Rectangle to pack. We first fill in their size and the packer will give
+                        // us their position.
+    stbtt_packedchar *PackedChars;  // Output glyphs
+    const ImWchar *SrcRanges;  // Ranges as requested by user (user is allowed to request too much,
+                               // e.g. 0x0020..0xFFFF)
+    int DstIndex;              // Index into atlas->Fonts[] and dst_tmp_array[]
+    int GlyphsHighest;         // Highest requested codepoint
+    int GlyphsCount;  // Glyph count (excluding missing glyphs and glyphs already set by an earlier
+                      // source font)
+    ImBoolVector GlyphsSet;    // Glyph bit map (random access, 1-bit per codepoint. This will be a
+                               // maximum of 8KB)
+    ImVector<int> GlyphsList;  // Glyph codepoints list (flattened version of GlyphsMap)
+};
+
+// Temporary data for one destination ImFont* (multiple source fonts can be merged into one
+// destination ImFont)
+struct ImFontBuildDstData
+{
+    int SrcCount;  // Number of source fonts targeting this destination font.
+    int GlyphsHighest;
+    int GlyphsCount;
+    ImBoolVector GlyphsSet;  // This is used to resolve collision when multiple sources are merged
+                             // into a same destination font.
+};
+
+static void UnpackBoolVectorToFlatIndexList(const ImBoolVector *in, ImVector<int> *out)
+{
+    IM_ASSERT(sizeof(in->Storage.Data[0]) == sizeof(int));
+    const int *it_begin = in->Storage.begin();
+    const int *it_end   = in->Storage.end();
+    for (const int *it = it_begin; it < it_end; it++)
+        if (int entries_32 = *it)
+            for (int bit_n = 0; bit_n < 32; bit_n++)
+                if (entries_32 & (1u << bit_n))
+                    out->push_back((int)((it - it_begin) << 5) + bit_n);
+}
+
+bool ImFontAtlasBuildWithStbTruetype(ImFontAtlas *atlas)
+{
+    IM_ASSERT(atlas->ConfigData.Size > 0);
+
+    ImFontAtlasBuildRegisterDefaultCustomRects(atlas);
+
+    // Clear atlas
+    atlas->TexID    = (ImTextureID)NULL;
+    atlas->TexWidth = atlas->TexHeight = 0;
+    atlas->TexUvScale                  = ImVec2(0.0f, 0.0f);
+    atlas->TexUvWhitePixel             = ImVec2(0.0f, 0.0f);
+    atlas->ClearTexData();
+
+    // Temporary storage for building
+    ImVector<ImFontBuildSrcData> src_tmp_array;
+    ImVector<ImFontBuildDstData> dst_tmp_array;
+    src_tmp_array.resize(atlas->ConfigData.Size);
+    dst_tmp_array.resize(atlas->Fonts.Size);
+    memset(src_tmp_array.Data, 0, (size_t)src_tmp_array.size_in_bytes());
+    memset(dst_tmp_array.Data, 0, (size_t)dst_tmp_array.size_in_bytes());
+
+    // 1. Initialize font loading structure, check font data validity
+    for (int src_i = 0; src_i < atlas->ConfigData.Size; src_i++)
+    {
+        ImFontBuildSrcData &src_tmp = src_tmp_array[src_i];
+        ImFontConfig &cfg           = atlas->ConfigData[src_i];
+        IM_ASSERT(cfg.DstFont &&
+                  (!cfg.DstFont->IsLoaded() || cfg.DstFont->ContainerAtlas == atlas));
+
+        // Find index from cfg.DstFont (we allow the user to set cfg.DstFont. Also it makes casual
+        // debugging nicer than when storing indices)
+        src_tmp.DstIndex = -1;
+        for (int output_i = 0; output_i < atlas->Fonts.Size && src_tmp.DstIndex == -1; output_i++)
+            if (cfg.DstFont == atlas->Fonts[output_i])
+                src_tmp.DstIndex = output_i;
+        IM_ASSERT(src_tmp.DstIndex != -1);  // cfg.DstFont not pointing within atlas->Fonts[] array?
+        if (src_tmp.DstIndex == -1)
+            return false;
+
+        // Initialize helper structure for font loading and verify that the TTF/OTF data is correct
+        const int font_offset =
+            stbtt_GetFontOffsetForIndex((unsigned char *)cfg.FontData, cfg.FontNo);
+        IM_ASSERT(font_offset >= 0 && "FontData is incorrect, or FontNo cannot be found.");
+        if (!stbtt_InitFont(&src_tmp.FontInfo, (unsigned char *)cfg.FontData, font_offset))
+            return false;
+
+        // Measure highest codepoints
+        ImFontBuildDstData &dst_tmp = dst_tmp_array[src_tmp.DstIndex];
+        src_tmp.SrcRanges = cfg.GlyphRanges ? cfg.GlyphRanges : atlas->GetGlyphRangesDefault();
+        for (const ImWchar *src_range = src_tmp.SrcRanges; src_range[0] && src_range[1];
+             src_range += 2)
+            src_tmp.GlyphsHighest = ImMax(src_tmp.GlyphsHighest, (int)src_range[1]);
+        dst_tmp.SrcCount++;
+        dst_tmp.GlyphsHighest = ImMax(dst_tmp.GlyphsHighest, src_tmp.GlyphsHighest);
+    }
+
+    // 2. For every requested codepoint, check for their presence in the font data, and handle
+    // redundancy or overlaps between source fonts to avoid unused glyphs.
+    int total_glyphs_count = 0;
+    for (int src_i = 0; src_i < src_tmp_array.Size; src_i++)
+    {
+        ImFontBuildSrcData &src_tmp = src_tmp_array[src_i];
+        ImFontBuildDstData &dst_tmp = dst_tmp_array[src_tmp.DstIndex];
+        src_tmp.GlyphsSet.Resize(src_tmp.GlyphsHighest + 1);
+        if (dst_tmp.GlyphsSet.Storage.empty())
+            dst_tmp.GlyphsSet.Resize(dst_tmp.GlyphsHighest + 1);
+
+        for (const ImWchar *src_range = src_tmp.SrcRanges; src_range[0] && src_range[1];
+             src_range += 2)
+            for (int codepoint = src_range[0]; codepoint <= src_range[1]; codepoint++)
+            {
+                if (dst_tmp.GlyphsSet.GetBit(
+                        codepoint))  // Don't overwrite existing glyphs. We could make this an
+                                     // option for MergeMode (e.g. MergeOverwrite==true)
+                    continue;
+                if (!stbtt_FindGlyphIndex(&src_tmp.FontInfo,
+                                          codepoint))  // It is actually in the font?
+                    continue;
+
+                // Add to avail set/counters
+                src_tmp.GlyphsCount++;
+                dst_tmp.GlyphsCount++;
+                src_tmp.GlyphsSet.SetBit(codepoint, true);
+                dst_tmp.GlyphsSet.SetBit(codepoint, true);
+                total_glyphs_count++;
+            }
+    }
+
+    // 3. Unpack our bit map into a flat list (we now have all the Unicode points that we know are
+    // requested _and_ available _and_ not overlapping another)
+    for (int src_i = 0; src_i < src_tmp_array.Size; src_i++)
+    {
+        ImFontBuildSrcData &src_tmp = src_tmp_array[src_i];
+        src_tmp.GlyphsList.reserve(src_tmp.GlyphsCount);
+        UnpackBoolVectorToFlatIndexList(&src_tmp.GlyphsSet, &src_tmp.GlyphsList);
+        src_tmp.GlyphsSet.Clear();
+        IM_ASSERT(src_tmp.GlyphsList.Size == src_tmp.GlyphsCount);
+    }
+    for (int dst_i = 0; dst_i < dst_tmp_array.Size; dst_i++)
+        dst_tmp_array[dst_i].GlyphsSet.Clear();
+    dst_tmp_array.clear();
+
+    // Allocate packing character data and flag packed characters buffer as non-packed
+    // (x0=y0=x1=y1=0) (We technically don't need to zero-clear buf_rects, but let's do it for the
+    // sake of sanity)
+    ImVector<stbrp_rect> buf_rects;
+    ImVector<stbtt_packedchar> buf_packedchars;
+    buf_rects.resize(total_glyphs_count);
+    buf_packedchars.resize(total_glyphs_count);
+    memset(buf_rects.Data, 0, (size_t)buf_rects.size_in_bytes());
+    memset(buf_packedchars.Data, 0, (size_t)buf_packedchars.size_in_bytes());
+
+    // 4. Gather glyphs sizes so we can pack them in our virtual canvas.
+    int total_surface         = 0;
+    int buf_rects_out_n       = 0;
+    int buf_packedchars_out_n = 0;
+    for (int src_i = 0; src_i < src_tmp_array.Size; src_i++)
+    {
+        ImFontBuildSrcData &src_tmp = src_tmp_array[src_i];
+        if (src_tmp.GlyphsCount == 0)
+            continue;
+
+        src_tmp.Rects       = &buf_rects[buf_rects_out_n];
+        src_tmp.PackedChars = &buf_packedchars[buf_packedchars_out_n];
+        buf_rects_out_n += src_tmp.GlyphsCount;
+        buf_packedchars_out_n += src_tmp.GlyphsCount;
+
+        // Convert our ranges in the format stb_truetype wants
+        ImFontConfig &cfg                                  = atlas->ConfigData[src_i];
+        src_tmp.PackRange.font_size                        = cfg.SizePixels;
+        src_tmp.PackRange.first_unicode_codepoint_in_range = 0;
+        src_tmp.PackRange.array_of_unicode_codepoints      = src_tmp.GlyphsList.Data;
+        src_tmp.PackRange.num_chars                        = src_tmp.GlyphsList.Size;
+        src_tmp.PackRange.chardata_for_range               = src_tmp.PackedChars;
+        src_tmp.PackRange.h_oversample                     = (unsigned char)cfg.OversampleH;
+        src_tmp.PackRange.v_oversample                     = (unsigned char)cfg.OversampleV;
+
+        // Gather the sizes of all rectangles we will need to pack (this loop is based on
+        // stbtt_PackFontRangesGatherRects)
+        const float scale =
+            (cfg.SizePixels > 0)
+                ? stbtt_ScaleForPixelHeight(&src_tmp.FontInfo, cfg.SizePixels)
+                : stbtt_ScaleForMappingEmToPixels(&src_tmp.FontInfo, -cfg.SizePixels);
+        const int padding = atlas->TexGlyphPadding;
+        for (int glyph_i = 0; glyph_i < src_tmp.GlyphsList.Size; glyph_i++)
+        {
+            int x0, y0, x1, y1;
+            const int glyph_index_in_font =
+                stbtt_FindGlyphIndex(&src_tmp.FontInfo, src_tmp.GlyphsList[glyph_i]);
+            IM_ASSERT(glyph_index_in_font != 0);
+            stbtt_GetGlyphBitmapBoxSubpixel(&src_tmp.FontInfo, glyph_index_in_font,
+                                            scale * cfg.OversampleH, scale * cfg.OversampleV, 0, 0,
+                                            &x0, &y0, &x1, &y1);
+            src_tmp.Rects[glyph_i].w = (stbrp_coord)(x1 - x0 + padding + cfg.OversampleH - 1);
+            src_tmp.Rects[glyph_i].h = (stbrp_coord)(y1 - y0 + padding + cfg.OversampleV - 1);
+            total_surface += src_tmp.Rects[glyph_i].w * src_tmp.Rects[glyph_i].h;
+        }
+    }
+
+    // We need a width for the skyline algorithm, any width!
+    // The exact width doesn't really matter much, but some API/GPU have texture size limitations
+    // and increasing width can decrease height. User can override TexDesiredWidth and
+    // TexGlyphPadding if they wish, otherwise we use a simple heuristic to select the width based
+    // on expected surface.
+    const int surface_sqrt = (int)ImSqrt((float)total_surface) + 1;
+    atlas->TexHeight       = 0;
+    if (atlas->TexDesiredWidth > 0)
+        atlas->TexWidth = atlas->TexDesiredWidth;
+    else
+        atlas->TexWidth =
+            (surface_sqrt >= 4096 * 0.7f)
+                ? 4096
+                : (surface_sqrt >= 2048 * 0.7f) ? 2048 : (surface_sqrt >= 1024 * 0.7f) ? 1024 : 512;
+
+    // 5. Start packing
+    // Pack our extra data rectangles first, so it will be on the upper-left corner of our texture
+    // (UV will have small values).
+    const int TEX_HEIGHT_MAX = 1024 * 32;
+    stbtt_pack_context spc   = {};
+    stbtt_PackBegin(&spc, NULL, atlas->TexWidth, TEX_HEIGHT_MAX, 0, atlas->TexGlyphPadding, NULL);
+    ImFontAtlasBuildPackCustomRects(atlas, spc.pack_info);
+
+    // 6. Pack each source font. No rendering yet, we are working with rectangles in an infinitely
+    // tall texture at this point.
+    for (int src_i = 0; src_i < src_tmp_array.Size; src_i++)
+    {
+        ImFontBuildSrcData &src_tmp = src_tmp_array[src_i];
+        if (src_tmp.GlyphsCount == 0)
+            continue;
+
+        stbrp_pack_rects((stbrp_context *)spc.pack_info, src_tmp.Rects, src_tmp.GlyphsCount);
+
+        // Extend texture height and mark missing glyphs as non-packed so we won't render them.
+        // FIXME: We are not handling packing failure here (would happen if we got off
+        // TEX_HEIGHT_MAX or if a single if larger than TexWidth?)
+        for (int glyph_i = 0; glyph_i < src_tmp.GlyphsCount; glyph_i++)
+            if (src_tmp.Rects[glyph_i].was_packed)
+                atlas->TexHeight =
+                    ImMax(atlas->TexHeight, src_tmp.Rects[glyph_i].y + src_tmp.Rects[glyph_i].h);
+    }
+
+    // 7. Allocate texture
+    atlas->TexHeight = (atlas->Flags & ImFontAtlasFlags_NoPowerOfTwoHeight)
+                           ? (atlas->TexHeight + 1)
+                           : ImUpperPowerOfTwo(atlas->TexHeight);
+    atlas->TexUvScale      = ImVec2(1.0f / atlas->TexWidth, 1.0f / atlas->TexHeight);
+    atlas->TexPixelsAlpha8 = (unsigned char *)IM_ALLOC(atlas->TexWidth * atlas->TexHeight);
+    memset(atlas->TexPixelsAlpha8, 0, atlas->TexWidth * atlas->TexHeight);
+    spc.pixels = atlas->TexPixelsAlpha8;
+    spc.height = atlas->TexHeight;
+
+    // 8. Render/rasterize font characters into the texture
+    for (int src_i = 0; src_i < src_tmp_array.Size; src_i++)
+    {
+        ImFontConfig &cfg           = atlas->ConfigData[src_i];
+        ImFontBuildSrcData &src_tmp = src_tmp_array[src_i];
+        if (src_tmp.GlyphsCount == 0)
+            continue;
+
+        stbtt_PackFontRangesRenderIntoRects(&spc, &src_tmp.FontInfo, &src_tmp.PackRange, 1,
+                                            src_tmp.Rects);
+
+        // Apply multiply operator
+        if (cfg.RasterizerMultiply != 1.0f)
+        {
+            unsigned char multiply_table[256];
+            ImFontAtlasBuildMultiplyCalcLookupTable(multiply_table, cfg.RasterizerMultiply);
+            stbrp_rect *r = &src_tmp.Rects[0];
+            for (int glyph_i = 0; glyph_i < src_tmp.GlyphsCount; glyph_i++, r++)
+                if (r->was_packed)
+                    ImFontAtlasBuildMultiplyRectAlpha8(multiply_table, atlas->TexPixelsAlpha8, r->x,
+                                                       r->y, r->w, r->h, atlas->TexWidth * 1);
+        }
+        src_tmp.Rects = NULL;
+    }
+
+    // End packing
+    stbtt_PackEnd(&spc);
+    buf_rects.clear();
+
+    // 9. Setup ImFont and glyphs for runtime
+    for (int src_i = 0; src_i < src_tmp_array.Size; src_i++)
+    {
+        ImFontBuildSrcData &src_tmp = src_tmp_array[src_i];
+        if (src_tmp.GlyphsCount == 0)
+            continue;
+
+        ImFontConfig &cfg = atlas->ConfigData[src_i];
+        ImFont *dst_font  = cfg.DstFont;  // We can have multiple input fonts writing into a same
+                                          // destination font (when using MergeMode=true)
+
+        const float font_scale = stbtt_ScaleForPixelHeight(&src_tmp.FontInfo, cfg.SizePixels);
+        int unscaled_ascent, unscaled_descent, unscaled_line_gap;
+        stbtt_GetFontVMetrics(&src_tmp.FontInfo, &unscaled_ascent, &unscaled_descent,
+                              &unscaled_line_gap);
+
+        const float ascent =
+            ImFloor(unscaled_ascent * font_scale + ((unscaled_ascent > 0.0f) ? +1 : -1));
+        const float descent =
+            ImFloor(unscaled_descent * font_scale + ((unscaled_descent > 0.0f) ? +1 : -1));
+        ImFontAtlasBuildSetupFont(atlas, dst_font, &cfg, ascent, descent);
+        const float font_off_x = cfg.GlyphOffset.x;
+        const float font_off_y = cfg.GlyphOffset.y + (float)(int)(dst_font->Ascent + 0.5f);
+
+        for (int glyph_i = 0; glyph_i < src_tmp.GlyphsCount; glyph_i++)
+        {
+            const int codepoint        = src_tmp.GlyphsList[glyph_i];
+            const stbtt_packedchar &pc = src_tmp.PackedChars[glyph_i];
+
+            const float char_advance_x_org = pc.xadvance;
+            const float char_advance_x_mod =
+                ImClamp(char_advance_x_org, cfg.GlyphMinAdvanceX, cfg.GlyphMaxAdvanceX);
+            float char_off_x = font_off_x;
+            if (char_advance_x_org != char_advance_x_mod)
+                char_off_x += cfg.PixelSnapH
+                                  ? (float)(int)((char_advance_x_mod - char_advance_x_org) * 0.5f)
+                                  : (char_advance_x_mod - char_advance_x_org) * 0.5f;
+
+            // Register glyph
+            stbtt_aligned_quad q;
+            float dummy_x = 0.0f, dummy_y = 0.0f;
+            stbtt_GetPackedQuad(src_tmp.PackedChars, atlas->TexWidth, atlas->TexHeight, glyph_i,
+                                &dummy_x, &dummy_y, &q, 0);
+            dst_font->AddGlyph((ImWchar)codepoint, q.x0 + char_off_x, q.y0 + font_off_y,
+                               q.x1 + char_off_x, q.y1 + font_off_y, q.s0, q.t0, q.s1, q.t1,
+                               char_advance_x_mod);
+        }
+    }
+
+    // Cleanup temporary (ImVector doesn't honor destructor)
+    for (int src_i = 0; src_i < src_tmp_array.Size; src_i++)
+        src_tmp_array[src_i].~ImFontBuildSrcData();
+
+    ImFontAtlasBuildFinish(atlas);
+    return true;
+}
+
+void ImFontAtlasBuildRegisterDefaultCustomRects(ImFontAtlas *atlas)
+{
+    if (atlas->CustomRectIds[0] >= 0)
+        return;
+    if (!(atlas->Flags & ImFontAtlasFlags_NoMouseCursors))
+        atlas->CustomRectIds[0] = atlas->AddCustomRectRegular(
+            FONT_ATLAS_DEFAULT_TEX_DATA_ID, FONT_ATLAS_DEFAULT_TEX_DATA_W_HALF * 2 + 1,
+            FONT_ATLAS_DEFAULT_TEX_DATA_H);
+    else
+        atlas->CustomRectIds[0] = atlas->AddCustomRectRegular(FONT_ATLAS_DEFAULT_TEX_DATA_ID, 2, 2);
+}
+
+void ImFontAtlasBuildSetupFont(ImFontAtlas *atlas,
+                               ImFont *font,
+                               ImFontConfig *font_config,
+                               float ascent,
+                               float descent)
+{
+    if (!font_config->MergeMode)
+    {
+        font->ClearOutputData();
+        font->FontSize       = font_config->SizePixels;
+        font->ConfigData     = font_config;
+        font->ContainerAtlas = atlas;
+        font->Ascent         = ascent;
+        font->Descent        = descent;
+    }
+    font->ConfigDataCount++;
+}
+
+void ImFontAtlasBuildPackCustomRects(ImFontAtlas *atlas, void *stbrp_context_opaque)
+{
+    stbrp_context *pack_context = (stbrp_context *)stbrp_context_opaque;
+    IM_ASSERT(pack_context != NULL);
+
+    ImVector<ImFontAtlas::CustomRect> &user_rects = atlas->CustomRects;
+    IM_ASSERT(user_rects.Size >= 1);  // We expect at least the default custom rects to be
+                                      // registered, else something went wrong.
+
+    ImVector<stbrp_rect> pack_rects;
+    pack_rects.resize(user_rects.Size);
+    memset(pack_rects.Data, 0, (size_t)pack_rects.size_in_bytes());
+    for (int i = 0; i < user_rects.Size; i++)
+    {
+        pack_rects[i].w = user_rects[i].Width;
+        pack_rects[i].h = user_rects[i].Height;
+    }
+    stbrp_pack_rects(pack_context, &pack_rects[0], pack_rects.Size);
+    for (int i = 0; i < pack_rects.Size; i++)
+        if (pack_rects[i].was_packed)
+        {
+            user_rects[i].X = pack_rects[i].x;
+            user_rects[i].Y = pack_rects[i].y;
+            IM_ASSERT(pack_rects[i].w == user_rects[i].Width &&
+                      pack_rects[i].h == user_rects[i].Height);
+            atlas->TexHeight = ImMax(atlas->TexHeight, pack_rects[i].y + pack_rects[i].h);
+        }
+}
+
+static void ImFontAtlasBuildRenderDefaultTexData(ImFontAtlas *atlas)
+{
+    IM_ASSERT(atlas->CustomRectIds[0] >= 0);
+    IM_ASSERT(atlas->TexPixelsAlpha8 != NULL);
+    ImFontAtlas::CustomRect &r = atlas->CustomRects[atlas->CustomRectIds[0]];
+    IM_ASSERT(r.ID == FONT_ATLAS_DEFAULT_TEX_DATA_ID);
+    IM_ASSERT(r.IsPacked());
+
+    const int w = atlas->TexWidth;
+    if (!(atlas->Flags & ImFontAtlasFlags_NoMouseCursors))
+    {
+        // Render/copy pixels
+        IM_ASSERT(r.Width == FONT_ATLAS_DEFAULT_TEX_DATA_W_HALF * 2 + 1 &&
+                  r.Height == FONT_ATLAS_DEFAULT_TEX_DATA_H);
+        for (int y = 0, n = 0; y < FONT_ATLAS_DEFAULT_TEX_DATA_H; y++)
+            for (int x = 0; x < FONT_ATLAS_DEFAULT_TEX_DATA_W_HALF; x++, n++)
+            {
+                const int offset0 = (int)(r.X + x) + (int)(r.Y + y) * w;
+                const int offset1 = offset0 + FONT_ATLAS_DEFAULT_TEX_DATA_W_HALF + 1;
+                atlas->TexPixelsAlpha8[offset0] =
+                    FONT_ATLAS_DEFAULT_TEX_DATA_PIXELS[n] == '.' ? 0xFF : 0x00;
+                atlas->TexPixelsAlpha8[offset1] =
+                    FONT_ATLAS_DEFAULT_TEX_DATA_PIXELS[n] == 'X' ? 0xFF : 0x00;
+            }
+    }
+    else
+    {
+        IM_ASSERT(r.Width == 2 && r.Height == 2);
+        const int offset                       = (int)(r.X) + (int)(r.Y) * w;
+        atlas->TexPixelsAlpha8[offset]         = atlas->TexPixelsAlpha8[offset + 1] =
+            atlas->TexPixelsAlpha8[offset + w] = atlas->TexPixelsAlpha8[offset + w + 1] = 0xFF;
+    }
+    atlas->TexUvWhitePixel =
+        ImVec2((r.X + 0.5f) * atlas->TexUvScale.x, (r.Y + 0.5f) * atlas->TexUvScale.y);
+}
+
+void ImFontAtlasBuildFinish(ImFontAtlas *atlas)
+{
+    // Render into our custom data block
+    ImFontAtlasBuildRenderDefaultTexData(atlas);
+
+    // Register custom rectangle glyphs
+    for (int i = 0; i < atlas->CustomRects.Size; i++)
+    {
+        const ImFontAtlas::CustomRect &r = atlas->CustomRects[i];
+        if (r.Font == NULL || r.ID > 0x10000)
+            continue;
+
+        IM_ASSERT(r.Font->ContainerAtlas == atlas);
+        ImVec2 uv0, uv1;
+        atlas->CalcCustomRectUV(&r, &uv0, &uv1);
+        r.Font->AddGlyph((ImWchar)r.ID, r.GlyphOffset.x, r.GlyphOffset.y, r.GlyphOffset.x + r.Width,
+                         r.GlyphOffset.y + r.Height, uv0.x, uv0.y, uv1.x, uv1.y, r.GlyphAdvanceX);
+    }
+
+    // Build all fonts lookup tables
+    for (int i = 0; i < atlas->Fonts.Size; i++)
+        if (atlas->Fonts[i]->DirtyLookupTables)
+            atlas->Fonts[i]->BuildLookupTable();
+}
+
+// Retrieve list of range (2 int per range, values are inclusive)
+const ImWchar *ImFontAtlas::GetGlyphRangesDefault()
+{
+    static const ImWchar ranges[] = {
+        0x0020,
+        0x00FF,  // Basic Latin + Latin Supplement
+        0,
+    };
+    return &ranges[0];
+}
+
+const ImWchar *ImFontAtlas::GetGlyphRangesKorean()
+{
+    static const ImWchar ranges[] = {
+        0x0020, 0x00FF,  // Basic Latin + Latin Supplement
+        0x3131, 0x3163,  // Korean alphabets
+        0xAC00, 0xD79D,  // Korean characters
+        0,
+    };
+    return &ranges[0];
+}
+
+const ImWchar *ImFontAtlas::GetGlyphRangesChineseFull()
+{
+    static const ImWchar ranges[] = {
+        0x0020, 0x00FF,  // Basic Latin + Latin Supplement
+        0x2000, 0x206F,  // General Punctuation
+        0x3000, 0x30FF,  // CJK Symbols and Punctuations, Hiragana, Katakana
+        0x31F0, 0x31FF,  // Katakana Phonetic Extensions
+        0xFF00, 0xFFEF,  // Half-width characters
+        0x4e00, 0x9FAF,  // CJK Ideograms
+        0,
+    };
+    return &ranges[0];
+}
+
+static void UnpackAccumulativeOffsetsIntoRanges(int base_codepoint,
+                                                const short *accumulative_offsets,
+                                                int accumulative_offsets_count,
+                                                ImWchar *out_ranges)
+{
+    for (int n = 0; n < accumulative_offsets_count; n++, out_ranges += 2)
+    {
+        out_ranges[0] = out_ranges[1] = (ImWchar)(base_codepoint + accumulative_offsets[n]);
+        base_codepoint += accumulative_offsets[n];
+    }
+    out_ranges[0] = 0;
+}
+
+//-------------------------------------------------------------------------
+// [SECTION] ImFontAtlas glyph ranges helpers
+//-------------------------------------------------------------------------
+
+const ImWchar *ImFontAtlas::GetGlyphRangesChineseSimplifiedCommon()
+{
+    // Store 2500 regularly used characters for Simplified Chinese.
+    // Sourced from
+    // https://zh.wiktionary.org/wiki/%E9%99%84%E5%BD%95:%E7%8E%B0%E4%BB%A3%E6%B1%89%E8%AF%AD%E5%B8%B8%E7%94%A8%E5%AD%97%E8%A1%A8
+    // This table covers 97.97% of all characters used during the month in July, 1987.
+    // You can use ImFontGlyphRangesBuilder to create your own ranges derived from this, by merging
+    // existing ranges or adding new characters. (Stored as accumulative offsets from the initial
+    // unicode codepoint 0x4E00. This encoding is designed to helps us compact the source code
+    // size.)
+    static const short accumulative_offsets_from_0x4E00[] = {
+        0,   1,  2,  4,  1,   1,  1,  1,   2,   1,   3,   2,  1,  2,   2,   1,   1,   1,   1,   1,
+        5,   2,  1,  2,  3,   3,  3,  2,   2,   4,   1,   1,  1,  2,   1,   5,   2,   3,   1,   2,
+        1,   2,  1,  1,  2,   1,  1,  2,   2,   1,   4,   1,  1,  1,   1,   5,   10,  1,   2,   19,
+        2,   1,  2,  1,  2,   1,  2,  1,   2,   1,   5,   1,  6,  3,   2,   1,   2,   2,   1,   1,
+        1,   4,  8,  5,  1,   1,  4,  1,   1,   3,   1,   2,  1,  5,   1,   2,   1,   1,   1,   10,
+        1,   1,  5,  2,  4,   6,  1,  4,   2,   2,   2,   12, 2,  1,   1,   6,   1,   1,   1,   4,
+        1,   1,  4,  6,  5,   1,  4,  2,   2,   4,   10,  7,  1,  1,   4,   2,   4,   2,   1,   4,
+        3,   6,  10, 12, 5,   7,  2,  14,  2,   9,   1,   1,  6,  7,   10,  4,   7,   13,  1,   5,
+        4,   8,  4,  1,  1,   2,  28, 5,   6,   1,   1,   5,  2,  5,   20,  2,   2,   9,   8,   11,
+        2,   9,  17, 1,  8,   6,  8,  27,  4,   6,   9,   20, 11, 27,  6,   68,  2,   2,   1,   1,
+        1,   2,  1,  2,  2,   7,  6,  11,  3,   3,   1,   1,  3,  1,   2,   1,   1,   1,   1,   1,
+        3,   1,  1,  8,  3,   4,  1,  5,   7,   2,   1,   4,  4,  8,   4,   2,   1,   2,   1,   1,
+        4,   5,  6,  3,  6,   2,  12, 3,   1,   3,   9,   2,  4,  3,   4,   1,   5,   3,   3,   1,
+        3,   7,  1,  5,  1,   1,  1,  1,   2,   3,   4,   5,  2,  3,   2,   6,   1,   1,   2,   1,
+        7,   1,  7,  3,  4,   5,  15, 2,   2,   1,   5,   3,  22, 19,  2,   1,   1,   1,   1,   2,
+        5,   1,  1,  1,  6,   1,  1,  12,  8,   2,   9,   18, 22, 4,   1,   1,   5,   1,   16,  1,
+        2,   7,  10, 15, 1,   1,  6,  2,   4,   1,   2,   4,  1,  6,   1,   1,   3,   2,   4,   1,
+        6,   4,  5,  1,  2,   1,  1,  2,   1,   10,  3,   1,  3,  2,   1,   9,   3,   2,   5,   7,
+        2,   19, 4,  3,  6,   1,  1,  1,   1,   1,   4,   3,  2,  1,   1,   1,   2,   5,   3,   1,
+        1,   1,  2,  2,  1,   1,  2,  1,   1,   2,   1,   3,  1,  1,   1,   3,   7,   1,   4,   1,
+        1,   2,  1,  1,  2,   1,  2,  4,   4,   3,   8,   1,  1,  1,   2,   1,   3,   5,   1,   3,
+        1,   3,  4,  6,  2,   2,  14, 4,   6,   6,   11,  9,  1,  15,  3,   1,   28,  5,   2,   5,
+        5,   3,  1,  3,  4,   5,  4,  6,   14,  3,   2,   3,  5,  21,  2,   7,   20,  10,  1,   2,
+        19,  2,  4,  28, 28,  2,  3,  2,   1,   14,  4,   1,  26, 28,  42,  12,  40,  3,   52,  79,
+        5,   14, 17, 3,  2,   2,  11, 3,   4,   6,   3,   1,  8,  2,   23,  4,   5,   8,   10,  4,
+        2,   7,  3,  5,  1,   1,  6,  3,   1,   2,   2,   2,  5,  28,  1,   1,   7,   7,   20,  5,
+        3,   29, 3,  17, 26,  1,  8,  4,   27,  3,   6,   11, 23, 5,   3,   4,   6,   13,  24,  16,
+        6,   5,  10, 25, 35,  7,  3,  2,   3,   3,   14,  3,  6,  2,   6,   1,   4,   2,   3,   8,
+        2,   1,  1,  3,  3,   3,  4,  1,   1,   13,  2,   2,  4,  5,   2,   1,   14,  14,  1,   2,
+        2,   1,  4,  5,  2,   3,  1,  14,  3,   12,  3,   17, 2,  16,  5,   1,   2,   1,   8,   9,
+        3,   19, 4,  2,  2,   4,  17, 25,  21,  20,  28,  75, 1,  10,  29,  103, 4,   1,   2,   1,
+        1,   4,  2,  4,  1,   2,  3,  24,  2,   2,   2,   1,  1,  2,   1,   3,   8,   1,   1,   1,
+        2,   1,  1,  3,  1,   1,  1,  6,   1,   5,   3,   1,  1,  1,   3,   4,   1,   1,   5,   2,
+        1,   5,  6,  13, 9,   16, 1,  1,   1,   1,   3,   2,  3,  2,   4,   5,   2,   5,   2,   2,
+        3,   7,  13, 7,  2,   2,  1,  1,   1,   1,   2,   3,  3,  2,   1,   6,   4,   9,   2,   1,
+        14,  2,  14, 2,  1,   18, 3,  4,   14,  4,   11,  41, 15, 23,  15,  23,  176, 1,   3,   4,
+        1,   1,  1,  1,  5,   3,  1,  2,   3,   7,   3,   1,  1,  2,   1,   2,   4,   4,   6,   2,
+        4,   1,  9,  7,  1,   10, 5,  8,   16,  29,  1,   1,  2,  2,   3,   1,   3,   5,   2,   4,
+        5,   4,  1,  1,  2,   2,  3,  3,   7,   1,   6,   10, 1,  17,  1,   44,  4,   6,   2,   1,
+        1,   6,  5,  4,  2,   10, 1,  6,   9,   2,   8,   1,  24, 1,   2,   13,  7,   8,   8,   2,
+        1,   4,  1,  3,  1,   3,  3,  5,   2,   5,   10,  9,  4,  9,   12,  2,   1,   6,   1,   10,
+        1,   1,  7,  7,  4,   10, 8,  3,   1,   13,  4,   3,  1,  6,   1,   3,   5,   2,   1,   2,
+        17,  16, 5,  2,  16,  6,  1,  4,   2,   1,   3,   3,  6,  8,   5,   11,  11,  1,   3,   3,
+        2,   4,  6,  10, 9,   5,  7,  4,   7,   4,   7,   1,  1,  4,   2,   1,   3,   6,   8,   7,
+        1,   6,  11, 5,  5,   3,  24, 9,   4,   2,   7,   13, 5,  1,   8,   82,  16,  61,  1,   1,
+        1,   4,  2,  2,  16,  10, 3,  8,   1,   1,   6,   4,  2,  1,   3,   1,   1,   1,   4,   3,
+        8,   4,  2,  2,  1,   1,  1,  1,   1,   6,   3,   5,  1,  1,   4,   6,   9,   2,   1,   1,
+        1,   2,  1,  7,  2,   1,  6,  1,   5,   4,   4,   3,  1,  8,   1,   3,   3,   1,   3,   2,
+        2,   2,  2,  3,  1,   6,  1,  2,   1,   2,   1,   3,  7,  1,   8,   2,   1,   2,   1,   5,
+        2,   5,  3,  5,  10,  1,  2,  1,   1,   3,   2,   5,  11, 3,   9,   3,   5,   1,   1,   5,
+        9,   1,  2,  1,  5,   7,  9,  9,   8,   1,   3,   3,  3,  6,   8,   2,   3,   2,   1,   1,
+        32,  6,  1,  2,  15,  9,  3,  7,   13,  1,   3,   10, 13, 2,   14,  1,   13,  10,  2,   1,
+        3,   10, 4,  15, 2,   15, 15, 10,  1,   3,   9,   6,  9,  32,  25,  26,  47,  7,   3,   2,
+        3,   1,  6,  3,  4,   3,  2,  8,   5,   4,   1,   9,  4,  2,   2,   19,  10,  6,   2,   3,
+        8,   1,  2,  2,  4,   2,  1,  9,   4,   4,   4,   6,  4,  8,   9,   2,   3,   1,   1,   1,
+        1,   3,  5,  5,  1,   3,  8,  4,   6,   2,   1,   4,  12, 1,   5,   3,   7,   13,  2,   5,
+        8,   1,  6,  1,  2,   5,  14, 6,   1,   5,   2,   4,  8,  15,  5,   1,   23,  6,   62,  2,
+        10,  1,  1,  8,  1,   2,  2,  10,  4,   2,   2,   9,  2,  1,   1,   3,   2,   3,   1,   5,
+        3,   3,  2,  1,  3,   8,  1,  1,   1,   11,  3,   1,  1,  4,   3,   7,   1,   14,  1,   2,
+        3,   12, 5,  2,  5,   1,  6,  7,   5,   7,   14,  11, 1,  3,   1,   8,   9,   12,  2,   1,
+        11,  8,  4,  4,  2,   6,  10, 9,   13,  1,   1,   3,  1,  5,   1,   3,   2,   4,   4,   1,
+        18,  2,  3,  14, 11,  4,  29, 4,   2,   7,   1,   3,  13, 9,   2,   2,   5,   3,   5,   20,
+        7,   16, 8,  5,  72,  34, 6,  4,   22,  12,  12,  28, 45, 36,  9,   7,   39,  9,   191, 1,
+        1,   1,  4,  11, 8,   4,  9,  2,   3,   22,  1,   1,  1,  1,   4,   17,  1,   7,   7,   1,
+        11,  31, 10, 2,  4,   8,  2,  3,   2,   1,   4,   2,  16, 4,   32,  2,   3,   19,  13,  4,
+        9,   1,  5,  2,  14,  8,  1,  1,   3,   6,   19,  6,  5,  1,   16,  6,   2,   10,  8,   5,
+        1,   2,  3,  1,  5,   5,  1,  11,  6,   6,   1,   3,  3,  2,   6,   3,   8,   1,   1,   4,
+        10,  7,  5,  7,  7,   5,  8,  9,   2,   1,   3,   4,  1,  1,   3,   1,   3,   3,   2,   6,
+        16,  1,  4,  6,  3,   1,  10, 6,   1,   3,   15,  2,  9,  2,   10,  25,  13,  9,   16,  6,
+        2,   2,  10, 11, 4,   3,  9,  1,   2,   6,   6,   5,  4,  30,  40,  1,   10,  7,   12,  14,
+        33,  6,  3,  6,  7,   3,  1,  3,   1,   11,  14,  4,  9,  5,   12,  11,  49,  18,  51,  31,
+        140, 31, 2,  2,  1,   5,  1,  8,   1,   10,  1,   4,  4,  3,   24,  1,   10,  1,   3,   6,
+        6,   16, 3,  4,  5,   2,  1,  4,   2,   57,  10,  6,  22, 2,   22,  3,   7,   22,  6,   10,
+        11,  36, 18, 16, 33,  36, 2,  5,   5,   1,   1,   1,  4,  10,  1,   4,   13,  2,   7,   5,
+        2,   9,  3,  4,  1,   7,  43, 3,   7,   3,   9,   14, 7,  9,   1,   11,  1,   1,   3,   7,
+        4,   18, 13, 1,  14,  1,  3,  6,   10,  73,  2,   2,  30, 6,   1,   11,  18,  19,  13,  22,
+        3,   46, 42, 37, 89,  7,  3,  16,  34,  2,   2,   3,  9,  1,   7,   1,   1,   1,   2,   2,
+        4,   10, 7,  3,  10,  3,  9,  5,   28,  9,   2,   6,  13, 7,   3,   1,   3,   10,  2,   7,
+        2,   11, 3,  6,  21,  54, 85, 2,   1,   4,   2,   2,  1,  39,  3,   21,  2,   2,   5,   1,
+        1,   1,  4,  1,  1,   3,  4,  15,  1,   3,   2,   4,  4,  2,   3,   8,   2,   20,  1,   8,
+        7,   13, 4,  1,  26,  6,  2,  9,   34,  4,   21,  52, 10, 4,   4,   1,   5,   12,  2,   11,
+        1,   7,  2,  30, 12,  44, 2,  30,  1,   1,   3,   6,  16, 9,   17,  39,  82,  2,   2,   24,
+        7,   1,  7,  3,  16,  9,  14, 44,  2,   1,   2,   1,  2,  3,   5,   2,   4,   1,   6,   7,
+        5,   3,  2,  6,  1,   11, 5,  11,  2,   1,   18,  19, 8,  1,   3,   24,  29,  2,   1,   3,
+        5,   2,  2,  1,  13,  6,  5,  1,   46,  11,  3,   5,  1,  1,   5,   8,   2,   10,  6,   12,
+        6,   3,  7,  11, 2,   4,  16, 13,  2,   5,   1,   1,  2,  2,   5,   2,   28,  5,   2,   23,
+        10,  8,  4,  4,  22,  39, 95, 38,  8,   14,  9,   5,  1,  13,  5,   4,   3,   13,  12,  11,
+        1,   9,  1,  27, 37,  2,  5,  4,   4,   63,  211, 95, 2,  2,   2,   1,   3,   5,   2,   1,
+        1,   2,  2,  1,  1,   1,  3,  2,   4,   1,   2,   1,  1,  5,   2,   2,   1,   1,   2,   3,
+        1,   3,  1,  1,  1,   3,  1,  4,   2,   1,   3,   6,  1,  1,   3,   7,   15,  5,   3,   2,
+        5,   3,  9,  11, 4,   2,  22, 1,   6,   3,   8,   7,  1,  4,   28,  4,   16,  3,   3,   25,
+        4,   4,  27, 27, 1,   4,  1,  2,   2,   7,   1,   3,  5,  2,   28,  8,   2,   14,  1,   8,
+        6,   16, 25, 3,  3,   3,  14, 3,   3,   1,   1,   2,  1,  4,   6,   3,   8,   4,   1,   1,
+        1,   2,  3,  6,  10,  6,  2,  3,   18,  3,   2,   5,  5,  4,   3,   1,   5,   2,   5,   4,
+        23,  7,  6,  12, 6,   4,  17, 11,  9,   5,   1,   1,  10, 5,   12,  1,   1,   11,  26,  33,
+        7,   3,  6,  1,  17,  7,  1,  5,   12,  1,   11,  2,  4,  1,   8,   14,  17,  23,  1,   2,
+        1,   7,  8,  16, 11,  9,  6,  5,   2,   6,   4,   16, 2,  8,   14,  1,   11,  8,   9,   1,
+        1,   1,  9,  25, 4,   11, 19, 7,   2,   15,  2,   12, 8,  52,  7,   5,   19,  2,   16,  4,
+        36,  8,  1,  16, 8,   24, 26, 4,   6,   2,   9,   5,  4,  36,  3,   28,  12,  25,  15,  37,
+        27,  17, 12, 59, 38,  5,  32, 127, 1,   2,   9,   17, 14, 4,   1,   2,   1,   1,   8,   11,
+        50,  4,  14, 2,  19,  16, 4,  17,  5,   4,   5,   26, 12, 45,  2,   23,  45,  104, 30,  12,
+        8,   3,  10, 2,  2,   3,  3,  1,   4,   20,  7,   2,  9,  6,   15,  2,   20,  1,   3,   16,
+        4,   11, 15, 6,  134, 2,  5,  59,  1,   2,   2,   2,  1,  9,   17,  3,   26,  137, 10,  211,
+        59,  1,  2,  4,  1,   4,  1,  1,   1,   2,   6,   2,  3,  1,   1,   2,   3,   2,   3,   1,
+        3,   4,  4,  2,  3,   3,  1,  4,   3,   1,   7,   2,  2,  3,   1,   2,   1,   3,   3,   3,
+        2,   2,  3,  2,  1,   3,  14, 6,   1,   3,   2,   9,  6,  15,  27,  9,   34,  145, 1,   1,
+        2,   1,  1,  1,  1,   2,  1,  1,   1,   1,   2,   2,  2,  3,   1,   2,   1,   1,   1,   2,
+        3,   5,  8,  3,  5,   2,  4,  1,   3,   2,   2,   2,  12, 4,   1,   1,   1,   10,  4,   5,
+        1,   20, 4,  16, 1,   15, 9,  5,   12,  2,   9,   2,  5,  4,   2,   26,  19,  7,   1,   26,
+        4,   30, 12, 15, 42,  1,  6,  8,   172, 1,   1,   4,  2,  1,   1,   11,  2,   2,   4,   2,
+        1,   2,  1,  10, 8,   1,  2,  1,   4,   5,   1,   2,  5,  1,   8,   4,   1,   3,   4,   2,
+        1,   6,  2,  1,  3,   4,  1,  2,   1,   1,   1,   1,  12, 5,   7,   2,   4,   3,   1,   1,
+        1,   3,  3,  6,  1,   2,  2,  3,   3,   3,   2,   1,  2,  12,  14,  11,  6,   6,   4,   12,
+        2,   8,  1,  7,  10,  1,  35, 7,   4,   13,  15,  4,  3,  23,  21,  28,  52,  5,   26,  5,
+        6,   1,  7,  10, 2,   7,  53, 3,   2,   1,   1,   1,  2,  163, 532, 1,   10,  11,  1,   3,
+        3,   4,  8,  2,  8,   6,  2,  2,   23,  22,  4,   2,  2,  4,   2,   1,   3,   1,   3,   3,
+        5,   9,  8,  2,  1,   2,  8,  1,   10,  2,   12,  21, 20, 15,  105, 2,   3,   1,   1,   3,
+        2,   3,  1,  1,  2,   5,  1,  4,   15,  11,  19,  1,  1,  1,   1,   5,   4,   5,   1,   1,
+        2,   5,  3,  5,  12,  1,  2,  5,   1,   11,  1,   1,  15, 9,   1,   4,   5,   3,   26,  8,
+        2,   1,  3,  1,  1,   15, 19, 2,   12,  1,   2,   5,  2,  7,   2,   19,  2,   20,  6,   26,
+        7,   5,  2,  2,  7,   34, 21, 13,  70,  2,   128, 1,  1,  2,   1,   1,   2,   1,   1,   3,
+        2,   2,  2,  15, 1,   4,  1,  3,   4,   42,  10,  6,  1,  49,  85,  8,   1,   2,   1,   1,
+        4,   4,  2,  3,  6,   1,  5,  7,   4,   3,   211, 4,  1,  2,   1,   2,   5,   1,   2,   4,
+        2,   2,  6,  5,  6,   10, 3,  4,   48,  100, 6,   2,  16, 296, 5,   27,  387, 2,   2,   3,
+        7,   16, 8,  5,  38,  15, 39, 21,  9,   10,  3,   7,  59, 13,  27,  21,  47,  5,   21,  6};
+    static ImWchar base_ranges[] =  // not zero-terminated
+        {
+            0x0020, 0x00FF,  // Basic Latin + Latin Supplement
+            0x2000, 0x206F,  // General Punctuation
+            0x3000, 0x30FF,  // CJK Symbols and Punctuations, Hiragana, Katakana
+            0x31F0, 0x31FF,  // Katakana Phonetic Extensions
+            0xFF00, 0xFFEF   // Half-width characters
+        };
+    static ImWchar full_ranges[IM_ARRAYSIZE(base_ranges) +
+                               IM_ARRAYSIZE(accumulative_offsets_from_0x4E00) * 2 + 1] = {0};
+    if (!full_ranges[0])
+    {
+        memcpy(full_ranges, base_ranges, sizeof(base_ranges));
+        UnpackAccumulativeOffsetsIntoRanges(0x4E00, accumulative_offsets_from_0x4E00,
+                                            IM_ARRAYSIZE(accumulative_offsets_from_0x4E00),
+                                            full_ranges + IM_ARRAYSIZE(base_ranges));
+    }
+    return &full_ranges[0];
+}
+
+const ImWchar *ImFontAtlas::GetGlyphRangesJapanese()
+{
+    // 1946 common ideograms code points for Japanese
+    // Sourced from
+    // http://theinstructionlimit.com/common-kanji-character-ranges-for-xna-spritefont-rendering
+    // FIXME: Source a list of the revised 2136 Joyo Kanji list from 2010 and rebuild this.
+    // You can use ImFontGlyphRangesBuilder to create your own ranges derived from this, by merging
+    // existing ranges or adding new characters. (Stored as accumulative offsets from the initial
+    // unicode codepoint 0x4E00. This encoding is designed to helps us compact the source code
+    // size.)
+    static const short accumulative_offsets_from_0x4E00[] = {
+        0,  1,   2,  4,  1,   1,  1,  1,  2,   1,   6,   2,   2,  1,  8,   5,  7,   11,  1,  2,
+        10, 10,  8,  2,  4,   20, 2,  11, 8,   2,   1,   2,   1,  6,  2,   1,  7,   5,   3,  7,
+        1,  1,   13, 7,  9,   1,  4,  6,  1,   2,   1,   10,  1,  1,  9,   2,  2,   4,   5,  6,
+        14, 1,   1,  9,  3,   18, 5,  4,  2,   2,   10,  7,   1,  1,  1,   3,  2,   4,   3,  23,
+        2,  10,  12, 2,  14,  2,  4,  13, 1,   6,   10,  3,   1,  7,  13,  6,  4,   13,  5,  2,
+        3,  17,  2,  2,  5,   7,  6,  4,  1,   7,   14,  16,  6,  13, 9,   15, 1,   1,   7,  16,
+        4,  7,   1,  19, 9,   2,  7,  15, 2,   6,   5,   13,  25, 4,  14,  13, 11,  25,  1,  1,
+        1,  2,   1,  2,  2,   3,  10, 11, 3,   3,   1,   1,   4,  4,  2,   1,  4,   9,   1,  4,
+        3,  5,   5,  2,  7,   12, 11, 15, 7,   16,  4,   5,   16, 2,  1,   1,  6,   3,   3,  1,
+        1,  2,   7,  6,  6,   7,  1,  4,  7,   6,   1,   1,   2,  1,  12,  3,  3,   9,   5,  8,
+        1,  11,  1,  2,  3,   18, 20, 4,  1,   3,   6,   1,   7,  3,  5,   5,  7,   2,   2,  12,
+        3,  1,   4,  2,  3,   2,  3,  11, 8,   7,   4,   17,  1,  9,  25,  1,  1,   4,   2,  2,
+        4,  1,   2,  7,  1,   1,  1,  3,  1,   2,   6,   16,  1,  2,  1,   1,  3,   12,  20, 2,
+        5,  20,  8,  7,  6,   2,  1,  1,  1,   1,   6,   2,   1,  2,  10,  1,  1,   6,   1,  3,
+        1,  2,   1,  4,  1,   12, 4,  1,  3,   1,   1,   1,   1,  1,  10,  4,  7,   5,   13, 1,
+        15, 1,   1,  30, 11,  9,  1,  15, 38,  14,  1,   32,  17, 20, 1,   9,  31,  2,   21, 9,
+        4,  49,  22, 2,  1,   13, 1,  11, 45,  35,  43,  55,  12, 19, 83,  1,  3,   2,   3,  13,
+        2,  1,   7,  3,  18,  3,  13, 8,  1,   8,   18,  5,   3,  7,  25,  24, 9,   24,  40, 3,
+        17, 24,  2,  1,  6,   2,  3,  16, 15,  6,   7,   3,   12, 1,  9,   7,  3,   3,   3,  15,
+        21, 5,   16, 4,  5,   12, 11, 11, 3,   6,   3,   2,   31, 3,  2,   1,  1,   23,  6,  6,
+        1,  4,   2,  6,  5,   2,  1,  1,  3,   3,   22,  2,   6,  2,  3,   17, 3,   2,   4,  5,
+        1,  9,   5,  1,  1,   6,  15, 12, 3,   17,  2,   14,  2,  8,  1,   23, 16,  4,   2,  23,
+        8,  15,  23, 20, 12,  25, 19, 47, 11,  21,  65,  46,  4,  3,  1,   5,  6,   1,   2,  5,
+        26, 2,   1,  1,  3,   11, 1,  1,  1,   2,   1,   2,   3,  1,  1,   10, 2,   3,   1,  1,
+        1,  3,   6,  3,  2,   2,  6,  6,  9,   2,   2,   2,   6,  2,  5,   10, 2,   4,   1,  2,
+        1,  2,   2,  3,  1,   1,  3,  1,  2,   9,   23,  9,   2,  1,  1,   1,  1,   5,   3,  2,
+        1,  10,  9,  6,  1,   10, 2,  31, 25,  3,   7,   5,   40, 1,  15,  6,  17,  7,   27, 180,
+        1,  3,   2,  2,  1,   1,  1,  6,  3,   10,  7,   1,   3,  6,  17,  8,  6,   2,   2,  1,
+        3,  5,   5,  8,  16,  14, 15, 1,  1,   4,   1,   2,   1,  1,  1,   3,  2,   7,   5,  6,
+        2,  5,   10, 1,  4,   2,  9,  1,  1,   11,  6,   1,   44, 1,  3,   7,  9,   5,   1,  3,
+        1,  1,   10, 7,  1,   10, 4,  2,  7,   21,  15,  7,   2,  5,  1,   8,  3,   4,   1,  3,
+        1,  6,   1,  4,  2,   1,  4,  10, 8,   1,   4,   5,   1,  5,  10,  2,  7,   1,   10, 1,
+        1,  3,   4,  11, 10,  29, 4,  7,  3,   5,   2,   3,   33, 5,  2,   19, 3,   1,   4,  2,
+        6,  31,  11, 1,  3,   3,  3,  1,  8,   10,  9,   12,  11, 12, 8,   3,  14,  8,   6,  11,
+        1,  4,   41, 3,  1,   2,  7,  13, 1,   5,   6,   2,   6,  12, 12,  22, 5,   9,   4,  8,
+        9,  9,   34, 6,  24,  1,  1,  20, 9,   9,   3,   4,   1,  7,  2,   2,  2,   6,   2,  28,
+        5,  3,   6,  1,  4,   6,  7,  4,  2,   1,   4,   2,   13, 6,  4,   4,  3,   1,   8,  8,
+        3,  2,   1,  5,  1,   2,  2,  3,  1,   11,  11,  7,   3,  6,  10,  8,  6,   16,  16, 22,
+        7,  12,  6,  21, 5,   4,  6,  6,  3,   6,   1,   3,   2,  1,  2,   8,  29,  1,   10, 1,
+        6,  13,  6,  6,  19,  31, 1,  13, 4,   4,   22,  17,  26, 33, 10,  4,  15,  12,  25, 6,
+        67, 10,  2,  3,  1,   6,  10, 2,  6,   2,   9,   1,   9,  4,  4,   1,  2,   16,  2,  5,
+        9,  2,   3,  8,  1,   8,  3,  9,  4,   8,   6,   4,   8,  11, 3,   2,  1,   1,   3,  26,
+        1,  7,   5,  1,  11,  1,  5,  3,  5,   2,   13,  6,   39, 5,  1,   5,  2,   11,  6,  10,
+        5,  1,   15, 5,  3,   6,  19, 21, 22,  2,   4,   1,   6,  1,  8,   1,  4,   8,   2,  4,
+        2,  2,   9,  2,  1,   1,  1,  4,  3,   6,   3,   12,  7,  1,  14,  2,  4,   10,  2,  13,
+        1,  17,  7,  3,  2,   1,  3,  2,  13,  7,   14,  12,  3,  1,  29,  2,  8,   9,   15, 14,
+        9,  14,  1,  3,  1,   6,  5,  9,  11,  3,   38,  43,  20, 7,  7,   8,  5,   15,  12, 19,
+        15, 81,  8,  7,  1,   5,  73, 13, 37,  28,  8,   8,   1,  15, 18,  20, 165, 28,  1,  6,
+        11, 8,   4,  14, 7,   15, 1,  3,  3,   6,   4,   1,   7,  14, 1,   1,  11,  30,  1,  5,
+        1,  4,   14, 1,  4,   2,  7,  52, 2,   6,   29,  3,   1,  9,  1,   21, 3,   5,   1,  26,
+        3,  11,  14, 11, 1,   17, 5,  1,  2,   1,   3,   2,   8,  1,  2,   9,  12,  1,   1,  2,
+        3,  8,   3,  24, 12,  7,  7,  5,  17,  3,   3,   3,   1,  23, 10,  4,  4,   6,   3,  1,
+        16, 17,  22, 3,  10,  21, 16, 16, 6,   4,   10,  2,   1,  1,  2,   8,  8,   6,   5,  3,
+        3,  3,   39, 25, 15,  1,  1,  16, 6,   7,   25,  15,  6,  6,  12,  1,  22,  13,  1,  4,
+        9,  5,   12, 2,  9,   1,  12, 28, 8,   3,   5,   10,  22, 60, 1,   2,  40,  4,   61, 63,
+        4,  1,   13, 12, 1,   4,  31, 12, 1,   14,  89,  5,   16, 6,  29,  14, 2,   5,   49, 18,
+        18, 5,   29, 33, 47,  1,  17, 1,  19,  12,  2,   9,   7,  39, 12,  3,  7,   12,  39, 3,
+        1,  46,  4,  12, 3,   8,  9,  5,  31,  15,  18,  3,   2,  2,  66,  19, 13,  17,  5,  3,
+        46, 124, 13, 57, 34,  2,  5,  4,  5,   8,   1,   1,   1,  4,  3,   1,  17,  5,   3,  5,
+        3,  1,   8,  5,  6,   3,  27, 3,  26,  7,   12,  7,   2,  17, 3,   7,  18,  78,  16, 4,
+        36, 1,   2,  1,  6,   2,  1,  39, 17,  7,   4,   13,  4,  4,  4,   1,  10,  4,   2,  4,
+        6,  3,   10, 1,  19,  1,  26, 2,  4,   33,  2,   73,  47, 7,  3,   8,  2,   4,   15, 18,
+        1,  29,  2,  41, 14,  1,  21, 16, 41,  7,   39,  25,  13, 44, 2,   2,  10,  1,   13, 7,
+        1,  7,   3,  5,  20,  4,  8,  2,  49,  1,   10,  6,   1,  6,  7,   10, 7,   11,  16, 3,
+        12, 20,  4,  10, 3,   1,  2,  11, 2,   28,  9,   2,   4,  7,  2,   15, 1,   27,  1,  28,
+        17, 4,   5,  10, 7,   3,  24, 10, 11,  6,   26,  3,   2,  7,  2,   2,  49,  16,  10, 16,
+        15, 4,   5,  27, 61,  30, 14, 38, 22,  2,   7,   5,   1,  3,  12,  23, 24,  17,  17, 3,
+        3,  2,   4,  1,  6,   2,  7,  5,  1,   1,   5,   1,   1,  9,  4,   1,  3,   6,   1,  8,
+        2,  8,   4,  14, 3,   5,  11, 4,  1,   3,   32,  1,   19, 4,  1,   13, 11,  5,   2,  1,
+        8,  6,   8,  1,  6,   5,  13, 3,  23,  11,  5,   3,   16, 3,  9,   10, 1,   24,  3,  198,
+        52, 4,   2,  2,  5,   14, 5,  4,  22,  5,   20,  4,   11, 6,  41,  1,  5,   2,   2,  11,
+        5,  2,   28, 35, 8,   22, 3,  18, 3,   10,  7,   5,   3,  4,  1,   5,  3,   8,   9,  3,
+        6,  2,   16, 22, 4,   5,  5,  3,  3,   18,  23,  2,   6,  23, 5,   27, 8,   1,   33, 2,
+        12, 43,  16, 5,  2,   3,  6,  1,  20,  4,   2,   9,   7,  1,  11,  2,  10,  3,   14, 31,
+        9,  3,   25, 18, 20,  2,  5,  5,  26,  14,  1,   11,  17, 12, 40,  19, 9,   6,   31, 83,
+        2,  7,   9,  19, 78,  12, 14, 21, 76,  12,  113, 79,  34, 4,  1,   1,  61,  18,  85, 10,
+        2,  2,   13, 31, 11,  50, 6,  33, 159, 179, 6,   6,   7,  4,  4,   2,  4,   2,   5,  8,
+        7,  20,  32, 22, 1,   3,  10, 6,  7,   28,  5,   10,  9,  2,  77,  19, 13,  2,   5,  1,
+        4,  4,   7,  4,  13,  3,  9,  31, 17,  3,   26,  2,   6,  6,  5,   4,  1,   7,   11, 3,
+        4,  2,   1,  6,  2,   20, 4,  1,  9,   2,   6,   3,   7,  1,  1,   1,  20,  2,   3,  1,
+        6,  2,   3,  6,  2,   4,  8,  1,  5,   13,  8,   4,   11, 23, 1,   10, 6,   2,   1,  3,
+        21, 2,   2,  4,  24,  31, 4,  10, 10,  2,   5,   192, 15, 4,  16,  7,  9,   51,  1,  2,
+        1,  1,   5,  1,  1,   2,  1,  3,  5,   3,   1,   3,   4,  1,  3,   1,  3,   3,   9,  8,
+        1,  2,   2,  2,  4,   4,  18, 12, 92,  2,   10,  4,   3,  14, 5,   25, 16,  42,  4,  14,
+        4,  2,   21, 5,  126, 30, 31, 2,  1,   5,   13,  3,   22, 5,  6,   6,  20,  12,  1,  14,
+        12, 87,  3,  19, 1,   8,  2,  9,  9,   3,   3,   23,  2,  3,  7,   6,  3,   1,   2,  3,
+        9,  1,   3,  1,  6,   3,  2,  1,  3,   11,  3,   1,   6,  10, 3,   2,  3,   1,   2,  1,
+        5,  1,   1,  11, 3,   6,  4,  1,  7,   2,   1,   2,   5,  5,  34,  4,  14,  18,  4,  19,
+        7,  5,   8,  2,  6,   79, 1,  5,  2,   14,  8,   2,   9,  2,  1,   36, 28,  16,  4,  1,
+        1,  1,   2,  12, 6,   42, 39, 16, 23,  7,   15,  15,  3,  2,  12,  7,  21,  64,  6,  9,
+        28, 8,   12, 3,  3,   41, 59, 24, 51,  55,  57,  294, 9,  9,  2,   6,  2,   15,  1,  2,
+        13, 38,  90, 9,  9,   9,  3,  11, 7,   1,   1,   1,   5,  6,  3,   2,  1,   2,   2,  3,
+        8,  1,   4,  4,  1,   5,  7,  1,  4,   3,   20,  4,   9,  1,  1,   1,  5,   5,   17, 1,
+        5,  2,   6,  2,  4,   1,  4,  5,  7,   3,   18,  11,  11, 32, 7,   5,  4,   7,   11, 127,
+        8,  4,   3,  3,  1,   10, 1,  1,  6,   21,  14,  1,   16, 1,  7,   1,  3,   6,   9,  65,
+        51, 4,   3,  13, 3,   10, 1,  1,  12,  9,   21,  110, 3,  19, 24,  1,  1,   10,  62, 4,
+        1,  29,  42, 78, 28,  20, 18, 82, 6,   3,   15,  6,   84, 58, 253, 15, 155, 264, 15, 21,
+        9,  14,  7,  58, 40,  39,
+    };
+    static ImWchar base_ranges[] =  // not zero-terminated
+        {
+            0x0020, 0x00FF,  // Basic Latin + Latin Supplement
+            0x3000, 0x30FF,  // CJK Symbols and Punctuations, Hiragana, Katakana
+            0x31F0, 0x31FF,  // Katakana Phonetic Extensions
+            0xFF00, 0xFFEF   // Half-width characters
+        };
+    static ImWchar full_ranges[IM_ARRAYSIZE(base_ranges) +
+                               IM_ARRAYSIZE(accumulative_offsets_from_0x4E00) * 2 + 1] = {0};
+    if (!full_ranges[0])
+    {
+        memcpy(full_ranges, base_ranges, sizeof(base_ranges));
+        UnpackAccumulativeOffsetsIntoRanges(0x4E00, accumulative_offsets_from_0x4E00,
+                                            IM_ARRAYSIZE(accumulative_offsets_from_0x4E00),
+                                            full_ranges + IM_ARRAYSIZE(base_ranges));
+    }
+    return &full_ranges[0];
+}
+
+const ImWchar *ImFontAtlas::GetGlyphRangesCyrillic()
+{
+    static const ImWchar ranges[] = {
+        0x0020, 0x00FF,  // Basic Latin + Latin Supplement
+        0x0400, 0x052F,  // Cyrillic + Cyrillic Supplement
+        0x2DE0, 0x2DFF,  // Cyrillic Extended-A
+        0xA640, 0xA69F,  // Cyrillic Extended-B
+        0,
+    };
+    return &ranges[0];
+}
+
+const ImWchar *ImFontAtlas::GetGlyphRangesThai()
+{
+    static const ImWchar ranges[] = {
+        0x0020, 0x00FF,  // Basic Latin
+        0x2010, 0x205E,  // Punctuations
+        0x0E00, 0x0E7F,  // Thai
+        0,
+    };
+    return &ranges[0];
+}
+
+const ImWchar *ImFontAtlas::GetGlyphRangesVietnamese()
+{
+    static const ImWchar ranges[] = {
+        0x0020, 0x00FF,  // Basic Latin
+        0x0102, 0x0103, 0x0110, 0x0111, 0x0128, 0x0129, 0x0168, 0x0169,
+        0x01A0, 0x01A1, 0x01AF, 0x01B0, 0x1EA0, 0x1EF9, 0,
+    };
+    return &ranges[0];
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] ImFontGlyphRangesBuilder
+//-----------------------------------------------------------------------------
+
+void ImFontGlyphRangesBuilder::AddText(const char *text, const char *text_end)
+{
+    while (text_end ? (text < text_end) : *text)
+    {
+        unsigned int c = 0;
+        int c_len      = ImTextCharFromUtf8(&c, text, text_end);
+        text += c_len;
+        if (c_len == 0)
+            break;
+        if (c < 0x10000)
+            AddChar((ImWchar)c);
+    }
+}
+
+void ImFontGlyphRangesBuilder::AddRanges(const ImWchar *ranges)
+{
+    for (; ranges[0]; ranges += 2)
+        for (ImWchar c = ranges[0]; c <= ranges[1]; c++)
+            AddChar(c);
+}
+
+void ImFontGlyphRangesBuilder::BuildRanges(ImVector<ImWchar> *out_ranges)
+{
+    int max_codepoint = 0x10000;
+    for (int n = 0; n < max_codepoint; n++)
+        if (GetBit(n))
+        {
+            out_ranges->push_back((ImWchar)n);
+            while (n < max_codepoint - 1 && GetBit(n + 1))
+                n++;
+            out_ranges->push_back((ImWchar)n);
+        }
+    out_ranges->push_back(0);
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] ImFont
+//-----------------------------------------------------------------------------
+
+ImFont::ImFont()
+{
+    FontSize          = 0.0f;
+    FallbackAdvanceX  = 0.0f;
+    FallbackChar      = (ImWchar)'?';
+    DisplayOffset     = ImVec2(0.0f, 0.0f);
+    FallbackGlyph     = NULL;
+    ContainerAtlas    = NULL;
+    ConfigData        = NULL;
+    ConfigDataCount   = 0;
+    DirtyLookupTables = false;
+    Scale             = 1.0f;
+    Ascent = Descent    = 0.0f;
+    MetricsTotalSurface = 0;
+}
+
+ImFont::~ImFont()
+{
+    ClearOutputData();
+}
+
+void ImFont::ClearOutputData()
+{
+    FontSize         = 0.0f;
+    FallbackAdvanceX = 0.0f;
+    Glyphs.clear();
+    IndexAdvanceX.clear();
+    IndexLookup.clear();
+    FallbackGlyph     = NULL;
+    ContainerAtlas    = NULL;
+    DirtyLookupTables = true;
+    Ascent = Descent    = 0.0f;
+    MetricsTotalSurface = 0;
+}
+
+void ImFont::BuildLookupTable()
+{
+    int max_codepoint = 0;
+    for (int i = 0; i != Glyphs.Size; i++)
+        max_codepoint = ImMax(max_codepoint, (int)Glyphs[i].Codepoint);
+
+    IM_ASSERT(Glyphs.Size < 0xFFFF);  // -1 is reserved
+    IndexAdvanceX.clear();
+    IndexLookup.clear();
+    DirtyLookupTables = false;
+    GrowIndex(max_codepoint + 1);
+    for (int i = 0; i < Glyphs.Size; i++)
+    {
+        int codepoint            = (int)Glyphs[i].Codepoint;
+        IndexAdvanceX[codepoint] = Glyphs[i].AdvanceX;
+        IndexLookup[codepoint]   = (ImWchar)i;
+    }
+
+    // Create a glyph to handle TAB
+    // FIXME: Needs proper TAB handling but it needs to be contextualized (or we could arbitrary say
+    // that each string starts at "column 0" ?)
+    if (FindGlyph((ImWchar)' '))
+    {
+        if (Glyphs.back().Codepoint != '\t')  // So we can call this function multiple times
+            Glyphs.resize(Glyphs.Size + 1);
+        ImFontGlyph &tab_glyph = Glyphs.back();
+        tab_glyph              = *FindGlyph((ImWchar)' ');
+        tab_glyph.Codepoint    = '\t';
+        tab_glyph.AdvanceX *= IM_TABSIZE;
+        IndexAdvanceX[(int)tab_glyph.Codepoint] = (float)tab_glyph.AdvanceX;
+        IndexLookup[(int)tab_glyph.Codepoint]   = (ImWchar)(Glyphs.Size - 1);
+    }
+
+    FallbackGlyph    = FindGlyphNoFallback(FallbackChar);
+    FallbackAdvanceX = FallbackGlyph ? FallbackGlyph->AdvanceX : 0.0f;
+    for (int i = 0; i < max_codepoint + 1; i++)
+        if (IndexAdvanceX[i] < 0.0f)
+            IndexAdvanceX[i] = FallbackAdvanceX;
+}
+
+void ImFont::SetFallbackChar(ImWchar c)
+{
+    FallbackChar = c;
+    BuildLookupTable();
+}
+
+void ImFont::GrowIndex(int new_size)
+{
+    IM_ASSERT(IndexAdvanceX.Size == IndexLookup.Size);
+    if (new_size <= IndexLookup.Size)
+        return;
+    IndexAdvanceX.resize(new_size, -1.0f);
+    IndexLookup.resize(new_size, (ImWchar)-1);
+}
+
+// x0/y0/x1/y1 are offset from the character upper-left layout position, in pixels. Therefore x0/y0
+// are often fairly close to zero. Not to be mistaken with texture coordinates, which are held by
+// u0/v0/u1/v1 in normalized format (0.0..1.0 on each texture axis).
+void ImFont::AddGlyph(ImWchar codepoint,
+                      float x0,
+                      float y0,
+                      float x1,
+                      float y1,
+                      float u0,
+                      float v0,
+                      float u1,
+                      float v1,
+                      float advance_x)
+{
+    Glyphs.resize(Glyphs.Size + 1);
+    ImFontGlyph &glyph = Glyphs.back();
+    glyph.Codepoint    = (ImWchar)codepoint;
+    glyph.X0           = x0;
+    glyph.Y0           = y0;
+    glyph.X1           = x1;
+    glyph.Y1           = y1;
+    glyph.U0           = u0;
+    glyph.V0           = v0;
+    glyph.U1           = u1;
+    glyph.V1           = v1;
+    glyph.AdvanceX     = advance_x + ConfigData->GlyphExtraSpacing.x;  // Bake spacing into AdvanceX
+
+    if (ConfigData->PixelSnapH)
+        glyph.AdvanceX = (float)(int)(glyph.AdvanceX + 0.5f);
+
+    // Compute rough surface usage metrics (+1 to account for average padding, +0.99 to round)
+    DirtyLookupTables = true;
+    MetricsTotalSurface += (int)((glyph.U1 - glyph.U0) * ContainerAtlas->TexWidth + 1.99f) *
+                           (int)((glyph.V1 - glyph.V0) * ContainerAtlas->TexHeight + 1.99f);
+}
+
+void ImFont::AddRemapChar(ImWchar dst, ImWchar src, bool overwrite_dst)
+{
+    IM_ASSERT(IndexLookup.Size >
+              0);  // Currently this can only be called AFTER the font has been built, aka after
+                   // calling ImFontAtlas::GetTexDataAs*() function.
+    int index_size = IndexLookup.Size;
+
+    if (dst < index_size && IndexLookup.Data[dst] == (ImWchar)-1 &&
+        !overwrite_dst)  // 'dst' already exists
+        return;
+    if (src >= index_size && dst >= index_size)  // both 'dst' and 'src' don't exist -> no-op
+        return;
+
+    GrowIndex(dst + 1);
+    IndexLookup[dst]   = (src < index_size) ? IndexLookup.Data[src] : (ImWchar)-1;
+    IndexAdvanceX[dst] = (src < index_size) ? IndexAdvanceX.Data[src] : 1.0f;
+}
+
+const ImFontGlyph *ImFont::FindGlyph(ImWchar c) const
+{
+    if (c >= IndexLookup.Size)
+        return FallbackGlyph;
+    const ImWchar i = IndexLookup.Data[c];
+    if (i == (ImWchar)-1)
+        return FallbackGlyph;
+    return &Glyphs.Data[i];
+}
+
+const ImFontGlyph *ImFont::FindGlyphNoFallback(ImWchar c) const
+{
+    if (c >= IndexLookup.Size)
+        return NULL;
+    const ImWchar i = IndexLookup.Data[c];
+    if (i == (ImWchar)-1)
+        return NULL;
+    return &Glyphs.Data[i];
+}
+
+const char *ImFont::CalcWordWrapPositionA(float scale,
+                                          const char *text,
+                                          const char *text_end,
+                                          float wrap_width) const
+{
+    // Simple word-wrapping for English, not full-featured. Please submit failing cases!
+    // FIXME: Much possible improvements (don't cut things like "word !", "word!!!" but cut within
+    // "word,,,,", more sensible support for punctuations, support for Unicode punctuations, etc.)
+
+    // For references, possible wrap point marked with ^
+    //  "aaa bbb, ccc,ddd. eee   fff. ggg!"
+    //      ^    ^    ^   ^   ^__    ^    ^
+
+    // List of hardcoded separators: .,;!?'"
+
+    // Skip extra blanks after a line returns (that includes not counting them in width computation)
+    // e.g. "Hello    world" --> "Hello" "World"
+
+    // Cut words that cannot possibly fit within one line.
+    // e.g.: "The tropical fish" with ~5 characters worth of width --> "The tr" "opical" "fish"
+
+    float line_width  = 0.0f;
+    float word_width  = 0.0f;
+    float blank_width = 0.0f;
+    wrap_width /= scale;  // We work with unscaled widths to avoid scaling every characters
+
+    const char *word_end      = text;
+    const char *prev_word_end = NULL;
+    bool inside_word          = true;
+
+    const char *s = text;
+    while (s < text_end)
+    {
+        unsigned int c = (unsigned int)*s;
+        const char *next_s;
+        if (c < 0x80)
+            next_s = s + 1;
+        else
+            next_s = s + ImTextCharFromUtf8(&c, s, text_end);
+        if (c == 0)
+            break;
+
+        if (c < 32)
+        {
+            if (c == '\n')
+            {
+                line_width = word_width = blank_width = 0.0f;
+                inside_word                           = true;
+                s                                     = next_s;
+                continue;
+            }
+            if (c == '\r')
+            {
+                s = next_s;
+                continue;
+            }
+        }
+
+        const float char_width =
+            ((int)c < IndexAdvanceX.Size ? IndexAdvanceX.Data[c] : FallbackAdvanceX);
+        if (ImCharIsBlankW(c))
+        {
+            if (inside_word)
+            {
+                line_width += blank_width;
+                blank_width = 0.0f;
+                word_end    = s;
+            }
+            blank_width += char_width;
+            inside_word = false;
+        }
+        else
+        {
+            word_width += char_width;
+            if (inside_word)
+            {
+                word_end = next_s;
+            }
+            else
+            {
+                prev_word_end = word_end;
+                line_width += word_width + blank_width;
+                word_width = blank_width = 0.0f;
+            }
+
+            // Allow wrapping after punctuation.
+            inside_word = !(c == '.' || c == ',' || c == ';' || c == '!' || c == '?' || c == '\"');
+        }
+
+        // We ignore blank width at the end of the line (they can be skipped)
+        if (line_width + word_width > wrap_width)
+        {
+            // Words that cannot possibly fit within an entire line will be cut anywhere.
+            if (word_width < wrap_width)
+                s = prev_word_end ? prev_word_end : word_end;
+            break;
+        }
+
+        s = next_s;
+    }
+
+    return s;
+}
+
+ImVec2 ImFont::CalcTextSizeA(float size,
+                             float max_width,
+                             float wrap_width,
+                             const char *text_begin,
+                             const char *text_end,
+                             const char **remaining) const
+{
+    if (!text_end)
+        text_end = text_begin + strlen(text_begin);  // FIXME-OPT: Need to avoid this.
+
+    const float line_height = size;
+    const float scale       = size / FontSize;
+
+    ImVec2 text_size = ImVec2(0, 0);
+    float line_width = 0.0f;
+
+    const bool word_wrap_enabled = (wrap_width > 0.0f);
+    const char *word_wrap_eol    = NULL;
+
+    const char *s = text_begin;
+    while (s < text_end)
+    {
+        if (word_wrap_enabled)
+        {
+            // Calculate how far we can render. Requires two passes on the string data but keeps the
+            // code simple and not intrusive for what's essentially an uncommon feature.
+            if (!word_wrap_eol)
+            {
+                word_wrap_eol = CalcWordWrapPositionA(scale, s, text_end, wrap_width - line_width);
+                if (word_wrap_eol ==
+                    s)  // Wrap_width is too small to fit anything. Force displaying 1 character to
+                        // minimize the height discontinuity.
+                    word_wrap_eol++;  // +1 may not be a character start point in UTF-8 but it's ok
+                                      // because we use s >= word_wrap_eol below
+            }
+
+            if (s >= word_wrap_eol)
+            {
+                if (text_size.x < line_width)
+                    text_size.x = line_width;
+                text_size.y += line_height;
+                line_width    = 0.0f;
+                word_wrap_eol = NULL;
+
+                // Wrapping skips upcoming blanks
+                while (s < text_end)
+                {
+                    const char c = *s;
+                    if (ImCharIsBlankA(c))
+                    {
+                        s++;
+                    }
+                    else if (c == '\n')
+                    {
+                        s++;
+                        break;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+                continue;
+            }
+        }
+
+        // Decode and advance source
+        const char *prev_s = s;
+        unsigned int c     = (unsigned int)*s;
+        if (c < 0x80)
+        {
+            s += 1;
+        }
+        else
+        {
+            s += ImTextCharFromUtf8(&c, s, text_end);
+            if (c == 0)  // Malformed UTF-8?
+                break;
+        }
+
+        if (c < 32)
+        {
+            if (c == '\n')
+            {
+                text_size.x = ImMax(text_size.x, line_width);
+                text_size.y += line_height;
+                line_width = 0.0f;
+                continue;
+            }
+            if (c == '\r')
+                continue;
+        }
+
+        const float char_width =
+            ((int)c < IndexAdvanceX.Size ? IndexAdvanceX.Data[c] : FallbackAdvanceX) * scale;
+        if (line_width + char_width >= max_width)
+        {
+            s = prev_s;
+            break;
+        }
+
+        line_width += char_width;
+    }
+
+    if (text_size.x < line_width)
+        text_size.x = line_width;
+
+    if (line_width > 0 || text_size.y == 0.0f)
+        text_size.y += line_height;
+
+    if (remaining)
+        *remaining = s;
+
+    return text_size;
+}
+
+void ImFont::RenderChar(ImDrawList *draw_list, float size, ImVec2 pos, ImU32 col, ImWchar c) const
+{
+    if (c == ' ' || c == '\t' || c == '\n' ||
+        c == '\r')  // Match behavior of RenderText(), those 4 codepoints are hard-coded.
+        return;
+    if (const ImFontGlyph *glyph = FindGlyph(c))
+    {
+        float scale = (size >= 0.0f) ? (size / FontSize) : 1.0f;
+        pos.x       = (float)(int)pos.x + DisplayOffset.x;
+        pos.y       = (float)(int)pos.y + DisplayOffset.y;
+        draw_list->PrimReserve(6, 4);
+        draw_list->PrimRectUV(ImVec2(pos.x + glyph->X0 * scale, pos.y + glyph->Y0 * scale),
+                              ImVec2(pos.x + glyph->X1 * scale, pos.y + glyph->Y1 * scale),
+                              ImVec2(glyph->U0, glyph->V0), ImVec2(glyph->U1, glyph->V1), col);
+    }
+}
+
+void ImFont::RenderText(ImDrawList *draw_list,
+                        float size,
+                        ImVec2 pos,
+                        ImU32 col,
+                        const ImVec4 &clip_rect,
+                        const char *text_begin,
+                        const char *text_end,
+                        float wrap_width,
+                        bool cpu_fine_clip) const
+{
+    if (!text_end)
+        text_end = text_begin +
+                   strlen(text_begin);  // ImGui:: functions generally already provides a valid
+                                        // text_end, so this is merely to handle direct calls.
+
+    // Align to be pixel perfect
+    pos.x   = (float)(int)pos.x + DisplayOffset.x;
+    pos.y   = (float)(int)pos.y + DisplayOffset.y;
+    float x = pos.x;
+    float y = pos.y;
+    if (y > clip_rect.w)
+        return;
+
+    const float scale            = size / FontSize;
+    const float line_height      = FontSize * scale;
+    const bool word_wrap_enabled = (wrap_width > 0.0f);
+    const char *word_wrap_eol    = NULL;
+
+    // Fast-forward to first visible line
+    const char *s = text_begin;
+    if (y + line_height < clip_rect.y && !word_wrap_enabled)
+        while (y + line_height < clip_rect.y && s < text_end)
+        {
+            s = (const char *)memchr(s, '\n', text_end - s);
+            s = s ? s + 1 : text_end;
+            y += line_height;
+        }
+
+    // For large text, scan for the last visible line in order to avoid over-reserving in the call
+    // to PrimReserve() Note that very large horizontal line will still be affected by the issue
+    // (e.g. a one megabyte string buffer without a newline will likely crash atm)
+    if (text_end - s > 10000 && !word_wrap_enabled)
+    {
+        const char *s_end = s;
+        float y_end       = y;
+        while (y_end < clip_rect.w && s_end < text_end)
+        {
+            s_end = (const char *)memchr(s_end, '\n', text_end - s_end);
+            s_end = s_end ? s_end + 1 : text_end;
+            y_end += line_height;
+        }
+        text_end = s_end;
+    }
+    if (s == text_end)
+        return;
+
+    // Reserve vertices for remaining worse case (over-reserving is useful and easily amortized)
+    const int vtx_count_max     = (int)(text_end - s) * 4;
+    const int idx_count_max     = (int)(text_end - s) * 6;
+    const int idx_expected_size = draw_list->IdxBuffer.Size + idx_count_max;
+    draw_list->PrimReserve(idx_count_max, vtx_count_max);
+
+    ImDrawVert *vtx_write        = draw_list->_VtxWritePtr;
+    ImDrawIdx *idx_write         = draw_list->_IdxWritePtr;
+    unsigned int vtx_current_idx = draw_list->_VtxCurrentIdx;
+
+    while (s < text_end)
+    {
+        if (word_wrap_enabled)
+        {
+            // Calculate how far we can render. Requires two passes on the string data but keeps the
+            // code simple and not intrusive for what's essentially an uncommon feature.
+            if (!word_wrap_eol)
+            {
+                word_wrap_eol = CalcWordWrapPositionA(scale, s, text_end, wrap_width - (x - pos.x));
+                if (word_wrap_eol ==
+                    s)  // Wrap_width is too small to fit anything. Force displaying 1 character to
+                        // minimize the height discontinuity.
+                    word_wrap_eol++;  // +1 may not be a character start point in UTF-8 but it's ok
+                                      // because we use s >= word_wrap_eol below
+            }
+
+            if (s >= word_wrap_eol)
+            {
+                x = pos.x;
+                y += line_height;
+                word_wrap_eol = NULL;
+
+                // Wrapping skips upcoming blanks
+                while (s < text_end)
+                {
+                    const char c = *s;
+                    if (ImCharIsBlankA(c))
+                    {
+                        s++;
+                    }
+                    else if (c == '\n')
+                    {
+                        s++;
+                        break;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+                continue;
+            }
+        }
+
+        // Decode and advance source
+        unsigned int c = (unsigned int)*s;
+        if (c < 0x80)
+        {
+            s += 1;
+        }
+        else
+        {
+            s += ImTextCharFromUtf8(&c, s, text_end);
+            if (c == 0)  // Malformed UTF-8?
+                break;
+        }
+
+        if (c < 32)
+        {
+            if (c == '\n')
+            {
+                x = pos.x;
+                y += line_height;
+                if (y > clip_rect.w)
+                    break;  // break out of main loop
+                continue;
+            }
+            if (c == '\r')
+                continue;
+        }
+
+        float char_width = 0.0f;
+        if (const ImFontGlyph *glyph = FindGlyph((ImWchar)c))
+        {
+            char_width = glyph->AdvanceX * scale;
+
+            // Arbitrarily assume that both space and tabs are empty glyphs as an optimization
+            if (c != ' ' && c != '\t')
+            {
+                // We don't do a second finer clipping test on the Y axis as we've already skipped
+                // anything before clip_rect.y and exit once we pass clip_rect.w
+                float x1 = x + glyph->X0 * scale;
+                float x2 = x + glyph->X1 * scale;
+                float y1 = y + glyph->Y0 * scale;
+                float y2 = y + glyph->Y1 * scale;
+                if (x1 <= clip_rect.z && x2 >= clip_rect.x)
+                {
+                    // Render a character
+                    float u1 = glyph->U0;
+                    float v1 = glyph->V0;
+                    float u2 = glyph->U1;
+                    float v2 = glyph->V1;
+
+                    // CPU side clipping used to fit text in their frame when the frame is too
+                    // small. Only does clipping for axis aligned quads.
+                    if (cpu_fine_clip)
+                    {
+                        if (x1 < clip_rect.x)
+                        {
+                            u1 = u1 + (1.0f - (x2 - clip_rect.x) / (x2 - x1)) * (u2 - u1);
+                            x1 = clip_rect.x;
+                        }
+                        if (y1 < clip_rect.y)
+                        {
+                            v1 = v1 + (1.0f - (y2 - clip_rect.y) / (y2 - y1)) * (v2 - v1);
+                            y1 = clip_rect.y;
+                        }
+                        if (x2 > clip_rect.z)
+                        {
+                            u2 = u1 + ((clip_rect.z - x1) / (x2 - x1)) * (u2 - u1);
+                            x2 = clip_rect.z;
+                        }
+                        if (y2 > clip_rect.w)
+                        {
+                            v2 = v1 + ((clip_rect.w - y1) / (y2 - y1)) * (v2 - v1);
+                            y2 = clip_rect.w;
+                        }
+                        if (y1 >= y2)
+                        {
+                            x += char_width;
+                            continue;
+                        }
+                    }
+
+                    // We are NOT calling PrimRectUV() here because non-inlined causes too much
+                    // overhead in a debug builds. Inlined here:
+                    {
+                        idx_write[0]       = (ImDrawIdx)(vtx_current_idx);
+                        idx_write[1]       = (ImDrawIdx)(vtx_current_idx + 1);
+                        idx_write[2]       = (ImDrawIdx)(vtx_current_idx + 2);
+                        idx_write[3]       = (ImDrawIdx)(vtx_current_idx);
+                        idx_write[4]       = (ImDrawIdx)(vtx_current_idx + 2);
+                        idx_write[5]       = (ImDrawIdx)(vtx_current_idx + 3);
+                        vtx_write[0].pos.x = x1;
+                        vtx_write[0].pos.y = y1;
+                        vtx_write[0].col   = col;
+                        vtx_write[0].uv.x  = u1;
+                        vtx_write[0].uv.y  = v1;
+                        vtx_write[1].pos.x = x2;
+                        vtx_write[1].pos.y = y1;
+                        vtx_write[1].col   = col;
+                        vtx_write[1].uv.x  = u2;
+                        vtx_write[1].uv.y  = v1;
+                        vtx_write[2].pos.x = x2;
+                        vtx_write[2].pos.y = y2;
+                        vtx_write[2].col   = col;
+                        vtx_write[2].uv.x  = u2;
+                        vtx_write[2].uv.y  = v2;
+                        vtx_write[3].pos.x = x1;
+                        vtx_write[3].pos.y = y2;
+                        vtx_write[3].col   = col;
+                        vtx_write[3].uv.x  = u1;
+                        vtx_write[3].uv.y  = v2;
+                        vtx_write += 4;
+                        vtx_current_idx += 4;
+                        idx_write += 6;
+                    }
+                }
+            }
+        }
+
+        x += char_width;
+    }
+
+    // Give back unused vertices
+    draw_list->VtxBuffer.resize((int)(vtx_write - draw_list->VtxBuffer.Data));
+    draw_list->IdxBuffer.resize((int)(idx_write - draw_list->IdxBuffer.Data));
+    draw_list->CmdBuffer[draw_list->CmdBuffer.Size - 1].ElemCount -=
+        (idx_expected_size - draw_list->IdxBuffer.Size);
+    draw_list->_VtxWritePtr   = vtx_write;
+    draw_list->_IdxWritePtr   = idx_write;
+    draw_list->_VtxCurrentIdx = vtx_current_idx;
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Internal Render Helpers
+// (progressively moved from imgui.cpp to here when they are redesigned to stop accessing ImGui
+// global state)
+//-----------------------------------------------------------------------------
+// - RenderMouseCursor()
+// - RenderArrowPointingAt()
+// - RenderRectFilledRangeH()
+// - RenderPixelEllipsis()
+//-----------------------------------------------------------------------------
+
+void ImGui::RenderMouseCursor(ImDrawList *draw_list,
+                              ImVec2 pos,
+                              float scale,
+                              ImGuiMouseCursor mouse_cursor)
+{
+    if (mouse_cursor == ImGuiMouseCursor_None)
+        return;
+    IM_ASSERT(mouse_cursor > ImGuiMouseCursor_None && mouse_cursor < ImGuiMouseCursor_COUNT);
+
+    const ImU32 col_shadow = IM_COL32(0, 0, 0, 48);
+    const ImU32 col_border = IM_COL32(0, 0, 0, 255);        // Black
+    const ImU32 col_fill   = IM_COL32(255, 255, 255, 255);  // White
+
+    ImFontAtlas *font_atlas = draw_list->_Data->Font->ContainerAtlas;
+    ImVec2 offset, size, uv[4];
+    if (font_atlas->GetMouseCursorTexData(mouse_cursor, &offset, &size, &uv[0], &uv[2]))
+    {
+        pos -= offset;
+        const ImTextureID tex_id = font_atlas->TexID;
+        draw_list->PushTextureID(tex_id);
+        draw_list->AddImage(tex_id, pos + ImVec2(1, 0) * scale,
+                            pos + ImVec2(1, 0) * scale + size * scale, uv[2], uv[3], col_shadow);
+        draw_list->AddImage(tex_id, pos + ImVec2(2, 0) * scale,
+                            pos + ImVec2(2, 0) * scale + size * scale, uv[2], uv[3], col_shadow);
+        draw_list->AddImage(tex_id, pos, pos + size * scale, uv[2], uv[3], col_border);
+        draw_list->AddImage(tex_id, pos, pos + size * scale, uv[0], uv[1], col_fill);
+        draw_list->PopTextureID();
+    }
+}
+
+// Render an arrow. 'pos' is position of the arrow tip. half_sz.x is length from base to tip.
+// half_sz.y is length on each side.
+void ImGui::RenderArrowPointingAt(ImDrawList *draw_list,
+                                  ImVec2 pos,
+                                  ImVec2 half_sz,
+                                  ImGuiDir direction,
+                                  ImU32 col)
+{
+    switch (direction)
+    {
+        case ImGuiDir_Left:
+            draw_list->AddTriangleFilled(ImVec2(pos.x + half_sz.x, pos.y - half_sz.y),
+                                         ImVec2(pos.x + half_sz.x, pos.y + half_sz.y), pos, col);
+            return;
+        case ImGuiDir_Right:
+            draw_list->AddTriangleFilled(ImVec2(pos.x - half_sz.x, pos.y + half_sz.y),
+                                         ImVec2(pos.x - half_sz.x, pos.y - half_sz.y), pos, col);
+            return;
+        case ImGuiDir_Up:
+            draw_list->AddTriangleFilled(ImVec2(pos.x + half_sz.x, pos.y + half_sz.y),
+                                         ImVec2(pos.x - half_sz.x, pos.y + half_sz.y), pos, col);
+            return;
+        case ImGuiDir_Down:
+            draw_list->AddTriangleFilled(ImVec2(pos.x - half_sz.x, pos.y - half_sz.y),
+                                         ImVec2(pos.x + half_sz.x, pos.y - half_sz.y), pos, col);
+            return;
+        case ImGuiDir_None:
+        case ImGuiDir_COUNT:
+            break;  // Fix warnings
+    }
+}
+
+static inline float ImAcos01(float x)
+{
+    if (x <= 0.0f)
+        return IM_PI * 0.5f;
+    if (x >= 1.0f)
+        return 0.0f;
+    return ImAcos(x);
+    // return (-0.69813170079773212f * x * x - 0.87266462599716477f) * x + 1.5707963267948966f; //
+    // Cheap approximation, may be enough for what we do.
+}
+
+// FIXME: Cleanup and move code to ImDrawList.
+void ImGui::RenderRectFilledRangeH(ImDrawList *draw_list,
+                                   const ImRect &rect,
+                                   ImU32 col,
+                                   float x_start_norm,
+                                   float x_end_norm,
+                                   float rounding)
+{
+    if (x_end_norm == x_start_norm)
+        return;
+    if (x_start_norm > x_end_norm)
+        ImSwap(x_start_norm, x_end_norm);
+
+    ImVec2 p0 = ImVec2(ImLerp(rect.Min.x, rect.Max.x, x_start_norm), rect.Min.y);
+    ImVec2 p1 = ImVec2(ImLerp(rect.Min.x, rect.Max.x, x_end_norm), rect.Max.y);
+    if (rounding == 0.0f)
+    {
+        draw_list->AddRectFilled(p0, p1, col, 0.0f);
+        return;
+    }
+
+    rounding =
+        ImClamp(ImMin((rect.Max.x - rect.Min.x) * 0.5f, (rect.Max.y - rect.Min.y) * 0.5f) - 1.0f,
+                0.0f, rounding);
+    const float inv_rounding = 1.0f / rounding;
+    const float arc0_b       = ImAcos01(1.0f - (p0.x - rect.Min.x) * inv_rounding);
+    const float arc0_e       = ImAcos01(1.0f - (p1.x - rect.Min.x) * inv_rounding);
+    const float half_pi = IM_PI * 0.5f;  // We will == compare to this because we know this is the
+                                         // exact value ImAcos01 can return.
+    const float x0 = ImMax(p0.x, rect.Min.x + rounding);
+    if (arc0_b == arc0_e)
+    {
+        draw_list->PathLineTo(ImVec2(x0, p1.y));
+        draw_list->PathLineTo(ImVec2(x0, p0.y));
+    }
+    else if (arc0_b == 0.0f && arc0_e == half_pi)
+    {
+        draw_list->PathArcToFast(ImVec2(x0, p1.y - rounding), rounding, 3, 6);  // BL
+        draw_list->PathArcToFast(ImVec2(x0, p0.y + rounding), rounding, 6, 9);  // TR
+    }
+    else
+    {
+        draw_list->PathArcTo(ImVec2(x0, p1.y - rounding), rounding, IM_PI - arc0_e, IM_PI - arc0_b,
+                             3);  // BL
+        draw_list->PathArcTo(ImVec2(x0, p0.y + rounding), rounding, IM_PI + arc0_b, IM_PI + arc0_e,
+                             3);  // TR
+    }
+    if (p1.x > rect.Min.x + rounding)
+    {
+        const float arc1_b = ImAcos01(1.0f - (rect.Max.x - p1.x) * inv_rounding);
+        const float arc1_e = ImAcos01(1.0f - (rect.Max.x - p0.x) * inv_rounding);
+        const float x1     = ImMin(p1.x, rect.Max.x - rounding);
+        if (arc1_b == arc1_e)
+        {
+            draw_list->PathLineTo(ImVec2(x1, p0.y));
+            draw_list->PathLineTo(ImVec2(x1, p1.y));
+        }
+        else if (arc1_b == 0.0f && arc1_e == half_pi)
+        {
+            draw_list->PathArcToFast(ImVec2(x1, p0.y + rounding), rounding, 9, 12);  // TR
+            draw_list->PathArcToFast(ImVec2(x1, p1.y - rounding), rounding, 0, 3);   // BR
+        }
+        else
+        {
+            draw_list->PathArcTo(ImVec2(x1, p0.y + rounding), rounding, -arc1_e, -arc1_b, 3);  // TR
+            draw_list->PathArcTo(ImVec2(x1, p1.y - rounding), rounding, +arc1_b, +arc1_e, 3);  // BR
+        }
+    }
+    draw_list->PathFillConvex(col);
+}
+
+// FIXME: Rendering an ellipsis "..." is a surprisingly tricky problem for us... we cannot rely on
+// font glyph having it, and regular dot are typically too wide. If we render a dot/shape ourselves
+// it comes with the risk that it wouldn't match the boldness or positioning of what the font
+// uses...
+void ImGui::RenderPixelEllipsis(ImDrawList *draw_list, ImVec2 pos, ImU32 col, int count)
+{
+    ImFont *font           = draw_list->_Data->Font;
+    const float font_scale = draw_list->_Data->FontSize / font->FontSize;
+    pos.y += (float)(int)(font->DisplayOffset.y + font->Ascent * font_scale + 0.5f - 1.0f);
+    for (int dot_n = 0; dot_n < count; dot_n++)
+        draw_list->AddRectFilled(ImVec2(pos.x + dot_n * 2.0f, pos.y),
+                                 ImVec2(pos.x + dot_n * 2.0f + 1.0f, pos.y + 1.0f), col);
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Decompression code
+//-----------------------------------------------------------------------------
+// Compressed with stb_compress() then converted to a C array and encoded as base85.
+// Use the program in misc/fonts/binary_to_compressed_c.cpp to create the array from a TTF file.
+// The purpose of encoding as base85 instead of "0x00,0x01,..." style is only save on _source code_
+// size. Decompression from stb.h (public domain) by Sean Barrett
+// https://github.com/nothings/stb/blob/master/stb.h
+//-----------------------------------------------------------------------------
+
+static unsigned int stb_decompress_length(const unsigned char *input)
+{
+    return (input[8] << 24) + (input[9] << 16) + (input[10] << 8) + input[11];
+}
+
+static unsigned char *stb__barrier_out_e, *stb__barrier_out_b;
+static const unsigned char *stb__barrier_in_b;
+static unsigned char *stb__dout;
+static void stb__match(const unsigned char *data, unsigned int length)
+{
+    // INVERSE of memmove... write each byte before copying the next...
+    IM_ASSERT(stb__dout + length <= stb__barrier_out_e);
+    if (stb__dout + length > stb__barrier_out_e)
+    {
+        stb__dout += length;
+        return;
+    }
+    if (data < stb__barrier_out_b)
+    {
+        stb__dout = stb__barrier_out_e + 1;
+        return;
+    }
+    while (length--)
+        *stb__dout++ = *data++;
+}
+
+static void stb__lit(const unsigned char *data, unsigned int length)
+{
+    IM_ASSERT(stb__dout + length <= stb__barrier_out_e);
+    if (stb__dout + length > stb__barrier_out_e)
+    {
+        stb__dout += length;
+        return;
+    }
+    if (data < stb__barrier_in_b)
+    {
+        stb__dout = stb__barrier_out_e + 1;
+        return;
+    }
+    memcpy(stb__dout, data, length);
+    stb__dout += length;
+}
+
+#define stb__in2(x) ((i[x] << 8) + i[(x) + 1])
+#define stb__in3(x) ((i[x] << 16) + stb__in2((x) + 1))
+#define stb__in4(x) ((i[x] << 24) + stb__in3((x) + 1))
+
+static const unsigned char *stb_decompress_token(const unsigned char *i)
+{
+    if (*i >= 0x20)
+    {  // use fewer if's for cases that expand small
+        if (*i >= 0x80)
+            stb__match(stb__dout - i[1] - 1, i[0] - 0x80 + 1), i += 2;
+        else if (*i >= 0x40)
+            stb__match(stb__dout - (stb__in2(0) - 0x4000 + 1), i[2] + 1), i += 3;
+        else /* *i >= 0x20 */
+            stb__lit(i + 1, i[0] - 0x20 + 1), i += 1 + (i[0] - 0x20 + 1);
+    }
+    else
+    {  // more ifs for cases that expand large, since overhead is amortized
+        if (*i >= 0x18)
+            stb__match(stb__dout - (stb__in3(0) - 0x180000 + 1), i[3] + 1), i += 4;
+        else if (*i >= 0x10)
+            stb__match(stb__dout - (stb__in3(0) - 0x100000 + 1), stb__in2(3) + 1), i += 5;
+        else if (*i >= 0x08)
+            stb__lit(i + 2, stb__in2(0) - 0x0800 + 1), i += 2 + (stb__in2(0) - 0x0800 + 1);
+        else if (*i == 0x07)
+            stb__lit(i + 3, stb__in2(1) + 1), i += 3 + (stb__in2(1) + 1);
+        else if (*i == 0x06)
+            stb__match(stb__dout - (stb__in3(1) + 1), i[4] + 1), i += 5;
+        else if (*i == 0x04)
+            stb__match(stb__dout - (stb__in3(1) + 1), stb__in2(4) + 1), i += 6;
+    }
+    return i;
+}
+
+static unsigned int stb_adler32(unsigned int adler32, unsigned char *buffer, unsigned int buflen)
+{
+    const unsigned long ADLER_MOD = 65521;
+    unsigned long s1 = adler32 & 0xffff, s2 = adler32 >> 16;
+    unsigned long blocklen, i;
+
+    blocklen = buflen % 5552;
+    while (buflen)
+    {
+        for (i = 0; i + 7 < blocklen; i += 8)
+        {
+            s1 += buffer[0], s2 += s1;
+            s1 += buffer[1], s2 += s1;
+            s1 += buffer[2], s2 += s1;
+            s1 += buffer[3], s2 += s1;
+            s1 += buffer[4], s2 += s1;
+            s1 += buffer[5], s2 += s1;
+            s1 += buffer[6], s2 += s1;
+            s1 += buffer[7], s2 += s1;
+
+            buffer += 8;
+        }
+
+        for (; i < blocklen; ++i)
+            s1 += *buffer++, s2 += s1;
+
+        s1 %= ADLER_MOD, s2 %= ADLER_MOD;
+        buflen -= blocklen;
+        blocklen = 5552;
+    }
+    return (unsigned int)(s2 << 16) + (unsigned int)s1;
+}
+
+static unsigned int stb_decompress(unsigned char *output,
+                                   const unsigned char *i,
+                                   unsigned int /*length*/)
+{
+    unsigned int olen;
+    if (stb__in4(0) != 0x57bC0000)
+        return 0;
+    if (stb__in4(4) != 0)
+        return 0;  // error! stream is > 4GB
+    olen               = stb_decompress_length(i);
+    stb__barrier_in_b  = i;
+    stb__barrier_out_e = output + olen;
+    stb__barrier_out_b = output;
+    i += 16;
+
+    stb__dout = output;
+    for (;;)
+    {
+        const unsigned char *old_i = i;
+        i                          = stb_decompress_token(i);
+        if (i == old_i)
+        {
+            if (*i == 0x05 && i[1] == 0xfa)
+            {
+                IM_ASSERT(stb__dout == output + olen);
+                if (stb__dout != output + olen)
+                    return 0;
+                if (stb_adler32(1, output, olen) != (unsigned int)stb__in4(2))
+                    return 0;
+                return olen;
+            }
+            else
+            {
+                IM_ASSERT(0); /* NOTREACHED */
+                return 0;
+            }
+        }
+        IM_ASSERT(stb__dout <= output + olen);
+        if (stb__dout > output + olen)
+            return 0;
+    }
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Default font data (ProggyClean.ttf)
+//-----------------------------------------------------------------------------
+// ProggyClean.ttf
+// Copyright (c) 2004, 2005 Tristan Grimmer
+// MIT license (see License.txt in http://www.upperbounds.net/download/ProggyClean.ttf.zip)
+// Download and more information at http://upperbounds.net
+//-----------------------------------------------------------------------------
+// File: 'ProggyClean.ttf' (41208 bytes)
+// Exported using misc/fonts/binary_to_compressed_c.cpp (with compression + base85 string encoding).
+// The purpose of encoding as base85 instead of "0x00,0x01,..." style is only save on _source code_
+// size.
+//-----------------------------------------------------------------------------
+static const char proggy_clean_ttf_compressed_data_base85[11980 + 1] =
+    "7])#######hV0qs'/###[),##/l:$#Q6>##5[n42>c-TH`->>#/"
+    "e>11NNV=Bv(*:.F?uu#(gRU.o0XGH`$vhLG1hxt9?W`#,5LsCp#-i>.r$<$6pD>Lb';9Crc6tgXmKVeU2cD4Eo3R/"
+    "2*>]b(MC;$jPfY.;h^`IWM9<Lh2TlS+f-s$o6Q<BWH`YiU.xfLq$N;$0iR/GX:U(jcW2p/"
+    "W*q?-qmnUCI;jHSAiFWM.R*kU@C=GH?a9wp8f$e.-4^Qg1)Q-GL(lf(r/7GrRgwV%MS=C#"
+    "`8ND>Qo#t'X#(v#Y9w0#1D$CIf;W'#pWUPXOuxXuU(H9M(1<q-UE31#^-V'8IRUo7Qf./"
+    "L>=Ke$$'5F%)]0^#0X@U.a<r:QLtFsLcL6##lOj)#.Y5<-R&KgLwqJfLgN&;Q?gI^#DY2uL"
+    "i@^rMl9t=cWq6##weg>$FBjVQTSDgEKnIS7EM9>ZY9w0#L;>>#Mx&4Mvt//"
+    "L[MkA#W@lK.N'[0#7RL_&#w+F%HtG9M#XL`N&.,GM4Pg;-<nLENhvx>-VsM.M0rJfLH2eTM`*oJMHRC`N"
+    "kfimM2J,W-jXS:)r0wK#@Fge$U>`w'N7G#$#fB#$E^$#:9:hk+eOe--6x)F7*E%?76%^GMHePW-Z5l'&GiF#$956:rS?"
+    "dA#fiK:)Yr+`&#0j@'DbG&#^$PG.Ll+DNa<XCMKEV*N)LN/N"
+    "*b=%Q6pia-Xg8I$<MR&,VdJe$<(7G;Ckl'&hF;;$<_=X(b.RS%%)###MPBuuE1V:v&cX&#2m#(&cV]`k9OhLMbn%s$G2,"
+    "B$BfD3X*sp5#l,$R#]x_X1xKX%b5U*[r5iMfUo9U`N99hG)"
+    "tm+/Us9pG)XPu`<0s-)WTt(gCRxIg(%6sfh=ktMKn3j)<6<b5Sk_/0(^]AaN#(p/"
+    "L>&VZ>1i%h1S9u5o@YaaW$e+b<TWFn/Z:Oh(Cx2$lNEoN^e)#CFY@@I;BOQ*sRwZtZxRcU7uW6CX"
+    "ow0i(?$Q[cjOd[P4d)]>ROPOpxTO7Stwi1::iB1q)C_=dV26J;2,]7op$]uQr@_V7$q^%lQwtuHY]=DX,n3L#0PHDO4f9>"
+    "dC@O>HBuKPpP*E,N+b3L#lpR/MrTEH.IAQk.a>D[.e;mc."
+    "x]Ip.PH^'/aqUO/$1WxLoW0[iLA<QT;5HKD+@qQ'NQ(3_PLhE48R.qAPSwQ0/WK?Z,[x?-J;jQTWA0X@KJ(_Y8N-:/"
+    "M74:/-ZpKrUss?d#dZq]DAbkU*JqkL+nwX@@47`5>w=4h(9.`G"
+    "CRUxHPeR`5Mjol(dUWxZa(>STrPkrJiWx`5U7F#.g*jrohGg`cg:lSTvEY/"
+    "EV_7H4Q9[Z%cnv;JQYZ5q.l7Zeas:HOIZOB?G<Nald$qs]@]L<J7bR*>gv:[7MI2k).'2($5FNP&EQ(,)"
+    "U]W]+fh18.vsai00);D3@4ku5P?DP8aJt+;qUM]=+b'8@;mViBKx0DE[-auGl8:PJ&Dj+M6OC]O^((##]`0i)drT;-7X`="
+    "-H3[igUnPG-NZlo.#k@h#=Ork$m>a>$-?Tm$UV(?#P6YY#"
+    "'/###xe7q.73rI3*pP/$1>s9)W,JrM7SN]'/"
+    "4C#v$U`0#V.[0>xQsH$fEmPMgY2u7Kh(G%siIfLSoS+MK2eTM$=5,M8p`A.;_R%#u[K#$x4AG8.kK/HSB==-'Ie/"
+    "QTtG?-.*^N-4B/ZM"
+    "_3YlQC7(p7q)&](`6_c)$/*JL(L-^(]$wIM`dPtOdGA,U3:w2M-0<q-]L_?^)1vw'.,MRsqVr.L;aN&#/"
+    "EgJ)PBc[-f>+WomX2u7lqM2iEumMTcsF?-aT=Z-97UEnXglEn1K-bnEO`gu"
+    "Ft(c%=;Am_Qs@jLooI&NX;]0#j4#F14;gl8-GQpgwhrq8'=l_f-b49'UOqkLu7-##oDY2L(te+Mch&gLYtJ,MEtJfLh'x'"
+    "M=$CS-ZZ%P]8bZ>#S?YY#%Q&q'3^Fw&?D)UDNrocM3A76/"
+    "/oL?#h7gl85[qW/"
+    "NDOk%16ij;+:1a'iNIdb-ou8.P*w,v5#EI$TWS>Pot-R*H'-SEpA:g)f+O$%%`kA#G=8RMmG1&O`>to8bC]T&$,n.LoO>"
+    "29sp3dt-52U%VM#q7'DHpg+#Z9%H[K<L"
+    "%a2E-grWVM3@2=-k22tL]4$##6We'8UJCKE[d_=%wI;'6X-GsLX4j^SgJ$##R*w,vP3wK#iiW&#*h^D&R?jp7+/"
+    "u&#(AP##XU8c$fSYW-J95_-Dp[g9wcO&#M-h1OcJlc-*vpw0xUX&#"
+    "OQFKNX@QI'IoPp7nb,QU//"
+    "MQ&ZDkKP)X<WSVL(68uVl&#c'[0#(s1X&xm$Y%B7*K:eDA323j998GXbA#pwMs-jgD$9QISB-A_(aN4xoFM^@C58D0+Q+"
+    "q3n0#3U1InDjF682-SjMXJK)("
+    "h$hxua_K]ul92%'BOU&#BRRh-slg8KDlr:%L71Ka:.A;%YULjDPmL<LYs8i#XwJOYaKPKc1h:'9Ke,g)b),78=I39B;"
+    "xiY$bgGw-&.Zi9InXDuYa%G*f2Bq7mn9^#p1vv%#(Wi-;/Z5h"
+    "o;#2:;%d&#x9v68C5g?ntX0X)pT`;%pB3q7mgGN)3%(P8nTd5L7GeA-GL@+%J3u2:(Yf>et`e;)f#Km8&+DC$I46>#Kr]]"
+    "u-[=99tts1.qb#q72g1WJO81q+eN'03'eM>&1XxY-caEnO"
+    "j%2n8)),?ILR5^.Ibn<-X-Mq7[a82Lq:F&#ce+S9wsCK*x`569E8ew'He]h:sI[2LM$[guka3ZRd6:t%IG:;$%YiJ:Nq=?"
+    "eAw;/:nnDq0(CYcMpG)qLN4$##&J<j$UpK<Q4a1]MupW^-"
+    "sj_$%[HK%'F####QRZJ::Y3EGl4'@%FkiAOg#p[##O`gukTfBHagL<LHw%q&OV0##F=6/"
+    ":chIm0@eCP8X]:kFI%hl8hgO@RcBhS-@Qb$%+m=hPDLg*%K8ln(wcf3/'DW-$.lR?n[nCH-"
+    "eXOONTJlh:.RYF%3'p6sq:UIMA945&^HFS87@$EP2iG<-lCO$%c`uKGD3rC$x0BL8aFn--`ke%#HMP'vh1/"
+    "R&O_J9'um,.<tx[@%wsJk&bUT2`0uMv7gg#qp/ij.L56'hl;.s5CUrxjO"
+    "M7-##.l+Au'A&O:-T72L]P`&=;ctp'XScX*rU.>-XTt,%OVU4)S1+R-#dg0/"
+    "Nn?Ku1^0f$B*P:Rowwm-`0PKjYDDM'3]d39VZHEl4,.j']Pk-M.h^&:0FACm$maq-&sgw0t7/6(^xtk%"
+    "LuH88Fj-ekm>GA#_>568x6(OFRl-IZp`&b,_P'$M<Jnq79VsJW/mWS*PUiq76;]/NM_>hLbxfc$mj`,O;&%W2m`Zh:/"
+    ")Uetw:aJ%]K9h:TcF]u_-Sj9,VK3M.*'&0D[Ca]J9gp8,kAW]"
+    "%(?A%R$f<->Zts'^kn=-^@c4%-pY6qI%J%1IGxfLU9CP8cbPlXv);C=b),<2mOvP8up,UVf3839acAWAW-W?#ao/"
+    "^#%KYo8fRULNd2.>%m]UK:n%r$'sw]J;5pAoO_#2mO3n,'=H5(et"
+    "Hg*`+RLgv>=4U8guD$I%D:W>-r5V*%j*W:Kvej.Lp$<M-SGZ':+Q_k+uvOSLiEo(<aD/"
+    "K<CCc`'Lx>'?;++O'>()jLR-^u68PHm8ZFWe+ej8h:9r6L*0//c&iH&R8pRbA#Kjm%upV1g:"
+    "a_#Ur7FuA#(tRh#.Y5K+@?3<-8m0$PEn;J:rh6?I6uG<-`wMU'ircp0LaE_OtlMb&1#6T.#FDKu#1Lw%u%+GM+X'e?"
+    "YLfjM[VO0MbuFp7;>Q&#WIo)0@F%q7c#4XAXN-U&VB<HFF*qL("
+    "$/V,;(kXZejWO`<[5?\?ewY(*9=%wDc;,u<'9t3W-(H1th3+G]ucQ]kLs7df($/"
+    "*JL]@*t7Bu_G3_7mp7<iaQjO@.kLg;x3B0lqp7Hf,^Ze7-##@/c58Mo(3;knp0%)A7?-W+eI'o8)b<"
+    "nKnw'Ho8C=Y>pqB>0ie&jhZ[?iLR@@_AvA-iQC(=ksRZRVp7`.=+NpBC%rh&3]R:8XDmE5^V8O(x<<aG/"
+    "1N$#FX$0V5Y6x'aErI3I$7x%E`v<-BY,)%-?Psf*l?%C3.mM(=/M0:JxG'?"
+    "7WhH%o'a<-80g0NBxoO(GH<dM]n.+%q@jH?f.UsJ2Ggs&4<-e47&Kl+f//"
+    "9@`b+?.TeN_&B8Ss?v;^Trk;f#YvJkl&w$]>-+k?'(<S:68tq*WoDfZu';mM?8X[ma8W%*`-=;D.(nc7/;"
+    ")g:T1=^J$&BRV(-lTmNB6xqB[@0*o.erM*<SWF]u2=st-*(6v>^](H.aREZSi,#1:[IXaZFOm<-ui#qUq2$##Ri;u75OK#"
+    "(RtaW-K-F`S+cF]uN`-KMQ%rP/Xri.LRcB##=YL3BgM/3M"
+    "D?@f&1'BW-)Ju<L25gl8uhVm1hL$##*8###'A3/"
+    "LkKW+(^rWX?5W_8g)a(m&K8P>#bmmWCMkk&#TR`C,5d>g)F;t,4:@_l8G/"
+    "5h4vUd%&%950:VXD'QdWoY-F$BtUwmfe$YqL'8(PWX("
+    "P?^@Po3$##`MSs?DWBZ/S>+4%>fX,VWv/w'KD`LP5IbH;rTV>n3cEK8U#bX]l-/"
+    "V+^lj3;vlMb&[5YQ8#pekX9JP3XUC72L,,?+Ni&co7ApnO*5NK,((W-i:$,kp'UDAO(G0Sq7MVjJs"
+    "bIu)'Z,*[>br5fX^:FPAWr-m2KgL<LUN098kTF&#lvo58=/vjDo;.;)Ka*hLR#/"
+    "k=rKbxuV`>Q_nN6'8uTG&#1T5g)uLv:873UpTLgH+#FgpH'_o1780Ph8KmxQJ8#H72L4@768@Tm&Q"
+    "h4CB/5OvmA&,Q&QbUoi$a_%3M01H)4x7I^&KQVgtFnV+;[Pc>[m4k//"
+    ",]1?#`VY[Jr*3&&slRfLiVZJ:]?=K3Sw=[$=uRB?3xk48@aeg<Z'<$#4H)6,>e0jT6'N#(q%.O=?2S]u*(m<-"
+    "V8J'(1)G][68hW$5'q[GC&5j`TE?m'esFGNRM)j,ffZ?-qx8;->g4t*:CIP/[Qap7/"
+    "9'#(1sao7w-.qNUdkJ)tCF&#B^;xGvn2r9FEPFFFcL@.iFNkTve$m%#QvQS8U@)2Z+3K:AKM5i"
+    "sZ88+dKQ)W6>J%CL<KE>`.d*(B`-n8D9oK<Up]c$X$(,)M8Zt7/"
+    "[rdkqTgl-0cuGMv'?>-XV1q['-5k'cAZ69e;D_?$ZPP&s^+7])$*$#@QYi9,5P&#9r+$%CE=68>K8r0=dSC%%(@p7"
+    ".m7jilQ02'0-VWAg<a/''3u.=4L$Y)6k/K:_[3=&jvL<L0C/"
+    "2'v:^;-DIBW,B4E68:kZ;%?8(Q8BH=kO65BW?xSG&#@uU,DS*,?.+(o(#1vCS8#CHF>TlGW'b)Tq7VT9q^*^$$.:&N@@"
+    "$&)WHtPm*5_rO0&e%K&#-30j(E4#'Zb.o/"
+    "(Tpm$>K'f@[PvFl,hfINTNU6u'0pao7%XUp9]5.>%h`8_=VYbxuel.NTSsJfLacFu3B'lQSu/m6-Oqem8T+oE--$0a/"
+    "k]uj9EwsG>%veR*"
+    "hv^BFpQj:K'#SJ,sB-'#](j.Lg92rTw-*n%@/;39rrJF,l#qV%OrtBeC6/"
+    ",;qB3ebNW[?,Hqj2L.1NP&GjUR=1D8QaS3Up&@*9wP?+lo7b?@%'k4`p0Z$22%K3+iCZj?XJN4Nm&+YF]u"
+    "@-W$U%VEQ/,,>>#)D<h#`)h0:<Q6909ua+&VU%n2:cG3FJ-%@Bj-DgLr`Hw&HAKjKjseK</"
+    "xKT*)B,N9X3]krc12t'pgTV(Lv-tL[xg_%=M_q7a^x?7Ubd>#%8cY#YZ?=,`Wdxu/ae&#"
+    "w6)R89tI#6@s'(6Bf7a&?S=^ZI_kS&ai`&=tE72L_D,;^R)7[$s<Eh#c&)q.MXI%#v9ROa5FZO%sF7q7Nwb&#ptUJ:"
+    "aqJe$Sl68%.D###EC><?-aF&#RNQv>o8lKN%5/$(vdfq7+ebA#"
+    "u1p]ovUKW&Y%q]'>$1@-[xfn$7ZTp7mM,G,Ko7a&Gu%G[RMxJs[0MM%wci.LFDK)(<c`Q8N)jEIF*+?P2a8g%)$q]"
+    "o2aH8C&<SibC/q,(e:v;-b#6[$NtDZ84Je2KNvB#$P5?tQ3nt(0"
+    "d=j.LQf./"
+    "Ll33+(;q3L-w=8dX$#WF&uIJ@-bfI>%:_i2B5CsR8&9Z&#=mPEnm0f`<&c)QL5uJ#%u%lJj+D-r;BoF&#4DoS97h5g)E#"
+    "o:&S4weDF,9^Hoe`h*L+_a*NrLW-1pG_&2UdB8"
+    "6e%B/:=>)N4xeW.*wft-;$'58-ESqr<b?UI(_%@[P46>#U`'6AQ]m&6/"
+    "`Z>#S?YY#Vc;r7U2&326d=w&H####?TZ`*4?&.MK?LP8Vxg>$[QXc%QJv92.(Db*B)gb*BM9dM*hJMAo*c&#"
+    "b0v=Pjer]$gG&JXDf->'StvU7505l9$AFvgYRI^&<^b68?j#q9QX4SM'RO#&sL1IM.rJfLUAj221]d##DW=m83u5;'bYx,"
+    "*Sl0hL(W;;$doB&O/TQ:(Z^xBdLjL<Lni;''X.`$#8+1GD"
+    ":k$YUWsbn8ogh6rxZ2Z9]%nd+>V#*8U_72Lh+2Q8Cj0i:6hp&$C/"
+    ":p(HK>T8Y[gHQ4`4)'$Ab(Nof%V'8hL&#<NEdtg(n'=S1A(Q1/I&4([%dM`,Iu'1:_hL>SfD07&6D<fp8dHM7/g+"
+    "tlPN9J*rKaPct&?'uBCem^jn%9_K)<,C5K3s=5g&GmJb*[SYq7K;TRLGCsM-$$;S%:Y@r7AK0pprpL<Lrh,q7e/"
+    "%KWK:50I^+m'vi`3?%Zp+<-d+$L-Sv:@.o19n$s0&39;kn;S%BSq*"
+    "$3WoJSCLweV[aZ'MQIjO<7;X-X;&+dMLvu#^UsGEC9WEc[X(wI7#2.(F0jV*eZf<-Qv3J-c+J5AlrB#$p(H68LvEA'"
+    "q3n0#m,[`*8Ft)FcYgEud]CWfm68,(aLA$@EFTgLXoBq/UPlp7"
+    ":d[/;r_ix=:TF`S5H-b<LI&HY(K=h#)]Lk$K14lVfm:x$H<3^Ql<M`$OhapBnkup'D#L$Pb_`N*g]2e;X/"
+    "Dtg,bsj&K#2[-:iYr'_wgH)NUIR8a1n#S?Yej'h8^58UbZd+^FKD*T@;6A"
+    "7aQC[K8d-(v6GI$x:T<&'Gp5Uf>@M.*J:;$-rv29'M]8qMv-tLp,'886iaC=Hb*YJoKJ,(j%K=H`K.v9HggqBIiZu'"
+    "QvBT.#=)0ukruV&.)3=(^1`o*Pj4<-<aN((^7('#Z0wK#5GX@7"
+    "u][`*S^43933A4rl][`*O4CgLEl]v$1Q3AeF37dbXk,.)vj#x'd`;qgbQR%FW,2(?LO=s%Sc68%NP'##Aotl8x=BE#"
+    "j1UD([3$M(]UI2LX3RpKN@;/#f'f/&_mt&F)XdF<9t4)Qa.*kT"
+    "LwQ'(TTB9.xH'>#MJ+gLq9-##@HuZPN0]u:h7.T..G:;$/"
+    "Usj(T7`Q8tT72LnYl<-qx8;-HV7Q-&Xdx%1a,hC=0u+HlsV>nuIQL-5<N?)NBS)QN*_I,?&)2'IM%L3I)X((e/dl2&8'<M"
+    ":^#M*Q+[T.Xri.LYS3v%fF`68h;b-X[/En'CR.q7E)p'/"
+    "kle2HM,u;^%OKC-N+Ll%F9CF<Nf'^#t2L,;27W:0O@6##U6W7:$rJfLWHj$#)woqBefIZ.PK<b*t7ed;p*_m;4ExK#h@&]"
+    ">"
+    "_>@kXQtMacfD.m-VAb8;IReM3$wf0''hra*so568'Ip&vRs849'MRYSp%:t:h5qSgwpEr$B>Q,;s(C#$)`svQuF$##-D,#"
+    "#,g68@2[T;.XSdN9Qe)rpt._K-#5wF)sP'##p#C0c%-Gb%"
+    "hd+<-j'Ai*x&&HMkT]C'OSl##5RG[JXaHN;d'uA#x._U;.`PU@(Z3dt4r152@:v,'R.Sj'w#0<-;kPI)FfJ&#AYJ&#//"
+    ")>-k=m=*XnK$>=)72L]0I%>.G690a:$##<,);?;72#?x9+d;"
+    "^V'9;jY@;)br#q^YQpx:X#Te$Z^'=-=bGhLf:D6&bNwZ9-ZD#n^9HhLMr5G;']d&6'wYmTFmL<LD)F^%[tC'8;+9E#C$g%"
+    "#5Y>q9wI>P(9mI[>kC-ekLC/R&CH+s'B;K-M6$EB%is00:"
+    "+A4[7xks.LrNk0&E)wILYF@2L'0Nb$+pv<(2.768/"
+    "FrY&h$^3i&@+G%JT'<-,v`3;_)I9M^AE]CN?Cl2AZg+%4iTpT3<n-&%H%b<FDj2M<hH=&Eh<2Len$b*aTX=-8QxN)"
+    "k11IM1c^j%"
+    "9s<L<NFSo)B?+<-(GxsF,^-Eh@$4dXhN$+#rxK8'je'D7k`e;)2pYwPA'_p9&@^18ml1^[@g4t*[JOa*[=Qp7(qJ_oOL^("
+    "'7fB&Hq-:sf,sNj8xq^>$U4O]GKx'm9)b@p7YsvK3w^YR-"
+    "CdQ*:Ir<($u&)#(&?L9Rg3H)4fiEp^iI9O8KnTj,]H?D*r7'M;PwZ9K0E^k&-cpI;.p/"
+    "6_vwoFMV<->#%Xi.LxVnrU(4&8/P+:hLSKj$#U%]49t'I:rgMi'FL@a:0Y-uA[39',(vbma*"
+    "hU%<-SRF`Tt:542R_VV$p@[p8DV[A,?1839FWdF<TddF<9Ah-6&9tWoDlh]&1SpGMq>Ti1O*H&#(AL8[_P%.M>v^-))"
+    "qOT*F5Cq0`Ye%+$B6i:7@0IX<N+T+0MlMBPQ*Vj>SsD<U4JHY"
+    "8kD2)2fU/M#$e.)T4,_=8hLim[&);?UkK'-x?'(:siIfL<$pFM`i<?%W(mGDHM%>iWP,##P`%/"
+    "L<eXi:@Z9C.7o=@(pXdAO/NLQ8lPl+HPOQa8wD8=^GlPa8TKI1CjhsCTSLJM'/Wl>-"
+    "S(qw%sf/@%#B6;/"
+    "U7K]uZbi^Oc^2n<bhPmUkMw>%t<)'mEVE''n`WnJra$^TKvX5B>;_aSEK',(hwa0:i4G?.Bci.(X[?b*($,=-n<.Q%`(X="
+    "?+@Am*Js0&=3bh8K]mL<LoNs'6,'85`"
+    "0?t/'_U59@]ddF<#LdF<eWdF<OuN/45rY<-L@&#+fm>69=Lb,OcZV/"
+    ");TTm8VI;?%OtJ<(b4mq7M6:u?KRdF<gR@2L=FNU-<b[(9c/ML3m;Z[$oF3g)GAWqpARc=<ROu7cL5l;-[A]%/"
+    "+fsd;l#SafT/"
+    "f*W]0=O'$(Tb<[)*@e775R-:Yob%g*>l*:xP?Yb.5)%w_I?7uk5JC+FS(m#i'k.'a0i)9<7b'fs'59hq$*5Uhv##pi^8+"
+    "hIEBF`nvo`;'l0.^S1<-wUK2/Coh58KKhLj"
+    "M=SO*rfO`+qC`W-On.=AJ56>>i2@2LH6A:&5q`?9I3@@'04&p2/"
+    "LVa*T-4<-i3;M9UvZd+N7>b*eIwg:CC)c<>nO&#<IGe;__.thjZl<%w(Wk2xmp4Q@I#I9,DF]u7-P=.-_:YJ]aS@V"
+    "?6*C()dOp7:WL,b&3Rg/"
+    ".cmM9&r^>$(>.Z-I&J(Q0Hd5Q%7Co-b`-c<N(6r@ip+AurK<m86QIth*#v;-OBqi+L7wDE-Ir8K['m+DDSLwK&/"
+    ".?-V%U_%3:qKNu$_b*B-kp7NaD'QdWQPK"
+    "Yq[@>P)hI;*_F]u`Rb[.j8_Q/<&>uu+VsH$sM9TA%?)(vmJ80),P7E>)tjD%2L=-t#fK[%`v=Q8<FfNkgg^oIbah*#8/"
+    "Qt$F&:K*-(N/'+1vMB,u()-a.VUU*#[e%gAAO(S>WlA2);Sa"
+    ">gXm8YB`1d@K#n]76-a$U,mF<fX]idqd)<3,]J7JmW4`6]uks=4-72L(jEk+:bJ0M^q-8Dm_Z?0olP1C9Sa&H[d&c$"
+    "ooQUj]Exd*3ZM@-WGW2%s',B-_M%>%Ul:#/'xoFM9QX-$.QN'>"
+    "[%$Z$uF6pA6Ki2O5:8w*vP1<-1`[G,)-m#>0`P&#eb#.3i)rtB61(o'$?X3B</"
+    "R90;eZ]%Ncq;-Tl]#F>2Qft^ae_5tKL9MUe9b*sLEQ95C&`=G?@Mj=wh*'3E>=-<)Gt*Iw)'QG:`@I"
+    "wOf7&]1i'S01B+Ev/Nac#9S;=;YQpg_6U`*kVY39xK,[/"
+    "6Aj7:'1Bm-_1EYfa1+o&o4hp7KN_Q(OlIo@S%;jVdn0'1<Vc52=u`3^o-n1'g4v58Hj&6_t7$##?M)c<$bgQ_'SY((-"
+    "xkA#"
+    "Y(,p'H9rIVY-b,'%bCPF7.J<Up^,(dU1VY*5#WkTU>h19w,WQhLI)3S#f$2(eb,jr*b;3Vw]*7NH%$c4Vs,eD9>XW8?N]"
+    "o+(*pgC%/72LV-u<Hp,3@e^9UB1J+ak9-TN/mhKPg+AJYd$"
+    "MlvAF_jCK*.O-^(63adMT->W%iewS8W6m2rtCpo'RS1R84=@paTKt)>=%&1[)*vp'u+x,VrwN;&]kuO9JDbg=pO$J*."
+    "jVe;u'm0dr9l,<*wMK*Oe=g8lV_KEBFkO'oU]^=[-792#ok,)"
+    "i]lR8qQ2oA8wcRCZ^7w/Njh;?.stX?Q1>S1q4Bn$)K1<-rGdO'$Wr.Lc.CG)$/*JL4tNR/"
+    ",SVO3,aUw'DJN:)Ss;wGn9A32ijw%FL+Z0Fn.U9;reSq)bmI32U==5ALuG&#Vf1398/pVo"
+    "1*c-(aY168o<`JsSbk-,1N;$>0:OUas(3:8Z972LSfF8eb=c-;>SPw7.6hn3m`9^Xkn(r.qS[0;T%&Qc=+STRxX'"
+    "q1BNk3&*eu2;&8q$&x>Q#Q7^Tf+6<(d%ZVmj2bDi%.3L2n+4W'$P"
+    "iDDG)g,r%+?,$@?uou5tSe2aN_AQU*<h`e-GI7)?OK2A.d7_c)?wQ5AS@DL3r#7fSkgl6-++D:'A,uq7SvlB$pcpH'"
+    "q3n0#_%dY#xCpr-l<F0NR@-##FEV6NTF6##$l84N1w?AO>'IAO"
+    "URQ##V^Fv-XFbGM7Fl(N<3DhLGF%q.1rC$#:T__&Pi68%0xi_&[qFJ(77j_&JWoF.V735&T,[R*:xFR*K5>>#`bW-?4Ne_"
+    "&6Ne_&6Ne_&n`kr-#GJcM6X;uM6X;uM(.a..^2TkL%oR(#"
+    ";u.T%fAr%4tJ8&><1=GHZ_+m9/#H1F^R#SC#*N=BA9(D?v[UiFY>>^8p,KKF.W]L29uLkLlu/"
+    "+4T<XoIB&hx=T1PcDaB&;HH+-AFr?(m9HZV)FKS8JCw;SD=6[^/DZUL`EUDf]GGlG&>"
+    "w$)F./^n3+rlo+DB;5sIYGNk+i1t-69Jg--0pao7Sm#K)pdHW&;LuDNH@H>#/"
+    "X-TI(;P>#,Gc>#0Su>#4`1?#8lC?#<xU?#@.i?#D:%@#HF7@#LRI@#P_[@#Tkn@#Xw*A#]-=A#a9OA#"
+    "d<F&#*;G##.GY##2Sl##6`($#:l:$#>xL$#B.`$#F:r$#JF.%#NR@%#R_R%#Vke%#Zww%#_-4&#3^Rh%Sflr-k'MS.o?."
+    "5/sWel/wpEM0%3'/1)K^f1-d>G21&v(35>V`39V7A4=onx4"
+    "A1OY5EI0;6Ibgr6M$HS7Q<)58C5w,;WoA*#[%T*#`1g*#d=#+#hI5+#lUG+#pbY+#tnl+#x$),#&1;,#*=M,#.I`,#2Ur,"
+    "#6b.-#;w[H#iQtA#m^0B#qjBB#uvTB##-hB#'9$C#+E6C#"
+    "/QHC#3^ZC#7jmC#;v)D#?,<D#C8ND#GDaD#KPsD#O]/"
+    "E#g1A5#KA*1#gC17#MGd;#8(02#L-d3#rWM4#Hga1#,<w0#T.j<#O#'2#CYN1#qa^:#_4m3#o@/"
+    "=#eG8=#t8J5#`+78#4uI-#"
+    "m3B2#SB[8#Q0@8#i[*9#iOn8#1Nm;#^sN9#qh<9#:=x-#P;K2#$%X9#bC+.#Rg;<#mN=.#MTF.#RZO.#2?)4#Y#(/#[)1/"
+    "#b;L/#dAU/#0Sv;#lY$0#n`-0#sf60#(F24#wrH0#%/e0#"
+    "TmD<#%JSMFove:CTBEXI:<eh2g)B,3h2^G3i;#d3jD>)4kMYD4lVu`4m`:&5niUA5@(A5BA1]PBB:xlBCC="
+    "2CDLXMCEUtiCf&0g2'tN?PGT4CPGT4CPGT4CPGT4CPGT4CPGT4CPGT4CP"
+    "GT4CPGT4CPGT4CPGT4CPGT4CPGT4CP-qekC`.9kEg^+F$kwViFJTB&5KTB&5KTB&5KTB&5KTB&5KTB&5KTB&5KTB&5KTB&"
+    "5KTB&5KTB&5KTB&5KTB&5KTB&5KTB&5o,^<-28ZI'O?;xp"
+    "O?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xp;7q-#lLYI:xvD=#";
+
+static const char *GetDefaultCompressedFontDataTTFBase85()
+{
+    return proggy_clean_ttf_compressed_data_base85;
+}

--- a/third_party/imgui/imgui_internal.h
+++ b/third_party/imgui/imgui_internal.h
@@ -1,0 +1,2701 @@
+// dear imgui, v1.72 WIP
+// (internal structures/api)
+
+// You may use this file to debug, understand or extend ImGui features but we don't provide any
+// guarantee of forward compatibility! Set:
+//   #define IMGUI_DEFINE_MATH_OPERATORS
+// To implement maths operators for ImVec2 (disabled by default to not collide with using
+// IM_VEC2_CLASS_EXTRA along with your own math types+operators)
+
+/*
+
+Index of this file:
+// Header mess
+// Forward declarations
+// STB libraries includes
+// Context pointer
+// Generic helpers
+// Misc data structures
+// Main imgui context
+// Tab bar, tab item
+// Internal API
+
+*/
+
+#pragma once
+
+//-----------------------------------------------------------------------------
+// Header mess
+//-----------------------------------------------------------------------------
+
+#ifndef IMGUI_VERSION
+#error Must include imgui.h before imgui_internal.h
+#endif
+
+#include <limits.h>  // INT_MIN, INT_MAX
+#include <math.h>    // sqrtf, fabsf, fmodf, powf, floorf, ceilf, cosf, sinf
+#include <stdio.h>   // FILE*
+#include <stdlib.h>  // NULL, malloc, free, qsort, atoi, atof
+
+// Visual Studio warnings
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4251)  // class 'xxx' needs to have dll-interface to be used by clients of
+                                 // struct 'xxx' // when IMGUI_API is set to__declspec(dllexport)
+#endif
+
+// Clang/GCC warnings with -Weverything
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"     // for stb_textedit.h
+#pragma clang diagnostic ignored "-Wmissing-prototypes"  // for stb_textedit.h
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#if __has_warning("-Wzero-as-null-pointer-constant")
+#pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
+#endif
+#if __has_warning("-Wdouble-promotion")
+#pragma clang diagnostic ignored "-Wdouble-promotion"
+#endif
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored \
+    "-Wpragmas"  // warning: unknown option after '#pragma GCC diagnostic' kind
+#pragma GCC diagnostic ignored \
+    "-Wclass-memaccess"  // [__GNUC__ >= 8] warning: 'memset/memcpy' clearing/writing an object of
+                         // type 'xxxx' with no trivial copy-assignment; use assignment or
+                         // value-initialization instead
+#endif
+
+//-----------------------------------------------------------------------------
+// Forward declarations
+//-----------------------------------------------------------------------------
+
+struct ImRect;                // An axis-aligned rectangle (2 points)
+struct ImDrawDataBuilder;     // Helper to build a ImDrawData instance
+struct ImDrawListSharedData;  // Data shared between all ImDrawList instances
+struct ImGuiColorMod;        // Stacked color modifier, backup of modified data so we can restore it
+struct ImGuiColumnData;      // Storage data for a single column
+struct ImGuiColumns;         // Storage data for a columns set
+struct ImGuiContext;         // Main Dear ImGui context
+struct ImGuiDataTypeInfo;    // Type information associated to a ImGuiDataType enum
+struct ImGuiGroupData;       // Stacked storage data for BeginGroup()/EndGroup()
+struct ImGuiInputTextState;  // Internal state of the currently focused/edited text input box
+struct ImGuiItemHoveredDataBackup;  // Backup and restore IsItemHovered() internal data
+struct ImGuiMenuColumns;            // Simple column measurement, currently used for MenuItem() only
+struct ImGuiNavMoveResult;          // Result of a directional navigation move query result
+struct ImGuiNextWindowData;         // Storage for SetNextWindow** functions
+struct ImGuiNextItemData;           // Storage for SetNextItem** functions
+struct ImGuiPopupData;              // Storage for current popup stack
+struct ImGuiSettingsHandler;        // Storage for one type registered in the .ini file
+struct ImGuiStyleMod;        // Stacked style modifier, backup of modified data so we can restore it
+struct ImGuiTabBar;          // Storage for a tab bar
+struct ImGuiTabItem;         // Storage for a tab item (within a tab bar)
+struct ImGuiWindow;          // Storage for one window
+struct ImGuiWindowTempData;  // Temporary storage for one window (that's the data which in theory we
+                             // could ditch at the end of the frame)
+struct ImGuiWindowSettings;  // Storage for window settings stored in .ini file (we keep one of
+                             // those even if the actual window wasn't instanced during this
+                             // session)
+
+// Use your programming IDE "Go to definition" facility on the names of the center columns to find
+// the actual flags/enum lists.
+typedef int ImGuiLayoutType;   // -> enum ImGuiLayoutType_         // Enum: Horizontal or vertical
+typedef int ImGuiButtonFlags;  // -> enum ImGuiButtonFlags_        // Flags: for ButtonEx(),
+                               // ButtonBehavior()
+typedef int ImGuiDragFlags;    // -> enum ImGuiDragFlags_          // Flags: for DragBehavior()
+typedef int ImGuiItemFlags;    // -> enum ImGuiItemFlags_          // Flags: for PushItemFlag()
+typedef int
+    ImGuiItemStatusFlags;  // -> enum ImGuiItemStatusFlags_    // Flags: for DC.LastItemStatusFlags
+typedef int
+    ImGuiNavHighlightFlags;  // -> enum ImGuiNavHighlightFlags_  // Flags: for RenderNavHighlight()
+typedef int
+    ImGuiNavDirSourceFlags;  // -> enum ImGuiNavDirSourceFlags_  // Flags: for GetNavInputAmount2d()
+typedef int
+    ImGuiNavMoveFlags;  // -> enum ImGuiNavMoveFlags_       // Flags: for navigation requests
+typedef int ImGuiNextItemDataFlags;    // -> enum ImGuiNextItemDataFlags_  // Flags: for
+                                       // SetNextItemXXX() functions
+typedef int ImGuiNextWindowDataFlags;  // -> enum ImGuiNextWindowDataFlags_// Flags: for
+                                       // SetNextWindowXXX() functions
+typedef int ImGuiSeparatorFlags;  // -> enum ImGuiSeparatorFlags_     // Flags: for SeparatorEx()
+typedef int ImGuiSliderFlags;     // -> enum ImGuiSliderFlags_        // Flags: for SliderBehavior()
+typedef int ImGuiTextFlags;       // -> enum ImGuiTextFlags_          // Flags: for TextEx()
+
+//-------------------------------------------------------------------------
+// STB libraries includes
+//-------------------------------------------------------------------------
+
+namespace ImStb
+{
+
+#undef STB_TEXTEDIT_STRING
+#undef STB_TEXTEDIT_CHARTYPE
+#define STB_TEXTEDIT_STRING ImGuiInputTextState
+#define STB_TEXTEDIT_CHARTYPE ImWchar
+#define STB_TEXTEDIT_GETWIDTH_NEWLINE -1.0f
+#define STB_TEXTEDIT_UNDOSTATECOUNT 99
+#define STB_TEXTEDIT_UNDOCHARCOUNT 999
+#include "imstb_textedit.h"
+
+}  // namespace ImStb
+
+//-----------------------------------------------------------------------------
+// Context pointer
+//-----------------------------------------------------------------------------
+
+#ifndef GImGui
+extern IMGUI_API ImGuiContext *GImGui;  // Current implicit context pointer
+#endif
+
+//-----------------------------------------------------------------------------
+// Generic helpers
+//-----------------------------------------------------------------------------
+
+#define IM_PI 3.14159265358979323846f
+#ifdef _WIN32
+#define IM_NEWLINE \
+    "\r\n"  // Play it nice with Windows users (2018/05 news: Microsoft announced that Notepad will
+            // finally display Unix-style carriage returns!)
+#else
+#define IM_NEWLINE "\n"
+#endif
+#define IM_TABSIZE (4)
+
+#define IMGUI_DEBUG_LOG(_FMT, ...) printf("[%05d] " _FMT, GImGui->FrameCount, __VA_ARGS__)
+#define IM_STATIC_ASSERT(_COND) typedef char static_assertion_##__line__[(_COND) ? 1 : -1]
+#define IM_F32_TO_INT8_UNBOUND(_VAL) \
+    ((int)((_VAL)*255.0f + ((_VAL) >= 0 ? 0.5f : -0.5f)))  // Unsaturated, for display purpose
+#define IM_F32_TO_INT8_SAT(_VAL) \
+    ((int)(ImSaturate(_VAL) * 255.0f + 0.5f))  // Saturated, always output 0..255
+
+// Enforce cdecl calling convention for functions called by the standard library, in case
+// compilation settings changed the default to e.g. __vectorcall
+#ifdef _MSC_VER
+#define IMGUI_CDECL __cdecl
+#else
+#define IMGUI_CDECL
+#endif
+
+// Helpers: UTF-8 <> wchar
+IMGUI_API int ImTextStrToUtf8(char *buf,
+                              int buf_size,
+                              const ImWchar *in_text,
+                              const ImWchar *in_text_end);  // return output UTF-8 bytes count
+IMGUI_API int ImTextCharFromUtf8(
+    unsigned int *out_char,
+    const char *in_text,
+    const char *in_text_end);  // read one character. return input UTF-8 bytes count
+IMGUI_API int ImTextStrFromUtf8(
+    ImWchar *buf,
+    int buf_size,
+    const char *in_text,
+    const char *in_text_end,
+    const char **in_remaining = NULL);  // return input UTF-8 bytes count
+IMGUI_API int ImTextCountCharsFromUtf8(
+    const char *in_text,
+    const char *in_text_end);  // return number of UTF-8 code-points (NOT bytes count)
+IMGUI_API int ImTextCountUtf8BytesFromChar(
+    const char *in_text,
+    const char *in_text_end);  // return number of bytes to express one char in UTF-8
+IMGUI_API int ImTextCountUtf8BytesFromStr(
+    const ImWchar *in_text,
+    const ImWchar *in_text_end);  // return number of bytes to express string in UTF-8
+
+// Helpers: Misc
+IMGUI_API ImU32 ImHashData(const void *data, size_t data_size, ImU32 seed = 0);
+IMGUI_API ImU32 ImHashStr(const char *data, size_t data_size = 0, ImU32 seed = 0);
+IMGUI_API void *ImFileLoadToMemory(const char *filename,
+                                   const char *file_open_mode,
+                                   size_t *out_file_size = NULL,
+                                   int padding_bytes     = 0);
+IMGUI_API FILE *ImFileOpen(const char *filename, const char *file_open_mode);
+static inline bool ImCharIsBlankA(char c)
+{
+    return c == ' ' || c == '\t';
+}
+static inline bool ImCharIsBlankW(unsigned int c)
+{
+    return c == ' ' || c == '\t' || c == 0x3000;
+}
+static inline bool ImIsPowerOfTwo(int v)
+{
+    return v != 0 && (v & (v - 1)) == 0;
+}
+static inline int ImUpperPowerOfTwo(int v)
+{
+    v--;
+    v |= v >> 1;
+    v |= v >> 2;
+    v |= v >> 4;
+    v |= v >> 8;
+    v |= v >> 16;
+    v++;
+    return v;
+}
+#define ImQsort qsort
+#ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+static inline ImU32 ImHash(const void *data, int size, ImU32 seed = 0)
+{
+    return size ? ImHashData(data, (size_t)size, seed) : ImHashStr((const char *)data, 0, seed);
+}  // [moved to ImHashStr/ImHashData in 1.68]
+#endif
+
+// Helpers: Geometry
+IMGUI_API ImVec2 ImLineClosestPoint(const ImVec2 &a, const ImVec2 &b, const ImVec2 &p);
+IMGUI_API bool ImTriangleContainsPoint(const ImVec2 &a,
+                                       const ImVec2 &b,
+                                       const ImVec2 &c,
+                                       const ImVec2 &p);
+IMGUI_API ImVec2 ImTriangleClosestPoint(const ImVec2 &a,
+                                        const ImVec2 &b,
+                                        const ImVec2 &c,
+                                        const ImVec2 &p);
+IMGUI_API void ImTriangleBarycentricCoords(const ImVec2 &a,
+                                           const ImVec2 &b,
+                                           const ImVec2 &c,
+                                           const ImVec2 &p,
+                                           float &out_u,
+                                           float &out_v,
+                                           float &out_w);
+IMGUI_API ImGuiDir ImGetDirQuadrantFromDelta(float dx, float dy);
+
+// Helpers: String
+IMGUI_API int ImStricmp(const char *str1, const char *str2);
+IMGUI_API int ImStrnicmp(const char *str1, const char *str2, size_t count);
+IMGUI_API void ImStrncpy(char *dst, const char *src, size_t count);
+IMGUI_API char *ImStrdup(const char *str);
+IMGUI_API char *ImStrdupcpy(char *dst, size_t *p_dst_size, const char *str);
+IMGUI_API const char *ImStrchrRange(const char *str_begin, const char *str_end, char c);
+IMGUI_API int ImStrlenW(const ImWchar *str);
+IMGUI_API const char *ImStreolRange(const char *str, const char *str_end);  // End end-of-line
+IMGUI_API const ImWchar *ImStrbolW(const ImWchar *buf_mid_line,
+                                   const ImWchar *buf_begin);  // Find beginning-of-line
+IMGUI_API const char *ImStristr(const char *haystack,
+                                const char *haystack_end,
+                                const char *needle,
+                                const char *needle_end);
+IMGUI_API void ImStrTrimBlanks(char *str);
+IMGUI_API int ImFormatString(char *buf, size_t buf_size, const char *fmt, ...) IM_FMTARGS(3);
+IMGUI_API int ImFormatStringV(char *buf, size_t buf_size, const char *fmt, va_list args)
+    IM_FMTLIST(3);
+IMGUI_API const char *ImParseFormatFindStart(const char *format);
+IMGUI_API const char *ImParseFormatFindEnd(const char *format);
+IMGUI_API const char *ImParseFormatTrimDecorations(const char *format, char *buf, size_t buf_size);
+IMGUI_API int ImParseFormatPrecision(const char *format, int default_value);
+
+// Helpers: ImVec2/ImVec4 operators
+// We are keeping those disabled by default so they don't leak in user space, to allow user enabling
+// implicit cast operators between ImVec2 and their own types (using IM_VEC2_CLASS_EXTRA etc.) We
+// unfortunately don't have a unary- operator for ImVec2 because this would needs to be defined
+// inside the class itself.
+#ifdef IMGUI_DEFINE_MATH_OPERATORS
+static inline ImVec2 operator*(const ImVec2 &lhs, const float rhs)
+{
+    return ImVec2(lhs.x * rhs, lhs.y * rhs);
+}
+static inline ImVec2 operator/(const ImVec2 &lhs, const float rhs)
+{
+    return ImVec2(lhs.x / rhs, lhs.y / rhs);
+}
+static inline ImVec2 operator+(const ImVec2 &lhs, const ImVec2 &rhs)
+{
+    return ImVec2(lhs.x + rhs.x, lhs.y + rhs.y);
+}
+static inline ImVec2 operator-(const ImVec2 &lhs, const ImVec2 &rhs)
+{
+    return ImVec2(lhs.x - rhs.x, lhs.y - rhs.y);
+}
+static inline ImVec2 operator*(const ImVec2 &lhs, const ImVec2 &rhs)
+{
+    return ImVec2(lhs.x * rhs.x, lhs.y * rhs.y);
+}
+static inline ImVec2 operator/(const ImVec2 &lhs, const ImVec2 &rhs)
+{
+    return ImVec2(lhs.x / rhs.x, lhs.y / rhs.y);
+}
+static inline ImVec2 &operator+=(ImVec2 &lhs, const ImVec2 &rhs)
+{
+    lhs.x += rhs.x;
+    lhs.y += rhs.y;
+    return lhs;
+}
+static inline ImVec2 &operator-=(ImVec2 &lhs, const ImVec2 &rhs)
+{
+    lhs.x -= rhs.x;
+    lhs.y -= rhs.y;
+    return lhs;
+}
+static inline ImVec2 &operator*=(ImVec2 &lhs, const float rhs)
+{
+    lhs.x *= rhs;
+    lhs.y *= rhs;
+    return lhs;
+}
+static inline ImVec2 &operator/=(ImVec2 &lhs, const float rhs)
+{
+    lhs.x /= rhs;
+    lhs.y /= rhs;
+    return lhs;
+}
+static inline ImVec4 operator+(const ImVec4 &lhs, const ImVec4 &rhs)
+{
+    return ImVec4(lhs.x + rhs.x, lhs.y + rhs.y, lhs.z + rhs.z, lhs.w + rhs.w);
+}
+static inline ImVec4 operator-(const ImVec4 &lhs, const ImVec4 &rhs)
+{
+    return ImVec4(lhs.x - rhs.x, lhs.y - rhs.y, lhs.z - rhs.z, lhs.w - rhs.w);
+}
+static inline ImVec4 operator*(const ImVec4 &lhs, const ImVec4 &rhs)
+{
+    return ImVec4(lhs.x * rhs.x, lhs.y * rhs.y, lhs.z * rhs.z, lhs.w * rhs.w);
+}
+#endif
+
+// Helpers: Maths
+// - Wrapper for standard libs functions. (Note that imgui_demo.cpp does _not_ use them to keep the
+// code easy to copy)
+#ifndef IMGUI_DISABLE_MATH_FUNCTIONS
+static inline float ImFabs(float x)
+{
+    return fabsf(x);
+}
+static inline float ImSqrt(float x)
+{
+    return sqrtf(x);
+}
+static inline float ImPow(float x, float y)
+{
+    return powf(x, y);
+}
+static inline double ImPow(double x, double y)
+{
+    return pow(x, y);
+}
+static inline float ImFmod(float x, float y)
+{
+    return fmodf(x, y);
+}
+static inline double ImFmod(double x, double y)
+{
+    return fmod(x, y);
+}
+static inline float ImCos(float x)
+{
+    return cosf(x);
+}
+static inline float ImSin(float x)
+{
+    return sinf(x);
+}
+static inline float ImAcos(float x)
+{
+    return acosf(x);
+}
+static inline float ImAtan2(float y, float x)
+{
+    return atan2f(y, x);
+}
+static inline double ImAtof(const char *s)
+{
+    return atof(s);
+}
+static inline float ImFloorStd(float x)
+{
+    return floorf(x);
+}  // we already uses our own ImFloor() { return (float)(int)v } internally so the standard one
+   // wrapper is named differently (it's used by stb_truetype)
+static inline float ImCeil(float x)
+{
+    return ceilf(x);
+}
+#endif
+// - ImMin/ImMax/ImClamp/ImLerp/ImSwap are used by widgets which support for variety of types:
+// signed/unsigned int/long long float/double (Exceptionally using templates here but we could also
+// redefine them for variety of types)
+template <typename T>
+static inline T ImMin(T lhs, T rhs)
+{
+    return lhs < rhs ? lhs : rhs;
+}
+template <typename T>
+static inline T ImMax(T lhs, T rhs)
+{
+    return lhs >= rhs ? lhs : rhs;
+}
+template <typename T>
+static inline T ImClamp(T v, T mn, T mx)
+{
+    return (v < mn) ? mn : (v > mx) ? mx : v;
+}
+template <typename T>
+static inline T ImLerp(T a, T b, float t)
+{
+    return (T)(a + (b - a) * t);
+}
+template <typename T>
+static inline void ImSwap(T &a, T &b)
+{
+    T tmp = a;
+    a     = b;
+    b     = tmp;
+}
+template <typename T>
+static inline T ImAddClampOverflow(T a, T b, T mn, T mx)
+{
+    if (b < 0 && (a < mn - b))
+        return mn;
+    if (b > 0 && (a > mx - b))
+        return mx;
+    return a + b;
+}
+template <typename T>
+static inline T ImSubClampOverflow(T a, T b, T mn, T mx)
+{
+    if (b > 0 && (a < mn + b))
+        return mn;
+    if (b < 0 && (a > mx + b))
+        return mx;
+    return a - b;
+}
+// - Misc maths helpers
+static inline ImVec2 ImMin(const ImVec2 &lhs, const ImVec2 &rhs)
+{
+    return ImVec2(lhs.x < rhs.x ? lhs.x : rhs.x, lhs.y < rhs.y ? lhs.y : rhs.y);
+}
+static inline ImVec2 ImMax(const ImVec2 &lhs, const ImVec2 &rhs)
+{
+    return ImVec2(lhs.x >= rhs.x ? lhs.x : rhs.x, lhs.y >= rhs.y ? lhs.y : rhs.y);
+}
+static inline ImVec2 ImClamp(const ImVec2 &v, const ImVec2 &mn, ImVec2 mx)
+{
+    return ImVec2((v.x < mn.x) ? mn.x : (v.x > mx.x) ? mx.x : v.x,
+                  (v.y < mn.y) ? mn.y : (v.y > mx.y) ? mx.y : v.y);
+}
+static inline ImVec2 ImLerp(const ImVec2 &a, const ImVec2 &b, float t)
+{
+    return ImVec2(a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t);
+}
+static inline ImVec2 ImLerp(const ImVec2 &a, const ImVec2 &b, const ImVec2 &t)
+{
+    return ImVec2(a.x + (b.x - a.x) * t.x, a.y + (b.y - a.y) * t.y);
+}
+static inline ImVec4 ImLerp(const ImVec4 &a, const ImVec4 &b, float t)
+{
+    return ImVec4(a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t, a.z + (b.z - a.z) * t,
+                  a.w + (b.w - a.w) * t);
+}
+static inline float ImSaturate(float f)
+{
+    return (f < 0.0f) ? 0.0f : (f > 1.0f) ? 1.0f : f;
+}
+static inline float ImLengthSqr(const ImVec2 &lhs)
+{
+    return lhs.x * lhs.x + lhs.y * lhs.y;
+}
+static inline float ImLengthSqr(const ImVec4 &lhs)
+{
+    return lhs.x * lhs.x + lhs.y * lhs.y + lhs.z * lhs.z + lhs.w * lhs.w;
+}
+static inline float ImInvLength(const ImVec2 &lhs, float fail_value)
+{
+    float d = lhs.x * lhs.x + lhs.y * lhs.y;
+    if (d > 0.0f)
+        return 1.0f / ImSqrt(d);
+    return fail_value;
+}
+static inline float ImFloor(float f)
+{
+    return (float)(int)f;
+}
+static inline ImVec2 ImFloor(const ImVec2 &v)
+{
+    return ImVec2((float)(int)v.x, (float)(int)v.y);
+}
+static inline int ImModPositive(int a, int b)
+{
+    return (a + b) % b;
+}
+static inline float ImDot(const ImVec2 &a, const ImVec2 &b)
+{
+    return a.x * b.x + a.y * b.y;
+}
+static inline ImVec2 ImRotate(const ImVec2 &v, float cos_a, float sin_a)
+{
+    return ImVec2(v.x * cos_a - v.y * sin_a, v.x * sin_a + v.y * cos_a);
+}
+static inline float ImLinearSweep(float current, float target, float speed)
+{
+    if (current < target)
+        return ImMin(current + speed, target);
+    if (current > target)
+        return ImMax(current - speed, target);
+    return current;
+}
+static inline ImVec2 ImMul(const ImVec2 &lhs, const ImVec2 &rhs)
+{
+    return ImVec2(lhs.x * rhs.x, lhs.y * rhs.y);
+}
+
+// Helper: ImBoolVector. Store 1-bit per value.
+// Note that Resize() currently clears the whole vector.
+struct ImBoolVector
+{
+    ImVector<int> Storage;
+    ImBoolVector() {}
+    void Resize(int sz)
+    {
+        Storage.resize((sz + 31) >> 5);
+        memset(Storage.Data, 0, (size_t)Storage.Size * sizeof(Storage.Data[0]));
+    }
+    void Clear() { Storage.clear(); }
+    bool GetBit(int n) const
+    {
+        int off  = (n >> 5);
+        int mask = 1 << (n & 31);
+        return (Storage[off] & mask) != 0;
+    }
+    void SetBit(int n, bool v)
+    {
+        int off  = (n >> 5);
+        int mask = 1 << (n & 31);
+        if (v)
+            Storage[off] |= mask;
+        else
+            Storage[off] &= ~mask;
+    }
+};
+
+// Helper: ImPool<>. Basic keyed storage for contiguous instances, slow/amortized insertion, O(1)
+// indexable, O(Log N) queries by ID over a dense/hot buffer, Honor constructor/destructor.
+// Add/remove invalidate all pointers. Indexes have the same lifetime as the associated object.
+typedef int ImPoolIdx;
+template <typename T>
+struct IMGUI_API ImPool
+{
+    ImVector<T> Data;   // Contiguous data
+    ImGuiStorage Map;   // ID->Index
+    ImPoolIdx FreeIdx;  // Next free idx to use
+
+    ImPool() { FreeIdx = 0; }
+    ~ImPool() { Clear(); }
+    T *GetByKey(ImGuiID key)
+    {
+        int idx = Map.GetInt(key, -1);
+        return (idx != -1) ? &Data[idx] : NULL;
+    }
+    T *GetByIndex(ImPoolIdx n) { return &Data[n]; }
+    ImPoolIdx GetIndex(const T *p) const
+    {
+        IM_ASSERT(p >= Data.Data && p < Data.Data + Data.Size);
+        return (ImPoolIdx)(p - Data.Data);
+    }
+    T *GetOrAddByKey(ImGuiID key)
+    {
+        int *p_idx = Map.GetIntRef(key, -1);
+        if (*p_idx != -1)
+            return &Data[*p_idx];
+        *p_idx = FreeIdx;
+        return Add();
+    }
+    bool Contains(const T *p) const { return (p >= Data.Data && p < Data.Data + Data.Size); }
+    void Clear()
+    {
+        for (int n = 0; n < Map.Data.Size; n++)
+        {
+            int idx = Map.Data[n].val_i;
+            if (idx != -1)
+                Data[idx].~T();
+        }
+        Map.Clear();
+        Data.clear();
+        FreeIdx = 0;
+    }
+    T *Add()
+    {
+        int idx = FreeIdx;
+        if (idx == Data.Size)
+        {
+            Data.resize(Data.Size + 1);
+            FreeIdx++;
+        }
+        else
+        {
+            FreeIdx = *(int *)&Data[idx];
+        }
+        IM_PLACEMENT_NEW(&Data[idx]) T();
+        return &Data[idx];
+    }
+    void Remove(ImGuiID key, const T *p) { Remove(key, GetIndex(p)); }
+    void Remove(ImGuiID key, ImPoolIdx idx)
+    {
+        Data[idx].~T();
+        *(int *)&Data[idx] = FreeIdx;
+        FreeIdx            = idx;
+        Map.SetInt(key, -1);
+    }
+    void Reserve(int capacity)
+    {
+        Data.reserve(capacity);
+        Map.Data.reserve(capacity);
+    }
+    int GetSize() const { return Data.Size; }
+};
+
+//-----------------------------------------------------------------------------
+// Misc data structures
+//-----------------------------------------------------------------------------
+
+enum ImGuiButtonFlags_
+{
+    ImGuiButtonFlags_None   = 0,
+    ImGuiButtonFlags_Repeat = 1 << 0,  // hold to repeat
+    ImGuiButtonFlags_PressedOnClickRelease =
+        1 << 1,  // [Default] return true on click + release on same item
+    ImGuiButtonFlags_PressedOnClick =
+        1 << 2,  // return true on click (default requires click+release)
+    ImGuiButtonFlags_PressedOnRelease =
+        1 << 3,  // return true on release (default requires click+release)
+    ImGuiButtonFlags_PressedOnDoubleClick =
+        1 << 4,  // return true on double-click (default requires click+release)
+    ImGuiButtonFlags_FlattenChildren =
+        1 << 5,  // allow interactions even if a child window is overlapping
+    ImGuiButtonFlags_AllowItemOverlap =
+        1 << 6,  // require previous frame HoveredId to either match id or be null before being
+                 // usable, use along with SetItemAllowOverlap()
+    ImGuiButtonFlags_DontClosePopups =
+        1 << 7,  // disable automatically closing parent popup on press // [UNUSED]
+    ImGuiButtonFlags_Disabled = 1 << 8,  // disable interactions
+    ImGuiButtonFlags_AlignTextBaseLine =
+        1 << 9,  // vertically align button to match text baseline - ButtonEx() only // FIXME:
+                 // Should be removed and handled by SmallButton(), not possible currently because
+                 // of DC.CursorPosPrevLine
+    ImGuiButtonFlags_NoKeyModifiers = 1 << 10,  // disable interaction if a key modifier is held
+    ImGuiButtonFlags_NoHoldingActiveID =
+        1
+        << 11,  // don't set ActiveId while holding the mouse (ImGuiButtonFlags_PressedOnClick only)
+    ImGuiButtonFlags_PressedOnDragDropHold =
+        1 << 12,  // press when held into while we are drag and dropping another item (used by e.g.
+                  // tree nodes, collapsing headers)
+    ImGuiButtonFlags_NoNavFocus     = 1 << 13,  // don't override navigation focus when activated
+    ImGuiButtonFlags_NoHoveredOnNav = 1 << 14   // don't report as hovered when navigated on
+};
+
+enum ImGuiSliderFlags_
+{
+    ImGuiSliderFlags_None     = 0,
+    ImGuiSliderFlags_Vertical = 1 << 0
+};
+
+enum ImGuiDragFlags_
+{
+    ImGuiDragFlags_None     = 0,
+    ImGuiDragFlags_Vertical = 1 << 0
+};
+
+enum ImGuiColumnsFlags_
+{
+    // Default: 0
+    ImGuiColumnsFlags_None     = 0,
+    ImGuiColumnsFlags_NoBorder = 1 << 0,  // Disable column dividers
+    ImGuiColumnsFlags_NoResize = 1 << 1,  // Disable resizing columns when clicking on the dividers
+    ImGuiColumnsFlags_NoPreserveWidths =
+        1 << 2,  // Disable column width preservation when adjusting columns
+    ImGuiColumnsFlags_NoForceWithinWindow = 1 << 3,  // Disable forcing columns to fit within window
+    ImGuiColumnsFlags_GrowParentContentsSize =
+        1 << 4  // (WIP) Restore pre-1.51 behavior of extending the parent window contents size but
+                // _without affecting the columns width at all_. Will eventually remove.
+};
+
+// Extend ImGuiSelectableFlags_
+enum ImGuiSelectableFlagsPrivate_
+{
+    // NB: need to be in sync with last value of ImGuiSelectableFlags_
+    ImGuiSelectableFlags_NoHoldingActiveID = 1 << 20,
+    ImGuiSelectableFlags_PressedOnClick    = 1 << 21,
+    ImGuiSelectableFlags_PressedOnRelease  = 1 << 22,
+    ImGuiSelectableFlags_DrawFillAvailWidth =
+        1 << 23,  // FIXME: We may be able to remove this (added in 6251d379 for menus)
+    ImGuiSelectableFlags_AllowItemOverlap = 1 << 24
+};
+
+// Extend ImGuiTreeNodeFlags_
+enum ImGuiTreeNodeFlagsPrivate_
+{
+    ImGuiTreeNodeFlags_ClipLabelForTrailingButton = 1 << 20
+};
+
+enum ImGuiSeparatorFlags_
+{
+    ImGuiSeparatorFlags_None       = 0,
+    ImGuiSeparatorFlags_Horizontal = 1 << 0,  // Axis default to current layout type, so generally
+                                              // Horizontal unless e.g. in a menu bar
+    ImGuiSeparatorFlags_Vertical       = 1 << 1,
+    ImGuiSeparatorFlags_SpanAllColumns = 1 << 2
+};
+
+// Transient per-window flags, reset at the beginning of the frame. For child window, inherited from
+// parent on first Begin(). This is going to be exposed in imgui.h when stabilized enough.
+enum ImGuiItemFlags_
+{
+    ImGuiItemFlags_NoTabStop = 1 << 0,  // false
+    ImGuiItemFlags_ButtonRepeat =
+        1 << 1,  // false    // Button() will return true multiple times based on io.KeyRepeatDelay
+                 // and io.KeyRepeatRate settings.
+    ImGuiItemFlags_Disabled = 1 << 2,  // false    // [BETA] Disable interactions but doesn't affect
+                                       // visuals yet. See github.com/ocornut/imgui/issues/211
+    ImGuiItemFlags_NoNav             = 1 << 3,  // false
+    ImGuiItemFlags_NoNavDefaultFocus = 1 << 4,  // false
+    ImGuiItemFlags_SelectableDontClosePopup =
+        1 << 5,  // false    // MenuItem/Selectable() automatically closes current Popup window
+    ImGuiItemFlags_MixedValue =
+        1 << 6,  // false    // [BETA] Represent a mixed/indeterminate value, generally
+                 // multi-selection where values differ. Currently only supported by Checkbox()
+                 // (later should support all sorts of widgets)
+    ImGuiItemFlags_Default_ = 0
+};
+
+// Storage for LastItem data
+enum ImGuiItemStatusFlags_
+{
+    ImGuiItemStatusFlags_None           = 0,
+    ImGuiItemStatusFlags_HoveredRect    = 1 << 0,
+    ImGuiItemStatusFlags_HasDisplayRect = 1 << 1,
+    ImGuiItemStatusFlags_Edited = 1 << 2,  // Value exposed by item was edited in the current frame
+                                           // (should match the bool return value of most widgets)
+    ImGuiItemStatusFlags_ToggledSelection =
+        1 << 3,  // Set when Selectable(), TreeNode() reports toggling a selection. We can't report
+                 // "Selected" because reporting the change allows us to handle clipping with less
+                 // issues.
+    ImGuiItemStatusFlags_HasDeactivated = 1
+                                          << 4,  // Set if the widget/group is able to provide data
+                                                 // for the ImGuiItemStatusFlags_Deactivated flag.
+    ImGuiItemStatusFlags_Deactivated =
+        1 << 5  // Only valid if ImGuiItemStatusFlags_HasDeactivated is set.
+
+#ifdef IMGUI_ENABLE_TEST_ENGINE
+    ,                                          // [imgui-test only]
+    ImGuiItemStatusFlags_Openable  = 1 << 10,  //
+    ImGuiItemStatusFlags_Opened    = 1 << 11,  //
+    ImGuiItemStatusFlags_Checkable = 1 << 12,  //
+    ImGuiItemStatusFlags_Checked   = 1 << 13   //
+#endif
+};
+
+enum ImGuiTextFlags_
+{
+    ImGuiTextFlags_None                       = 0,
+    ImGuiTextFlags_NoWidthForLargeClippedText = 1 << 0
+};
+
+// FIXME: this is in development, not exposed/functional as a generic feature yet.
+// Horizontal/Vertical enums are fixed to 0/1 so they may be used to index ImVec2
+enum ImGuiLayoutType_
+{
+    ImGuiLayoutType_Horizontal = 0,
+    ImGuiLayoutType_Vertical   = 1
+};
+
+enum ImGuiLogType
+{
+    ImGuiLogType_None = 0,
+    ImGuiLogType_TTY,
+    ImGuiLogType_File,
+    ImGuiLogType_Buffer,
+    ImGuiLogType_Clipboard
+};
+
+// X/Y enums are fixed to 0/1 so they may be used to index ImVec2
+enum ImGuiAxis
+{
+    ImGuiAxis_None = -1,
+    ImGuiAxis_X    = 0,
+    ImGuiAxis_Y    = 1
+};
+
+enum ImGuiPlotType
+{
+    ImGuiPlotType_Lines,
+    ImGuiPlotType_Histogram
+};
+
+enum ImGuiInputSource
+{
+    ImGuiInputSource_None = 0,
+    ImGuiInputSource_Mouse,
+    ImGuiInputSource_Nav,
+    ImGuiInputSource_NavKeyboard,  // Only used occasionally for storage, not tested/handled by most
+                                   // code
+    ImGuiInputSource_NavGamepad,   // "
+    ImGuiInputSource_COUNT
+};
+
+// FIXME-NAV: Clarify/expose various repeat delay/rate
+enum ImGuiInputReadMode
+{
+    ImGuiInputReadMode_Down,
+    ImGuiInputReadMode_Pressed,
+    ImGuiInputReadMode_Released,
+    ImGuiInputReadMode_Repeat,
+    ImGuiInputReadMode_RepeatSlow,
+    ImGuiInputReadMode_RepeatFast
+};
+
+enum ImGuiNavHighlightFlags_
+{
+    ImGuiNavHighlightFlags_None        = 0,
+    ImGuiNavHighlightFlags_TypeDefault = 1 << 0,
+    ImGuiNavHighlightFlags_TypeThin    = 1 << 1,
+    ImGuiNavHighlightFlags_AlwaysDraw =
+        1 << 2,  // Draw rectangular highlight if (g.NavId == id) _even_ when using the mouse.
+    ImGuiNavHighlightFlags_NoRounding = 1 << 3
+};
+
+enum ImGuiNavDirSourceFlags_
+{
+    ImGuiNavDirSourceFlags_None      = 0,
+    ImGuiNavDirSourceFlags_Keyboard  = 1 << 0,
+    ImGuiNavDirSourceFlags_PadDPad   = 1 << 1,
+    ImGuiNavDirSourceFlags_PadLStick = 1 << 2
+};
+
+enum ImGuiNavMoveFlags_
+{
+    ImGuiNavMoveFlags_None  = 0,
+    ImGuiNavMoveFlags_LoopX = 1 << 0,  // On failed request, restart from opposite side
+    ImGuiNavMoveFlags_LoopY = 1 << 1,
+    ImGuiNavMoveFlags_WrapX =
+        1 << 2,  // On failed request, request from opposite side one line down (when NavDir==right)
+                 // or one line up (when NavDir==left)
+    ImGuiNavMoveFlags_WrapY = 1 << 3,  // This is not super useful for provided for completeness
+    ImGuiNavMoveFlags_AllowCurrentNavId =
+        1 << 4,  // Allow scoring and considering the current NavId as a move target candidate. This
+                 // is used when the move source is offset (e.g. pressing PageDown actually needs to
+                 // send a Up move request, if we are pressing PageDown from the bottom-most item we
+                 // need to stay in place)
+    ImGuiNavMoveFlags_AlsoScoreVisibleSet =
+        1 << 5  // Store alternate result in NavMoveResultLocalVisibleSet that only comprise
+                // elements that are already fully visible.
+};
+
+enum ImGuiNavForward
+{
+    ImGuiNavForward_None,
+    ImGuiNavForward_ForwardQueued,
+    ImGuiNavForward_ForwardActive
+};
+
+enum ImGuiNavLayer
+{
+    ImGuiNavLayer_Main = 0,  // Main scrolling layer
+    ImGuiNavLayer_Menu = 1,  // Menu layer (access with Alt/ImGuiNavInput_Menu)
+    ImGuiNavLayer_COUNT
+};
+
+enum ImGuiPopupPositionPolicy
+{
+    ImGuiPopupPositionPolicy_Default,
+    ImGuiPopupPositionPolicy_ComboBox
+};
+
+// 1D vector (this odd construct is used to facilitate the transition between 1D and 2D, and the
+// maintenance of some branches/patches)
+struct ImVec1
+{
+    float x;
+    ImVec1() { x = 0.0f; }
+    ImVec1(float _x) { x = _x; }
+};
+
+// 2D axis aligned bounding-box
+// NB: we can't rely on ImVec2 math operators being available here
+struct IMGUI_API ImRect
+{
+    ImVec2 Min;  // Upper-left
+    ImVec2 Max;  // Lower-right
+
+    ImRect() : Min(FLT_MAX, FLT_MAX), Max(-FLT_MAX, -FLT_MAX) {}
+    ImRect(const ImVec2 &min, const ImVec2 &max) : Min(min), Max(max) {}
+    ImRect(const ImVec4 &v) : Min(v.x, v.y), Max(v.z, v.w) {}
+    ImRect(float x1, float y1, float x2, float y2) : Min(x1, y1), Max(x2, y2) {}
+
+    ImVec2 GetCenter() const { return ImVec2((Min.x + Max.x) * 0.5f, (Min.y + Max.y) * 0.5f); }
+    ImVec2 GetSize() const { return ImVec2(Max.x - Min.x, Max.y - Min.y); }
+    float GetWidth() const { return Max.x - Min.x; }
+    float GetHeight() const { return Max.y - Min.y; }
+    ImVec2 GetTL() const { return Min; }                   // Top-left
+    ImVec2 GetTR() const { return ImVec2(Max.x, Min.y); }  // Top-right
+    ImVec2 GetBL() const { return ImVec2(Min.x, Max.y); }  // Bottom-left
+    ImVec2 GetBR() const { return Max; }                   // Bottom-right
+    bool Contains(const ImVec2 &p) const
+    {
+        return p.x >= Min.x && p.y >= Min.y && p.x < Max.x && p.y < Max.y;
+    }
+    bool Contains(const ImRect &r) const
+    {
+        return r.Min.x >= Min.x && r.Min.y >= Min.y && r.Max.x <= Max.x && r.Max.y <= Max.y;
+    }
+    bool Overlaps(const ImRect &r) const
+    {
+        return r.Min.y < Max.y && r.Max.y > Min.y && r.Min.x < Max.x && r.Max.x > Min.x;
+    }
+    void Add(const ImVec2 &p)
+    {
+        if (Min.x > p.x)
+            Min.x = p.x;
+        if (Min.y > p.y)
+            Min.y = p.y;
+        if (Max.x < p.x)
+            Max.x = p.x;
+        if (Max.y < p.y)
+            Max.y = p.y;
+    }
+    void Add(const ImRect &r)
+    {
+        if (Min.x > r.Min.x)
+            Min.x = r.Min.x;
+        if (Min.y > r.Min.y)
+            Min.y = r.Min.y;
+        if (Max.x < r.Max.x)
+            Max.x = r.Max.x;
+        if (Max.y < r.Max.y)
+            Max.y = r.Max.y;
+    }
+    void Expand(const float amount)
+    {
+        Min.x -= amount;
+        Min.y -= amount;
+        Max.x += amount;
+        Max.y += amount;
+    }
+    void Expand(const ImVec2 &amount)
+    {
+        Min.x -= amount.x;
+        Min.y -= amount.y;
+        Max.x += amount.x;
+        Max.y += amount.y;
+    }
+    void Translate(const ImVec2 &d)
+    {
+        Min.x += d.x;
+        Min.y += d.y;
+        Max.x += d.x;
+        Max.y += d.y;
+    }
+    void TranslateX(float dx)
+    {
+        Min.x += dx;
+        Max.x += dx;
+    }
+    void TranslateY(float dy)
+    {
+        Min.y += dy;
+        Max.y += dy;
+    }
+    void ClipWith(const ImRect &r)
+    {
+        Min = ImMax(Min, r.Min);
+        Max = ImMin(Max, r.Max);
+    }  // Simple version, may lead to an inverted rectangle, which is fine for Contains/Overlaps
+       // test but not for display.
+    void ClipWithFull(const ImRect &r)
+    {
+        Min = ImClamp(Min, r.Min, r.Max);
+        Max = ImClamp(Max, r.Min, r.Max);
+    }  // Full version, ensure both points are fully clipped.
+    void Floor()
+    {
+        Min.x = (float)(int)Min.x;
+        Min.y = (float)(int)Min.y;
+        Max.x = (float)(int)Max.x;
+        Max.y = (float)(int)Max.y;
+    }
+    bool IsInverted() const { return Min.x > Max.x || Min.y > Max.y; }
+};
+
+// Type information associated to one ImGuiDataType. Retrieve with DataTypeGetInfo().
+struct ImGuiDataTypeInfo
+{
+    size_t Size;           // Size in byte
+    const char *PrintFmt;  // Default printf format for the type
+    const char *ScanFmt;   // Default scanf format for the type
+};
+
+// Stacked color modifier, backup of modified data so we can restore it
+struct ImGuiColorMod
+{
+    ImGuiCol Col;
+    ImVec4 BackupValue;
+};
+
+// Stacked style modifier, backup of modified data so we can restore it. Data type inferred from the
+// variable.
+struct ImGuiStyleMod
+{
+    ImGuiStyleVar VarIdx;
+    union {
+        int BackupInt[2];
+        float BackupFloat[2];
+    };
+    ImGuiStyleMod(ImGuiStyleVar idx, int v)
+    {
+        VarIdx       = idx;
+        BackupInt[0] = v;
+    }
+    ImGuiStyleMod(ImGuiStyleVar idx, float v)
+    {
+        VarIdx         = idx;
+        BackupFloat[0] = v;
+    }
+    ImGuiStyleMod(ImGuiStyleVar idx, ImVec2 v)
+    {
+        VarIdx         = idx;
+        BackupFloat[0] = v.x;
+        BackupFloat[1] = v.y;
+    }
+};
+
+// Stacked storage data for BeginGroup()/EndGroup()
+struct ImGuiGroupData
+{
+    ImVec2 BackupCursorPos;
+    ImVec2 BackupCursorMaxPos;
+    ImVec1 BackupIndent;
+    ImVec1 BackupGroupOffset;
+    ImVec2 BackupCurrLineSize;
+    float BackupCurrLineTextBaseOffset;
+    ImGuiID BackupActiveIdIsAlive;
+    bool BackupActiveIdPreviousFrameIsAlive;
+    bool EmitItem;
+};
+
+// Simple column measurement, currently used for MenuItem() only.. This is very
+// short-sighted/throw-away code and NOT a generic helper.
+struct IMGUI_API ImGuiMenuColumns
+{
+    float Spacing;
+    float Width, NextWidth;
+    float Pos[3], NextWidths[3];
+
+    ImGuiMenuColumns();
+    void Update(int count, float spacing, bool clear);
+    float DeclColumns(float w0, float w1, float w2);
+    float CalcExtraSpace(float avail_w);
+};
+
+// Internal state of the currently focused/edited text input box
+struct IMGUI_API ImGuiInputTextState
+{
+    ImGuiID ID;            // widget id owning the text state
+    int CurLenW, CurLenA;  // we need to maintain our buffer length in both UTF-8 and wchar format.
+                           // UTF-8 len is valid even if TextA is not.
+    ImVector<ImWchar> TextW;  // edit buffer, we need to persist but can't guarantee the persistence
+                              // of the user-provided buffer. so we copy into own buffer.
+    ImVector<char> TextA;  // temporary UTF8 buffer for callbacks and other operations. this is not
+                           // updated in every code-path! size=capacity.
+    ImVector<char>
+        InitialTextA;   // backup of end-user buffer at the time of focus (in UTF-8, unaltered)
+    bool TextAIsValid;  // temporary UTF8 buffer is not initially valid before we make the widget
+                        // active (until then we pull the data from user argument)
+    int BufCapacityA;   // end-user buffer capacity
+    float ScrollX;      // horizontal scrolling/offset
+    ImStb::STB_TexteditState Stb;  // state for stb_textedit.h
+    float CursorAnim;  // timer for cursor blink, reset on every user action so the cursor reappears
+                       // immediately
+    bool CursorFollow;  // set when we want scrolling to follow the current cursor position (not
+                        // always!)
+    bool SelectedAllMouseLock;  // after a double-click to select all, we ignore further mouse drags
+                                // to update selection
+
+    // Temporarily set when active
+    ImGuiInputTextFlags UserFlags;
+    ImGuiInputTextCallback UserCallback;
+    void *UserCallbackData;
+
+    ImGuiInputTextState() { memset(this, 0, sizeof(*this)); }
+    void ClearFreeMemory()
+    {
+        TextW.clear();
+        TextA.clear();
+        InitialTextA.clear();
+    }
+    void CursorAnimReset()
+    {
+        CursorAnim = -0.30f;
+    }  // After a user-input the cursor stays on for a while without blinking
+    void CursorClamp()
+    {
+        Stb.cursor       = ImMin(Stb.cursor, CurLenW);
+        Stb.select_start = ImMin(Stb.select_start, CurLenW);
+        Stb.select_end   = ImMin(Stb.select_end, CurLenW);
+    }
+    bool HasSelection() const { return Stb.select_start != Stb.select_end; }
+    void ClearSelection() { Stb.select_start = Stb.select_end = Stb.cursor; }
+    void SelectAll()
+    {
+        Stb.select_start = 0;
+        Stb.cursor = Stb.select_end = CurLenW;
+        Stb.has_preferred_x         = 0;
+    }
+    int GetUndoAvailCount() const { return Stb.undostate.undo_point; }
+    int GetRedoAvailCount() const { return STB_TEXTEDIT_UNDOSTATECOUNT - Stb.undostate.redo_point; }
+    void OnKeyPressed(
+        int key);  // Cannot be inline because we call in code in stb_textedit.h implementation
+};
+
+// Windows data saved in imgui.ini file
+struct ImGuiWindowSettings
+{
+    char *Name;
+    ImGuiID ID;
+    ImVec2 Pos;
+    ImVec2 Size;
+    bool Collapsed;
+
+    ImGuiWindowSettings()
+    {
+        Name = NULL;
+        ID   = 0;
+        Pos = Size = ImVec2(0, 0);
+        Collapsed  = false;
+    }
+};
+
+struct ImGuiSettingsHandler
+{
+    const char *TypeName;  // Short description stored in .ini file. Disallowed characters: '[' ']'
+    ImGuiID TypeHash;      // == ImHashStr(TypeName)
+    void *(*ReadOpenFn)(
+        ImGuiContext *ctx,
+        ImGuiSettingsHandler *handler,
+        const char *name);  // Read: Called when entering into a new ini entry e.g. "[Window][Name]"
+    void (*ReadLineFn)(
+        ImGuiContext *ctx,
+        ImGuiSettingsHandler *handler,
+        void *entry,
+        const char *line);  // Read: Called for every line of text within an ini entry
+    void (*WriteAllFn)(ImGuiContext *ctx,
+                       ImGuiSettingsHandler *handler,
+                       ImGuiTextBuffer *out_buf);  // Write: Output every entries into 'out_buf'
+    void *UserData;
+
+    ImGuiSettingsHandler() { memset(this, 0, sizeof(*this)); }
+};
+
+// Storage for current popup stack
+struct ImGuiPopupData
+{
+    ImGuiID PopupId;  // Set on OpenPopup()
+    ImGuiWindow
+        *Window;  // Resolved on BeginPopup() - may stay unresolved if user never calls OpenPopup()
+    ImGuiWindow
+        *SourceWindow;     // Set on OpenPopup() copy of NavWindow at the time of opening the popup
+    int OpenFrameCount;    // Set on OpenPopup()
+    ImGuiID OpenParentId;  // Set on OpenPopup(), we need this to differentiate multiple menu sets
+                           // from each others (e.g. inside menu bar vs loose menu items)
+    ImVec2 OpenPopupPos;  // Set on OpenPopup(), preferred popup position (typically == OpenMousePos
+                          // when using mouse)
+    ImVec2 OpenMousePos;  // Set on OpenPopup(), copy of mouse position at the time of opening popup
+
+    ImGuiPopupData()
+    {
+        PopupId = 0;
+        Window = SourceWindow = NULL;
+        OpenFrameCount        = -1;
+        OpenParentId          = 0;
+    }
+};
+
+struct ImGuiColumnData
+{
+    float OffsetNorm;  // Column start offset, normalized 0.0 (far left) -> 1.0 (far right)
+    float OffsetNormBeforeResize;
+    ImGuiColumnsFlags Flags;  // Not exposed
+    ImRect ClipRect;
+
+    ImGuiColumnData()
+    {
+        OffsetNorm = OffsetNormBeforeResize = 0.0f;
+        Flags                               = ImGuiColumnsFlags_None;
+    }
+};
+
+struct ImGuiColumns
+{
+    ImGuiID ID;
+    ImGuiColumnsFlags Flags;
+    bool IsFirstFrame;
+    bool IsBeingResized;
+    int Current;
+    int Count;
+    float OffMinX, OffMaxX;  // Offsets from HostWorkRect.Min.x
+    float LineMinY, LineMaxY;
+    float HostCursorPosY;     // Backup of CursorPos at the time of BeginColumns()
+    float HostCursorMaxPosX;  // Backup of CursorMaxPos at the time of BeginColumns()
+    ImRect HostClipRect;      // Backup of ClipRect at the time of BeginColumns()
+    ImRect HostWorkRect;      // Backup of WorkRect at the time of BeginColumns()
+    ImVector<ImGuiColumnData> Columns;
+
+    ImGuiColumns() { Clear(); }
+    void Clear()
+    {
+        ID             = 0;
+        Flags          = ImGuiColumnsFlags_None;
+        IsFirstFrame   = false;
+        IsBeingResized = false;
+        Current        = 0;
+        Count          = 1;
+        OffMinX = OffMaxX = 0.0f;
+        LineMinY = LineMaxY = 0.0f;
+        HostCursorPosY      = 0.0f;
+        HostCursorMaxPosX   = 0.0f;
+        Columns.clear();
+    }
+};
+
+// Data shared between all ImDrawList instances
+struct IMGUI_API ImDrawListSharedData
+{
+    ImVec2 TexUvWhitePixel;  // UV of white pixel in the atlas
+    ImFont *Font;            // Current/default font (optional, for simplified AddText overload)
+    float FontSize;  // Current/default font size (optional, for simplified AddText overload)
+    float CurveTessellationTol;
+    ImVec4 ClipRectFullscreen;     // Value for PushClipRectFullscreen()
+    ImDrawListFlags InitialFlags;  // Initial flags at the beginning of the frame (it is possible to
+                                   // alter flags on a per-drawlist basis afterwards)
+
+    // Const data
+    // FIXME: Bake rounded corners fill/borders in atlas
+    ImVec2 CircleVtx12[12];
+
+    ImDrawListSharedData();
+};
+
+struct ImDrawDataBuilder
+{
+    ImVector<ImDrawList *> Layers[2];  // Global layers for: regular, tooltip
+
+    void Clear()
+    {
+        for (int n = 0; n < IM_ARRAYSIZE(Layers); n++)
+            Layers[n].resize(0);
+    }
+    void ClearFreeMemory()
+    {
+        for (int n = 0; n < IM_ARRAYSIZE(Layers); n++)
+            Layers[n].clear();
+    }
+    IMGUI_API void FlattenIntoSingleLayer();
+};
+
+struct ImGuiNavMoveResult
+{
+    ImGuiID ID;             // Best candidate
+    ImGuiID SelectScopeId;  // Best candidate window current selectable group ID
+    ImGuiWindow *Window;    // Best candidate window
+    float DistBox;          // Best candidate box distance to current NavId
+    float DistCenter;       // Best candidate center distance to current NavId
+    float DistAxial;
+    ImRect RectRel;  // Best candidate bounding box in window relative space
+
+    ImGuiNavMoveResult() { Clear(); }
+    void Clear()
+    {
+        ID = SelectScopeId = 0;
+        Window             = NULL;
+        DistBox = DistCenter = DistAxial = FLT_MAX;
+        RectRel                          = ImRect();
+    }
+};
+
+enum ImGuiNextWindowDataFlags_
+{
+    ImGuiNextWindowDataFlags_None              = 0,
+    ImGuiNextWindowDataFlags_HasPos            = 1 << 0,
+    ImGuiNextWindowDataFlags_HasSize           = 1 << 1,
+    ImGuiNextWindowDataFlags_HasContentSize    = 1 << 2,
+    ImGuiNextWindowDataFlags_HasCollapsed      = 1 << 3,
+    ImGuiNextWindowDataFlags_HasSizeConstraint = 1 << 4,
+    ImGuiNextWindowDataFlags_HasFocus          = 1 << 5,
+    ImGuiNextWindowDataFlags_HasBgAlpha        = 1 << 6
+};
+
+// Storage for SetNexWindow** functions
+struct ImGuiNextWindowData
+{
+    ImGuiNextWindowDataFlags Flags;
+    ImGuiCond PosCond;
+    ImGuiCond SizeCond;
+    ImGuiCond CollapsedCond;
+    ImVec2 PosVal;
+    ImVec2 PosPivotVal;
+    ImVec2 SizeVal;
+    ImVec2 ContentSizeVal;
+    bool CollapsedVal;
+    ImRect SizeConstraintRect;
+    ImGuiSizeCallback SizeCallback;
+    void *SizeCallbackUserData;
+    float BgAlphaVal;
+    ImVec2 MenuBarOffsetMinVal;  // *Always on* This is not exposed publicly, so we don't clear it.
+
+    ImGuiNextWindowData() { memset(this, 0, sizeof(*this)); }
+    inline void ClearFlags() { Flags = ImGuiNextWindowDataFlags_None; }
+};
+
+enum ImGuiNextItemDataFlags_
+{
+    ImGuiNextItemDataFlags_None     = 0,
+    ImGuiNextItemDataFlags_HasWidth = 1 << 0,
+    ImGuiNextItemDataFlags_HasOpen  = 1 << 1
+};
+
+struct ImGuiNextItemData
+{
+    ImGuiNextItemDataFlags Flags;
+    float Width;   // Set by SetNextItemWidth().
+    bool OpenVal;  // Set by SetNextItemOpen() function.
+    ImGuiCond OpenCond;
+
+    ImGuiNextItemData() { memset(this, 0, sizeof(*this)); }
+    inline void ClearFlags() { Flags = ImGuiNextItemDataFlags_None; }
+};
+
+//-----------------------------------------------------------------------------
+// Tabs
+//-----------------------------------------------------------------------------
+
+struct ImGuiShrinkWidthItem
+{
+    int Index;
+    float Width;
+};
+
+struct ImGuiTabBarRef
+{
+    ImGuiTabBar *Ptr;  // Either field can be set, not both. Dock node tab bars are loose while
+                       // BeginTabBar() ones are in a pool.
+    int IndexInMainPool;
+
+    ImGuiTabBarRef(ImGuiTabBar *ptr)
+    {
+        Ptr             = ptr;
+        IndexInMainPool = -1;
+    }
+    ImGuiTabBarRef(int index_in_main_pool)
+    {
+        Ptr             = NULL;
+        IndexInMainPool = index_in_main_pool;
+    }
+};
+
+//-----------------------------------------------------------------------------
+// Main imgui context
+//-----------------------------------------------------------------------------
+
+struct ImGuiContext
+{
+    bool Initialized;
+    bool FrameScopeActive;                // Set by NewFrame(), cleared by EndFrame()
+    bool FrameScopePushedImplicitWindow;  // Set by NewFrame(), cleared by EndFrame()
+    bool FontAtlasOwnedByContext;  // Io.Fonts-> is owned by the ImGuiContext and will be destructed
+                                   // along with it.
+    ImGuiIO IO;
+    ImGuiStyle Style;
+    ImFont *Font;        // (Shortcut) == FontStack.empty() ? IO.Font : FontStack.back()
+    float FontSize;      // (Shortcut) == FontBaseSize * g.CurrentWindow->FontWindowScale ==
+                         // window->FontSize(). Text height for current window.
+    float FontBaseSize;  // (Shortcut) == IO.FontGlobalScale * Font->Scale * Font->FontSize. Base
+                         // text height.
+    ImDrawListSharedData DrawListSharedData;
+    double Time;
+    int FrameCount;
+    int FrameCountEnded;
+    int FrameCountRendered;
+
+    // Windows state
+    ImVector<ImGuiWindow *> Windows;            // Windows, sorted in display order, back to front
+    ImVector<ImGuiWindow *> WindowsFocusOrder;  // Windows, sorted in focus order, back to front
+    ImVector<ImGuiWindow *> WindowsSortBuffer;
+    ImVector<ImGuiWindow *> CurrentWindowStack;
+    ImGuiStorage WindowsById;
+    int WindowsActiveCount;
+    ImGuiWindow *CurrentWindow;      // Being drawn into
+    ImGuiWindow *HoveredWindow;      // Will catch mouse inputs
+    ImGuiWindow *HoveredRootWindow;  // Will catch mouse inputs (for focus/move only)
+    ImGuiWindow
+        *MovingWindow;  // Track the window we clicked on (in order to preserve focus). The actually
+                        // window that is moved is generally MovingWindow->RootWindow.
+
+    // Item/widgets state and tracking information
+    ImGuiID HoveredId;  // Hovered widget
+    bool HoveredIdAllowOverlap;
+    ImGuiID HoveredIdPreviousFrame;
+    float HoveredIdTimer;           // Measure contiguous hovering time
+    float HoveredIdNotActiveTimer;  // Measure contiguous hovering time where the item has not been
+                                    // active
+    ImGuiID ActiveId;               // Active widget
+    ImGuiID ActiveIdIsAlive;  // Active widget has been seen this frame (we can't use a bool as the
+                              // ActiveId may change within the frame)
+    float ActiveIdTimer;
+    bool ActiveIdIsJustActivated;  // Set at the time of activation for one frame
+    bool ActiveIdAllowOverlap;  // Active widget allows another widget to steal active id (generally
+                                // for overlapping widgets, but not always)
+    bool ActiveIdHasBeenPressedBefore;  // Track whether the active id led to a press (this is to
+                                        // allow changing between PressOnClick and PressOnRelease
+                                        // without pressing twice). Used by range_select branch.
+    bool ActiveIdHasBeenEditedBefore;   // Was the value associated to the widget Edited over the
+                                        // course of the Active state.
+    bool ActiveIdHasBeenEditedThisFrame;
+    int ActiveIdAllowNavDirFlags;  // Active widget allows using directional navigation (e.g. can
+                                   // activate a button and move away from it)
+    int ActiveIdBlockNavInputFlags;
+    ImVec2 ActiveIdClickOffset;  // Clicked offset from upper-left corner, if applicable (currently
+                                 // only set by ButtonBehavior)
+    ImGuiWindow *ActiveIdWindow;
+    ImGuiInputSource ActiveIdSource;  // Activating with mouse or nav (gamepad/keyboard)
+    ImGuiID ActiveIdPreviousFrame;
+    bool ActiveIdPreviousFrameIsAlive;
+    bool ActiveIdPreviousFrameHasBeenEditedBefore;
+    ImGuiWindow *ActiveIdPreviousFrameWindow;
+
+    ImGuiID LastActiveId;     // Store the last non-zero ActiveId, useful for animation.
+    float LastActiveIdTimer;  // Store the last non-zero ActiveId timer since the beginning of
+                              // activation, useful for animation.
+
+    // Next window/item data
+    ImGuiNextWindowData NextWindowData;  // Storage for SetNextWindow** functions
+    ImGuiNextItemData NextItemData;      // Storage for SetNextItem** functions
+
+    // Shared stacks
+    ImVector<ImGuiColorMod> ColorModifiers;   // Stack for PushStyleColor()/PopStyleColor()
+    ImVector<ImGuiStyleMod> StyleModifiers;   // Stack for PushStyleVar()/PopStyleVar()
+    ImVector<ImFont *> FontStack;             // Stack for PushFont()/PopFont()
+    ImVector<ImGuiPopupData> OpenPopupStack;  // Which popups are open (persistent)
+    ImVector<ImGuiPopupData>
+        BeginPopupStack;  // Which level of BeginPopup() we are in (reset every frame)
+
+    // Navigation data (for gamepad/keyboard)
+    ImGuiWindow *NavWindow;  // Focused window for navigation. Could be called 'FocusWindow'
+    ImGuiID NavId;           // Focused item for navigation
+    ImGuiID NavActivateId;   // ~~ (g.ActiveId == 0) && IsNavInputPressed(ImGuiNavInput_Activate) ?
+                             // NavId : 0, also set when calling ActivateItem()
+    ImGuiID NavActivateDownId;     // ~~ IsNavInputDown(ImGuiNavInput_Activate) ? NavId : 0
+    ImGuiID NavActivatePressedId;  // ~~ IsNavInputPressed(ImGuiNavInput_Activate) ? NavId : 0
+    ImGuiID NavInputId;            // ~~ IsNavInputPressed(ImGuiNavInput_Input) ? NavId : 0
+    ImGuiID NavJustTabbedId;       // Just tabbed to this id.
+    ImGuiID NavJustMovedToId;  // Just navigated to this id (result of a successfully MoveRequest).
+    ImGuiID NavJustMovedToMultiSelectScopeId;  // Just navigated to this select scope id (result of
+                                               // a successfully MoveRequest).
+    ImGuiID NavNextActivateId;                 // Set by ActivateItem(), queued until next frame.
+    ImGuiInputSource NavInputSource;  // Keyboard or Gamepad mode? THIS WILL ONLY BE None or
+                                      // NavGamepad or NavKeyboard.
+    ImRect NavScoringRectScreen;      // Rectangle used for scoring, in screen space. Based of
+                                  // window->DC.NavRefRectRel[], modified for directional navigation
+                                  // scoring.
+    int NavScoringCount;  // Metrics for debugging
+    ImGuiWindow
+        *NavWindowingTarget;  // When selecting a window (holding Menu+FocusPrev/Next, or equivalent
+                              // of CTRL-TAB) this window is temporarily displayed top-most.
+    ImGuiWindow *NavWindowingTargetAnim;  // Record of last valid NavWindowingTarget until
+                                          // DimBgRatio and NavWindowingHighlightAlpha becomes 0.0f
+    ImGuiWindow *NavWindowingList;
+    float NavWindowingTimer;
+    float NavWindowingHighlightAlpha;
+    bool NavWindowingToggleLayer;
+    ImGuiNavLayer NavLayer;  // Layer we are navigating on. For now the system is hard-coded for
+                             // 0=main contents and 1=menu/title bar, may expose layers later.
+    int NavIdTabCounter;     // == NavWindow->DC.FocusIdxTabCounter at time of NavId processing
+    bool NavIdIsAlive;       // Nav widget has been seen this frame ~~ NavRefRectRel is valid
+    bool NavMousePosDirty;   // When set we will update mouse position if (io.ConfigFlags &
+                             // ImGuiConfigFlags_NavEnableSetMousePos) if set (NB: this not enabled
+                             // by default)
+    bool NavDisableHighlight;   // When user starts using mouse, we hide gamepad/keyboard highlight
+                                // (NB: but they are still available, which is why
+                                // NavDisableHighlight isn't always != NavDisableMouseHover)
+    bool NavDisableMouseHover;  // When user starts using gamepad/keyboard, we hide mouse hovering
+                                // highlight until mouse is touched again.
+    bool NavAnyRequest;         // ~~ NavMoveRequest || NavInitRequest
+    bool NavInitRequest;        // Init request for appearing window to select first item
+    bool NavInitRequestFromMove;
+    ImGuiID NavInitResultId;
+    ImRect NavInitResultRectRel;
+    bool NavMoveFromClampedRefRect;  // Set by manual scrolling, if we scroll to a point where NavId
+                                     // isn't visible we reset navigation from visible items
+    bool NavMoveRequest;             // Move request for this frame
+    ImGuiNavMoveFlags NavMoveRequestFlags;
+    ImGuiNavForward NavMoveRequestForward;  // None / ForwardQueued / ForwardActive (this is used to
+                                            // navigate sibling parent menus from a child menu)
+    ImGuiDir NavMoveDir, NavMoveDirLast;    // Direction of the move request (left/right/up/down),
+                                            // direction of the previous move request
+    ImGuiDir NavMoveClipDir;
+    ImGuiNavMoveResult NavMoveResultLocal;  // Best move request candidate within NavWindow
+    ImGuiNavMoveResult
+        NavMoveResultLocalVisibleSet;  // Best move request candidate within NavWindow that are
+                                       // mostly visible (when using
+                                       // ImGuiNavMoveFlags_AlsoScoreVisibleSet flag)
+    ImGuiNavMoveResult
+        NavMoveResultOther;  // Best move request candidate within NavWindow's flattened hierarchy
+                             // (when using ImGuiWindowFlags_NavFlattened flag)
+
+    // Tabbing system (older than Nav, active even if Nav is disabled. FIXME-NAV: This needs a
+    // redesign!)
+    ImGuiWindow *FocusRequestCurrWindow;  //
+    ImGuiWindow *FocusRequestNextWindow;  //
+    int FocusRequestCurrCounterAll;  // Any item being requested for focus, stored as an index (we
+                                     // on layout to be stable between the frame pressing TAB and
+                                     // the next frame, semi-ouch)
+    int FocusRequestCurrCounterTab;  // Tab item being requested for focus, stored as an index
+    int FocusRequestNextCounterAll;  // Stored for next frame
+    int FocusRequestNextCounterTab;  // "
+    bool FocusTabPressed;            //
+
+    // Render
+    ImDrawData DrawData;  // Main ImDrawData instance to pass render information to the user
+    ImDrawDataBuilder DrawDataBuilder;
+    float DimBgRatio;  // 0.0..1.0 animation when fading in a dimming background (for modal window
+                       // and CTRL+TAB list)
+    ImDrawList BackgroundDrawList;  // First draw list to be rendered.
+    ImDrawList
+        ForegroundDrawList;  // Last draw list to be rendered. This is where we the render software
+                             // mouse cursor (if io.MouseDrawCursor is set) and most debug overlays.
+    ImGuiMouseCursor MouseCursor;
+
+    // Drag and Drop
+    bool DragDropActive;
+    bool DragDropWithinSourceOrTarget;
+    ImGuiDragDropFlags DragDropSourceFlags;
+    int DragDropSourceFrameCount;
+    int DragDropMouseButton;
+    ImGuiPayload DragDropPayload;
+    ImRect DragDropTargetRect;
+    ImGuiID DragDropTargetId;
+    ImGuiDragDropFlags DragDropAcceptFlags;
+    float DragDropAcceptIdCurrRectSurface;  // Target item surface (we resolve overlapping targets
+                                            // by prioritizing the smaller surface)
+    ImGuiID DragDropAcceptIdCurr;  // Target item id (set at the time of accepting the payload)
+    ImGuiID DragDropAcceptIdPrev;  // Target item id from previous frame (we need to store this to
+                                   // allow for overlapping drag and drop targets)
+    int DragDropAcceptFrameCount;  // Last time a target expressed a desire to accept the source
+    ImVector<unsigned char> DragDropPayloadBufHeap;  // We don't expose the ImVector<> directly
+    unsigned char DragDropPayloadBufLocal[8];        // Local buffer for small payloads
+
+    // Tab bars
+    ImPool<ImGuiTabBar> TabBars;
+    ImGuiTabBar *CurrentTabBar;
+    ImVector<ImGuiTabBarRef> CurrentTabBarStack;
+    ImVector<ImGuiShrinkWidthItem> ShrinkWidthBuffer;
+
+    // Widget state
+    ImVec2 LastValidMousePos;
+    ImGuiInputTextState InputTextState;
+    ImFont InputTextPasswordFont;
+    ImGuiID TempInputTextId;  // Temporary text input when CTRL+clicking on a slider, etc.
+    ImGuiColorEditFlags ColorEditOptions;  // Store user options for color edit widgets
+    ImVec4 ColorPickerRef;
+    bool DragCurrentAccumDirty;
+    float DragCurrentAccum;  // Accumulator for dragging modification. Always high-precision, not
+                             // rounded by end-user precision settings
+    float DragSpeedDefaultRatio;  // If speed == 0.0f, uses (max-min) * DragSpeedDefaultRatio
+    float ScrollbarClickDeltaToGrabCenter;  // Distance between mouse and center of grab box,
+                                            // normalized in parent space. Use storage?
+    int TooltipOverrideCount;
+    ImVector<char> PrivateClipboard;  // If no custom clipboard handler is defined
+
+    // Range-Select/Multi-Select
+    // [This is unused in this branch, but left here to facilitate merging/syncing multiple
+    // branches]
+    ImGuiID MultiSelectScopeId;
+
+    // Platform support
+    ImVec2 PlatformImePos;  // Cursor position request & last passed to the OS Input Method Editor
+    ImVec2 PlatformImeLastPos;
+
+    // Settings
+    bool SettingsLoaded;
+    float SettingsDirtyTimer;         // Save .ini Settings to memory when time reaches zero
+    ImGuiTextBuffer SettingsIniData;  // In memory .ini settings
+    ImVector<ImGuiSettingsHandler> SettingsHandlers;  // List of .ini settings handlers
+    ImVector<ImGuiWindowSettings>
+        SettingsWindows;  // ImGuiWindow .ini settings entries (parsed from the last loaded .ini
+                          // file and maintained on saving)
+
+    // Logging
+    bool LogEnabled;
+    ImGuiLogType LogType;
+    FILE *LogFile;              // If != NULL log to stdout/ file
+    ImGuiTextBuffer LogBuffer;  // Accumulation buffer when log to clipboard. This is pointer so our
+                                // GImGui static constructor doesn't call heap allocators.
+    float LogLinePosY;
+    bool LogLineFirstItem;
+    int LogDepthRef;
+    int LogDepthToExpand;
+    int LogDepthToExpandDefault;  // Default/stored value for LogDepthMaxExpand if not specified in
+                                  // the LogXXX function call.
+
+    // Misc
+    float FramerateSecPerFrame[120];  // Calculate estimate of framerate for user over the last 2
+                                      // seconds.
+    int FramerateSecPerFrameIdx;
+    float FramerateSecPerFrameAccum;
+    int WantCaptureMouseNextFrame;  // Explicit capture via
+                                    // CaptureKeyboardFromApp()/CaptureMouseFromApp() sets those
+                                    // flags
+    int WantCaptureKeyboardNextFrame;
+    int WantTextInputNextFrame;
+    char TempBuffer[1024 * 3 + 1];  // Temporary text buffer
+
+    ImGuiContext(ImFontAtlas *shared_font_atlas)
+        : BackgroundDrawList(&DrawListSharedData), ForegroundDrawList(&DrawListSharedData)
+    {
+        Initialized      = false;
+        FrameScopeActive = FrameScopePushedImplicitWindow = false;
+        Font                                              = NULL;
+        FontSize = FontBaseSize = 0.0f;
+        FontAtlasOwnedByContext = shared_font_atlas ? false : true;
+        IO.Fonts                = shared_font_atlas ? shared_font_atlas : IM_NEW(ImFontAtlas)();
+        Time                    = 0.0f;
+        FrameCount              = 0;
+        FrameCountEnded = FrameCountRendered = -1;
+
+        WindowsActiveCount = 0;
+        CurrentWindow      = NULL;
+        HoveredWindow      = NULL;
+        HoveredRootWindow  = NULL;
+        MovingWindow       = NULL;
+
+        HoveredId              = 0;
+        HoveredIdAllowOverlap  = false;
+        HoveredIdPreviousFrame = 0;
+        HoveredIdTimer = HoveredIdNotActiveTimer = 0.0f;
+        ActiveId                                 = 0;
+        ActiveIdIsAlive                          = 0;
+        ActiveIdTimer                            = 0.0f;
+        ActiveIdIsJustActivated                  = false;
+        ActiveIdAllowOverlap                     = false;
+        ActiveIdHasBeenPressedBefore             = false;
+        ActiveIdHasBeenEditedBefore              = false;
+        ActiveIdHasBeenEditedThisFrame           = false;
+        ActiveIdAllowNavDirFlags                 = 0x00;
+        ActiveIdBlockNavInputFlags               = 0x00;
+        ActiveIdClickOffset                      = ImVec2(-1, -1);
+        ActiveIdWindow                           = NULL;
+        ActiveIdSource                           = ImGuiInputSource_None;
+
+        ActiveIdPreviousFrame                    = 0;
+        ActiveIdPreviousFrameIsAlive             = false;
+        ActiveIdPreviousFrameHasBeenEditedBefore = false;
+        ActiveIdPreviousFrameWindow              = NULL;
+
+        LastActiveId      = 0;
+        LastActiveIdTimer = 0.0f;
+
+        NavWindow = NULL;
+        NavId = NavActivateId = NavActivateDownId = NavActivatePressedId = NavInputId = 0;
+        NavJustTabbedId = NavJustMovedToId = NavJustMovedToMultiSelectScopeId = NavNextActivateId =
+            0;
+        NavInputSource       = ImGuiInputSource_None;
+        NavScoringRectScreen = ImRect();
+        NavScoringCount      = 0;
+        NavWindowingTarget = NavWindowingTargetAnim = NavWindowingList = NULL;
+        NavWindowingTimer = NavWindowingHighlightAlpha = 0.0f;
+        NavWindowingToggleLayer                        = false;
+        NavLayer                                       = ImGuiNavLayer_Main;
+        NavIdTabCounter                                = INT_MAX;
+        NavIdIsAlive                                   = false;
+        NavMousePosDirty                               = false;
+        NavDisableHighlight                            = true;
+        NavDisableMouseHover                           = false;
+        NavAnyRequest                                  = false;
+        NavInitRequest                                 = false;
+        NavInitRequestFromMove                         = false;
+        NavInitResultId                                = 0;
+        NavMoveFromClampedRefRect                      = false;
+        NavMoveRequest                                 = false;
+        NavMoveRequestFlags                            = 0;
+        NavMoveRequestForward                          = ImGuiNavForward_None;
+        NavMoveDir = NavMoveDirLast = NavMoveClipDir = ImGuiDir_None;
+
+        FocusRequestCurrWindow = FocusRequestNextWindow = NULL;
+        FocusRequestCurrCounterAll = FocusRequestCurrCounterTab = INT_MAX;
+        FocusRequestNextCounterAll = FocusRequestNextCounterTab = INT_MAX;
+        FocusTabPressed                                         = false;
+
+        DimBgRatio                    = 0.0f;
+        BackgroundDrawList._OwnerName = "##Background";  // Give it a name for debugging
+        ForegroundDrawList._OwnerName = "##Foreground";  // Give it a name for debugging
+        MouseCursor                   = ImGuiMouseCursor_Arrow;
+
+        DragDropActive = DragDropWithinSourceOrTarget = false;
+        DragDropSourceFlags                           = 0;
+        DragDropSourceFrameCount                      = -1;
+        DragDropMouseButton                           = -1;
+        DragDropTargetId                              = 0;
+        DragDropAcceptFlags                           = 0;
+        DragDropAcceptIdCurrRectSurface               = 0.0f;
+        DragDropAcceptIdPrev = DragDropAcceptIdCurr = 0;
+        DragDropAcceptFrameCount                    = -1;
+        memset(DragDropPayloadBufLocal, 0, sizeof(DragDropPayloadBufLocal));
+
+        CurrentTabBar = NULL;
+
+        LastValidMousePos               = ImVec2(0.0f, 0.0f);
+        TempInputTextId                 = 0;
+        ColorEditOptions                = ImGuiColorEditFlags__OptionsDefault;
+        DragCurrentAccumDirty           = false;
+        DragCurrentAccum                = 0.0f;
+        DragSpeedDefaultRatio           = 1.0f / 100.0f;
+        ScrollbarClickDeltaToGrabCenter = 0.0f;
+        TooltipOverrideCount            = 0;
+
+        MultiSelectScopeId = 0;
+
+        PlatformImePos = PlatformImeLastPos = ImVec2(FLT_MAX, FLT_MAX);
+
+        SettingsLoaded     = false;
+        SettingsDirtyTimer = 0.0f;
+
+        LogEnabled       = false;
+        LogType          = ImGuiLogType_None;
+        LogFile          = NULL;
+        LogLinePosY      = FLT_MAX;
+        LogLineFirstItem = false;
+        LogDepthRef      = 0;
+        LogDepthToExpand = LogDepthToExpandDefault = 2;
+
+        memset(FramerateSecPerFrame, 0, sizeof(FramerateSecPerFrame));
+        FramerateSecPerFrameIdx   = 0;
+        FramerateSecPerFrameAccum = 0.0f;
+        WantCaptureMouseNextFrame = WantCaptureKeyboardNextFrame = WantTextInputNextFrame = -1;
+        memset(TempBuffer, 0, sizeof(TempBuffer));
+    }
+};
+
+//-----------------------------------------------------------------------------
+// ImGuiWindow
+//-----------------------------------------------------------------------------
+
+// Transient per-window data, reset at the beginning of the frame. This used to be called
+// ImGuiDrawContext, hence the DC variable name in ImGuiWindow.
+// FIXME: That's theory, in practice the delimitation between ImGuiWindow and ImGuiWindowTempData is
+// quite tenuous and could be reconsidered.
+struct IMGUI_API ImGuiWindowTempData
+{
+    ImVec2 CursorPos;
+    ImVec2 CursorPosPrevLine;
+    ImVec2 CursorStartPos;  // Initial position in client area with padding
+    ImVec2 CursorMaxPos;    // Used to implicitly calculate the size of our contents, always growing
+                            // during the frame. Used to calculate window->ContentSize at the
+                            // beginning of next frame
+    ImVec2 CurrLineSize;
+    ImVec2 PrevLineSize;
+    float CurrLineTextBaseOffset;
+    float PrevLineTextBaseOffset;
+    int TreeDepth;
+    ImU32 TreeStoreMayJumpToParentOnPop;  // Store a copy of !g.NavIdIsAlive for TreeDepth 0..31..
+                                          // Could be turned into a ImU64 if necessary.
+    ImGuiID LastItemId;
+    ImGuiItemStatusFlags LastItemStatusFlags;
+    ImRect LastItemRect;            // Interaction rect
+    ImRect LastItemDisplayRect;     // End-user display rect (only valid if LastItemStatusFlags &
+                                    // ImGuiItemStatusFlags_HasDisplayRect)
+    ImGuiNavLayer NavLayerCurrent;  // Current layer, 0..31 (we currently only use 0..1)
+    int NavLayerCurrentMask;        // = (1 << NavLayerCurrent) used by ItemAdd prior to clipping.
+    int NavLayerActiveMask;         // Which layer have been written to (result from previous frame)
+    int NavLayerActiveMaskNext;     // Which layer have been written to (buffer for current frame)
+    bool NavHideHighlightOneFrame;
+    bool NavHasScroll;      // Set when scrolling can be used (ScrollMax > 0.0f)
+    bool MenuBarAppending;  // FIXME: Remove this
+    ImVec2 MenuBarOffset;   // MenuBarOffset.x is sort of equivalent of a per-layer CursorPos.x,
+                            // saved/restored as we switch to the menu bar. The only situation when
+                            // MenuBarOffset.y is > 0 if when (SafeAreaPadding.y > FramePadding.y),
+                            // often used on TVs.
+    ImVector<ImGuiWindow *> ChildWindows;
+    ImGuiStorage *StateStorage;
+    ImGuiLayoutType LayoutType;
+    ImGuiLayoutType ParentLayoutType;  // Layout type of parent window at the time of Begin()
+    int FocusCounterAll;  // Counter for focus/tabbing system. Start at -1 and increase as assigned
+                          // via FocusableItemRegister() (FIXME-NAV: Needs redesign)
+    int FocusCounterTab;  // (same, but only count widgets which you can Tab through)
+
+    // We store the current settings outside of the vectors to increase memory locality (reduce
+    // cache misses). The vectors are rarely modified. Also it allows us to not heap allocate for
+    // short-lived windows which are not using those settings.
+    ImGuiItemFlags ItemFlags;  // == ItemFlagsStack.back() [empty == ImGuiItemFlags_Default]
+    float ItemWidth;  // == ItemWidthStack.back(). 0.0: default, >0.0: width in pixels, <0.0: align
+                      // xx pixels to the right of window
+    float TextWrapPos;  // == TextWrapPosStack.back() [empty == -1.0f]
+    ImVector<ImGuiItemFlags> ItemFlagsStack;
+    ImVector<float> ItemWidthStack;
+    ImVector<float> TextWrapPosStack;
+    ImVector<ImGuiGroupData> GroupStack;
+    short StackSizesBackup[6];  // Store size of various stacks for asserting
+
+    ImVec1 Indent;  // Indentation / start position from left of window (increased by
+                    // TreePush/TreePop, etc.)
+    ImVec1 GroupOffset;
+    ImVec1 ColumnsOffset;  // Offset to the current column (if ColumnsCurrent > 0). FIXME: This and
+                           // the above should be a stack to allow use cases like
+                           // Tree->Column->Tree. Need revamp columns API.
+    ImGuiColumns *CurrentColumns;  // Current columns set
+
+    ImGuiWindowTempData()
+    {
+        CursorPos = CursorPosPrevLine = CursorStartPos = CursorMaxPos = ImVec2(0.0f, 0.0f);
+        CurrLineSize = PrevLineSize = ImVec2(0.0f, 0.0f);
+        CurrLineTextBaseOffset = PrevLineTextBaseOffset = 0.0f;
+        TreeDepth                                       = 0;
+        TreeStoreMayJumpToParentOnPop                   = 0x00;
+        LastItemId                                      = 0;
+        LastItemStatusFlags                             = 0;
+        LastItemRect = LastItemDisplayRect = ImRect();
+        NavLayerActiveMask = NavLayerActiveMaskNext = 0x00;
+        NavLayerCurrent                             = ImGuiNavLayer_Main;
+        NavLayerCurrentMask                         = (1 << ImGuiNavLayer_Main);
+        NavHideHighlightOneFrame                    = false;
+        NavHasScroll                                = false;
+        MenuBarAppending                            = false;
+        MenuBarOffset                               = ImVec2(0.0f, 0.0f);
+        StateStorage                                = NULL;
+        LayoutType = ParentLayoutType = ImGuiLayoutType_Vertical;
+        FocusCounterAll = FocusCounterTab = -1;
+
+        ItemFlags   = ImGuiItemFlags_Default_;
+        ItemWidth   = 0.0f;
+        TextWrapPos = -1.0f;
+        memset(StackSizesBackup, 0, sizeof(StackSizesBackup));
+
+        Indent         = ImVec1(0.0f);
+        GroupOffset    = ImVec1(0.0f);
+        ColumnsOffset  = ImVec1(0.0f);
+        CurrentColumns = NULL;
+    }
+};
+
+// Storage for one window
+struct IMGUI_API ImGuiWindow
+{
+    char *Name;
+    ImGuiID ID;              // == ImHash(Name)
+    ImGuiWindowFlags Flags;  // See enum ImGuiWindowFlags_
+    ImVec2 Pos;              // Position (always rounded-up to nearest pixel)
+    ImVec2 Size;             // Current size (==SizeFull or collapsed title bar size)
+    ImVec2 SizeFull;         // Size when non collapsed
+    ImVec2 ContentSize;      // Size of contents/scrollable client area (calculated from the extents
+                             // reach of the cursor) from previous frame. Does not include window
+                             // decoration or window padding.
+    ImVec2 ContentSizeExplicit;  // Size of contents/scrollable client area explicitly request by
+                                 // the user via SetNextWindowContentSize().
+    ImVec2 WindowPadding;        // Window padding at the time of begin.
+    float WindowRounding;        // Window rounding at the time of begin.
+    float WindowBorderSize;      // Window border size at the time of begin.
+    int NameBufLen;              // Size of buffer storing Name. May be larger than strlen(Name)!
+    ImGuiID MoveId;              // == window->GetID("#MOVE")
+    ImGuiID ChildId;  // ID of corresponding item in parent window (for navigation to return from
+                      // child window to parent window)
+    ImVec2 Scroll;
+    ImVec2 ScrollMax;
+    ImVec2
+        ScrollTarget;  // target scroll position. stored as cursor position with scrolling canceled
+                       // out, so the highest point is always 0.0f. (FLT_MAX for no change)
+    ImVec2 ScrollTargetCenterRatio;  // 0.0f = scroll so that target position is at top, 0.5f =
+                                     // scroll so that target position is centered
+    ImVec2 ScrollbarSizes;           // Size taken by scrollbars on each axis
+    bool ScrollbarX, ScrollbarY;
+    bool Active;  // Set to true on Begin(), unless Collapsed
+    bool WasActive;
+    bool WriteAccessed;  // Set to true when any widget access the current window
+    bool Collapsed;      // Set when collapsing window to become only title-bar
+    bool WantCollapseToggle;
+    bool SkipItems;       // Set when items can safely be all clipped (e.g. window not visible or
+                          // collapsed)
+    bool Appearing;       // Set during the frame where the window is appearing (or re-appearing)
+    bool Hidden;          // Do not display (== (HiddenFrames*** > 0))
+    bool HasCloseButton;  // Set when the window has a close button (p_open != NULL)
+    signed char ResizeBorderHeld;  // Current border being held for resize (-1: none, otherwise 0-3)
+    short BeginCount;  // Number of Begin() during the current frame (generally 0 or 1, 1+ if
+                       // appending via multiple Begin/End pairs)
+    short BeginOrderWithinParent;   // Order within immediate parent window, if we are a child
+                                    // window. Otherwise 0.
+    short BeginOrderWithinContext;  // Order within entire imgui context. This is mostly used for
+                                    // debugging submission order related issues.
+    ImGuiID PopupId;  // ID in the popup stack when this window is used as a popup/menu (because we
+                      // use generic Name/ID for recycling)
+    int AutoFitFramesX, AutoFitFramesY;
+    bool AutoFitOnlyGrows;
+    int AutoFitChildAxises;
+    ImGuiDir AutoPosLastDirection;
+    int HiddenFramesCanSkipItems;     // Hide the window for N frames
+    int HiddenFramesCannotSkipItems;  // Hide the window for N frames while allowing items to be
+                                      // submitted so we can measure their size
+    ImGuiCond
+        SetWindowPosAllowFlags;  // store acceptable condition flags for SetNextWindowPos() use.
+    ImGuiCond
+        SetWindowSizeAllowFlags;  // store acceptable condition flags for SetNextWindowSize() use.
+    ImGuiCond SetWindowCollapsedAllowFlags;  // store acceptable condition flags for
+                                             // SetNextWindowCollapsed() use.
+    ImVec2 SetWindowPosVal;    // store window position when using a non-zero Pivot (position set
+                               // needs to be processed when we know the window size)
+    ImVec2 SetWindowPosPivot;  // store window pivot for positioning. ImVec2(0,0) when positioning
+                               // from top-left corner; ImVec2(0.5f,0.5f) for centering; ImVec2(1,1)
+                               // for bottom right.
+
+    ImGuiWindowTempData DC;  // Temporary per-window data, reset at the beginning of the frame. This
+                             // used to be called ImGuiDrawContext, hence the "DC" variable name.
+    ImVector<ImGuiID>
+        IDStack;  // ID stack. ID are hashes seeded with the value at the top of the stack
+
+    // The best way to understand what those rectangles are is to use the 'Metrics -> Tools -> Show
+    // windows rectangles' viewer. The main 'OuterRect', omitted as a field, is window->Rect().
+    ImRect OuterRectClipped;  // == Window->Rect() just after setup in Begin(). == window->Rect()
+                              // for root window.
+    ImRect InnerRect;         // Inner rectangle (omit title bar, menu bar, scroll bar)
+    ImRect InnerClipRect;  // == InnerRect shrunk by WindowPadding*0.5f on each side, clipped within
+                           // viewport or parent clip rect.
+    ImRect
+        WorkRect;  // Cover the whole scrolling region, shrunk by WindowPadding*1.0f on each side.
+                   // This is meant to replace ContentsRegionRect over time (from 1.71+ onward).
+    ImRect ClipRect;  // Current clipping/scissoring rectangle, evolve as we are using
+                      // PushClipRect(), etc. == DrawList->clip_rect_stack.back().
+    ImRect
+        ContentsRegionRect;  // FIXME: This is currently confusing/misleading. It is essentially
+                             // WorkRect but not handling of scrolling. We currently rely on it as
+                             // right/bottom aligned sizing operation need some size to rely on.
+
+    int LastFrameActive;  // Last frame number the window was Active.
+    float ItemWidthDefault;
+    ImGuiMenuColumns MenuColumns;  // Simplified columns storage for menu items
+    ImGuiStorage StateStorage;
+    ImVector<ImGuiColumns> ColumnsStorage;
+    float FontWindowScale;  // User scale multiplier per-window
+    int SettingsIdx;  // Index into SettingsWindow[] (indices are always valid as we only grow the
+                      // array from the back)
+
+    ImDrawList *DrawList;  // == &DrawListInst (for backward compatibility reason with code using
+                           // imgui_internal.h we keep this a pointer)
+    ImDrawList DrawListInst;
+    ImGuiWindow *ParentWindow;  // If we are a child _or_ popup window, this is pointing to our
+                                // parent. Otherwise NULL.
+    ImGuiWindow *RootWindow;    // Point to ourself or first ancestor that is not a child window.
+    ImGuiWindow
+        *RootWindowForTitleBarHighlight;  // Point to ourself or first ancestor which will display
+                                          // TitleBgActive color when this window is active.
+    ImGuiWindow *RootWindowForNav;  // Point to ourself or first ancestor which doesn't have the
+                                    // NavFlattened flag.
+
+    ImGuiWindow
+        *NavLastChildNavWindow;  // When going to the menu bar, we remember the child window we came
+                                 // from. (This could probably be made implicit if we kept g.Windows
+                                 // sorted by last focused including child window.)
+    ImGuiID NavLastIds[ImGuiNavLayer_COUNT];  // Last known NavId for this window, per layer (0/1)
+    ImRect NavRectRel[ImGuiNavLayer_COUNT];   // Reference rectangle, in window relative space
+
+  public:
+    ImGuiWindow(ImGuiContext *context, const char *name);
+    ~ImGuiWindow();
+
+    ImGuiID GetID(const char *str, const char *str_end = NULL);
+    ImGuiID GetID(const void *ptr);
+    ImGuiID GetID(int n);
+    ImGuiID GetIDNoKeepAlive(const char *str, const char *str_end = NULL);
+    ImGuiID GetIDNoKeepAlive(const void *ptr);
+    ImGuiID GetIDNoKeepAlive(int n);
+    ImGuiID GetIDFromRectangle(const ImRect &r_abs);
+
+    // We don't use g.FontSize because the window may be != g.CurrentWidow.
+    ImRect Rect() const { return ImRect(Pos.x, Pos.y, Pos.x + Size.x, Pos.y + Size.y); }
+    float CalcFontSize() const { return GImGui->FontBaseSize * FontWindowScale; }
+    float TitleBarHeight() const
+    {
+        return (Flags & ImGuiWindowFlags_NoTitleBar)
+                   ? 0.0f
+                   : CalcFontSize() + GImGui->Style.FramePadding.y * 2.0f;
+    }
+    ImRect TitleBarRect() const
+    {
+        return ImRect(Pos, ImVec2(Pos.x + SizeFull.x, Pos.y + TitleBarHeight()));
+    }
+    float MenuBarHeight() const
+    {
+        return (Flags & ImGuiWindowFlags_MenuBar)
+                   ? DC.MenuBarOffset.y + CalcFontSize() + GImGui->Style.FramePadding.y * 2.0f
+                   : 0.0f;
+    }
+    ImRect MenuBarRect() const
+    {
+        float y1 = Pos.y + TitleBarHeight();
+        return ImRect(Pos.x, y1, Pos.x + SizeFull.x, y1 + MenuBarHeight());
+    }
+};
+
+// Backup and restore just enough data to be able to use IsItemHovered() on item A after another B
+// in the same window has overwritten the data.
+struct ImGuiItemHoveredDataBackup
+{
+    ImGuiID LastItemId;
+    ImGuiItemStatusFlags LastItemStatusFlags;
+    ImRect LastItemRect;
+    ImRect LastItemDisplayRect;
+
+    ImGuiItemHoveredDataBackup() { Backup(); }
+    void Backup()
+    {
+        ImGuiWindow *window = GImGui->CurrentWindow;
+        LastItemId          = window->DC.LastItemId;
+        LastItemStatusFlags = window->DC.LastItemStatusFlags;
+        LastItemRect        = window->DC.LastItemRect;
+        LastItemDisplayRect = window->DC.LastItemDisplayRect;
+    }
+    void Restore() const
+    {
+        ImGuiWindow *window            = GImGui->CurrentWindow;
+        window->DC.LastItemId          = LastItemId;
+        window->DC.LastItemStatusFlags = LastItemStatusFlags;
+        window->DC.LastItemRect        = LastItemRect;
+        window->DC.LastItemDisplayRect = LastItemDisplayRect;
+    }
+};
+
+//-----------------------------------------------------------------------------
+// Tab bar, tab item
+//-----------------------------------------------------------------------------
+
+// Extend ImGuiTabBarFlags_
+enum ImGuiTabBarFlagsPrivate_
+{
+    ImGuiTabBarFlags_DockNode =
+        1 << 20,  // Part of a dock node [we don't use this in the master branch but it facilitate
+                  // branch syncing to keep this around]
+    ImGuiTabBarFlags_IsFocused = 1 << 21,
+    ImGuiTabBarFlags_SaveSettings =
+        1 << 22  // FIXME: Settings are handled by the docking system, this only request the tab bar
+                 // to mark settings dirty when reordering tabs
+};
+
+// Extend ImGuiTabItemFlags_
+enum ImGuiTabItemFlagsPrivate_
+{
+    ImGuiTabItemFlags_NoCloseButton = 1 << 20  // Store whether p_open is set or not, which we need
+                                               // to recompute WidthContents during layout.
+};
+
+// Storage for one active tab item (sizeof() 26~32 bytes)
+struct ImGuiTabItem
+{
+    ImGuiID ID;
+    ImGuiTabItemFlags Flags;
+    int LastFrameVisible;
+    int LastFrameSelected;  // This allows us to infer an ordered list of the last activated tabs
+                            // with little maintenance
+    int NameOffset;       // When Window==NULL, offset to name within parent ImGuiTabBar::TabsNames
+    float Offset;         // Position relative to beginning of tab
+    float Width;          // Width currently displayed
+    float WidthContents;  // Width of actual contents, stored during BeginTabItem() call
+
+    ImGuiTabItem()
+    {
+        ID = Flags       = 0;
+        LastFrameVisible = LastFrameSelected = -1;
+        NameOffset                           = -1;
+        Offset = Width = WidthContents = 0.0f;
+    }
+};
+
+// Storage for a tab bar (sizeof() 92~96 bytes)
+struct ImGuiTabBar
+{
+    ImVector<ImGuiTabItem> Tabs;
+    ImGuiID ID;             // Zero for tab-bars used by docking
+    ImGuiID SelectedTabId;  // Selected tab
+    ImGuiID NextSelectedTabId;
+    ImGuiID VisibleTabId;  // Can occasionally be != SelectedTabId (e.g. when previewing contents
+                           // for CTRL+TAB preview)
+    int CurrFrameVisible;
+    int PrevFrameVisible;
+    ImRect BarRect;
+    float ContentsHeight;
+    float OffsetMax;      // Distance from BarRect.Min.x, locked during layout
+    float OffsetNextTab;  // Distance from BarRect.Min.x, incremented with each BeginTabItem() call,
+                          // not used if ImGuiTabBarFlags_Reorderable if set.
+    float ScrollingAnim;
+    float ScrollingTarget;
+    float ScrollingTargetDistToVisibility;
+    float ScrollingSpeed;
+    ImGuiTabBarFlags Flags;
+    ImGuiID ReorderRequestTabId;
+    int ReorderRequestDir;
+    bool WantLayout;
+    bool VisibleTabWasSubmitted;
+    short LastTabItemIdx;  // For BeginTabItem()/EndTabItem()
+    ImVec2 FramePadding;   // style.FramePadding locked at the time of BeginTabBar()
+    ImGuiTextBuffer
+        TabsNames;  // For non-docking tab bar we re-append names in a contiguous buffer.
+
+    ImGuiTabBar();
+    int GetTabOrder(const ImGuiTabItem *tab) const { return Tabs.index_from_ptr(tab); }
+    const char *GetTabName(const ImGuiTabItem *tab) const
+    {
+        IM_ASSERT(tab->NameOffset != -1 && tab->NameOffset < TabsNames.Buf.Size);
+        return TabsNames.Buf.Data + tab->NameOffset;
+    }
+};
+
+//-----------------------------------------------------------------------------
+// Internal API
+// No guarantee of forward compatibility here.
+//-----------------------------------------------------------------------------
+
+namespace ImGui
+{
+// We should always have a CurrentWindow in the stack (there is an implicit "Debug" window)
+// If this ever crash because g.CurrentWindow is NULL it means that either
+// - ImGui::NewFrame() has never been called, which is illegal.
+// - You are calling ImGui functions after ImGui::EndFrame()/ImGui::Render() and before the next
+// ImGui::NewFrame(), which is also illegal.
+inline ImGuiWindow *GetCurrentWindowRead()
+{
+    ImGuiContext &g = *GImGui;
+    return g.CurrentWindow;
+}
+inline ImGuiWindow *GetCurrentWindow()
+{
+    ImGuiContext &g                = *GImGui;
+    g.CurrentWindow->WriteAccessed = true;
+    return g.CurrentWindow;
+}
+IMGUI_API ImGuiWindow *FindWindowByID(ImGuiID id);
+IMGUI_API ImGuiWindow *FindWindowByName(const char *name);
+IMGUI_API void FocusWindow(ImGuiWindow *window);
+IMGUI_API void FocusTopMostWindowUnderOne(ImGuiWindow *under_this_window,
+                                          ImGuiWindow *ignore_window);
+IMGUI_API void BringWindowToFocusFront(ImGuiWindow *window);
+IMGUI_API void BringWindowToDisplayFront(ImGuiWindow *window);
+IMGUI_API void BringWindowToDisplayBack(ImGuiWindow *window);
+IMGUI_API void UpdateWindowParentAndRootLinks(ImGuiWindow *window,
+                                              ImGuiWindowFlags flags,
+                                              ImGuiWindow *parent_window);
+IMGUI_API ImVec2 CalcWindowExpectedSize(ImGuiWindow *window);
+IMGUI_API bool IsWindowChildOf(ImGuiWindow *window, ImGuiWindow *potential_parent);
+IMGUI_API bool IsWindowNavFocusable(ImGuiWindow *window);
+IMGUI_API void SetWindowScrollX(ImGuiWindow *window, float new_scroll_x);
+IMGUI_API void SetWindowScrollY(ImGuiWindow *window, float new_scroll_y);
+IMGUI_API ImRect GetWindowAllowedExtentRect(ImGuiWindow *window);
+IMGUI_API void SetWindowPos(ImGuiWindow *window, const ImVec2 &pos, ImGuiCond cond = 0);
+IMGUI_API void SetWindowSize(ImGuiWindow *window, const ImVec2 &size, ImGuiCond cond = 0);
+IMGUI_API void SetWindowCollapsed(ImGuiWindow *window, bool collapsed, ImGuiCond cond = 0);
+
+IMGUI_API void SetCurrentFont(ImFont *font);
+inline ImFont *GetDefaultFont()
+{
+    ImGuiContext &g = *GImGui;
+    return g.IO.FontDefault ? g.IO.FontDefault : g.IO.Fonts->Fonts[0];
+}
+
+// Init
+IMGUI_API void Initialize(ImGuiContext *context);
+IMGUI_API void Shutdown(
+    ImGuiContext *context);  // Since 1.60 this is a _private_ function. You can call
+                             // DestroyContext() to destroy the context created by CreateContext().
+
+// NewFrame
+IMGUI_API void UpdateHoveredWindowAndCaptureFlags();
+IMGUI_API void StartMouseMovingWindow(ImGuiWindow *window);
+IMGUI_API void UpdateMouseMovingWindowNewFrame();
+IMGUI_API void UpdateMouseMovingWindowEndFrame();
+
+// Settings
+IMGUI_API void MarkIniSettingsDirty();
+IMGUI_API void MarkIniSettingsDirty(ImGuiWindow *window);
+IMGUI_API ImGuiWindowSettings *CreateNewWindowSettings(const char *name);
+IMGUI_API ImGuiWindowSettings *FindWindowSettings(ImGuiID id);
+IMGUI_API ImGuiWindowSettings *FindOrCreateWindowSettings(const char *name);
+IMGUI_API ImGuiSettingsHandler *FindSettingsHandler(const char *type_name);
+
+// Basic Accessors
+inline ImGuiID GetItemID()
+{
+    ImGuiContext &g = *GImGui;
+    return g.CurrentWindow->DC.LastItemId;
+}
+inline ImGuiID GetActiveID()
+{
+    ImGuiContext &g = *GImGui;
+    return g.ActiveId;
+}
+inline ImGuiID GetFocusID()
+{
+    ImGuiContext &g = *GImGui;
+    return g.NavId;
+}
+IMGUI_API void SetActiveID(ImGuiID id, ImGuiWindow *window);
+IMGUI_API void SetFocusID(ImGuiID id, ImGuiWindow *window);
+IMGUI_API void ClearActiveID();
+IMGUI_API ImGuiID GetHoveredID();
+IMGUI_API void SetHoveredID(ImGuiID id);
+IMGUI_API void KeepAliveID(ImGuiID id);
+IMGUI_API void MarkItemEdited(ImGuiID id);
+IMGUI_API void PushOverrideID(ImGuiID id);
+
+// Basic Helpers for widget code
+IMGUI_API void ItemSize(const ImVec2 &size, float text_offset_y = 0.0f);
+IMGUI_API void ItemSize(const ImRect &bb, float text_offset_y = 0.0f);
+IMGUI_API bool ItemAdd(const ImRect &bb, ImGuiID id, const ImRect *nav_bb = NULL);
+IMGUI_API bool ItemHoverable(const ImRect &bb, ImGuiID id);
+IMGUI_API bool IsClippedEx(const ImRect &bb, ImGuiID id, bool clip_even_when_logged);
+IMGUI_API bool FocusableItemRegister(ImGuiWindow *window,
+                                     ImGuiID id);  // Return true if focus is requested
+IMGUI_API void FocusableItemUnregister(ImGuiWindow *window);
+IMGUI_API ImVec2 CalcItemSize(ImVec2 size, float default_w, float default_h);
+IMGUI_API float CalcWrapWidthForPos(const ImVec2 &pos, float wrap_pos_x);
+IMGUI_API void PushMultiItemsWidths(int components, float width_full);
+IMGUI_API void PushItemFlag(ImGuiItemFlags option, bool enabled);
+IMGUI_API void PopItemFlag();
+IMGUI_API bool IsItemToggledSelection();  // Was the last item selection toggled? (after
+                                          // Selectable(), TreeNode() etc. We only returns toggle
+                                          // _event_ in order to handle clipping correctly)
+IMGUI_API ImVec2 GetContentRegionMaxAbs();
+IMGUI_API void ShrinkWidths(ImGuiShrinkWidthItem *items, int count, float width_excess);
+
+// Logging/Capture
+IMGUI_API void LogBegin(ImGuiLogType type,
+                        int auto_open_depth);  // -> BeginCapture() when we design v2 api, for now
+                                               // stay under the radar by using the old name.
+IMGUI_API void LogToBuffer(int auto_open_depth = -1);  // Start logging/capturing to internal buffer
+
+// Popups, Modals, Tooltips
+IMGUI_API void OpenPopupEx(ImGuiID id);
+IMGUI_API void ClosePopupToLevel(int remaining, bool restore_focus_to_window_under_popup);
+IMGUI_API void ClosePopupsOverWindow(ImGuiWindow *ref_window,
+                                     bool restore_focus_to_window_under_popup);
+IMGUI_API bool IsPopupOpen(ImGuiID id);  // Test for id within current popup stack level (currently
+                                         // begin-ed into); this doesn't scan the whole popup stack!
+IMGUI_API bool BeginPopupEx(ImGuiID id, ImGuiWindowFlags extra_flags);
+IMGUI_API void BeginTooltipEx(ImGuiWindowFlags extra_flags, bool override_previous_tooltip = true);
+IMGUI_API ImGuiWindow *GetTopMostPopupModal();
+IMGUI_API ImVec2 FindBestWindowPosForPopup(ImGuiWindow *window);
+IMGUI_API ImVec2
+FindBestWindowPosForPopupEx(const ImVec2 &ref_pos,
+                            const ImVec2 &size,
+                            ImGuiDir *last_dir,
+                            const ImRect &r_outer,
+                            const ImRect &r_avoid,
+                            ImGuiPopupPositionPolicy policy = ImGuiPopupPositionPolicy_Default);
+
+// Navigation
+IMGUI_API void NavInitWindow(ImGuiWindow *window, bool force_reinit);
+IMGUI_API bool NavMoveRequestButNoResultYet();
+IMGUI_API void NavMoveRequestCancel();
+IMGUI_API void NavMoveRequestForward(ImGuiDir move_dir,
+                                     ImGuiDir clip_dir,
+                                     const ImRect &bb_rel,
+                                     ImGuiNavMoveFlags move_flags);
+IMGUI_API void NavMoveRequestTryWrapping(ImGuiWindow *window, ImGuiNavMoveFlags move_flags);
+IMGUI_API float GetNavInputAmount(ImGuiNavInput n, ImGuiInputReadMode mode);
+IMGUI_API ImVec2 GetNavInputAmount2d(ImGuiNavDirSourceFlags dir_sources,
+                                     ImGuiInputReadMode mode,
+                                     float slow_factor = 0.0f,
+                                     float fast_factor = 0.0f);
+IMGUI_API int CalcTypematicPressedRepeatAmount(float t,
+                                               float t_prev,
+                                               float repeat_delay,
+                                               float repeat_rate);
+IMGUI_API void ActivateItem(ImGuiID id);  // Remotely activate a button, checkbox, tree node etc.
+                                          // given its unique ID. activation is queued and processed
+                                          // on the next frame when the item is encountered again.
+IMGUI_API void SetNavID(ImGuiID id, int nav_layer);
+IMGUI_API void SetNavIDWithRectRel(ImGuiID id, int nav_layer, const ImRect &rect_rel);
+
+// Inputs
+inline bool IsKeyPressedMap(ImGuiKey key, bool repeat = true)
+{
+    const int key_index = GImGui->IO.KeyMap[key];
+    return (key_index >= 0) ? IsKeyPressed(key_index, repeat) : false;
+}
+inline bool IsNavInputDown(ImGuiNavInput n)
+{
+    return GImGui->IO.NavInputs[n] > 0.0f;
+}
+inline bool IsNavInputPressed(ImGuiNavInput n, ImGuiInputReadMode mode)
+{
+    return GetNavInputAmount(n, mode) > 0.0f;
+}
+inline bool IsNavInputPressedAnyOfTwo(ImGuiNavInput n1, ImGuiNavInput n2, ImGuiInputReadMode mode)
+{
+    return (GetNavInputAmount(n1, mode) + GetNavInputAmount(n2, mode)) > 0.0f;
+}
+
+// Drag and Drop
+IMGUI_API bool BeginDragDropTargetCustom(const ImRect &bb, ImGuiID id);
+IMGUI_API void ClearDragDrop();
+IMGUI_API bool IsDragDropPayloadBeingAccepted();
+
+// New Columns API (FIXME-WIP)
+IMGUI_API void BeginColumns(
+    const char *str_id,
+    int count,
+    ImGuiColumnsFlags flags = 0);  // setup number of columns. use an identifier to distinguish
+                                   // multiple column sets. close with EndColumns().
+IMGUI_API void EndColumns();       // close columns
+IMGUI_API void PushColumnClipRect(int column_index);
+IMGUI_API void PushColumnsBackground();
+IMGUI_API void PopColumnsBackground();
+IMGUI_API ImGuiID GetColumnsID(const char *str_id, int count);
+IMGUI_API ImGuiColumns *FindOrCreateColumns(ImGuiWindow *window, ImGuiID id);
+
+// Tab Bars
+IMGUI_API bool BeginTabBarEx(ImGuiTabBar *tab_bar, const ImRect &bb, ImGuiTabBarFlags flags);
+IMGUI_API ImGuiTabItem *TabBarFindTabByID(ImGuiTabBar *tab_bar, ImGuiID tab_id);
+IMGUI_API void TabBarRemoveTab(ImGuiTabBar *tab_bar, ImGuiID tab_id);
+IMGUI_API void TabBarCloseTab(ImGuiTabBar *tab_bar, ImGuiTabItem *tab);
+IMGUI_API void TabBarQueueChangeTabOrder(ImGuiTabBar *tab_bar, const ImGuiTabItem *tab, int dir);
+IMGUI_API bool TabItemEx(ImGuiTabBar *tab_bar,
+                         const char *label,
+                         bool *p_open,
+                         ImGuiTabItemFlags flags);
+IMGUI_API ImVec2 TabItemCalcSize(const char *label, bool has_close_button);
+IMGUI_API void TabItemBackground(ImDrawList *draw_list,
+                                 const ImRect &bb,
+                                 ImGuiTabItemFlags flags,
+                                 ImU32 col);
+IMGUI_API bool TabItemLabelAndCloseButton(ImDrawList *draw_list,
+                                          const ImRect &bb,
+                                          ImGuiTabItemFlags flags,
+                                          ImVec2 frame_padding,
+                                          const char *label,
+                                          ImGuiID tab_id,
+                                          ImGuiID close_button_id);
+
+// Render helpers
+// AVOID USING OUTSIDE OF IMGUI.CPP! NOT FOR PUBLIC CONSUMPTION. THOSE FUNCTIONS ARE A MESS. THEIR
+// SIGNATURE AND BEHAVIOR WILL CHANGE, THEY NEED TO BE REFACTORED INTO SOMETHING DECENT. NB: All
+// position are in absolute pixels coordinates (we are never using window coordinates internally)
+IMGUI_API void RenderText(ImVec2 pos,
+                          const char *text,
+                          const char *text_end      = NULL,
+                          bool hide_text_after_hash = true);
+IMGUI_API void RenderTextWrapped(ImVec2 pos,
+                                 const char *text,
+                                 const char *text_end,
+                                 float wrap_width);
+IMGUI_API void RenderTextClipped(const ImVec2 &pos_min,
+                                 const ImVec2 &pos_max,
+                                 const char *text,
+                                 const char *text_end,
+                                 const ImVec2 *text_size_if_known,
+                                 const ImVec2 &align     = ImVec2(0, 0),
+                                 const ImRect *clip_rect = NULL);
+IMGUI_API void RenderTextClippedEx(ImDrawList *draw_list,
+                                   const ImVec2 &pos_min,
+                                   const ImVec2 &pos_max,
+                                   const char *text,
+                                   const char *text_end,
+                                   const ImVec2 *text_size_if_known,
+                                   const ImVec2 &align     = ImVec2(0, 0),
+                                   const ImRect *clip_rect = NULL);
+IMGUI_API void RenderTextEllipsis(ImDrawList *draw_list,
+                                  const ImVec2 &pos_min,
+                                  const ImVec2 &pos_max,
+                                  float clip_max_x,
+                                  float ellipsis_max_x,
+                                  const char *text,
+                                  const char *text_end,
+                                  const ImVec2 *text_size_if_known);
+IMGUI_API void RenderFrame(ImVec2 p_min,
+                           ImVec2 p_max,
+                           ImU32 fill_col,
+                           bool border    = true,
+                           float rounding = 0.0f);
+IMGUI_API void RenderFrameBorder(ImVec2 p_min, ImVec2 p_max, float rounding = 0.0f);
+IMGUI_API void RenderColorRectWithAlphaCheckerboard(ImVec2 p_min,
+                                                    ImVec2 p_max,
+                                                    ImU32 fill_col,
+                                                    float grid_step,
+                                                    ImVec2 grid_off,
+                                                    float rounding             = 0.0f,
+                                                    int rounding_corners_flags = ~0);
+IMGUI_API void RenderCheckMark(ImVec2 pos, ImU32 col, float sz);
+IMGUI_API void RenderNavHighlight(
+    const ImRect &bb,
+    ImGuiID id,
+    ImGuiNavHighlightFlags flags = ImGuiNavHighlightFlags_TypeDefault);  // Navigation highlight
+IMGUI_API const char *FindRenderedTextEnd(
+    const char *text,
+    const char *text_end = NULL);  // Find the optional ## from which we stop displaying text.
+IMGUI_API void LogRenderedText(const ImVec2 *ref_pos,
+                               const char *text,
+                               const char *text_end = NULL);
+
+// Render helpers (those functions don't access any ImGui state!)
+IMGUI_API void RenderArrow(ImDrawList *draw_list,
+                           ImVec2 pos,
+                           ImU32 col,
+                           ImGuiDir dir,
+                           float scale = 1.0f);
+IMGUI_API void RenderBullet(ImDrawList *draw_list, ImVec2 pos, ImU32 col);
+IMGUI_API void RenderMouseCursor(ImDrawList *draw_list,
+                                 ImVec2 pos,
+                                 float scale,
+                                 ImGuiMouseCursor mouse_cursor = ImGuiMouseCursor_Arrow);
+IMGUI_API void RenderArrowPointingAt(ImDrawList *draw_list,
+                                     ImVec2 pos,
+                                     ImVec2 half_sz,
+                                     ImGuiDir direction,
+                                     ImU32 col);
+IMGUI_API void RenderRectFilledRangeH(ImDrawList *draw_list,
+                                      const ImRect &rect,
+                                      ImU32 col,
+                                      float x_start_norm,
+                                      float x_end_norm,
+                                      float rounding);
+IMGUI_API void RenderPixelEllipsis(ImDrawList *draw_list, ImVec2 pos, ImU32 col, int count);
+
+#ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+// 2019/06/07: Updating prototypes of some of the internal functions. Leaving those for reference
+// for a short while.
+inline void RenderArrow(ImVec2 pos, ImGuiDir dir, float scale = 1.0f)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    RenderArrow(window->DrawList, pos, GetColorU32(ImGuiCol_Text), dir, scale);
+}
+inline void RenderBullet(ImVec2 pos)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    RenderBullet(window->DrawList, pos, GetColorU32(ImGuiCol_Text));
+}
+#endif
+
+// Widgets
+IMGUI_API void TextEx(const char *text, const char *text_end = NULL, ImGuiTextFlags flags = 0);
+IMGUI_API bool ButtonEx(const char *label,
+                        const ImVec2 &size_arg = ImVec2(0, 0),
+                        ImGuiButtonFlags flags = 0);
+IMGUI_API bool CloseButton(ImGuiID id, const ImVec2 &pos);
+IMGUI_API bool CollapseButton(ImGuiID id, const ImVec2 &pos);
+IMGUI_API bool ArrowButtonEx(const char *str_id,
+                             ImGuiDir dir,
+                             ImVec2 size_arg,
+                             ImGuiButtonFlags flags);
+IMGUI_API void Scrollbar(ImGuiAxis axis);
+IMGUI_API bool ScrollbarEx(const ImRect &bb,
+                           ImGuiID id,
+                           ImGuiAxis axis,
+                           float *p_scroll_v,
+                           float avail_v,
+                           float contents_v,
+                           ImDrawCornerFlags rounding_corners);
+IMGUI_API ImGuiID GetScrollbarID(ImGuiWindow *window, ImGuiAxis axis);
+IMGUI_API void SeparatorEx(ImGuiSeparatorFlags flags);
+
+// Widgets low-level behaviors
+IMGUI_API bool ButtonBehavior(const ImRect &bb,
+                              ImGuiID id,
+                              bool *out_hovered,
+                              bool *out_held,
+                              ImGuiButtonFlags flags = 0);
+IMGUI_API bool DragBehavior(ImGuiID id,
+                            ImGuiDataType data_type,
+                            void *v,
+                            float v_speed,
+                            const void *v_min,
+                            const void *v_max,
+                            const char *format,
+                            float power,
+                            ImGuiDragFlags flags);
+IMGUI_API bool SliderBehavior(const ImRect &bb,
+                              ImGuiID id,
+                              ImGuiDataType data_type,
+                              void *v,
+                              const void *v_min,
+                              const void *v_max,
+                              const char *format,
+                              float power,
+                              ImGuiSliderFlags flags,
+                              ImRect *out_grab_bb);
+IMGUI_API bool SplitterBehavior(const ImRect &bb,
+                                ImGuiID id,
+                                ImGuiAxis axis,
+                                float *size1,
+                                float *size2,
+                                float min_size1,
+                                float min_size2,
+                                float hover_extend           = 0.0f,
+                                float hover_visibility_delay = 0.0f);
+IMGUI_API bool TreeNodeBehavior(ImGuiID id,
+                                ImGuiTreeNodeFlags flags,
+                                const char *label,
+                                const char *label_end = NULL);
+IMGUI_API bool TreeNodeBehaviorIsOpen(
+    ImGuiID id,
+    ImGuiTreeNodeFlags flags =
+        0);  // Consume previous SetNextItemOpen() data, if any. May return true when logging
+IMGUI_API void TreePushOverrideID(ImGuiID id);
+
+// Template functions are instantiated in imgui_widgets.cpp for a finite number of types.
+// To use them externally (for custom widget) you may need an "extern template" statement in your
+// code in order to link to existing instances and silence Clang warnings (see #2036). e.g. " extern
+// template IMGUI_API float RoundScalarWithFormatT<float, float>(const char* format, ImGuiDataType
+// data_type, float v); "
+template <typename T, typename SIGNED_T, typename FLOAT_T>
+IMGUI_API bool DragBehaviorT(ImGuiDataType data_type,
+                             T *v,
+                             float v_speed,
+                             T v_min,
+                             T v_max,
+                             const char *format,
+                             float power,
+                             ImGuiDragFlags flags);
+template <typename T, typename SIGNED_T, typename FLOAT_T>
+IMGUI_API bool SliderBehaviorT(const ImRect &bb,
+                               ImGuiID id,
+                               ImGuiDataType data_type,
+                               T *v,
+                               T v_min,
+                               T v_max,
+                               const char *format,
+                               float power,
+                               ImGuiSliderFlags flags,
+                               ImRect *out_grab_bb);
+template <typename T, typename FLOAT_T>
+IMGUI_API float SliderCalcRatioFromValueT(ImGuiDataType data_type,
+                                          T v,
+                                          T v_min,
+                                          T v_max,
+                                          float power,
+                                          float linear_zero_pos);
+template <typename T, typename SIGNED_T>
+IMGUI_API T RoundScalarWithFormatT(const char *format, ImGuiDataType data_type, T v);
+
+// Data type helpers
+IMGUI_API const ImGuiDataTypeInfo *DataTypeGetInfo(ImGuiDataType data_type);
+IMGUI_API int DataTypeFormatString(char *buf,
+                                   int buf_size,
+                                   ImGuiDataType data_type,
+                                   const void *data_ptr,
+                                   const char *format);
+IMGUI_API void DataTypeApplyOp(ImGuiDataType data_type,
+                               int op,
+                               void *output,
+                               void *arg_1,
+                               const void *arg_2);
+IMGUI_API bool DataTypeApplyOpFromText(const char *buf,
+                                       const char *initial_value_buf,
+                                       ImGuiDataType data_type,
+                                       void *data_ptr,
+                                       const char *format);
+
+// InputText
+IMGUI_API bool InputTextEx(const char *label,
+                           const char *hint,
+                           char *buf,
+                           int buf_size,
+                           const ImVec2 &size_arg,
+                           ImGuiInputTextFlags flags,
+                           ImGuiInputTextCallback callback = NULL,
+                           void *user_data                 = NULL);
+IMGUI_API bool TempInputTextScalar(const ImRect &bb,
+                                   ImGuiID id,
+                                   const char *label,
+                                   ImGuiDataType data_type,
+                                   void *data_ptr,
+                                   const char *format);
+inline bool TempInputTextIsActive(ImGuiID id)
+{
+    ImGuiContext &g = *GImGui;
+    return (g.ActiveId == id && g.TempInputTextId == id);
+}
+
+// Color
+IMGUI_API void ColorTooltip(const char *text, const float *col, ImGuiColorEditFlags flags);
+IMGUI_API void ColorEditOptionsPopup(const float *col, ImGuiColorEditFlags flags);
+IMGUI_API void ColorPickerOptionsPopup(const float *ref_col, ImGuiColorEditFlags flags);
+
+// Plot
+IMGUI_API void PlotEx(ImGuiPlotType plot_type,
+                      const char *label,
+                      float (*values_getter)(void *data, int idx),
+                      void *data,
+                      int values_count,
+                      int values_offset,
+                      const char *overlay_text,
+                      float scale_min,
+                      float scale_max,
+                      ImVec2 frame_size);
+
+// Shade functions (write over already created vertices)
+IMGUI_API void ShadeVertsLinearColorGradientKeepAlpha(ImDrawList *draw_list,
+                                                      int vert_start_idx,
+                                                      int vert_end_idx,
+                                                      ImVec2 gradient_p0,
+                                                      ImVec2 gradient_p1,
+                                                      ImU32 col0,
+                                                      ImU32 col1);
+IMGUI_API void ShadeVertsLinearUV(ImDrawList *draw_list,
+                                  int vert_start_idx,
+                                  int vert_end_idx,
+                                  const ImVec2 &a,
+                                  const ImVec2 &b,
+                                  const ImVec2 &uv_a,
+                                  const ImVec2 &uv_b,
+                                  bool clamp);
+
+}  // namespace ImGui
+
+// ImFontAtlas internals
+IMGUI_API bool ImFontAtlasBuildWithStbTruetype(ImFontAtlas *atlas);
+IMGUI_API void ImFontAtlasBuildRegisterDefaultCustomRects(ImFontAtlas *atlas);
+IMGUI_API void ImFontAtlasBuildSetupFont(ImFontAtlas *atlas,
+                                         ImFont *font,
+                                         ImFontConfig *font_config,
+                                         float ascent,
+                                         float descent);
+IMGUI_API void ImFontAtlasBuildPackCustomRects(ImFontAtlas *atlas, void *stbrp_context_opaque);
+IMGUI_API void ImFontAtlasBuildFinish(ImFontAtlas *atlas);
+IMGUI_API void ImFontAtlasBuildMultiplyCalcLookupTable(unsigned char out_table[256],
+                                                       float in_multiply_factor);
+IMGUI_API void ImFontAtlasBuildMultiplyRectAlpha8(const unsigned char table[256],
+                                                  unsigned char *pixels,
+                                                  int x,
+                                                  int y,
+                                                  int w,
+                                                  int h,
+                                                  int stride);
+
+// Test engine hooks (imgui-test)
+//#define IMGUI_ENABLE_TEST_ENGINE
+#ifdef IMGUI_ENABLE_TEST_ENGINE
+extern void ImGuiTestEngineHook_PreNewFrame(ImGuiContext *ctx);
+extern void ImGuiTestEngineHook_PostNewFrame(ImGuiContext *ctx);
+extern void ImGuiTestEngineHook_ItemAdd(ImGuiContext *ctx, const ImRect &bb, ImGuiID id);
+extern void ImGuiTestEngineHook_ItemInfo(ImGuiContext *ctx,
+                                         ImGuiID id,
+                                         const char *label,
+                                         ImGuiItemStatusFlags flags);
+extern void ImGuiTestEngineHook_Log(ImGuiContext *ctx, const char *fmt, ...);
+#define IMGUI_TEST_ENGINE_ITEM_ADD(_BB, _ID) \
+    ImGuiTestEngineHook_ItemAdd(&g, _BB, _ID)  // Register item bounding box
+#define IMGUI_TEST_ENGINE_ITEM_INFO(_ID, _LABEL, _FLAGS) \
+    ImGuiTestEngineHook_ItemInfo(&g, _ID, _LABEL,        \
+                                 _FLAGS)  // Register item label and status flags (optional)
+#define IMGUI_TEST_ENGINE_LOG(_FMT, ...) \
+    ImGuiTestEngineHook_Log(&g, _FMT, __VA_ARGS__)  // Custom log entry from user land into test log
+#else
+#define IMGUI_TEST_ENGINE_ITEM_ADD(_BB, _ID) \
+    do                                       \
+    {                                        \
+    } while (0)
+#define IMGUI_TEST_ENGINE_ITEM_INFO(_ID, _LABEL, _FLAGS) \
+    do                                                   \
+    {                                                    \
+    } while (0)
+#define IMGUI_TEST_ENGINE_LOG(_FMT, ...) \
+    do                                   \
+    {                                    \
+    } while (0)
+#endif
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif

--- a/third_party/imgui/imgui_widgets.cpp
+++ b/third_party/imgui/imgui_widgets.cpp
@@ -1,0 +1,8939 @@
+// dear imgui, v1.72 WIP
+// (widgets code)
+
+/*
+
+Index of this file:
+
+// [SECTION] Forward Declarations
+// [SECTION] Widgets: Text, etc.
+// [SECTION] Widgets: Main (Button, Image, Checkbox, RadioButton, ProgressBar, Bullet, etc.)
+// [SECTION] Widgets: Low-level Layout helpers (Spacing, Dummy, NewLine, Separator, etc.)
+// [SECTION] Widgets: ComboBox
+// [SECTION] Data Type and Data Formatting Helpers
+// [SECTION] Widgets: DragScalar, DragFloat, DragInt, etc.
+// [SECTION] Widgets: SliderScalar, SliderFloat, SliderInt, etc.
+// [SECTION] Widgets: InputScalar, InputFloat, InputInt, etc.
+// [SECTION] Widgets: InputText, InputTextMultiline
+// [SECTION] Widgets: ColorEdit, ColorPicker, ColorButton, etc.
+// [SECTION] Widgets: TreeNode, CollapsingHeader, etc.
+// [SECTION] Widgets: Selectable
+// [SECTION] Widgets: ListBox
+// [SECTION] Widgets: PlotLines, PlotHistogram
+// [SECTION] Widgets: Value helpers
+// [SECTION] Widgets: MenuItem, BeginMenu, EndMenu, etc.
+// [SECTION] Widgets: BeginTabBar, EndTabBar, etc.
+// [SECTION] Widgets: BeginTabItem, EndTabItem, etc.
+
+*/
+
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#include "imgui.h"
+#ifndef IMGUI_DEFINE_MATH_OPERATORS
+#define IMGUI_DEFINE_MATH_OPERATORS
+#endif
+#include "imgui_internal.h"
+
+#include <ctype.h>                         // toupper
+#if defined(_MSC_VER) && _MSC_VER <= 1500  // MSVC 2008 or earlier
+#include <stddef.h>                        // intptr_t
+#else
+#include <stdint.h>  // intptr_t
+#endif
+
+// Visual Studio warnings
+#ifdef _MSC_VER
+#pragma warning(disable : 4127)  // condition expression is constant
+#pragma warning(disable : 4996)  // 'This function or variable may be unsafe': strcpy, strdup,
+                                 // sprintf, vsnprintf, sscanf, fopen
+#endif
+
+// Clang/GCC warnings with -Weverything
+#if defined(__clang__)
+#pragma clang diagnostic ignored "-Wold-style-cast"  // warning : use of old-style cast // yes, they
+                                                     // are more terse.
+#pragma clang diagnostic ignored \
+    "-Wfloat-equal"  // warning : comparing floating point with == or != is unsafe   // storing and
+                     // comparing against same constants (typically 0.0f) is ok.
+#pragma clang diagnostic ignored \
+    "-Wformat-nonliteral"  // warning : format string is not a string literal              //
+                           // passing non-literal to vsnformat(). yes, user passing incorrect format
+                           // strings can crash the code.
+#pragma clang diagnostic ignored \
+    "-Wsign-conversion"  // warning : implicit conversion changes signedness             //
+#if __has_warning("-Wzero-as-null-pointer-constant")
+#pragma clang diagnostic ignored \
+    "-Wzero-as-null-pointer-constant"  // warning : zero as null pointer constant              //
+                                       // some standard header variations use #define NULL 0
+#endif
+#if __has_warning("-Wdouble-promotion")
+#pragma clang diagnostic ignored \
+    "-Wdouble-promotion"  // warning: implicit conversion from 'float' to 'double' when passing
+                          // argument to function  // using printf() is a misery with this as C++
+                          // va_arg ellipsis changes float to double.
+#endif
+#elif defined(__GNUC__)
+#pragma GCC diagnostic ignored \
+    "-Wpragmas"  // warning: unknown option after '#pragma GCC diagnostic' kind
+#pragma GCC diagnostic ignored \
+    "-Wformat-nonliteral"  // warning: format not a string literal, format string not checked
+#pragma GCC diagnostic ignored \
+    "-Wclass-memaccess"  // [__GNUC__ >= 8] warning: 'memset/memcpy' clearing/writing an object of
+                         // type 'xxxx' with no trivial copy-assignment; use assignment or
+                         // value-initialization instead
+#endif
+
+//-------------------------------------------------------------------------
+// Data
+//-------------------------------------------------------------------------
+
+// Those MIN/MAX values are not define because we need to point to them
+static const signed char IM_S8_MIN     = -128;
+static const signed char IM_S8_MAX     = 127;
+static const unsigned char IM_U8_MIN   = 0;
+static const unsigned char IM_U8_MAX   = 0xFF;
+static const signed short IM_S16_MIN   = -32768;
+static const signed short IM_S16_MAX   = 32767;
+static const unsigned short IM_U16_MIN = 0;
+static const unsigned short IM_U16_MAX = 0xFFFF;
+static const ImS32 IM_S32_MIN          = INT_MIN;  // (-2147483647 - 1), (0x80000000);
+static const ImS32 IM_S32_MAX          = INT_MAX;  // (2147483647), (0x7FFFFFFF)
+static const ImU32 IM_U32_MIN          = 0;
+static const ImU32 IM_U32_MAX          = UINT_MAX;  // (0xFFFFFFFF)
+#ifdef LLONG_MIN
+static const ImS64 IM_S64_MIN = LLONG_MIN;  // (-9223372036854775807ll - 1ll);
+static const ImS64 IM_S64_MAX = LLONG_MAX;  // (9223372036854775807ll);
+#else
+static const ImS64 IM_S64_MIN = -9223372036854775807LL - 1;
+static const ImS64 IM_S64_MAX = 9223372036854775807LL;
+#endif
+static const ImU64 IM_U64_MIN = 0;
+#ifdef ULLONG_MAX
+static const ImU64 IM_U64_MAX = ULLONG_MAX;  // (0xFFFFFFFFFFFFFFFFull);
+#else
+static const ImU64 IM_U64_MAX = (2ULL * 9223372036854775807LL + 1);
+#endif
+
+//-------------------------------------------------------------------------
+// [SECTION] Forward Declarations
+//-------------------------------------------------------------------------
+
+// For InputTextEx()
+static bool InputTextFilterCharacter(unsigned int *p_char,
+                                     ImGuiInputTextFlags flags,
+                                     ImGuiInputTextCallback callback,
+                                     void *user_data);
+static int InputTextCalcTextLenAndLineCount(const char *text_begin, const char **out_text_end);
+static ImVec2 InputTextCalcTextSizeW(const ImWchar *text_begin,
+                                     const ImWchar *text_end,
+                                     const ImWchar **remaining = NULL,
+                                     ImVec2 *out_offset        = NULL,
+                                     bool stop_on_new_line     = false);
+
+//-------------------------------------------------------------------------
+// [SECTION] Widgets: Text, etc.
+//-------------------------------------------------------------------------
+// - TextUnformatted()
+// - Text()
+// - TextV()
+// - TextColored()
+// - TextColoredV()
+// - TextDisabled()
+// - TextDisabledV()
+// - TextWrapped()
+// - TextWrappedV()
+// - LabelText()
+// - LabelTextV()
+// - BulletText()
+// - BulletTextV()
+//-------------------------------------------------------------------------
+
+void ImGui::TextEx(const char *text, const char *text_end, ImGuiTextFlags flags)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return;
+
+    ImGuiContext &g = *GImGui;
+    IM_ASSERT(text != NULL);
+    const char *text_begin = text;
+    if (text_end == NULL)
+        text_end = text + strlen(text);  // FIXME-OPT
+
+    const ImVec2 text_pos(window->DC.CursorPos.x,
+                          window->DC.CursorPos.y + window->DC.CurrLineTextBaseOffset);
+    const float wrap_pos_x  = window->DC.TextWrapPos;
+    const bool wrap_enabled = (wrap_pos_x >= 0.0f);
+    if (text_end - text > 2000 && !wrap_enabled)
+    {
+        // Long text!
+        // Perform manual coarse clipping to optimize for long multi-line text
+        // - From this point we will only compute the width of lines that are visible. Optimization
+        // only available when word-wrapping is disabled.
+        // - We also don't vertically center the text within the line full height, which is unlikely
+        // to matter because we are likely the biggest and only item on the line.
+        // - We use memchr(), pay attention that well optimized versions of those str/mem functions
+        // are much faster than a casually written loop.
+        const char *line        = text;
+        const float line_height = GetTextLineHeight();
+        ImVec2 text_size(0, 0);
+
+        // Lines to skip (can't skip when logging text)
+        ImVec2 pos = text_pos;
+        if (!g.LogEnabled)
+        {
+            int lines_skippable = (int)((window->ClipRect.Min.y - text_pos.y) / line_height);
+            if (lines_skippable > 0)
+            {
+                int lines_skipped = 0;
+                while (line < text_end && lines_skipped < lines_skippable)
+                {
+                    const char *line_end = (const char *)memchr(line, '\n', text_end - line);
+                    if (!line_end)
+                        line_end = text_end;
+                    if ((flags & ImGuiTextFlags_NoWidthForLargeClippedText) == 0)
+                        text_size.x = ImMax(text_size.x, CalcTextSize(line, line_end).x);
+                    line = line_end + 1;
+                    lines_skipped++;
+                }
+                pos.y += lines_skipped * line_height;
+            }
+        }
+
+        // Lines to render
+        if (line < text_end)
+        {
+            ImRect line_rect(pos, pos + ImVec2(FLT_MAX, line_height));
+            while (line < text_end)
+            {
+                if (IsClippedEx(line_rect, 0, false))
+                    break;
+
+                const char *line_end = (const char *)memchr(line, '\n', text_end - line);
+                if (!line_end)
+                    line_end = text_end;
+                text_size.x = ImMax(text_size.x, CalcTextSize(line, line_end).x);
+                RenderText(pos, line, line_end, false);
+                line = line_end + 1;
+                line_rect.Min.y += line_height;
+                line_rect.Max.y += line_height;
+                pos.y += line_height;
+            }
+
+            // Count remaining lines
+            int lines_skipped = 0;
+            while (line < text_end)
+            {
+                const char *line_end = (const char *)memchr(line, '\n', text_end - line);
+                if (!line_end)
+                    line_end = text_end;
+                if ((flags & ImGuiTextFlags_NoWidthForLargeClippedText) == 0)
+                    text_size.x = ImMax(text_size.x, CalcTextSize(line, line_end).x);
+                line = line_end + 1;
+                lines_skipped++;
+            }
+            pos.y += lines_skipped * line_height;
+        }
+        text_size.y = (pos - text_pos).y;
+
+        ImRect bb(text_pos, text_pos + text_size);
+        ItemSize(text_size);
+        ItemAdd(bb, 0);
+    }
+    else
+    {
+        const float wrap_width =
+            wrap_enabled ? CalcWrapWidthForPos(window->DC.CursorPos, wrap_pos_x) : 0.0f;
+        const ImVec2 text_size = CalcTextSize(text_begin, text_end, false, wrap_width);
+
+        ImRect bb(text_pos, text_pos + text_size);
+        ItemSize(text_size);
+        if (!ItemAdd(bb, 0))
+            return;
+
+        // Render (we don't hide text after ## in this end-user function)
+        RenderTextWrapped(bb.Min, text_begin, text_end, wrap_width);
+    }
+}
+
+void ImGui::TextUnformatted(const char *text, const char *text_end)
+{
+    TextEx(text, text_end, ImGuiTextFlags_NoWidthForLargeClippedText);
+}
+
+void ImGui::Text(const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    TextV(fmt, args);
+    va_end(args);
+}
+
+void ImGui::TextV(const char *fmt, va_list args)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return;
+
+    ImGuiContext &g = *GImGui;
+    const char *text_end =
+        g.TempBuffer + ImFormatStringV(g.TempBuffer, IM_ARRAYSIZE(g.TempBuffer), fmt, args);
+    TextEx(g.TempBuffer, text_end, ImGuiTextFlags_NoWidthForLargeClippedText);
+}
+
+void ImGui::TextColored(const ImVec4 &col, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    TextColoredV(col, fmt, args);
+    va_end(args);
+}
+
+void ImGui::TextColoredV(const ImVec4 &col, const char *fmt, va_list args)
+{
+    PushStyleColor(ImGuiCol_Text, col);
+    TextV(fmt, args);
+    PopStyleColor();
+}
+
+void ImGui::TextDisabled(const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    TextDisabledV(fmt, args);
+    va_end(args);
+}
+
+void ImGui::TextDisabledV(const char *fmt, va_list args)
+{
+    PushStyleColor(ImGuiCol_Text, GImGui->Style.Colors[ImGuiCol_TextDisabled]);
+    TextV(fmt, args);
+    PopStyleColor();
+}
+
+void ImGui::TextWrapped(const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    TextWrappedV(fmt, args);
+    va_end(args);
+}
+
+void ImGui::TextWrappedV(const char *fmt, va_list args)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    bool need_backup =
+        (window->DC.TextWrapPos < 0.0f);  // Keep existing wrap position if one is already set
+    if (need_backup)
+        PushTextWrapPos(0.0f);
+    TextV(fmt, args);
+    if (need_backup)
+        PopTextWrapPos();
+}
+
+void ImGui::LabelText(const char *label, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    LabelTextV(label, fmt, args);
+    va_end(args);
+}
+
+// Add a label+text combo aligned to other label+value widgets
+void ImGui::LabelTextV(const char *label, const char *fmt, va_list args)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return;
+
+    ImGuiContext &g         = *GImGui;
+    const ImGuiStyle &style = g.Style;
+    const float w           = CalcItemWidth();
+
+    const ImVec2 label_size = CalcTextSize(label, NULL, true);
+    const ImRect value_bb(
+        window->DC.CursorPos,
+        window->DC.CursorPos + ImVec2(w, label_size.y + style.FramePadding.y * 2));
+    const ImRect total_bb(window->DC.CursorPos,
+                          window->DC.CursorPos +
+                              ImVec2(w + (label_size.x > 0.0f ? style.ItemInnerSpacing.x : 0.0f),
+                                     style.FramePadding.y * 2) +
+                              label_size);
+    ItemSize(total_bb, style.FramePadding.y);
+    if (!ItemAdd(total_bb, 0))
+        return;
+
+    // Render
+    const char *value_text_begin = &g.TempBuffer[0];
+    const char *value_text_end =
+        value_text_begin + ImFormatStringV(g.TempBuffer, IM_ARRAYSIZE(g.TempBuffer), fmt, args);
+    RenderTextClipped(value_bb.Min, value_bb.Max, value_text_begin, value_text_end, NULL,
+                      ImVec2(0.0f, 0.5f));
+    if (label_size.x > 0.0f)
+        RenderText(ImVec2(value_bb.Max.x + style.ItemInnerSpacing.x,
+                          value_bb.Min.y + style.FramePadding.y),
+                   label);
+}
+
+void ImGui::BulletText(const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    BulletTextV(fmt, args);
+    va_end(args);
+}
+
+// Text with a little bullet aligned to the typical tree node.
+void ImGui::BulletTextV(const char *fmt, va_list args)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return;
+
+    ImGuiContext &g         = *GImGui;
+    const ImGuiStyle &style = g.Style;
+
+    const char *text_begin = g.TempBuffer;
+    const char *text_end =
+        text_begin + ImFormatStringV(g.TempBuffer, IM_ARRAYSIZE(g.TempBuffer), fmt, args);
+    const ImVec2 label_size = CalcTextSize(text_begin, text_end, false);
+    const float text_base_offset_y =
+        ImMax(0.0f, window->DC.CurrLineTextBaseOffset);  // Latch before ItemSize changes it
+    const float line_height = ImMax(
+        ImMin(window->DC.CurrLineSize.y, g.FontSize + g.Style.FramePadding.y * 2), g.FontSize);
+    const ImRect bb(
+        window->DC.CursorPos,
+        window->DC.CursorPos +
+            ImVec2(g.FontSize +
+                       (label_size.x > 0.0f ? (label_size.x + style.FramePadding.x * 2) : 0.0f),
+                   ImMax(line_height, label_size.y)));  // Empty text doesn't add padding
+    ItemSize(bb);
+    if (!ItemAdd(bb, 0))
+        return;
+
+    // Render
+    ImU32 text_col = GetColorU32(ImGuiCol_Text);
+    RenderBullet(window->DrawList,
+                 bb.Min + ImVec2(style.FramePadding.x + g.FontSize * 0.5f, line_height * 0.5f),
+                 text_col);
+    RenderText(bb.Min + ImVec2(g.FontSize + style.FramePadding.x * 2, text_base_offset_y),
+               text_begin, text_end, false);
+}
+
+//-------------------------------------------------------------------------
+// [SECTION] Widgets: Main
+//-------------------------------------------------------------------------
+// - ButtonBehavior() [Internal]
+// - Button()
+// - SmallButton()
+// - InvisibleButton()
+// - ArrowButton()
+// - CloseButton() [Internal]
+// - CollapseButton() [Internal]
+// - ScrollbarEx() [Internal]
+// - Scrollbar() [Internal]
+// - Image()
+// - ImageButton()
+// - Checkbox()
+// - CheckboxFlags()
+// - RadioButton()
+// - ProgressBar()
+// - Bullet()
+//-------------------------------------------------------------------------
+
+// The ButtonBehavior() function is key to many interactions and used by many/most widgets.
+// Because we handle so many cases (keyboard/gamepad navigation, drag and drop) and many specific
+// behavior (via ImGuiButtonFlags_), this code is a little complex. By far the most common path is
+// interacting with the Mouse using the default ImGuiButtonFlags_PressedOnClickRelease button
+// behavior. See the series of events below and the corresponding state reported by dear imgui:
+//------------------------------------------------------------------------------------------------------------------------------------------------
+// with PressedOnClickRelease:             return-value  IsItemHovered()  IsItemActive()
+// IsItemActivated()  IsItemDeactivated()  IsItemClicked()
+//   Frame N+0 (mouse is outside bb)        -             -                -               - - -
+//   Frame N+1 (mouse moves inside bb)      -             true             -               - - -
+//   Frame N+2 (mouse button is down)       -             true             true            true -
+//   true Frame N+3 (mouse button is down)       -             true             true            - -
+//   - Frame N+4 (mouse moves outside bb)     -             -                true            - - -
+//   Frame N+5 (mouse moves inside bb)      -             true             true            - - -
+//   Frame N+6 (mouse button is released)   true          true             -               - true -
+//   Frame N+7 (mouse button is released)   -             true             -               - - -
+//   Frame N+8 (mouse moves outside bb)     -             -                -               - - -
+//------------------------------------------------------------------------------------------------------------------------------------------------
+// with PressedOnClick:                    return-value  IsItemHovered()  IsItemActive()
+// IsItemActivated()  IsItemDeactivated()  IsItemClicked()
+//   Frame N+2 (mouse button is down)       true          true             true            true -
+//   true Frame N+3 (mouse button is down)       -             true             true            - -
+//   - Frame N+6 (mouse button is released)   -             true             -               - true
+//   - Frame N+7 (mouse button is released)   -             true             -               - - -
+//------------------------------------------------------------------------------------------------------------------------------------------------
+// with PressedOnRelease:                  return-value  IsItemHovered()  IsItemActive()
+// IsItemActivated()  IsItemDeactivated()  IsItemClicked()
+//   Frame N+2 (mouse button is down)       -             true             -               - - true
+//   Frame N+3 (mouse button is down)       -             true             -               - - -
+//   Frame N+6 (mouse button is released)   true          true             -               - - -
+//   Frame N+7 (mouse button is released)   -             true             -               - - -
+//------------------------------------------------------------------------------------------------------------------------------------------------
+// with PressedOnDoubleClick:              return-value  IsItemHovered()  IsItemActive()
+// IsItemActivated()  IsItemDeactivated()  IsItemClicked()
+//   Frame N+0 (mouse button is down)       -             true             -               - - true
+//   Frame N+1 (mouse button is down)       -             true             -               - - -
+//   Frame N+2 (mouse button is released)   -             true             -               - - -
+//   Frame N+3 (mouse button is released)   -             true             -               - - -
+//   Frame N+4 (mouse button is down)       true          true             true            true -
+//   true Frame N+5 (mouse button is down)       -             true             true            - -
+//   - Frame N+6 (mouse button is released)   -             true             -               - true
+//   - Frame N+7 (mouse button is released)   -             true             -               - - -
+//------------------------------------------------------------------------------------------------------------------------------------------------
+// Note that some combinations are supported,
+// - PressedOnDragDropHold can generally be associated with any flag.
+// - PressedOnDoubleClick can be associated by PressedOnClickRelease/PressedOnRelease, in which case
+// the second release event won't be reported.
+//------------------------------------------------------------------------------------------------------------------------------------------------
+// The behavior of the return-value changes when ImGuiButtonFlags_Repeat is set:
+//                                         Repeat+                  Repeat+           Repeat+
+//                                         Repeat+ PressedOnClickRelease    PressedOnClick
+//                                         PressedOnRelease    PressedOnDoubleClick
+//-------------------------------------------------------------------------------------------------------------------------------------------------
+//   Frame N+0 (mouse button is down)       -                        true              - true
+//   ...                                    -                        -                 - - Frame N +
+//   RepeatDelay                  true                     true              - true
+//   ...                                    -                        -                 - - Frame N +
+//   RepeatDelay + RepeatRate*N   true                     true              - true
+//-------------------------------------------------------------------------------------------------------------------------------------------------
+
+bool ImGui::ButtonBehavior(const ImRect &bb,
+                           ImGuiID id,
+                           bool *out_hovered,
+                           bool *out_held,
+                           ImGuiButtonFlags flags)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = GetCurrentWindow();
+
+    if (flags & ImGuiButtonFlags_Disabled)
+    {
+        if (out_hovered)
+            *out_hovered = false;
+        if (out_held)
+            *out_held = false;
+        if (g.ActiveId == id)
+            ClearActiveID();
+        return false;
+    }
+
+    // Default behavior requires click+release on same spot
+    if ((flags & (ImGuiButtonFlags_PressedOnClickRelease | ImGuiButtonFlags_PressedOnClick |
+                  ImGuiButtonFlags_PressedOnRelease | ImGuiButtonFlags_PressedOnDoubleClick)) == 0)
+        flags |= ImGuiButtonFlags_PressedOnClickRelease;
+
+    ImGuiWindow *backup_hovered_window = g.HoveredWindow;
+    const bool flatten_hovered_children =
+        (flags & ImGuiButtonFlags_FlattenChildren) && g.HoveredRootWindow == window;
+    if (flatten_hovered_children)
+        g.HoveredWindow = window;
+
+#ifdef IMGUI_ENABLE_TEST_ENGINE
+    if (id != 0 && window->DC.LastItemId != id)
+        ImGuiTestEngineHook_ItemAdd(&g, bb, id);
+#endif
+
+    bool pressed = false;
+    bool hovered = ItemHoverable(bb, id);
+
+    // Drag source doesn't report as hovered
+    if (hovered && g.DragDropActive && g.DragDropPayload.SourceId == id &&
+        !(g.DragDropSourceFlags & ImGuiDragDropFlags_SourceNoDisableHover))
+        hovered = false;
+
+    // Special mode for Drag and Drop where holding button pressed for a long time while dragging
+    // another item triggers the button
+    if (g.DragDropActive && (flags & ImGuiButtonFlags_PressedOnDragDropHold) &&
+        !(g.DragDropSourceFlags & ImGuiDragDropFlags_SourceNoHoldToOpenOthers))
+        if (IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByActiveItem))
+        {
+            hovered = true;
+            SetHoveredID(id);
+            if (CalcTypematicPressedRepeatAmount(
+                    g.HoveredIdTimer + 0.0001f, g.HoveredIdTimer + 0.0001f - g.IO.DeltaTime, 0.01f,
+                    0.70f))  // FIXME: Our formula for CalcTypematicPressedRepeatAmount() is fishy
+            {
+                pressed = true;
+                FocusWindow(window);
+            }
+        }
+
+    if (flatten_hovered_children)
+        g.HoveredWindow = backup_hovered_window;
+
+    // AllowOverlap mode (rarely used) requires previous frame HoveredId to be null or to match.
+    // This allows using patterns where a later submitted widget overlaps a previous one.
+    if (hovered && (flags & ImGuiButtonFlags_AllowItemOverlap) &&
+        (g.HoveredIdPreviousFrame != id && g.HoveredIdPreviousFrame != 0))
+        hovered = false;
+
+    // Mouse
+    if (hovered)
+    {
+        if (!(flags & ImGuiButtonFlags_NoKeyModifiers) ||
+            (!g.IO.KeyCtrl && !g.IO.KeyShift && !g.IO.KeyAlt))
+        {
+            if ((flags & ImGuiButtonFlags_PressedOnClickRelease) && g.IO.MouseClicked[0])
+            {
+                SetActiveID(id, window);
+                if (!(flags & ImGuiButtonFlags_NoNavFocus))
+                    SetFocusID(id, window);
+                FocusWindow(window);
+            }
+            if (((flags & ImGuiButtonFlags_PressedOnClick) && g.IO.MouseClicked[0]) ||
+                ((flags & ImGuiButtonFlags_PressedOnDoubleClick) && g.IO.MouseDoubleClicked[0]))
+            {
+                pressed = true;
+                if (flags & ImGuiButtonFlags_NoHoldingActiveID)
+                    ClearActiveID();
+                else
+                    SetActiveID(id, window);  // Hold on ID
+                FocusWindow(window);
+            }
+            if ((flags & ImGuiButtonFlags_PressedOnRelease) && g.IO.MouseReleased[0])
+            {
+                if (!((flags & ImGuiButtonFlags_Repeat) &&
+                      g.IO.MouseDownDurationPrev[0] >=
+                          g.IO.KeyRepeatDelay))  // Repeat mode trumps <on release>
+                    pressed = true;
+                ClearActiveID();
+            }
+
+            // 'Repeat' mode acts when held regardless of _PressedOn flags (see table above).
+            // Relies on repeat logic of IsMouseClicked() but we may as well do it ourselves if we
+            // end up exposing finer RepeatDelay/RepeatRate settings.
+            if ((flags & ImGuiButtonFlags_Repeat) && g.ActiveId == id &&
+                g.IO.MouseDownDuration[0] > 0.0f && IsMouseClicked(0, true))
+                pressed = true;
+        }
+
+        if (pressed)
+            g.NavDisableHighlight = true;
+    }
+
+    // Gamepad/Keyboard navigation
+    // We report navigated item as hovered but we don't set g.HoveredId to not interfere with mouse.
+    if (g.NavId == id && !g.NavDisableHighlight && g.NavDisableMouseHover &&
+        (g.ActiveId == 0 || g.ActiveId == id || g.ActiveId == window->MoveId))
+        if (!(flags & ImGuiButtonFlags_NoHoveredOnNav))
+            hovered = true;
+
+    if (g.NavActivateDownId == id)
+    {
+        bool nav_activated_by_code   = (g.NavActivateId == id);
+        bool nav_activated_by_inputs = IsNavInputPressed(
+            ImGuiNavInput_Activate, (flags & ImGuiButtonFlags_Repeat) ? ImGuiInputReadMode_Repeat
+                                                                      : ImGuiInputReadMode_Pressed);
+        if (nav_activated_by_code || nav_activated_by_inputs)
+            pressed = true;
+        if (nav_activated_by_code || nav_activated_by_inputs || g.ActiveId == id)
+        {
+            // Set active id so it can be queried by user via IsItemActive(), equivalent of holding
+            // the mouse button.
+            g.NavActivateId = id;  // This is so SetActiveId assign a Nav source
+            SetActiveID(id, window);
+            if ((nav_activated_by_code || nav_activated_by_inputs) &&
+                !(flags & ImGuiButtonFlags_NoNavFocus))
+                SetFocusID(id, window);
+            g.ActiveIdAllowNavDirFlags = (1 << ImGuiDir_Left) | (1 << ImGuiDir_Right) |
+                                         (1 << ImGuiDir_Up) | (1 << ImGuiDir_Down);
+        }
+    }
+
+    bool held = false;
+    if (g.ActiveId == id)
+    {
+        if (pressed)
+            g.ActiveIdHasBeenPressedBefore = true;
+        if (g.ActiveIdSource == ImGuiInputSource_Mouse)
+        {
+            if (g.ActiveIdIsJustActivated)
+                g.ActiveIdClickOffset = g.IO.MousePos - bb.Min;
+            if (g.IO.MouseDown[0])
+            {
+                held = true;
+            }
+            else
+            {
+                if (hovered && (flags & ImGuiButtonFlags_PressedOnClickRelease) &&
+                    !g.DragDropActive)
+                {
+                    bool is_double_click_release =
+                        (flags & ImGuiButtonFlags_PressedOnDoubleClick) &&
+                        g.IO.MouseDownWasDoubleClick[0];
+                    bool is_repeating_already =
+                        (flags & ImGuiButtonFlags_Repeat) &&
+                        g.IO.MouseDownDurationPrev[0] >=
+                            g.IO.KeyRepeatDelay;  // Repeat mode trumps <on release>
+                    if (!is_double_click_release && !is_repeating_already)
+                        pressed = true;
+                }
+                ClearActiveID();
+            }
+            if (!(flags & ImGuiButtonFlags_NoNavFocus))
+                g.NavDisableHighlight = true;
+        }
+        else if (g.ActiveIdSource == ImGuiInputSource_Nav)
+        {
+            if (g.NavActivateDownId != id)
+                ClearActiveID();
+        }
+    }
+
+    if (out_hovered)
+        *out_hovered = hovered;
+    if (out_held)
+        *out_held = held;
+
+    return pressed;
+}
+
+bool ImGui::ButtonEx(const char *label, const ImVec2 &size_arg, ImGuiButtonFlags flags)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    ImGuiContext &g         = *GImGui;
+    const ImGuiStyle &style = g.Style;
+    const ImGuiID id        = window->GetID(label);
+    const ImVec2 label_size = CalcTextSize(label, NULL, true);
+
+    ImVec2 pos = window->DC.CursorPos;
+    if ((flags & ImGuiButtonFlags_AlignTextBaseLine) &&
+        style.FramePadding.y <
+            window->DC.CurrLineTextBaseOffset)  // Try to vertically align buttons that are
+                                                // smaller/have no padding so that text baseline
+                                                // matches (bit hacky, since it shouldn't be a flag)
+        pos.y += window->DC.CurrLineTextBaseOffset - style.FramePadding.y;
+    ImVec2 size = CalcItemSize(size_arg, label_size.x + style.FramePadding.x * 2.0f,
+                               label_size.y + style.FramePadding.y * 2.0f);
+
+    const ImRect bb(pos, pos + size);
+    ItemSize(size, style.FramePadding.y);
+    if (!ItemAdd(bb, id))
+        return false;
+
+    if (window->DC.ItemFlags & ImGuiItemFlags_ButtonRepeat)
+        flags |= ImGuiButtonFlags_Repeat;
+    bool hovered, held;
+    bool pressed = ButtonBehavior(bb, id, &hovered, &held, flags);
+    if (pressed)
+        MarkItemEdited(id);
+
+    // Render
+    const ImU32 col =
+        GetColorU32((held && hovered) ? ImGuiCol_ButtonActive
+                                      : hovered ? ImGuiCol_ButtonHovered : ImGuiCol_Button);
+    RenderNavHighlight(bb, id);
+    RenderFrame(bb.Min, bb.Max, col, true, style.FrameRounding);
+    RenderTextClipped(bb.Min + style.FramePadding, bb.Max - style.FramePadding, label, NULL,
+                      &label_size, style.ButtonTextAlign, &bb);
+
+    // Automatically close popups
+    // if (pressed && !(flags & ImGuiButtonFlags_DontClosePopups) && (window->Flags &
+    // ImGuiWindowFlags_Popup))
+    //    CloseCurrentPopup();
+
+    IMGUI_TEST_ENGINE_ITEM_INFO(id, label, window->DC.LastItemStatusFlags);
+    return pressed;
+}
+
+bool ImGui::Button(const char *label, const ImVec2 &size_arg)
+{
+    return ButtonEx(label, size_arg, 0);
+}
+
+// Small buttons fits within text without additional vertical spacing.
+bool ImGui::SmallButton(const char *label)
+{
+    ImGuiContext &g        = *GImGui;
+    float backup_padding_y = g.Style.FramePadding.y;
+    g.Style.FramePadding.y = 0.0f;
+    bool pressed           = ButtonEx(label, ImVec2(0, 0), ImGuiButtonFlags_AlignTextBaseLine);
+    g.Style.FramePadding.y = backup_padding_y;
+    return pressed;
+}
+
+// Tip: use ImGui::PushID()/PopID() to push indices or pointers in the ID stack.
+// Then you can keep 'str_id' empty or the same for all your buttons (instead of creating a string
+// based on a non-string id)
+bool ImGui::InvisibleButton(const char *str_id, const ImVec2 &size_arg)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    // Cannot use zero-size for InvisibleButton(). Unlike Button() there is not way to fallback
+    // using the label size.
+    IM_ASSERT(size_arg.x != 0.0f && size_arg.y != 0.0f);
+
+    const ImGuiID id = window->GetID(str_id);
+    ImVec2 size      = CalcItemSize(size_arg, 0.0f, 0.0f);
+    const ImRect bb(window->DC.CursorPos, window->DC.CursorPos + size);
+    ItemSize(size);
+    if (!ItemAdd(bb, id))
+        return false;
+
+    bool hovered, held;
+    bool pressed = ButtonBehavior(bb, id, &hovered, &held);
+
+    return pressed;
+}
+
+bool ImGui::ArrowButtonEx(const char *str_id, ImGuiDir dir, ImVec2 size, ImGuiButtonFlags flags)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    ImGuiContext &g  = *GImGui;
+    const ImGuiID id = window->GetID(str_id);
+    const ImRect bb(window->DC.CursorPos, window->DC.CursorPos + size);
+    const float default_size = GetFrameHeight();
+    ItemSize(size, (size.y >= default_size) ? g.Style.FramePadding.y : 0.0f);
+    if (!ItemAdd(bb, id))
+        return false;
+
+    if (window->DC.ItemFlags & ImGuiItemFlags_ButtonRepeat)
+        flags |= ImGuiButtonFlags_Repeat;
+
+    bool hovered, held;
+    bool pressed = ButtonBehavior(bb, id, &hovered, &held, flags);
+
+    // Render
+    const ImU32 bg_col =
+        GetColorU32((held && hovered) ? ImGuiCol_ButtonActive
+                                      : hovered ? ImGuiCol_ButtonHovered : ImGuiCol_Button);
+    const ImU32 text_col = GetColorU32(ImGuiCol_Text);
+    RenderNavHighlight(bb, id);
+    RenderFrame(bb.Min, bb.Max, bg_col, true, g.Style.FrameRounding);
+    RenderArrow(window->DrawList,
+                bb.Min + ImVec2(ImMax(0.0f, (size.x - g.FontSize) * 0.5f),
+                                ImMax(0.0f, (size.y - g.FontSize) * 0.5f)),
+                text_col, dir);
+
+    return pressed;
+}
+
+bool ImGui::ArrowButton(const char *str_id, ImGuiDir dir)
+{
+    float sz = GetFrameHeight();
+    return ArrowButtonEx(str_id, dir, ImVec2(sz, sz), 0);
+}
+
+// Button to close a window
+bool ImGui::CloseButton(ImGuiID id, const ImVec2 &pos)  //, float size)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+
+    // We intentionally allow interaction when clipped so that a mechanical Alt,Right,Validate
+    // sequence close a window. (this isn't the regular behavior of buttons, but it doesn't affect
+    // the user much because navigation tends to keep items visible).
+    const ImRect bb(pos, pos + ImVec2(g.FontSize, g.FontSize) + g.Style.FramePadding * 2.0f);
+    bool is_clipped = !ItemAdd(bb, id);
+
+    bool hovered, held;
+    bool pressed = ButtonBehavior(bb, id, &hovered, &held);
+    if (is_clipped)
+        return pressed;
+
+    // Render
+    ImU32 col     = GetColorU32(held ? ImGuiCol_ButtonActive : ImGuiCol_ButtonHovered);
+    ImVec2 center = bb.GetCenter();
+    if (hovered)
+        window->DrawList->AddCircleFilled(center, ImMax(2.0f, g.FontSize * 0.5f + 1.0f), col, 12);
+
+    float cross_extent = g.FontSize * 0.5f * 0.7071f - 1.0f;
+    ImU32 cross_col    = GetColorU32(ImGuiCol_Text);
+    center -= ImVec2(0.5f, 0.5f);
+    window->DrawList->AddLine(center + ImVec2(+cross_extent, +cross_extent),
+                              center + ImVec2(-cross_extent, -cross_extent), cross_col, 1.0f);
+    window->DrawList->AddLine(center + ImVec2(+cross_extent, -cross_extent),
+                              center + ImVec2(-cross_extent, +cross_extent), cross_col, 1.0f);
+
+    return pressed;
+}
+
+bool ImGui::CollapseButton(ImGuiID id, const ImVec2 &pos)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+
+    ImRect bb(pos, pos + ImVec2(g.FontSize, g.FontSize) + g.Style.FramePadding * 2.0f);
+    ItemAdd(bb, id);
+    bool hovered, held;
+    bool pressed = ButtonBehavior(bb, id, &hovered, &held, ImGuiButtonFlags_None);
+
+    // Render
+    ImU32 bg_col =
+        GetColorU32((held && hovered) ? ImGuiCol_ButtonActive
+                                      : hovered ? ImGuiCol_ButtonHovered : ImGuiCol_Button);
+    ImU32 text_col = GetColorU32(ImGuiCol_Text);
+    ImVec2 center  = bb.GetCenter();
+    if (hovered || held)
+        window->DrawList->AddCircleFilled(center /*+ ImVec2(0.0f, -0.5f)*/,
+                                          g.FontSize * 0.5f + 1.0f, bg_col, 12);
+    RenderArrow(window->DrawList, bb.Min + g.Style.FramePadding, text_col,
+                window->Collapsed ? ImGuiDir_Right : ImGuiDir_Down, 1.0f);
+
+    // Switch to moving the window after mouse is moved beyond the initial drag threshold
+    if (IsItemActive() && IsMouseDragging())
+        StartMouseMovingWindow(window);
+
+    return pressed;
+}
+
+ImGuiID ImGui::GetScrollbarID(ImGuiWindow *window, ImGuiAxis axis)
+{
+    return window->GetIDNoKeepAlive(axis == ImGuiAxis_X ? "#SCROLLX" : "#SCROLLY");
+}
+
+// Vertical/Horizontal scrollbar
+// The entire piece of code below is rather confusing because:
+// - We handle absolute seeking (when first clicking outside the grab) and relative manipulation
+// (afterward or when clicking inside the grab)
+// - We store values as normalized ratio and in a form that allows the window content to change
+// while we are holding on a scrollbar
+// - We handle both horizontal and vertical scrollbars, which makes the terminology not ideal.
+// Still, the code should probably be made simpler..
+bool ImGui::ScrollbarEx(const ImRect &bb_frame,
+                        ImGuiID id,
+                        ImGuiAxis axis,
+                        float *p_scroll_v,
+                        float size_avail_v,
+                        float size_contents_v,
+                        ImDrawCornerFlags rounding_corners)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+    if (window->SkipItems)
+        return false;
+
+    const float bb_frame_width  = bb_frame.GetWidth();
+    const float bb_frame_height = bb_frame.GetHeight();
+    if (bb_frame_width <= 0.0f || bb_frame_height <= 0.0f)
+        return false;
+
+    // When we are too small, start hiding and disabling the grab (this reduce visual noise on very
+    // small window and facilitate using the resize grab)
+    float alpha = 1.0f;
+    if ((axis == ImGuiAxis_Y) && bb_frame_height < g.FontSize + g.Style.FramePadding.y * 2.0f)
+        alpha = ImSaturate((bb_frame_height - g.FontSize) / (g.Style.FramePadding.y * 2.0f));
+    if (alpha <= 0.0f)
+        return false;
+
+    const ImGuiStyle &style      = g.Style;
+    const bool allow_interaction = (alpha >= 1.0f);
+    const bool horizontal        = (axis == ImGuiAxis_X);
+
+    ImRect bb = bb_frame;
+    bb.Expand(ImVec2(-ImClamp((float)(int)((bb_frame_width - 2.0f) * 0.5f), 0.0f, 3.0f),
+                     -ImClamp((float)(int)((bb_frame_height - 2.0f) * 0.5f), 0.0f, 3.0f)));
+
+    // V denote the main, longer axis of the scrollbar (= height for a vertical scrollbar)
+    const float scrollbar_size_v = horizontal ? bb.GetWidth() : bb.GetHeight();
+
+    // Calculate the height of our grabbable box. It generally represent the amount visible (vs the
+    // total scrollable amount) But we maintain a minimum size in pixel to allow for the user to
+    // still aim inside.
+    IM_ASSERT(ImMax(size_contents_v, size_avail_v) >
+              0.0f);  // Adding this assert to check if the ImMax(XXX,1.0f) is still needed. PLEASE
+                      // CONTACT ME if this triggers.
+    const float win_size_v    = ImMax(ImMax(size_contents_v, size_avail_v), 1.0f);
+    const float grab_h_pixels = ImClamp(scrollbar_size_v * (size_avail_v / win_size_v),
+                                        style.GrabMinSize, scrollbar_size_v);
+    const float grab_h_norm   = grab_h_pixels / scrollbar_size_v;
+
+    // Handle input right away. None of the code of Begin() is relying on scrolling position before
+    // calling Scrollbar().
+    bool held    = false;
+    bool hovered = false;
+    ButtonBehavior(bb, id, &hovered, &held, ImGuiButtonFlags_NoNavFocus);
+
+    float scroll_max   = ImMax(1.0f, size_contents_v - size_avail_v);
+    float scroll_ratio = ImSaturate(*p_scroll_v / scroll_max);
+    float grab_v_norm  = scroll_ratio * (scrollbar_size_v - grab_h_pixels) / scrollbar_size_v;
+    if (held && allow_interaction && grab_h_norm < 1.0f)
+    {
+        float scrollbar_pos_v = horizontal ? bb.Min.x : bb.Min.y;
+        float mouse_pos_v     = horizontal ? g.IO.MousePos.x : g.IO.MousePos.y;
+
+        // Click position in scrollbar normalized space (0.0f->1.0f)
+        const float clicked_v_norm = ImSaturate((mouse_pos_v - scrollbar_pos_v) / scrollbar_size_v);
+        SetHoveredID(id);
+
+        bool seek_absolute = false;
+        if (g.ActiveIdIsJustActivated)
+        {
+            // On initial click calculate the distance between mouse and the center of the grab
+            seek_absolute =
+                (clicked_v_norm < grab_v_norm || clicked_v_norm > grab_v_norm + grab_h_norm);
+            if (seek_absolute)
+                g.ScrollbarClickDeltaToGrabCenter = 0.0f;
+            else
+                g.ScrollbarClickDeltaToGrabCenter =
+                    clicked_v_norm - grab_v_norm - grab_h_norm * 0.5f;
+        }
+
+        // Apply scroll
+        // It is ok to modify Scroll here because we are being called in Begin() after the
+        // calculation of ContentSize and before setting up our starting position
+        const float scroll_v_norm =
+            ImSaturate((clicked_v_norm - g.ScrollbarClickDeltaToGrabCenter - grab_h_norm * 0.5f) /
+                       (1.0f - grab_h_norm));
+        *p_scroll_v =
+            (float)(int)(0.5f + scroll_v_norm * scroll_max);  //(win_size_contents_v - win_size_v));
+
+        // Update values for rendering
+        scroll_ratio = ImSaturate(*p_scroll_v / scroll_max);
+        grab_v_norm  = scroll_ratio * (scrollbar_size_v - grab_h_pixels) / scrollbar_size_v;
+
+        // Update distance to grab now that we have seeked and saturated
+        if (seek_absolute)
+            g.ScrollbarClickDeltaToGrabCenter = clicked_v_norm - grab_v_norm - grab_h_norm * 0.5f;
+    }
+
+    // Render
+    window->DrawList->AddRectFilled(bb_frame.Min, bb_frame.Max, GetColorU32(ImGuiCol_ScrollbarBg),
+                                    window->WindowRounding, rounding_corners);
+    const ImU32 grab_col =
+        GetColorU32(held ? ImGuiCol_ScrollbarGrabActive
+                         : hovered ? ImGuiCol_ScrollbarGrabHovered : ImGuiCol_ScrollbarGrab,
+                    alpha);
+    ImRect grab_rect;
+    if (horizontal)
+        grab_rect = ImRect(ImLerp(bb.Min.x, bb.Max.x, grab_v_norm), bb.Min.y,
+                           ImLerp(bb.Min.x, bb.Max.x, grab_v_norm) + grab_h_pixels, bb.Max.y);
+    else
+        grab_rect = ImRect(bb.Min.x, ImLerp(bb.Min.y, bb.Max.y, grab_v_norm), bb.Max.x,
+                           ImLerp(bb.Min.y, bb.Max.y, grab_v_norm) + grab_h_pixels);
+    window->DrawList->AddRectFilled(grab_rect.Min, grab_rect.Max, grab_col,
+                                    style.ScrollbarRounding);
+
+    return held;
+}
+
+void ImGui::Scrollbar(ImGuiAxis axis)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+
+    const ImGuiID id = GetScrollbarID(window, axis);
+    KeepAliveID(id);
+
+    // Calculate scrollbar bounding box
+    const ImRect outer_rect    = window->Rect();
+    const ImRect inner_rect    = window->InnerRect;
+    const float border_size    = window->WindowBorderSize;
+    const float scrollbar_size = window->ScrollbarSizes[axis ^ 1];
+    IM_ASSERT(scrollbar_size > 0.0f);
+    const float other_scrollbar_size = window->ScrollbarSizes[axis];
+    ImDrawCornerFlags rounding_corners =
+        (other_scrollbar_size <= 0.0f) ? ImDrawCornerFlags_BotRight : 0;
+    ImRect bb;
+    if (axis == ImGuiAxis_X)
+    {
+        bb.Min = ImVec2(inner_rect.Min.x,
+                        ImMax(outer_rect.Min.y, outer_rect.Max.y - border_size - scrollbar_size));
+        bb.Max = ImVec2(inner_rect.Max.x, outer_rect.Max.y);
+        rounding_corners |= ImDrawCornerFlags_BotLeft;
+    }
+    else
+    {
+        bb.Min = ImVec2(ImMax(outer_rect.Min.x, outer_rect.Max.x - border_size - scrollbar_size),
+                        inner_rect.Min.y);
+        bb.Max = ImVec2(outer_rect.Max.x, window->InnerRect.Max.y);
+        rounding_corners |= ((window->Flags & ImGuiWindowFlags_NoTitleBar) &&
+                             !(window->Flags & ImGuiWindowFlags_MenuBar))
+                                ? ImDrawCornerFlags_TopRight
+                                : 0;
+    }
+    ScrollbarEx(bb, id, axis, &window->Scroll[axis], inner_rect.Max[axis] - inner_rect.Min[axis],
+                window->ContentSize[axis] + window->WindowPadding[axis] * 2.0f, rounding_corners);
+}
+
+void ImGui::Image(ImTextureID user_texture_id,
+                  const ImVec2 &size,
+                  const ImVec2 &uv0,
+                  const ImVec2 &uv1,
+                  const ImVec4 &tint_col,
+                  const ImVec4 &border_col)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return;
+
+    ImRect bb(window->DC.CursorPos, window->DC.CursorPos + size);
+    if (border_col.w > 0.0f)
+        bb.Max += ImVec2(2, 2);
+    ItemSize(bb);
+    if (!ItemAdd(bb, 0))
+        return;
+
+    if (border_col.w > 0.0f)
+    {
+        window->DrawList->AddRect(bb.Min, bb.Max, GetColorU32(border_col), 0.0f);
+        window->DrawList->AddImage(user_texture_id, bb.Min + ImVec2(1, 1), bb.Max - ImVec2(1, 1),
+                                   uv0, uv1, GetColorU32(tint_col));
+    }
+    else
+    {
+        window->DrawList->AddImage(user_texture_id, bb.Min, bb.Max, uv0, uv1,
+                                   GetColorU32(tint_col));
+    }
+}
+
+// frame_padding < 0: uses FramePadding from style (default)
+// frame_padding = 0: no framing
+// frame_padding > 0: set framing size
+// The color used are the button colors.
+bool ImGui::ImageButton(ImTextureID user_texture_id,
+                        const ImVec2 &size,
+                        const ImVec2 &uv0,
+                        const ImVec2 &uv1,
+                        int frame_padding,
+                        const ImVec4 &bg_col,
+                        const ImVec4 &tint_col)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    ImGuiContext &g         = *GImGui;
+    const ImGuiStyle &style = g.Style;
+
+    // Default to using texture ID as ID. User can still push string/integer prefixes.
+    // We could hash the size/uv to create a unique ID but that would prevent the user from
+    // animating UV.
+    PushID((void *)(intptr_t)user_texture_id);
+    const ImGuiID id = window->GetID("#image");
+    PopID();
+
+    const ImVec2 padding = (frame_padding >= 0) ? ImVec2((float)frame_padding, (float)frame_padding)
+                                                : style.FramePadding;
+    const ImRect bb(window->DC.CursorPos, window->DC.CursorPos + size + padding * 2);
+    const ImRect image_bb(window->DC.CursorPos + padding, window->DC.CursorPos + padding + size);
+    ItemSize(bb);
+    if (!ItemAdd(bb, id))
+        return false;
+
+    bool hovered, held;
+    bool pressed = ButtonBehavior(bb, id, &hovered, &held);
+
+    // Render
+    const ImU32 col =
+        GetColorU32((held && hovered) ? ImGuiCol_ButtonActive
+                                      : hovered ? ImGuiCol_ButtonHovered : ImGuiCol_Button);
+    RenderNavHighlight(bb, id);
+    RenderFrame(bb.Min, bb.Max, col, true,
+                ImClamp((float)ImMin(padding.x, padding.y), 0.0f, style.FrameRounding));
+    if (bg_col.w > 0.0f)
+        window->DrawList->AddRectFilled(image_bb.Min, image_bb.Max, GetColorU32(bg_col));
+    window->DrawList->AddImage(user_texture_id, image_bb.Min, image_bb.Max, uv0, uv1,
+                               GetColorU32(tint_col));
+
+    return pressed;
+}
+
+bool ImGui::Checkbox(const char *label, bool *v)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    ImGuiContext &g         = *GImGui;
+    const ImGuiStyle &style = g.Style;
+    const ImGuiID id        = window->GetID(label);
+    const ImVec2 label_size = CalcTextSize(label, NULL, true);
+
+    const float square_sz = GetFrameHeight();
+    const ImVec2 pos      = window->DC.CursorPos;
+    const ImRect total_bb(
+        pos, pos + ImVec2(square_sz + (label_size.x > 0.0f ? style.ItemInnerSpacing.x + label_size.x
+                                                           : 0.0f),
+                          label_size.y + style.FramePadding.y * 2.0f));
+    ItemSize(total_bb, style.FramePadding.y);
+    if (!ItemAdd(total_bb, id))
+        return false;
+
+    bool hovered, held;
+    bool pressed = ButtonBehavior(total_bb, id, &hovered, &held);
+    if (pressed)
+    {
+        *v = !(*v);
+        MarkItemEdited(id);
+    }
+
+    const ImRect check_bb(pos, pos + ImVec2(square_sz, square_sz));
+    RenderNavHighlight(total_bb, id);
+    RenderFrame(
+        check_bb.Min, check_bb.Max,
+        GetColorU32((held && hovered) ? ImGuiCol_FrameBgActive
+                                      : hovered ? ImGuiCol_FrameBgHovered : ImGuiCol_FrameBg),
+        true, style.FrameRounding);
+    ImU32 check_col = GetColorU32(ImGuiCol_CheckMark);
+    if (window->DC.ItemFlags & ImGuiItemFlags_MixedValue)
+    {
+        // Undocumented tristate/mixed/indeterminate checkbox (#2644)
+        ImVec2 pad(ImMax(1.0f, (float)(int)(square_sz / 3.6f)),
+                   ImMax(1.0f, (float)(int)(square_sz / 3.6f)));
+        window->DrawList->AddRectFilled(check_bb.Min + pad, check_bb.Max - pad, check_col,
+                                        style.FrameRounding);
+    }
+    else if (*v)
+    {
+        const float pad = ImMax(1.0f, (float)(int)(square_sz / 6.0f));
+        RenderCheckMark(check_bb.Min + ImVec2(pad, pad), check_col, square_sz - pad * 2.0f);
+    }
+
+    if (g.LogEnabled)
+        LogRenderedText(&total_bb.Min, *v ? "[x]" : "[ ]");
+    if (label_size.x > 0.0f)
+        RenderText(ImVec2(check_bb.Max.x + style.ItemInnerSpacing.x,
+                          check_bb.Min.y + style.FramePadding.y),
+                   label);
+
+    IMGUI_TEST_ENGINE_ITEM_INFO(id, label,
+                                window->DC.ItemFlags | ImGuiItemStatusFlags_Checkable |
+                                    (*v ? ImGuiItemStatusFlags_Checked : 0));
+    return pressed;
+}
+
+bool ImGui::CheckboxFlags(const char *label, unsigned int *flags, unsigned int flags_value)
+{
+    bool v       = ((*flags & flags_value) == flags_value);
+    bool pressed = Checkbox(label, &v);
+    if (pressed)
+    {
+        if (v)
+            *flags |= flags_value;
+        else
+            *flags &= ~flags_value;
+    }
+
+    return pressed;
+}
+
+bool ImGui::RadioButton(const char *label, bool active)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    ImGuiContext &g         = *GImGui;
+    const ImGuiStyle &style = g.Style;
+    const ImGuiID id        = window->GetID(label);
+    const ImVec2 label_size = CalcTextSize(label, NULL, true);
+
+    const float square_sz = GetFrameHeight();
+    const ImVec2 pos      = window->DC.CursorPos;
+    const ImRect check_bb(pos, pos + ImVec2(square_sz, square_sz));
+    const ImRect total_bb(
+        pos, pos + ImVec2(square_sz + (label_size.x > 0.0f ? style.ItemInnerSpacing.x + label_size.x
+                                                           : 0.0f),
+                          label_size.y + style.FramePadding.y * 2.0f));
+    ItemSize(total_bb, style.FramePadding.y);
+    if (!ItemAdd(total_bb, id))
+        return false;
+
+    ImVec2 center      = check_bb.GetCenter();
+    center.x           = (float)(int)center.x + 0.5f;
+    center.y           = (float)(int)center.y + 0.5f;
+    const float radius = (square_sz - 1.0f) * 0.5f;
+
+    bool hovered, held;
+    bool pressed = ButtonBehavior(total_bb, id, &hovered, &held);
+    if (pressed)
+        MarkItemEdited(id);
+
+    RenderNavHighlight(total_bb, id);
+    window->DrawList->AddCircleFilled(
+        center, radius,
+        GetColorU32((held && hovered) ? ImGuiCol_FrameBgActive
+                                      : hovered ? ImGuiCol_FrameBgHovered : ImGuiCol_FrameBg),
+        16);
+    if (active)
+    {
+        const float pad = ImMax(1.0f, (float)(int)(square_sz / 6.0f));
+        window->DrawList->AddCircleFilled(center, radius - pad, GetColorU32(ImGuiCol_CheckMark),
+                                          16);
+    }
+
+    if (style.FrameBorderSize > 0.0f)
+    {
+        window->DrawList->AddCircle(center + ImVec2(1, 1), radius,
+                                    GetColorU32(ImGuiCol_BorderShadow), 16, style.FrameBorderSize);
+        window->DrawList->AddCircle(center, radius, GetColorU32(ImGuiCol_Border), 16,
+                                    style.FrameBorderSize);
+    }
+
+    if (g.LogEnabled)
+        LogRenderedText(&total_bb.Min, active ? "(x)" : "( )");
+    if (label_size.x > 0.0f)
+        RenderText(ImVec2(check_bb.Max.x + style.ItemInnerSpacing.x,
+                          check_bb.Min.y + style.FramePadding.y),
+                   label);
+
+    return pressed;
+}
+
+bool ImGui::RadioButton(const char *label, int *v, int v_button)
+{
+    const bool pressed = RadioButton(label, *v == v_button);
+    if (pressed)
+        *v = v_button;
+    return pressed;
+}
+
+// size_arg (for each axis) < 0.0f: align to end, 0.0f: auto, > 0.0f: specified size
+void ImGui::ProgressBar(float fraction, const ImVec2 &size_arg, const char *overlay)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return;
+
+    ImGuiContext &g         = *GImGui;
+    const ImGuiStyle &style = g.Style;
+
+    ImVec2 pos  = window->DC.CursorPos;
+    ImVec2 size = CalcItemSize(size_arg, CalcItemWidth(), g.FontSize + style.FramePadding.y * 2.0f);
+    ImRect bb(pos, pos + size);
+    ItemSize(size, style.FramePadding.y);
+    if (!ItemAdd(bb, 0))
+        return;
+
+    // Render
+    fraction = ImSaturate(fraction);
+    RenderFrame(bb.Min, bb.Max, GetColorU32(ImGuiCol_FrameBg), true, style.FrameRounding);
+    bb.Expand(ImVec2(-style.FrameBorderSize, -style.FrameBorderSize));
+    const ImVec2 fill_br = ImVec2(ImLerp(bb.Min.x, bb.Max.x, fraction), bb.Max.y);
+    RenderRectFilledRangeH(window->DrawList, bb, GetColorU32(ImGuiCol_PlotHistogram), 0.0f,
+                           fraction, style.FrameRounding);
+
+    // Default displaying the fraction as percentage string, but user can override it
+    char overlay_buf[32];
+    if (!overlay)
+    {
+        ImFormatString(overlay_buf, IM_ARRAYSIZE(overlay_buf), "%.0f%%", fraction * 100 + 0.01f);
+        overlay = overlay_buf;
+    }
+
+    ImVec2 overlay_size = CalcTextSize(overlay, NULL);
+    if (overlay_size.x > 0.0f)
+        RenderTextClipped(ImVec2(ImClamp(fill_br.x + style.ItemSpacing.x, bb.Min.x,
+                                         bb.Max.x - overlay_size.x - style.ItemInnerSpacing.x),
+                                 bb.Min.y),
+                          bb.Max, overlay, NULL, &overlay_size, ImVec2(0.0f, 0.5f), &bb);
+}
+
+void ImGui::Bullet()
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return;
+
+    ImGuiContext &g         = *GImGui;
+    const ImGuiStyle &style = g.Style;
+    const float line_height = ImMax(
+        ImMin(window->DC.CurrLineSize.y, g.FontSize + g.Style.FramePadding.y * 2), g.FontSize);
+    const ImRect bb(window->DC.CursorPos, window->DC.CursorPos + ImVec2(g.FontSize, line_height));
+    ItemSize(bb);
+    if (!ItemAdd(bb, 0))
+    {
+        SameLine(0, style.FramePadding.x * 2);
+        return;
+    }
+
+    // Render and stay on same line
+    ImU32 text_col = GetColorU32(ImGuiCol_Text);
+    RenderBullet(window->DrawList,
+                 bb.Min + ImVec2(style.FramePadding.x + g.FontSize * 0.5f, line_height * 0.5f),
+                 text_col);
+    SameLine(0, style.FramePadding.x * 2.0f);
+}
+
+//-------------------------------------------------------------------------
+// [SECTION] Widgets: Low-level Layout helpers
+//-------------------------------------------------------------------------
+// - Spacing()
+// - Dummy()
+// - NewLine()
+// - AlignTextToFramePadding()
+// - SeparatorEx() [Internal]
+// - Separator()
+// - SplitterBehavior() [Internal]
+// - ShrinkWidths() [Internal]
+//-------------------------------------------------------------------------
+
+void ImGui::Spacing()
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return;
+    ItemSize(ImVec2(0, 0));
+}
+
+void ImGui::Dummy(const ImVec2 &size)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return;
+
+    const ImRect bb(window->DC.CursorPos, window->DC.CursorPos + size);
+    ItemSize(size);
+    ItemAdd(bb, 0);
+}
+
+void ImGui::NewLine()
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return;
+
+    ImGuiContext &g                          = *GImGui;
+    const ImGuiLayoutType backup_layout_type = window->DC.LayoutType;
+    window->DC.LayoutType                    = ImGuiLayoutType_Vertical;
+    if (window->DC.CurrLineSize.y >
+        0.0f)  // In the event that we are on a line with items that is smaller that FontSize high,
+               // we will preserve its height.
+        ItemSize(ImVec2(0, 0));
+    else
+        ItemSize(ImVec2(0.0f, g.FontSize));
+    window->DC.LayoutType = backup_layout_type;
+}
+
+void ImGui::AlignTextToFramePadding()
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return;
+
+    ImGuiContext &g = *GImGui;
+    window->DC.CurrLineSize.y =
+        ImMax(window->DC.CurrLineSize.y, g.FontSize + g.Style.FramePadding.y * 2);
+    window->DC.CurrLineTextBaseOffset =
+        ImMax(window->DC.CurrLineTextBaseOffset, g.Style.FramePadding.y);
+}
+
+// Horizontal/vertical separating line
+void ImGui::SeparatorEx(ImGuiSeparatorFlags flags)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return;
+
+    ImGuiContext &g = *GImGui;
+    IM_ASSERT(ImIsPowerOfTwo(
+        flags & (ImGuiSeparatorFlags_Horizontal |
+                 ImGuiSeparatorFlags_Vertical)));  // Check that only 1 option is selected
+
+    float thickness_draw   = 1.0f;
+    float thickness_layout = 0.0f;
+    if (flags & ImGuiSeparatorFlags_Vertical)
+    {
+        // Vertical separator, for menu bars (use current line height). Not exposed because it is
+        // misleading and it doesn't have an effect on regular layout.
+        float y1 = window->DC.CursorPos.y;
+        float y2 = window->DC.CursorPos.y + window->DC.CurrLineSize.y;
+        const ImRect bb(ImVec2(window->DC.CursorPos.x, y1),
+                        ImVec2(window->DC.CursorPos.x + thickness_draw, y2));
+        ItemSize(ImVec2(thickness_layout, 0.0f));
+        if (!ItemAdd(bb, 0))
+            return;
+
+        // Draw
+        window->DrawList->AddLine(ImVec2(bb.Min.x, bb.Min.y), ImVec2(bb.Min.x, bb.Max.y),
+                                  GetColorU32(ImGuiCol_Separator));
+        if (g.LogEnabled)
+            LogText(" |");
+    }
+    else if (flags & ImGuiSeparatorFlags_Horizontal)
+    {
+        // Horizontal Separator
+        float x1 = window->Pos.x;
+        float x2 = window->Pos.x + window->Size.x;
+        if (!window->DC.GroupStack.empty())
+            x1 += window->DC.Indent.x;
+
+        ImGuiColumns *columns =
+            (flags & ImGuiSeparatorFlags_SpanAllColumns) ? window->DC.CurrentColumns : NULL;
+        if (columns)
+            PushColumnsBackground();
+
+        // We don't provide our width to the layout so that it doesn't get feed back into AutoFit
+        const ImRect bb(ImVec2(x1, window->DC.CursorPos.y),
+                        ImVec2(x2, window->DC.CursorPos.y + thickness_draw));
+        ItemSize(ImVec2(0.0f, thickness_layout));
+        if (!ItemAdd(bb, 0))
+        {
+            if (columns)
+                PopColumnsBackground();
+            return;
+        }
+
+        // Draw
+        window->DrawList->AddLine(bb.Min, ImVec2(bb.Max.x, bb.Min.y),
+                                  GetColorU32(ImGuiCol_Separator));
+        if (g.LogEnabled)
+            LogRenderedText(&bb.Min, "--------------------------------");
+
+        if (columns)
+        {
+            PopColumnsBackground();
+            columns->LineMinY = window->DC.CursorPos.y;
+        }
+    }
+}
+
+void ImGui::Separator()
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+    if (window->SkipItems)
+        return;
+
+    // Those flags should eventually be overridable by the user
+    ImGuiSeparatorFlags flags = (window->DC.LayoutType == ImGuiLayoutType_Horizontal)
+                                    ? ImGuiSeparatorFlags_Vertical
+                                    : ImGuiSeparatorFlags_Horizontal;
+    flags |= ImGuiSeparatorFlags_SpanAllColumns;
+    SeparatorEx(flags);
+}
+
+// Using 'hover_visibility_delay' allows us to hide the highlight and mouse cursor for a short time,
+// which can be convenient to reduce visual noise.
+bool ImGui::SplitterBehavior(const ImRect &bb,
+                             ImGuiID id,
+                             ImGuiAxis axis,
+                             float *size1,
+                             float *size2,
+                             float min_size1,
+                             float min_size2,
+                             float hover_extend,
+                             float hover_visibility_delay)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+
+    const ImGuiItemFlags item_flags_backup = window->DC.ItemFlags;
+    window->DC.ItemFlags |= ImGuiItemFlags_NoNav | ImGuiItemFlags_NoNavDefaultFocus;
+    bool item_add        = ItemAdd(bb, id);
+    window->DC.ItemFlags = item_flags_backup;
+    if (!item_add)
+        return false;
+
+    bool hovered, held;
+    ImRect bb_interact = bb;
+    bb_interact.Expand(axis == ImGuiAxis_Y ? ImVec2(0.0f, hover_extend)
+                                           : ImVec2(hover_extend, 0.0f));
+    ButtonBehavior(bb_interact, id, &hovered, &held,
+                   ImGuiButtonFlags_FlattenChildren | ImGuiButtonFlags_AllowItemOverlap);
+    if (g.ActiveId != id)
+        SetItemAllowOverlap();
+
+    if (held || (g.HoveredId == id && g.HoveredIdPreviousFrame == id &&
+                 g.HoveredIdTimer >= hover_visibility_delay))
+        SetMouseCursor(axis == ImGuiAxis_Y ? ImGuiMouseCursor_ResizeNS : ImGuiMouseCursor_ResizeEW);
+
+    ImRect bb_render = bb;
+    if (held)
+    {
+        ImVec2 mouse_delta_2d = g.IO.MousePos - g.ActiveIdClickOffset - bb_interact.Min;
+        float mouse_delta     = (axis == ImGuiAxis_Y) ? mouse_delta_2d.y : mouse_delta_2d.x;
+
+        // Minimum pane size
+        float size_1_maximum_delta = ImMax(0.0f, *size1 - min_size1);
+        float size_2_maximum_delta = ImMax(0.0f, *size2 - min_size2);
+        if (mouse_delta < -size_1_maximum_delta)
+            mouse_delta = -size_1_maximum_delta;
+        if (mouse_delta > size_2_maximum_delta)
+            mouse_delta = size_2_maximum_delta;
+
+        // Apply resize
+        if (mouse_delta != 0.0f)
+        {
+            if (mouse_delta < 0.0f)
+                IM_ASSERT(*size1 + mouse_delta >= min_size1);
+            if (mouse_delta > 0.0f)
+                IM_ASSERT(*size2 - mouse_delta >= min_size2);
+            *size1 += mouse_delta;
+            *size2 -= mouse_delta;
+            bb_render.Translate((axis == ImGuiAxis_X) ? ImVec2(mouse_delta, 0.0f)
+                                                      : ImVec2(0.0f, mouse_delta));
+            MarkItemEdited(id);
+        }
+    }
+
+    // Render
+    const ImU32 col = GetColorU32(held ? ImGuiCol_SeparatorActive
+                                       : (hovered && g.HoveredIdTimer >= hover_visibility_delay)
+                                             ? ImGuiCol_SeparatorHovered
+                                             : ImGuiCol_Separator);
+    window->DrawList->AddRectFilled(bb_render.Min, bb_render.Max, col, g.Style.FrameRounding);
+
+    return held;
+}
+
+static int IMGUI_CDECL ShrinkWidthItemComparer(const void *lhs, const void *rhs)
+{
+    const ImGuiShrinkWidthItem *a = (const ImGuiShrinkWidthItem *)lhs;
+    const ImGuiShrinkWidthItem *b = (const ImGuiShrinkWidthItem *)rhs;
+    if (int d = (int)(b->Width - a->Width))
+        return d;
+    return (b->Index - a->Index);
+}
+
+// Shrink excess width from a set of item, by removing width from the larger items first.
+void ImGui::ShrinkWidths(ImGuiShrinkWidthItem *items, int count, float width_excess)
+{
+    if (count > 1)
+        ImQsort(items, (size_t)count, sizeof(ImGuiShrinkWidthItem), ShrinkWidthItemComparer);
+    int count_same_width = 1;
+    while (width_excess > 0.0f && count_same_width < count)
+    {
+        while (count_same_width < count && items[0].Width == items[count_same_width].Width)
+            count_same_width++;
+        float width_to_remove_per_item_max = (count_same_width < count)
+                                                 ? (items[0].Width - items[count_same_width].Width)
+                                                 : (items[0].Width - 1.0f);
+        float width_to_remove_per_item =
+            ImMin(width_excess / count_same_width, width_to_remove_per_item_max);
+        for (int item_n = 0; item_n < count_same_width; item_n++)
+            items[item_n].Width -= width_to_remove_per_item;
+        width_excess -= width_to_remove_per_item * count_same_width;
+    }
+}
+
+//-------------------------------------------------------------------------
+// [SECTION] Widgets: ComboBox
+//-------------------------------------------------------------------------
+// - BeginCombo()
+// - EndCombo()
+// - Combo()
+//-------------------------------------------------------------------------
+
+static float CalcMaxPopupHeightFromItemCount(int items_count)
+{
+    ImGuiContext &g = *GImGui;
+    if (items_count <= 0)
+        return FLT_MAX;
+    return (g.FontSize + g.Style.ItemSpacing.y) * items_count - g.Style.ItemSpacing.y +
+           (g.Style.WindowPadding.y * 2);
+}
+
+bool ImGui::BeginCombo(const char *label, const char *preview_value, ImGuiComboFlags flags)
+{
+    // Always consume the SetNextWindowSizeConstraint() call in our early return paths
+    ImGuiContext &g = *GImGui;
+    bool has_window_size_constraint =
+        (g.NextWindowData.Flags & ImGuiNextWindowDataFlags_HasSizeConstraint) != 0;
+    g.NextWindowData.Flags &= ~ImGuiNextWindowDataFlags_HasSizeConstraint;
+
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    IM_ASSERT((flags & (ImGuiComboFlags_NoArrowButton | ImGuiComboFlags_NoPreview)) !=
+              (ImGuiComboFlags_NoArrowButton |
+               ImGuiComboFlags_NoPreview));  // Can't use both flags together
+
+    const ImGuiStyle &style = g.Style;
+    const ImGuiID id        = window->GetID(label);
+
+    const float arrow_size  = (flags & ImGuiComboFlags_NoArrowButton) ? 0.0f : GetFrameHeight();
+    const ImVec2 label_size = CalcTextSize(label, NULL, true);
+    const float expected_w  = CalcItemWidth();
+    const float w           = (flags & ImGuiComboFlags_NoPreview) ? arrow_size : expected_w;
+    const ImRect frame_bb(
+        window->DC.CursorPos,
+        window->DC.CursorPos + ImVec2(w, label_size.y + style.FramePadding.y * 2.0f));
+    const ImRect total_bb(
+        frame_bb.Min,
+        frame_bb.Max +
+            ImVec2(label_size.x > 0.0f ? style.ItemInnerSpacing.x + label_size.x : 0.0f, 0.0f));
+    ItemSize(total_bb, style.FramePadding.y);
+    if (!ItemAdd(total_bb, id, &frame_bb))
+        return false;
+
+    bool hovered, held;
+    bool pressed    = ButtonBehavior(frame_bb, id, &hovered, &held);
+    bool popup_open = IsPopupOpen(id);
+
+    const ImU32 frame_col = GetColorU32(hovered ? ImGuiCol_FrameBgHovered : ImGuiCol_FrameBg);
+    const float value_x2  = ImMax(frame_bb.Min.x, frame_bb.Max.x - arrow_size);
+    RenderNavHighlight(frame_bb, id);
+    if (!(flags & ImGuiComboFlags_NoPreview))
+        window->DrawList->AddRectFilled(
+            frame_bb.Min, ImVec2(value_x2, frame_bb.Max.y), frame_col, style.FrameRounding,
+            (flags & ImGuiComboFlags_NoArrowButton) ? ImDrawCornerFlags_All
+                                                    : ImDrawCornerFlags_Left);
+    if (!(flags & ImGuiComboFlags_NoArrowButton))
+    {
+        ImU32 bg_col =
+            GetColorU32((popup_open || hovered) ? ImGuiCol_ButtonHovered : ImGuiCol_Button);
+        ImU32 text_col = GetColorU32(ImGuiCol_Text);
+        window->DrawList->AddRectFilled(
+            ImVec2(value_x2, frame_bb.Min.y), frame_bb.Max, bg_col, style.FrameRounding,
+            (w <= arrow_size) ? ImDrawCornerFlags_All : ImDrawCornerFlags_Right);
+        RenderArrow(window->DrawList,
+                    ImVec2(value_x2 + style.FramePadding.y, frame_bb.Min.y + style.FramePadding.y),
+                    text_col, ImGuiDir_Down);
+    }
+    RenderFrameBorder(frame_bb.Min, frame_bb.Max, style.FrameRounding);
+    if (preview_value != NULL && !(flags & ImGuiComboFlags_NoPreview))
+        RenderTextClipped(frame_bb.Min + style.FramePadding, ImVec2(value_x2, frame_bb.Max.y),
+                          preview_value, NULL, NULL, ImVec2(0.0f, 0.0f));
+    if (label_size.x > 0)
+        RenderText(ImVec2(frame_bb.Max.x + style.ItemInnerSpacing.x,
+                          frame_bb.Min.y + style.FramePadding.y),
+                   label);
+
+    if ((pressed || g.NavActivateId == id) && !popup_open)
+    {
+        if (window->DC.NavLayerCurrent == 0)
+            window->NavLastIds[0] = id;
+        OpenPopupEx(id);
+        popup_open = true;
+    }
+
+    if (!popup_open)
+        return false;
+
+    if (has_window_size_constraint)
+    {
+        g.NextWindowData.Flags |= ImGuiNextWindowDataFlags_HasSizeConstraint;
+        g.NextWindowData.SizeConstraintRect.Min.x =
+            ImMax(g.NextWindowData.SizeConstraintRect.Min.x, w);
+    }
+    else
+    {
+        if ((flags & ImGuiComboFlags_HeightMask_) == 0)
+            flags |= ImGuiComboFlags_HeightRegular;
+        IM_ASSERT(ImIsPowerOfTwo(flags & ImGuiComboFlags_HeightMask_));  // Only one
+        int popup_max_height_in_items = -1;
+        if (flags & ImGuiComboFlags_HeightRegular)
+            popup_max_height_in_items = 8;
+        else if (flags & ImGuiComboFlags_HeightSmall)
+            popup_max_height_in_items = 4;
+        else if (flags & ImGuiComboFlags_HeightLarge)
+            popup_max_height_in_items = 20;
+        SetNextWindowSizeConstraints(
+            ImVec2(w, 0.0f),
+            ImVec2(FLT_MAX, CalcMaxPopupHeightFromItemCount(popup_max_height_in_items)));
+    }
+
+    char name[16];
+    ImFormatString(name, IM_ARRAYSIZE(name), "##Combo_%02d",
+                   g.BeginPopupStack.Size);  // Recycle windows based on depth
+
+    // Peak into expected window size so we can position it
+    if (ImGuiWindow *popup_window = FindWindowByName(name))
+        if (popup_window->WasActive)
+        {
+            ImVec2 size_expected = CalcWindowExpectedSize(popup_window);
+            if (flags & ImGuiComboFlags_PopupAlignLeft)
+                popup_window->AutoPosLastDirection = ImGuiDir_Left;
+            ImRect r_outer = GetWindowAllowedExtentRect(popup_window);
+            ImVec2 pos     = FindBestWindowPosForPopupEx(frame_bb.GetBL(), size_expected,
+                                                     &popup_window->AutoPosLastDirection, r_outer,
+                                                     frame_bb, ImGuiPopupPositionPolicy_ComboBox);
+            SetNextWindowPos(pos);
+        }
+
+    // Horizontally align ourselves with the framed text
+    ImGuiWindowFlags window_flags = ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_Popup |
+                                    ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize |
+                                    ImGuiWindowFlags_NoSavedSettings;
+    PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(style.FramePadding.x, style.WindowPadding.y));
+    bool ret = Begin(name, NULL, window_flags);
+    PopStyleVar();
+    if (!ret)
+    {
+        EndPopup();
+        IM_ASSERT(0);  // This should never happen as we tested for IsPopupOpen() above
+        return false;
+    }
+    return true;
+}
+
+void ImGui::EndCombo()
+{
+    EndPopup();
+}
+
+// Getter for the old Combo() API: const char*[]
+static bool Items_ArrayGetter(void *data, int idx, const char **out_text)
+{
+    const char *const *items = (const char *const *)data;
+    if (out_text)
+        *out_text = items[idx];
+    return true;
+}
+
+// Getter for the old Combo() API: "item1\0item2\0item3\0"
+static bool Items_SingleStringGetter(void *data, int idx, const char **out_text)
+{
+    // FIXME-OPT: we could pre-compute the indices to fasten this. But only 1 active combo means the
+    // waste is limited.
+    const char *items_separated_by_zeros = (const char *)data;
+    int items_count                      = 0;
+    const char *p                        = items_separated_by_zeros;
+    while (*p)
+    {
+        if (idx == items_count)
+            break;
+        p += strlen(p) + 1;
+        items_count++;
+    }
+    if (!*p)
+        return false;
+    if (out_text)
+        *out_text = p;
+    return true;
+}
+
+// Old API, prefer using BeginCombo() nowadays if you can.
+bool ImGui::Combo(const char *label,
+                  int *current_item,
+                  bool (*items_getter)(void *, int, const char **),
+                  void *data,
+                  int items_count,
+                  int popup_max_height_in_items)
+{
+    ImGuiContext &g = *GImGui;
+
+    // Call the getter to obtain the preview string which is a parameter to BeginCombo()
+    const char *preview_value = NULL;
+    if (*current_item >= 0 && *current_item < items_count)
+        items_getter(data, *current_item, &preview_value);
+
+    // The old Combo() API exposed "popup_max_height_in_items". The new more general BeginCombo()
+    // API doesn't have/need it, but we emulate it here.
+    if (popup_max_height_in_items != -1 &&
+        !(g.NextWindowData.Flags & ImGuiNextWindowDataFlags_HasSizeConstraint))
+        SetNextWindowSizeConstraints(
+            ImVec2(0, 0),
+            ImVec2(FLT_MAX, CalcMaxPopupHeightFromItemCount(popup_max_height_in_items)));
+
+    if (!BeginCombo(label, preview_value, ImGuiComboFlags_None))
+        return false;
+
+    // Display items
+    // FIXME-OPT: Use clipper (but we need to disable it on the appearing frame to make sure our
+    // call to SetItemDefaultFocus() is processed)
+    bool value_changed = false;
+    for (int i = 0; i < items_count; i++)
+    {
+        PushID((void *)(intptr_t)i);
+        const bool item_selected = (i == *current_item);
+        const char *item_text;
+        if (!items_getter(data, i, &item_text))
+            item_text = "*Unknown item*";
+        if (Selectable(item_text, item_selected))
+        {
+            value_changed = true;
+            *current_item = i;
+        }
+        if (item_selected)
+            SetItemDefaultFocus();
+        PopID();
+    }
+
+    EndCombo();
+    return value_changed;
+}
+
+// Combo box helper allowing to pass an array of strings.
+bool ImGui::Combo(const char *label,
+                  int *current_item,
+                  const char *const items[],
+                  int items_count,
+                  int height_in_items)
+{
+    const bool value_changed =
+        Combo(label, current_item, Items_ArrayGetter, (void *)items, items_count, height_in_items);
+    return value_changed;
+}
+
+// Combo box helper allowing to pass all items in a single string literal holding multiple
+// zero-terminated items "item1\0item2\0"
+bool ImGui::Combo(const char *label,
+                  int *current_item,
+                  const char *items_separated_by_zeros,
+                  int height_in_items)
+{
+    int items_count = 0;
+    const char *p = items_separated_by_zeros;  // FIXME-OPT: Avoid computing this, or at least only
+                                               // when combo is open
+    while (*p)
+    {
+        p += strlen(p) + 1;
+        items_count++;
+    }
+    bool value_changed = Combo(label, current_item, Items_SingleStringGetter,
+                               (void *)items_separated_by_zeros, items_count, height_in_items);
+    return value_changed;
+}
+
+//-------------------------------------------------------------------------
+// [SECTION] Data Type and Data Formatting Helpers [Internal]
+//-------------------------------------------------------------------------
+// - PatchFormatStringFloatToInt()
+// - DataTypeGetInfo()
+// - DataTypeFormatString()
+// - DataTypeApplyOp()
+// - DataTypeApplyOpFromText()
+// - GetMinimumStepAtDecimalPrecision
+// - RoundScalarWithFormat<>()
+//-------------------------------------------------------------------------
+
+static const ImGuiDataTypeInfo GDataTypeInfo[] = {
+    {sizeof(char), "%d", "%d"},                                         // ImGuiDataType_S8
+    {sizeof(unsigned char), "%u", "%u"},  {sizeof(short), "%d", "%d"},  // ImGuiDataType_S16
+    {sizeof(unsigned short), "%u", "%u"}, {sizeof(int), "%d", "%d"},    // ImGuiDataType_S32
+    {sizeof(unsigned int), "%u", "%u"},
+#ifdef _MSC_VER
+    {sizeof(ImS64), "%I64d", "%I64d"},  // ImGuiDataType_S64
+    {sizeof(ImU64), "%I64u", "%I64u"},
+#else
+    {sizeof(ImS64), "%lld", "%lld"},  // ImGuiDataType_S64
+    {sizeof(ImU64), "%llu", "%llu"},
+#endif
+    {sizeof(float), "%f", "%f"},    // ImGuiDataType_Float (float are promoted to double in va_arg)
+    {sizeof(double), "%f", "%lf"},  // ImGuiDataType_Double
+};
+IM_STATIC_ASSERT(IM_ARRAYSIZE(GDataTypeInfo) == ImGuiDataType_COUNT);
+
+// FIXME-LEGACY: Prior to 1.61 our DragInt() function internally used floats and because of this the
+// compile-time default value for format was "%.0f". Even though we changed the compile-time
+// default, we expect users to have carried %f around, which would break the display of DragInt()
+// calls. To honor backward compatibility we are rewriting the format string, unless
+// IMGUI_DISABLE_OBSOLETE_FUNCTIONS is enabled. What could possibly go wrong?!
+static const char *PatchFormatStringFloatToInt(const char *fmt)
+{
+    if (fmt[0] == '%' && fmt[1] == '.' && fmt[2] == '0' && fmt[3] == 'f' &&
+        fmt[4] == 0)  // Fast legacy path for "%.0f" which is expected to be the most common case.
+        return "%d";
+    const char *fmt_start = ImParseFormatFindStart(fmt);  // Find % (if any, and ignore %%)
+    const char *fmt_end   = ImParseFormatFindEnd(
+        fmt_start);  // Find end of format specifier, which itself is an exercise of
+                       // confidence/recklessness (because snprintf is dependent on libc or user).
+    if (fmt_end > fmt_start && fmt_end[-1] == 'f')
+    {
+#ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+        if (fmt_start == fmt && fmt_end[0] == 0)
+            return "%d";
+        ImGuiContext &g = *GImGui;
+        ImFormatString(
+            g.TempBuffer, IM_ARRAYSIZE(g.TempBuffer), "%.*s%%d%s", (int)(fmt_start - fmt), fmt,
+            fmt_end);  // Honor leading and trailing decorations, but lose alignment/precision.
+        return g.TempBuffer;
+#else
+        IM_ASSERT(0 &&
+                  "DragInt(): Invalid format string!");  // Old versions used a default parameter of
+                                                         // "%.0f", please replace with e.g. "%d"
+#endif
+    }
+    return fmt;
+}
+
+const ImGuiDataTypeInfo *ImGui::DataTypeGetInfo(ImGuiDataType data_type)
+{
+    IM_ASSERT(data_type >= 0 && data_type < ImGuiDataType_COUNT);
+    return &GDataTypeInfo[data_type];
+}
+
+int ImGui::DataTypeFormatString(char *buf,
+                                int buf_size,
+                                ImGuiDataType data_type,
+                                const void *data_ptr,
+                                const char *format)
+{
+    // Signedness doesn't matter when pushing integer arguments
+    if (data_type == ImGuiDataType_S32 || data_type == ImGuiDataType_U32)
+        return ImFormatString(buf, buf_size, format, *(const ImU32 *)data_ptr);
+    if (data_type == ImGuiDataType_S64 || data_type == ImGuiDataType_U64)
+        return ImFormatString(buf, buf_size, format, *(const ImU64 *)data_ptr);
+    if (data_type == ImGuiDataType_Float)
+        return ImFormatString(buf, buf_size, format, *(const float *)data_ptr);
+    if (data_type == ImGuiDataType_Double)
+        return ImFormatString(buf, buf_size, format, *(const double *)data_ptr);
+    if (data_type == ImGuiDataType_S8)
+        return ImFormatString(buf, buf_size, format, *(const ImS8 *)data_ptr);
+    if (data_type == ImGuiDataType_U8)
+        return ImFormatString(buf, buf_size, format, *(const ImU8 *)data_ptr);
+    if (data_type == ImGuiDataType_S16)
+        return ImFormatString(buf, buf_size, format, *(const ImS16 *)data_ptr);
+    if (data_type == ImGuiDataType_U16)
+        return ImFormatString(buf, buf_size, format, *(const ImU16 *)data_ptr);
+    IM_ASSERT(0);
+    return 0;
+}
+
+void ImGui::DataTypeApplyOp(ImGuiDataType data_type,
+                            int op,
+                            void *output,
+                            void *arg1,
+                            const void *arg2)
+{
+    IM_ASSERT(op == '+' || op == '-');
+    switch (data_type)
+    {
+        case ImGuiDataType_S8:
+            if (op == '+')
+            {
+                *(ImS8 *)output = ImAddClampOverflow(*(const ImS8 *)arg1, *(const ImS8 *)arg2,
+                                                     IM_S8_MIN, IM_S8_MAX);
+            }
+            if (op == '-')
+            {
+                *(ImS8 *)output = ImSubClampOverflow(*(const ImS8 *)arg1, *(const ImS8 *)arg2,
+                                                     IM_S8_MIN, IM_S8_MAX);
+            }
+            return;
+        case ImGuiDataType_U8:
+            if (op == '+')
+            {
+                *(ImU8 *)output = ImAddClampOverflow(*(const ImU8 *)arg1, *(const ImU8 *)arg2,
+                                                     IM_U8_MIN, IM_U8_MAX);
+            }
+            if (op == '-')
+            {
+                *(ImU8 *)output = ImSubClampOverflow(*(const ImU8 *)arg1, *(const ImU8 *)arg2,
+                                                     IM_U8_MIN, IM_U8_MAX);
+            }
+            return;
+        case ImGuiDataType_S16:
+            if (op == '+')
+            {
+                *(ImS16 *)output = ImAddClampOverflow(*(const ImS16 *)arg1, *(const ImS16 *)arg2,
+                                                      IM_S16_MIN, IM_S16_MAX);
+            }
+            if (op == '-')
+            {
+                *(ImS16 *)output = ImSubClampOverflow(*(const ImS16 *)arg1, *(const ImS16 *)arg2,
+                                                      IM_S16_MIN, IM_S16_MAX);
+            }
+            return;
+        case ImGuiDataType_U16:
+            if (op == '+')
+            {
+                *(ImU16 *)output = ImAddClampOverflow(*(const ImU16 *)arg1, *(const ImU16 *)arg2,
+                                                      IM_U16_MIN, IM_U16_MAX);
+            }
+            if (op == '-')
+            {
+                *(ImU16 *)output = ImSubClampOverflow(*(const ImU16 *)arg1, *(const ImU16 *)arg2,
+                                                      IM_U16_MIN, IM_U16_MAX);
+            }
+            return;
+        case ImGuiDataType_S32:
+            if (op == '+')
+            {
+                *(ImS32 *)output = ImAddClampOverflow(*(const ImS32 *)arg1, *(const ImS32 *)arg2,
+                                                      IM_S32_MIN, IM_S32_MAX);
+            }
+            if (op == '-')
+            {
+                *(ImS32 *)output = ImSubClampOverflow(*(const ImS32 *)arg1, *(const ImS32 *)arg2,
+                                                      IM_S32_MIN, IM_S32_MAX);
+            }
+            return;
+        case ImGuiDataType_U32:
+            if (op == '+')
+            {
+                *(ImU32 *)output = ImAddClampOverflow(*(const ImU32 *)arg1, *(const ImU32 *)arg2,
+                                                      IM_U32_MIN, IM_U32_MAX);
+            }
+            if (op == '-')
+            {
+                *(ImU32 *)output = ImSubClampOverflow(*(const ImU32 *)arg1, *(const ImU32 *)arg2,
+                                                      IM_U32_MIN, IM_U32_MAX);
+            }
+            return;
+        case ImGuiDataType_S64:
+            if (op == '+')
+            {
+                *(ImS64 *)output = ImAddClampOverflow(*(const ImS64 *)arg1, *(const ImS64 *)arg2,
+                                                      IM_S64_MIN, IM_S64_MAX);
+            }
+            if (op == '-')
+            {
+                *(ImS64 *)output = ImSubClampOverflow(*(const ImS64 *)arg1, *(const ImS64 *)arg2,
+                                                      IM_S64_MIN, IM_S64_MAX);
+            }
+            return;
+        case ImGuiDataType_U64:
+            if (op == '+')
+            {
+                *(ImU64 *)output = ImAddClampOverflow(*(const ImU64 *)arg1, *(const ImU64 *)arg2,
+                                                      IM_U64_MIN, IM_U64_MAX);
+            }
+            if (op == '-')
+            {
+                *(ImU64 *)output = ImSubClampOverflow(*(const ImU64 *)arg1, *(const ImU64 *)arg2,
+                                                      IM_U64_MIN, IM_U64_MAX);
+            }
+            return;
+        case ImGuiDataType_Float:
+            if (op == '+')
+            {
+                *(float *)output = *(const float *)arg1 + *(const float *)arg2;
+            }
+            if (op == '-')
+            {
+                *(float *)output = *(const float *)arg1 - *(const float *)arg2;
+            }
+            return;
+        case ImGuiDataType_Double:
+            if (op == '+')
+            {
+                *(double *)output = *(const double *)arg1 + *(const double *)arg2;
+            }
+            if (op == '-')
+            {
+                *(double *)output = *(const double *)arg1 - *(const double *)arg2;
+            }
+            return;
+        case ImGuiDataType_COUNT:
+            break;
+    }
+    IM_ASSERT(0);
+}
+
+// User can input math operators (e.g. +100) to edit a numerical values.
+// NB: This is _not_ a full expression evaluator. We should probably add one and replace this dumb
+// mess..
+bool ImGui::DataTypeApplyOpFromText(const char *buf,
+                                    const char *initial_value_buf,
+                                    ImGuiDataType data_type,
+                                    void *data_ptr,
+                                    const char *format)
+{
+    while (ImCharIsBlankA(*buf))
+        buf++;
+
+    // We don't support '-' op because it would conflict with inputing negative value.
+    // Instead you can use +-100 to subtract from an existing value
+    char op = buf[0];
+    if (op == '+' || op == '*' || op == '/')
+    {
+        buf++;
+        while (ImCharIsBlankA(*buf))
+            buf++;
+    }
+    else
+    {
+        op = 0;
+    }
+    if (!buf[0])
+        return false;
+
+    // Copy the value in an opaque buffer so we can compare at the end of the function if it changed
+    // at all.
+    IM_ASSERT(data_type < ImGuiDataType_COUNT);
+    int data_backup[2];
+    const ImGuiDataTypeInfo *type_info = ImGui::DataTypeGetInfo(data_type);
+    IM_ASSERT(type_info->Size <= sizeof(data_backup));
+    memcpy(data_backup, data_ptr, type_info->Size);
+
+    if (format == NULL)
+        format = type_info->ScanFmt;
+
+    // FIXME-LEGACY: The aim is to remove those operators and write a proper expression evaluator at
+    // some point..
+    int arg1i = 0;
+    if (data_type == ImGuiDataType_S32)
+    {
+        int *v      = (int *)data_ptr;
+        int arg0i   = *v;
+        float arg1f = 0.0f;
+        if (op && sscanf(initial_value_buf, format, &arg0i) < 1)
+            return false;
+        // Store operand in a float so we can use fractional value for multipliers (*1.1), but
+        // constant always parsed as integer so we can fit big integers (e.g. 2000000003) past float
+        // precision
+        if (op == '+')
+        {
+            if (sscanf(buf, "%d", &arg1i))
+                *v = (int)(arg0i + arg1i);
+        }  // Add (use "+-" to subtract)
+        else if (op == '*')
+        {
+            if (sscanf(buf, "%f", &arg1f))
+                *v = (int)(arg0i * arg1f);
+        }  // Multiply
+        else if (op == '/')
+        {
+            if (sscanf(buf, "%f", &arg1f) && arg1f != 0.0f)
+                *v = (int)(arg0i / arg1f);
+        }  // Divide
+        else
+        {
+            if (sscanf(buf, format, &arg1i) == 1)
+                *v = arg1i;
+        }  // Assign constant
+    }
+    else if (data_type == ImGuiDataType_Float)
+    {
+        // For floats we have to ignore format with precision (e.g. "%.2f") because sscanf doesn't
+        // take them in
+        format      = "%f";
+        float *v    = (float *)data_ptr;
+        float arg0f = *v, arg1f = 0.0f;
+        if (op && sscanf(initial_value_buf, format, &arg0f) < 1)
+            return false;
+        if (sscanf(buf, format, &arg1f) < 1)
+            return false;
+        if (op == '+')
+        {
+            *v = arg0f + arg1f;
+        }  // Add (use "+-" to subtract)
+        else if (op == '*')
+        {
+            *v = arg0f * arg1f;
+        }  // Multiply
+        else if (op == '/')
+        {
+            if (arg1f != 0.0f)
+                *v = arg0f / arg1f;
+        }  // Divide
+        else
+        {
+            *v = arg1f;
+        }  // Assign constant
+    }
+    else if (data_type == ImGuiDataType_Double)
+    {
+        format = "%lf";  // scanf differentiate float/double unlike printf which forces everything
+                         // to double because of ellipsis
+        double *v    = (double *)data_ptr;
+        double arg0f = *v, arg1f = 0.0;
+        if (op && sscanf(initial_value_buf, format, &arg0f) < 1)
+            return false;
+        if (sscanf(buf, format, &arg1f) < 1)
+            return false;
+        if (op == '+')
+        {
+            *v = arg0f + arg1f;
+        }  // Add (use "+-" to subtract)
+        else if (op == '*')
+        {
+            *v = arg0f * arg1f;
+        }  // Multiply
+        else if (op == '/')
+        {
+            if (arg1f != 0.0f)
+                *v = arg0f / arg1f;
+        }  // Divide
+        else
+        {
+            *v = arg1f;
+        }  // Assign constant
+    }
+    else if (data_type == ImGuiDataType_U32 || data_type == ImGuiDataType_S64 ||
+             data_type == ImGuiDataType_U64)
+    {
+        // All other types assign constant
+        // We don't bother handling support for legacy operators since they are a little too crappy.
+        // Instead we will later implement a proper expression evaluator in the future.
+        sscanf(buf, format, data_ptr);
+    }
+    else
+    {
+        // Small types need a 32-bit buffer to receive the result from scanf()
+        int v32;
+        sscanf(buf, format, &v32);
+        if (data_type == ImGuiDataType_S8)
+            *(ImS8 *)data_ptr = (ImS8)ImClamp(v32, (int)IM_S8_MIN, (int)IM_S8_MAX);
+        else if (data_type == ImGuiDataType_U8)
+            *(ImU8 *)data_ptr = (ImU8)ImClamp(v32, (int)IM_U8_MIN, (int)IM_U8_MAX);
+        else if (data_type == ImGuiDataType_S16)
+            *(ImS16 *)data_ptr = (ImS16)ImClamp(v32, (int)IM_S16_MIN, (int)IM_S16_MAX);
+        else if (data_type == ImGuiDataType_U16)
+            *(ImU16 *)data_ptr = (ImU16)ImClamp(v32, (int)IM_U16_MIN, (int)IM_U16_MAX);
+        else
+            IM_ASSERT(0);
+    }
+
+    return memcmp(data_backup, data_ptr, type_info->Size) != 0;
+}
+
+static float GetMinimumStepAtDecimalPrecision(int decimal_precision)
+{
+    static const float min_steps[10] = {1.0f,     0.1f,      0.01f,      0.001f,      0.0001f,
+                                        0.00001f, 0.000001f, 0.0000001f, 0.00000001f, 0.000000001f};
+    if (decimal_precision < 0)
+        return FLT_MIN;
+    return (decimal_precision < IM_ARRAYSIZE(min_steps)) ? min_steps[decimal_precision]
+                                                         : ImPow(10.0f, (float)-decimal_precision);
+}
+
+template <typename TYPE>
+static const char *ImAtoi(const char *src, TYPE *output)
+{
+    int negative = 0;
+    if (*src == '-')
+    {
+        negative = 1;
+        src++;
+    }
+    if (*src == '+')
+    {
+        src++;
+    }
+    TYPE v = 0;
+    while (*src >= '0' && *src <= '9')
+        v = (v * 10) + (*src++ - '0');
+    *output = negative ? -v : v;
+    return src;
+}
+
+template <typename TYPE, typename SIGNEDTYPE>
+TYPE ImGui::RoundScalarWithFormatT(const char *format, ImGuiDataType data_type, TYPE v)
+{
+    const char *fmt_start = ImParseFormatFindStart(format);
+    if (fmt_start[0] != '%' ||
+        fmt_start[1] == '%')  // Don't apply if the value is not visible in the format string
+        return v;
+    char v_str[64];
+    ImFormatString(v_str, IM_ARRAYSIZE(v_str), fmt_start, v);
+    const char *p = v_str;
+    while (*p == ' ')
+        p++;
+    if (data_type == ImGuiDataType_Float || data_type == ImGuiDataType_Double)
+        v = (TYPE)ImAtof(p);
+    else
+        ImAtoi(p, (SIGNEDTYPE *)&v);
+    return v;
+}
+
+//-------------------------------------------------------------------------
+// [SECTION] Widgets: DragScalar, DragFloat, DragInt, etc.
+//-------------------------------------------------------------------------
+// - DragBehaviorT<>() [Internal]
+// - DragBehavior() [Internal]
+// - DragScalar()
+// - DragScalarN()
+// - DragFloat()
+// - DragFloat2()
+// - DragFloat3()
+// - DragFloat4()
+// - DragFloatRange2()
+// - DragInt()
+// - DragInt2()
+// - DragInt3()
+// - DragInt4()
+// - DragIntRange2()
+//-------------------------------------------------------------------------
+
+// This is called by DragBehavior() when the widget is active (held by mouse or being manipulated
+// with Nav controls)
+template <typename TYPE, typename SIGNEDTYPE, typename FLOATTYPE>
+bool ImGui::DragBehaviorT(ImGuiDataType data_type,
+                          TYPE *v,
+                          float v_speed,
+                          const TYPE v_min,
+                          const TYPE v_max,
+                          const char *format,
+                          float power,
+                          ImGuiDragFlags flags)
+{
+    ImGuiContext &g      = *GImGui;
+    const ImGuiAxis axis = (flags & ImGuiDragFlags_Vertical) ? ImGuiAxis_Y : ImGuiAxis_X;
+    const bool is_decimal =
+        (data_type == ImGuiDataType_Float) || (data_type == ImGuiDataType_Double);
+    const bool has_min_max = (v_min != v_max);
+    const bool is_power = (power != 1.0f && is_decimal && has_min_max && (v_max - v_min < FLT_MAX));
+
+    // Default tweak speed
+    if (v_speed == 0.0f && has_min_max && (v_max - v_min < FLT_MAX))
+        v_speed = (float)((v_max - v_min) * g.DragSpeedDefaultRatio);
+
+    // Inputs accumulates into g.DragCurrentAccum, which is flushed into the current value as soon
+    // as it makes a difference with our precision settings
+    float adjust_delta = 0.0f;
+    if (g.ActiveIdSource == ImGuiInputSource_Mouse && IsMousePosValid() &&
+        g.IO.MouseDragMaxDistanceSqr[0] > 1.0f * 1.0f)
+    {
+        adjust_delta = g.IO.MouseDelta[axis];
+        if (g.IO.KeyAlt)
+            adjust_delta *= 1.0f / 100.0f;
+        if (g.IO.KeyShift)
+            adjust_delta *= 10.0f;
+    }
+    else if (g.ActiveIdSource == ImGuiInputSource_Nav)
+    {
+        int decimal_precision = is_decimal ? ImParseFormatPrecision(format, 3) : 0;
+        adjust_delta =
+            GetNavInputAmount2d(ImGuiNavDirSourceFlags_Keyboard | ImGuiNavDirSourceFlags_PadDPad,
+                                ImGuiInputReadMode_RepeatFast, 1.0f / 10.0f, 10.0f)[axis];
+        v_speed = ImMax(v_speed, GetMinimumStepAtDecimalPrecision(decimal_precision));
+    }
+    adjust_delta *= v_speed;
+
+    // For vertical drag we currently assume that Up=higher value (like we do with vertical
+    // sliders). This may become a parameter.
+    if (axis == ImGuiAxis_Y)
+        adjust_delta = -adjust_delta;
+
+    // Clear current value on activation
+    // Avoid altering values and clamping when we are _already_ past the limits and heading in the
+    // same direction, so e.g. if range is 0..255, current value is 300 and we are pushing to the
+    // right side, keep the 300.
+    bool is_just_activated = g.ActiveIdIsJustActivated;
+    bool is_already_past_limits_and_pushing_outward =
+        has_min_max &&
+        ((*v >= v_max && adjust_delta > 0.0f) || (*v <= v_min && adjust_delta < 0.0f));
+    bool is_drag_direction_change_with_power =
+        is_power && ((adjust_delta < 0 && g.DragCurrentAccum > 0) ||
+                     (adjust_delta > 0 && g.DragCurrentAccum < 0));
+    if (is_just_activated || is_already_past_limits_and_pushing_outward ||
+        is_drag_direction_change_with_power)
+    {
+        g.DragCurrentAccum      = 0.0f;
+        g.DragCurrentAccumDirty = false;
+    }
+    else if (adjust_delta != 0.0f)
+    {
+        g.DragCurrentAccum += adjust_delta;
+        g.DragCurrentAccumDirty = true;
+    }
+
+    if (!g.DragCurrentAccumDirty)
+        return false;
+
+    TYPE v_cur                              = *v;
+    FLOATTYPE v_old_ref_for_accum_remainder = (FLOATTYPE)0.0f;
+
+    if (is_power)
+    {
+        // Offset + round to user desired precision, with a curve on the v_min..v_max range to get
+        // more precision on one side of the range
+        FLOATTYPE v_old_norm_curved =
+            ImPow((FLOATTYPE)(v_cur - v_min) / (FLOATTYPE)(v_max - v_min), (FLOATTYPE)1.0f / power);
+        FLOATTYPE v_new_norm_curved = v_old_norm_curved + (g.DragCurrentAccum / (v_max - v_min));
+        v_cur = v_min + (TYPE)ImPow(ImSaturate((float)v_new_norm_curved), power) * (v_max - v_min);
+        v_old_ref_for_accum_remainder = v_old_norm_curved;
+    }
+    else
+    {
+        v_cur += (TYPE)g.DragCurrentAccum;
+    }
+
+    // Round to user desired precision based on format string
+    v_cur = RoundScalarWithFormatT<TYPE, SIGNEDTYPE>(format, data_type, v_cur);
+
+    // Preserve remainder after rounding has been applied. This also allow slow tweaking of values.
+    g.DragCurrentAccumDirty = false;
+    if (is_power)
+    {
+        FLOATTYPE v_cur_norm_curved =
+            ImPow((FLOATTYPE)(v_cur - v_min) / (FLOATTYPE)(v_max - v_min), (FLOATTYPE)1.0f / power);
+        g.DragCurrentAccum -= (float)(v_cur_norm_curved - v_old_ref_for_accum_remainder);
+    }
+    else
+    {
+        g.DragCurrentAccum -= (float)((SIGNEDTYPE)v_cur - (SIGNEDTYPE)*v);
+    }
+
+    // Lose zero sign for float/double
+    if (v_cur == (TYPE)-0)
+        v_cur = (TYPE)0;
+
+    // Clamp values (+ handle overflow/wrap-around for integer types)
+    if (*v != v_cur && has_min_max)
+    {
+        if (v_cur < v_min || (v_cur > *v && adjust_delta < 0.0f && !is_decimal))
+            v_cur = v_min;
+        if (v_cur > v_max || (v_cur < *v && adjust_delta > 0.0f && !is_decimal))
+            v_cur = v_max;
+    }
+
+    // Apply result
+    if (*v == v_cur)
+        return false;
+    *v = v_cur;
+    return true;
+}
+
+bool ImGui::DragBehavior(ImGuiID id,
+                         ImGuiDataType data_type,
+                         void *v,
+                         float v_speed,
+                         const void *v_min,
+                         const void *v_max,
+                         const char *format,
+                         float power,
+                         ImGuiDragFlags flags)
+{
+    ImGuiContext &g = *GImGui;
+    if (g.ActiveId == id)
+    {
+        if (g.ActiveIdSource == ImGuiInputSource_Mouse && !g.IO.MouseDown[0])
+            ClearActiveID();
+        else if (g.ActiveIdSource == ImGuiInputSource_Nav && g.NavActivatePressedId == id &&
+                 !g.ActiveIdIsJustActivated)
+            ClearActiveID();
+    }
+    if (g.ActiveId != id)
+        return false;
+
+    switch (data_type)
+    {
+        case ImGuiDataType_S8:
+        {
+            ImS32 v32 = (ImS32) * (ImS8 *)v;
+            bool r    = DragBehaviorT<ImS32, ImS32, float>(
+                ImGuiDataType_S32, &v32, v_speed, v_min ? *(const ImS8 *)v_min : IM_S8_MIN,
+                v_max ? *(const ImS8 *)v_max : IM_S8_MAX, format, power, flags);
+            if (r)
+                *(ImS8 *)v = (ImS8)v32;
+            return r;
+        }
+        case ImGuiDataType_U8:
+        {
+            ImU32 v32 = (ImU32) * (ImU8 *)v;
+            bool r    = DragBehaviorT<ImU32, ImS32, float>(
+                ImGuiDataType_U32, &v32, v_speed, v_min ? *(const ImU8 *)v_min : IM_U8_MIN,
+                v_max ? *(const ImU8 *)v_max : IM_U8_MAX, format, power, flags);
+            if (r)
+                *(ImU8 *)v = (ImU8)v32;
+            return r;
+        }
+        case ImGuiDataType_S16:
+        {
+            ImS32 v32 = (ImS32) * (ImS16 *)v;
+            bool r    = DragBehaviorT<ImS32, ImS32, float>(
+                ImGuiDataType_S32, &v32, v_speed, v_min ? *(const ImS16 *)v_min : IM_S16_MIN,
+                v_max ? *(const ImS16 *)v_max : IM_S16_MAX, format, power, flags);
+            if (r)
+                *(ImS16 *)v = (ImS16)v32;
+            return r;
+        }
+        case ImGuiDataType_U16:
+        {
+            ImU32 v32 = (ImU32) * (ImU16 *)v;
+            bool r    = DragBehaviorT<ImU32, ImS32, float>(
+                ImGuiDataType_U32, &v32, v_speed, v_min ? *(const ImU16 *)v_min : IM_U16_MIN,
+                v_max ? *(const ImU16 *)v_max : IM_U16_MAX, format, power, flags);
+            if (r)
+                *(ImU16 *)v = (ImU16)v32;
+            return r;
+        }
+        case ImGuiDataType_S32:
+            return DragBehaviorT<ImS32, ImS32, float>(
+                data_type, (ImS32 *)v, v_speed, v_min ? *(const ImS32 *)v_min : IM_S32_MIN,
+                v_max ? *(const ImS32 *)v_max : IM_S32_MAX, format, power, flags);
+        case ImGuiDataType_U32:
+            return DragBehaviorT<ImU32, ImS32, float>(
+                data_type, (ImU32 *)v, v_speed, v_min ? *(const ImU32 *)v_min : IM_U32_MIN,
+                v_max ? *(const ImU32 *)v_max : IM_U32_MAX, format, power, flags);
+        case ImGuiDataType_S64:
+            return DragBehaviorT<ImS64, ImS64, double>(
+                data_type, (ImS64 *)v, v_speed, v_min ? *(const ImS64 *)v_min : IM_S64_MIN,
+                v_max ? *(const ImS64 *)v_max : IM_S64_MAX, format, power, flags);
+        case ImGuiDataType_U64:
+            return DragBehaviorT<ImU64, ImS64, double>(
+                data_type, (ImU64 *)v, v_speed, v_min ? *(const ImU64 *)v_min : IM_U64_MIN,
+                v_max ? *(const ImU64 *)v_max : IM_U64_MAX, format, power, flags);
+        case ImGuiDataType_Float:
+            return DragBehaviorT<float, float, float>(
+                data_type, (float *)v, v_speed, v_min ? *(const float *)v_min : -FLT_MAX,
+                v_max ? *(const float *)v_max : FLT_MAX, format, power, flags);
+        case ImGuiDataType_Double:
+            return DragBehaviorT<double, double, double>(
+                data_type, (double *)v, v_speed, v_min ? *(const double *)v_min : -DBL_MAX,
+                v_max ? *(const double *)v_max : DBL_MAX, format, power, flags);
+        case ImGuiDataType_COUNT:
+            break;
+    }
+    IM_ASSERT(0);
+    return false;
+}
+
+bool ImGui::DragScalar(const char *label,
+                       ImGuiDataType data_type,
+                       void *v,
+                       float v_speed,
+                       const void *v_min,
+                       const void *v_max,
+                       const char *format,
+                       float power)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    if (power != 1.0f)
+        IM_ASSERT(v_min != NULL &&
+                  v_max != NULL);  // When using a power curve the drag needs to have known bounds
+
+    ImGuiContext &g         = *GImGui;
+    const ImGuiStyle &style = g.Style;
+    const ImGuiID id        = window->GetID(label);
+    const float w           = CalcItemWidth();
+    const ImVec2 label_size = CalcTextSize(label, NULL, true);
+    const ImRect frame_bb(
+        window->DC.CursorPos,
+        window->DC.CursorPos + ImVec2(w, label_size.y + style.FramePadding.y * 2.0f));
+    const ImRect total_bb(
+        frame_bb.Min,
+        frame_bb.Max +
+            ImVec2(label_size.x > 0.0f ? style.ItemInnerSpacing.x + label_size.x : 0.0f, 0.0f));
+
+    ItemSize(total_bb, style.FramePadding.y);
+    if (!ItemAdd(total_bb, id, &frame_bb))
+        return false;
+
+    // Default format string when passing NULL
+    if (format == NULL)
+        format = DataTypeGetInfo(data_type)->PrintFmt;
+    else if (data_type == ImGuiDataType_S32 &&
+             strcmp(format, "%d") != 0)  // (FIXME-LEGACY: Patch old "%.0f" format string to use
+                                         // "%d", read function more details.)
+        format = PatchFormatStringFloatToInt(format);
+
+    // Tabbing or CTRL-clicking on Drag turns it into an input box
+    const bool hovered        = ItemHoverable(frame_bb, id);
+    bool temp_input_is_active = TempInputTextIsActive(id);
+    bool temp_input_start     = false;
+    if (!temp_input_is_active)
+    {
+        const bool focus_requested = FocusableItemRegister(window, id);
+        const bool clicked         = (hovered && g.IO.MouseClicked[0]);
+        const bool double_clicked  = (hovered && g.IO.MouseDoubleClicked[0]);
+        if (focus_requested || clicked || double_clicked || g.NavActivateId == id ||
+            g.NavInputId == id)
+        {
+            SetActiveID(id, window);
+            SetFocusID(id, window);
+            FocusWindow(window);
+            g.ActiveIdAllowNavDirFlags = (1 << ImGuiDir_Up) | (1 << ImGuiDir_Down);
+            if (focus_requested || (clicked && g.IO.KeyCtrl) || double_clicked ||
+                g.NavInputId == id)
+            {
+                temp_input_start = true;
+                FocusableItemUnregister(window);
+            }
+        }
+    }
+    if (temp_input_is_active || temp_input_start)
+        return TempInputTextScalar(frame_bb, id, label, data_type, v, format);
+
+    // Draw frame
+    const ImU32 frame_col = GetColorU32(
+        g.ActiveId == id ? ImGuiCol_FrameBgActive
+                         : g.HoveredId == id ? ImGuiCol_FrameBgHovered : ImGuiCol_FrameBg);
+    RenderNavHighlight(frame_bb, id);
+    RenderFrame(frame_bb.Min, frame_bb.Max, frame_col, true, style.FrameRounding);
+
+    // Drag behavior
+    const bool value_changed =
+        DragBehavior(id, data_type, v, v_speed, v_min, v_max, format, power, ImGuiDragFlags_None);
+    if (value_changed)
+        MarkItemEdited(id);
+
+    // Display value using user-provided display format so user can add prefix/suffix/decorations to
+    // the value.
+    char value_buf[64];
+    const char *value_buf_end =
+        value_buf + DataTypeFormatString(value_buf, IM_ARRAYSIZE(value_buf), data_type, v, format);
+    RenderTextClipped(frame_bb.Min, frame_bb.Max, value_buf, value_buf_end, NULL,
+                      ImVec2(0.5f, 0.5f));
+
+    if (label_size.x > 0.0f)
+        RenderText(ImVec2(frame_bb.Max.x + style.ItemInnerSpacing.x,
+                          frame_bb.Min.y + style.FramePadding.y),
+                   label);
+
+    IMGUI_TEST_ENGINE_ITEM_INFO(id, label, window->DC.ItemFlags);
+    return value_changed;
+}
+
+bool ImGui::DragScalarN(const char *label,
+                        ImGuiDataType data_type,
+                        void *v,
+                        int components,
+                        float v_speed,
+                        const void *v_min,
+                        const void *v_max,
+                        const char *format,
+                        float power)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    ImGuiContext &g    = *GImGui;
+    bool value_changed = false;
+    BeginGroup();
+    PushID(label);
+    PushMultiItemsWidths(components, CalcItemWidth());
+    size_t type_size = GDataTypeInfo[data_type].Size;
+    for (int i = 0; i < components; i++)
+    {
+        PushID(i);
+        if (i > 0)
+            SameLine(0, g.Style.ItemInnerSpacing.x);
+        value_changed |= DragScalar("", data_type, v, v_speed, v_min, v_max, format, power);
+        PopID();
+        PopItemWidth();
+        v = (void *)((char *)v + type_size);
+    }
+    PopID();
+
+    const char *label_end = FindRenderedTextEnd(label);
+    if (label != label_end)
+    {
+        SameLine(0, g.Style.ItemInnerSpacing.x);
+        TextEx(label, label_end);
+    }
+
+    EndGroup();
+    return value_changed;
+}
+
+bool ImGui::DragFloat(const char *label,
+                      float *v,
+                      float v_speed,
+                      float v_min,
+                      float v_max,
+                      const char *format,
+                      float power)
+{
+    return DragScalar(label, ImGuiDataType_Float, v, v_speed, &v_min, &v_max, format, power);
+}
+
+bool ImGui::DragFloat2(const char *label,
+                       float v[2],
+                       float v_speed,
+                       float v_min,
+                       float v_max,
+                       const char *format,
+                       float power)
+{
+    return DragScalarN(label, ImGuiDataType_Float, v, 2, v_speed, &v_min, &v_max, format, power);
+}
+
+bool ImGui::DragFloat3(const char *label,
+                       float v[3],
+                       float v_speed,
+                       float v_min,
+                       float v_max,
+                       const char *format,
+                       float power)
+{
+    return DragScalarN(label, ImGuiDataType_Float, v, 3, v_speed, &v_min, &v_max, format, power);
+}
+
+bool ImGui::DragFloat4(const char *label,
+                       float v[4],
+                       float v_speed,
+                       float v_min,
+                       float v_max,
+                       const char *format,
+                       float power)
+{
+    return DragScalarN(label, ImGuiDataType_Float, v, 4, v_speed, &v_min, &v_max, format, power);
+}
+
+bool ImGui::DragFloatRange2(const char *label,
+                            float *v_current_min,
+                            float *v_current_max,
+                            float v_speed,
+                            float v_min,
+                            float v_max,
+                            const char *format,
+                            const char *format_max,
+                            float power)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    ImGuiContext &g = *GImGui;
+    PushID(label);
+    BeginGroup();
+    PushMultiItemsWidths(2, CalcItemWidth());
+
+    bool value_changed =
+        DragFloat("##min", v_current_min, v_speed, (v_min >= v_max) ? -FLT_MAX : v_min,
+                  (v_min >= v_max) ? *v_current_max : ImMin(v_max, *v_current_max), format, power);
+    PopItemWidth();
+    SameLine(0, g.Style.ItemInnerSpacing.x);
+    value_changed |=
+        DragFloat("##max", v_current_max, v_speed,
+                  (v_min >= v_max) ? *v_current_min : ImMax(v_min, *v_current_min),
+                  (v_min >= v_max) ? FLT_MAX : v_max, format_max ? format_max : format, power);
+    PopItemWidth();
+    SameLine(0, g.Style.ItemInnerSpacing.x);
+
+    TextEx(label, FindRenderedTextEnd(label));
+    EndGroup();
+    PopID();
+    return value_changed;
+}
+
+// NB: v_speed is float to allow adjusting the drag speed with more precision
+bool ImGui::DragInt(const char *label,
+                    int *v,
+                    float v_speed,
+                    int v_min,
+                    int v_max,
+                    const char *format)
+{
+    return DragScalar(label, ImGuiDataType_S32, v, v_speed, &v_min, &v_max, format);
+}
+
+bool ImGui::DragInt2(const char *label,
+                     int v[2],
+                     float v_speed,
+                     int v_min,
+                     int v_max,
+                     const char *format)
+{
+    return DragScalarN(label, ImGuiDataType_S32, v, 2, v_speed, &v_min, &v_max, format);
+}
+
+bool ImGui::DragInt3(const char *label,
+                     int v[3],
+                     float v_speed,
+                     int v_min,
+                     int v_max,
+                     const char *format)
+{
+    return DragScalarN(label, ImGuiDataType_S32, v, 3, v_speed, &v_min, &v_max, format);
+}
+
+bool ImGui::DragInt4(const char *label,
+                     int v[4],
+                     float v_speed,
+                     int v_min,
+                     int v_max,
+                     const char *format)
+{
+    return DragScalarN(label, ImGuiDataType_S32, v, 4, v_speed, &v_min, &v_max, format);
+}
+
+bool ImGui::DragIntRange2(const char *label,
+                          int *v_current_min,
+                          int *v_current_max,
+                          float v_speed,
+                          int v_min,
+                          int v_max,
+                          const char *format,
+                          const char *format_max)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    ImGuiContext &g = *GImGui;
+    PushID(label);
+    BeginGroup();
+    PushMultiItemsWidths(2, CalcItemWidth());
+
+    bool value_changed =
+        DragInt("##min", v_current_min, v_speed, (v_min >= v_max) ? INT_MIN : v_min,
+                (v_min >= v_max) ? *v_current_max : ImMin(v_max, *v_current_max), format);
+    PopItemWidth();
+    SameLine(0, g.Style.ItemInnerSpacing.x);
+    value_changed |= DragInt("##max", v_current_max, v_speed,
+                             (v_min >= v_max) ? *v_current_min : ImMax(v_min, *v_current_min),
+                             (v_min >= v_max) ? INT_MAX : v_max, format_max ? format_max : format);
+    PopItemWidth();
+    SameLine(0, g.Style.ItemInnerSpacing.x);
+
+    TextEx(label, FindRenderedTextEnd(label));
+    EndGroup();
+    PopID();
+
+    return value_changed;
+}
+
+//-------------------------------------------------------------------------
+// [SECTION] Widgets: SliderScalar, SliderFloat, SliderInt, etc.
+//-------------------------------------------------------------------------
+// - SliderBehaviorT<>() [Internal]
+// - SliderBehavior() [Internal]
+// - SliderScalar()
+// - SliderScalarN()
+// - SliderFloat()
+// - SliderFloat2()
+// - SliderFloat3()
+// - SliderFloat4()
+// - SliderAngle()
+// - SliderInt()
+// - SliderInt2()
+// - SliderInt3()
+// - SliderInt4()
+// - VSliderScalar()
+// - VSliderFloat()
+// - VSliderInt()
+//-------------------------------------------------------------------------
+
+template <typename TYPE, typename FLOATTYPE>
+float ImGui::SliderCalcRatioFromValueT(ImGuiDataType data_type,
+                                       TYPE v,
+                                       TYPE v_min,
+                                       TYPE v_max,
+                                       float power,
+                                       float linear_zero_pos)
+{
+    if (v_min == v_max)
+        return 0.0f;
+
+    const bool is_power =
+        (power != 1.0f) && (data_type == ImGuiDataType_Float || data_type == ImGuiDataType_Double);
+    const TYPE v_clamped = (v_min < v_max) ? ImClamp(v, v_min, v_max) : ImClamp(v, v_max, v_min);
+    if (is_power)
+    {
+        if (v_clamped < 0.0f)
+        {
+            const float f = 1.0f - (float)((v_clamped - v_min) / (ImMin((TYPE)0, v_max) - v_min));
+            return (1.0f - ImPow(f, 1.0f / power)) * linear_zero_pos;
+        }
+        else
+        {
+            const float f =
+                (float)((v_clamped - ImMax((TYPE)0, v_min)) / (v_max - ImMax((TYPE)0, v_min)));
+            return linear_zero_pos + ImPow(f, 1.0f / power) * (1.0f - linear_zero_pos);
+        }
+    }
+
+    // Linear slider
+    return (float)((FLOATTYPE)(v_clamped - v_min) / (FLOATTYPE)(v_max - v_min));
+}
+
+// FIXME: Move some of the code into SliderBehavior(). Current responsability is larger than what
+// the equivalent DragBehaviorT<> does, we also do some rendering, etc.
+template <typename TYPE, typename SIGNEDTYPE, typename FLOATTYPE>
+bool ImGui::SliderBehaviorT(const ImRect &bb,
+                            ImGuiID id,
+                            ImGuiDataType data_type,
+                            TYPE *v,
+                            const TYPE v_min,
+                            const TYPE v_max,
+                            const char *format,
+                            float power,
+                            ImGuiSliderFlags flags,
+                            ImRect *out_grab_bb)
+{
+    ImGuiContext &g         = *GImGui;
+    const ImGuiStyle &style = g.Style;
+
+    const ImGuiAxis axis = (flags & ImGuiSliderFlags_Vertical) ? ImGuiAxis_Y : ImGuiAxis_X;
+    const bool is_decimal =
+        (data_type == ImGuiDataType_Float) || (data_type == ImGuiDataType_Double);
+    const bool is_power = (power != 1.0f) && is_decimal;
+
+    const float grab_padding = 2.0f;
+    const float slider_sz    = (bb.Max[axis] - bb.Min[axis]) - grab_padding * 2.0f;
+    float grab_sz            = style.GrabMinSize;
+    SIGNEDTYPE v_range       = (v_min < v_max ? v_max - v_min : v_min - v_max);
+    if (!is_decimal && v_range >= 0)  // v_range < 0 may happen on integer overflows
+        grab_sz = ImMax((float)(slider_sz / (v_range + 1)),
+                        style.GrabMinSize);  // For integer sliders: if possible have the grab size
+                                             // represent 1 unit
+    grab_sz                           = ImMin(grab_sz, slider_sz);
+    const float slider_usable_sz      = slider_sz - grab_sz;
+    const float slider_usable_pos_min = bb.Min[axis] + grab_padding + grab_sz * 0.5f;
+    const float slider_usable_pos_max = bb.Max[axis] - grab_padding - grab_sz * 0.5f;
+
+    // For power curve sliders that cross over sign boundary we want the curve to be symmetric
+    // around 0.0f
+    float linear_zero_pos;  // 0.0->1.0f
+    if (is_power && v_min * v_max < 0.0f)
+    {
+        // Different sign
+        const FLOATTYPE linear_dist_min_to_0 =
+            ImPow(v_min >= 0 ? (FLOATTYPE)v_min : -(FLOATTYPE)v_min, (FLOATTYPE)1.0f / power);
+        const FLOATTYPE linear_dist_max_to_0 =
+            ImPow(v_max >= 0 ? (FLOATTYPE)v_max : -(FLOATTYPE)v_max, (FLOATTYPE)1.0f / power);
+        linear_zero_pos =
+            (float)(linear_dist_min_to_0 / (linear_dist_min_to_0 + linear_dist_max_to_0));
+    }
+    else
+    {
+        // Same sign
+        linear_zero_pos = v_min < 0.0f ? 1.0f : 0.0f;
+    }
+
+    // Process interacting with the slider
+    bool value_changed = false;
+    if (g.ActiveId == id)
+    {
+        bool set_new_value = false;
+        float clicked_t    = 0.0f;
+        if (g.ActiveIdSource == ImGuiInputSource_Mouse)
+        {
+            if (!g.IO.MouseDown[0])
+            {
+                ClearActiveID();
+            }
+            else
+            {
+                const float mouse_abs_pos = g.IO.MousePos[axis];
+                clicked_t =
+                    (slider_usable_sz > 0.0f)
+                        ? ImClamp((mouse_abs_pos - slider_usable_pos_min) / slider_usable_sz, 0.0f,
+                                  1.0f)
+                        : 0.0f;
+                if (axis == ImGuiAxis_Y)
+                    clicked_t = 1.0f - clicked_t;
+                set_new_value = true;
+            }
+        }
+        else if (g.ActiveIdSource == ImGuiInputSource_Nav)
+        {
+            const ImVec2 delta2 = GetNavInputAmount2d(
+                ImGuiNavDirSourceFlags_Keyboard | ImGuiNavDirSourceFlags_PadDPad,
+                ImGuiInputReadMode_RepeatFast, 0.0f, 0.0f);
+            float delta = (axis == ImGuiAxis_X) ? delta2.x : -delta2.y;
+            if (g.NavActivatePressedId == id && !g.ActiveIdIsJustActivated)
+            {
+                ClearActiveID();
+            }
+            else if (delta != 0.0f)
+            {
+                clicked_t = SliderCalcRatioFromValueT<TYPE, FLOATTYPE>(data_type, *v, v_min, v_max,
+                                                                       power, linear_zero_pos);
+                const int decimal_precision = is_decimal ? ImParseFormatPrecision(format, 3) : 0;
+                if ((decimal_precision > 0) || is_power)
+                {
+                    delta /= 100.0f;  // Gamepad/keyboard tweak speeds in % of slider bounds
+                    if (IsNavInputDown(ImGuiNavInput_TweakSlow))
+                        delta /= 10.0f;
+                }
+                else
+                {
+                    if ((v_range >= -100.0f && v_range <= 100.0f) ||
+                        IsNavInputDown(ImGuiNavInput_TweakSlow))
+                        delta = ((delta < 0.0f) ? -1.0f : +1.0f) /
+                                (float)v_range;  // Gamepad/keyboard tweak speeds in integer steps
+                    else
+                        delta /= 100.0f;
+                }
+                if (IsNavInputDown(ImGuiNavInput_TweakFast))
+                    delta *= 10.0f;
+                set_new_value = true;
+                if ((clicked_t >= 1.0f && delta > 0.0f) ||
+                    (clicked_t <= 0.0f && delta < 0.0f))  // This is to avoid applying the
+                                                          // saturation when already past the limits
+                    set_new_value = false;
+                else
+                    clicked_t = ImSaturate(clicked_t + delta);
+            }
+        }
+
+        if (set_new_value)
+        {
+            TYPE v_new;
+            if (is_power)
+            {
+                // Account for power curve scale on both sides of the zero
+                if (clicked_t < linear_zero_pos)
+                {
+                    // Negative: rescale to the negative range before powering
+                    float a = 1.0f - (clicked_t / linear_zero_pos);
+                    a       = ImPow(a, power);
+                    v_new   = ImLerp(ImMin(v_max, (TYPE)0), v_min, a);
+                }
+                else
+                {
+                    // Positive: rescale to the positive range before powering
+                    float a;
+                    if (ImFabs(linear_zero_pos - 1.0f) > 1.e-6f)
+                        a = (clicked_t - linear_zero_pos) / (1.0f - linear_zero_pos);
+                    else
+                        a = clicked_t;
+                    a     = ImPow(a, power);
+                    v_new = ImLerp(ImMax(v_min, (TYPE)0), v_max, a);
+                }
+            }
+            else
+            {
+                // Linear slider
+                if (is_decimal)
+                {
+                    v_new = ImLerp(v_min, v_max, clicked_t);
+                }
+                else
+                {
+                    // For integer values we want the clicking position to match the grab box so we
+                    // round above This code is carefully tuned to work with large values (e.g. high
+                    // ranges of U64) while preserving this property..
+                    FLOATTYPE v_new_off_f = (v_max - v_min) * clicked_t;
+                    TYPE v_new_off_floor  = (TYPE)(v_new_off_f);
+                    TYPE v_new_off_round  = (TYPE)(v_new_off_f + (FLOATTYPE)0.5);
+                    if (!is_decimal && v_new_off_floor < v_new_off_round)
+                        v_new = v_min + v_new_off_round;
+                    else
+                        v_new = v_min + v_new_off_floor;
+                }
+            }
+
+            // Round to user desired precision based on format string
+            v_new = RoundScalarWithFormatT<TYPE, SIGNEDTYPE>(format, data_type, v_new);
+
+            // Apply result
+            if (*v != v_new)
+            {
+                *v            = v_new;
+                value_changed = true;
+            }
+        }
+    }
+
+    if (slider_sz < 1.0f)
+    {
+        *out_grab_bb = ImRect(bb.Min, bb.Min);
+    }
+    else
+    {
+        // Output grab position so it can be displayed by the caller
+        float grab_t = SliderCalcRatioFromValueT<TYPE, FLOATTYPE>(data_type, *v, v_min, v_max,
+                                                                  power, linear_zero_pos);
+        if (axis == ImGuiAxis_Y)
+            grab_t = 1.0f - grab_t;
+        const float grab_pos = ImLerp(slider_usable_pos_min, slider_usable_pos_max, grab_t);
+        if (axis == ImGuiAxis_X)
+            *out_grab_bb = ImRect(grab_pos - grab_sz * 0.5f, bb.Min.y + grab_padding,
+                                  grab_pos + grab_sz * 0.5f, bb.Max.y - grab_padding);
+        else
+            *out_grab_bb = ImRect(bb.Min.x + grab_padding, grab_pos - grab_sz * 0.5f,
+                                  bb.Max.x - grab_padding, grab_pos + grab_sz * 0.5f);
+    }
+
+    return value_changed;
+}
+
+// For 32-bits and larger types, slider bounds are limited to half the natural type range.
+// So e.g. an integer Slider between INT_MAX-10 and INT_MAX will fail, but an integer Slider between
+// INT_MAX/2-10 and INT_MAX/2 will be ok. It would be possible to lift that limitation with some
+// work but it doesn't seem to be worth it for sliders.
+bool ImGui::SliderBehavior(const ImRect &bb,
+                           ImGuiID id,
+                           ImGuiDataType data_type,
+                           void *v,
+                           const void *v_min,
+                           const void *v_max,
+                           const char *format,
+                           float power,
+                           ImGuiSliderFlags flags,
+                           ImRect *out_grab_bb)
+{
+    switch (data_type)
+    {
+        case ImGuiDataType_S8:
+        {
+            ImS32 v32 = (ImS32) * (ImS8 *)v;
+            bool r    = SliderBehaviorT<ImS32, ImS32, float>(
+                bb, id, ImGuiDataType_S32, &v32, *(const ImS8 *)v_min, *(const ImS8 *)v_max, format,
+                power, flags, out_grab_bb);
+            if (r)
+                *(ImS8 *)v = (ImS8)v32;
+            return r;
+        }
+        case ImGuiDataType_U8:
+        {
+            ImU32 v32 = (ImU32) * (ImU8 *)v;
+            bool r    = SliderBehaviorT<ImU32, ImS32, float>(
+                bb, id, ImGuiDataType_U32, &v32, *(const ImU8 *)v_min, *(const ImU8 *)v_max, format,
+                power, flags, out_grab_bb);
+            if (r)
+                *(ImU8 *)v = (ImU8)v32;
+            return r;
+        }
+        case ImGuiDataType_S16:
+        {
+            ImS32 v32 = (ImS32) * (ImS16 *)v;
+            bool r    = SliderBehaviorT<ImS32, ImS32, float>(
+                bb, id, ImGuiDataType_S32, &v32, *(const ImS16 *)v_min, *(const ImS16 *)v_max,
+                format, power, flags, out_grab_bb);
+            if (r)
+                *(ImS16 *)v = (ImS16)v32;
+            return r;
+        }
+        case ImGuiDataType_U16:
+        {
+            ImU32 v32 = (ImU32) * (ImU16 *)v;
+            bool r    = SliderBehaviorT<ImU32, ImS32, float>(
+                bb, id, ImGuiDataType_U32, &v32, *(const ImU16 *)v_min, *(const ImU16 *)v_max,
+                format, power, flags, out_grab_bb);
+            if (r)
+                *(ImU16 *)v = (ImU16)v32;
+            return r;
+        }
+        case ImGuiDataType_S32:
+            IM_ASSERT(*(const ImS32 *)v_min >= IM_S32_MIN / 2 &&
+                      *(const ImS32 *)v_max <= IM_S32_MAX / 2);
+            return SliderBehaviorT<ImS32, ImS32, float>(
+                bb, id, data_type, (ImS32 *)v, *(const ImS32 *)v_min, *(const ImS32 *)v_max, format,
+                power, flags, out_grab_bb);
+        case ImGuiDataType_U32:
+            IM_ASSERT(*(const ImU32 *)v_min <= IM_U32_MAX / 2);
+            return SliderBehaviorT<ImU32, ImS32, float>(
+                bb, id, data_type, (ImU32 *)v, *(const ImU32 *)v_min, *(const ImU32 *)v_max, format,
+                power, flags, out_grab_bb);
+        case ImGuiDataType_S64:
+            IM_ASSERT(*(const ImS64 *)v_min >= IM_S64_MIN / 2 &&
+                      *(const ImS64 *)v_max <= IM_S64_MAX / 2);
+            return SliderBehaviorT<ImS64, ImS64, double>(
+                bb, id, data_type, (ImS64 *)v, *(const ImS64 *)v_min, *(const ImS64 *)v_max, format,
+                power, flags, out_grab_bb);
+        case ImGuiDataType_U64:
+            IM_ASSERT(*(const ImU64 *)v_min <= IM_U64_MAX / 2);
+            return SliderBehaviorT<ImU64, ImS64, double>(
+                bb, id, data_type, (ImU64 *)v, *(const ImU64 *)v_min, *(const ImU64 *)v_max, format,
+                power, flags, out_grab_bb);
+        case ImGuiDataType_Float:
+            IM_ASSERT(*(const float *)v_min >= -FLT_MAX / 2.0f &&
+                      *(const float *)v_max <= FLT_MAX / 2.0f);
+            return SliderBehaviorT<float, float, float>(
+                bb, id, data_type, (float *)v, *(const float *)v_min, *(const float *)v_max, format,
+                power, flags, out_grab_bb);
+        case ImGuiDataType_Double:
+            IM_ASSERT(*(const double *)v_min >= -DBL_MAX / 2.0f &&
+                      *(const double *)v_max <= DBL_MAX / 2.0f);
+            return SliderBehaviorT<double, double, double>(
+                bb, id, data_type, (double *)v, *(const double *)v_min, *(const double *)v_max,
+                format, power, flags, out_grab_bb);
+        case ImGuiDataType_COUNT:
+            break;
+    }
+    IM_ASSERT(0);
+    return false;
+}
+
+bool ImGui::SliderScalar(const char *label,
+                         ImGuiDataType data_type,
+                         void *v,
+                         const void *v_min,
+                         const void *v_max,
+                         const char *format,
+                         float power)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    ImGuiContext &g         = *GImGui;
+    const ImGuiStyle &style = g.Style;
+    const ImGuiID id        = window->GetID(label);
+    const float w           = CalcItemWidth();
+
+    const ImVec2 label_size = CalcTextSize(label, NULL, true);
+    const ImRect frame_bb(
+        window->DC.CursorPos,
+        window->DC.CursorPos + ImVec2(w, label_size.y + style.FramePadding.y * 2.0f));
+    const ImRect total_bb(
+        frame_bb.Min,
+        frame_bb.Max +
+            ImVec2(label_size.x > 0.0f ? style.ItemInnerSpacing.x + label_size.x : 0.0f, 0.0f));
+
+    ItemSize(total_bb, style.FramePadding.y);
+    if (!ItemAdd(total_bb, id, &frame_bb))
+        return false;
+
+    // Default format string when passing NULL
+    if (format == NULL)
+        format = DataTypeGetInfo(data_type)->PrintFmt;
+    else if (data_type == ImGuiDataType_S32 &&
+             strcmp(format, "%d") != 0)  // (FIXME-LEGACY: Patch old "%.0f" format string to use
+                                         // "%d", read function more details.)
+        format = PatchFormatStringFloatToInt(format);
+
+    // Tabbing or CTRL-clicking on Slider turns it into an input box
+    const bool hovered        = ItemHoverable(frame_bb, id);
+    bool temp_input_is_active = TempInputTextIsActive(id);
+    bool temp_input_start     = false;
+    if (!temp_input_is_active)
+    {
+        const bool focus_requested = FocusableItemRegister(window, id);
+        const bool clicked         = (hovered && g.IO.MouseClicked[0]);
+        if (focus_requested || clicked || g.NavActivateId == id || g.NavInputId == id)
+        {
+            SetActiveID(id, window);
+            SetFocusID(id, window);
+            FocusWindow(window);
+            g.ActiveIdAllowNavDirFlags = (1 << ImGuiDir_Up) | (1 << ImGuiDir_Down);
+            if (focus_requested || (clicked && g.IO.KeyCtrl) || g.NavInputId == id)
+            {
+                temp_input_start = true;
+                FocusableItemUnregister(window);
+            }
+        }
+    }
+    if (temp_input_is_active || temp_input_start)
+        return TempInputTextScalar(frame_bb, id, label, data_type, v, format);
+
+    // Draw frame
+    const ImU32 frame_col = GetColorU32(
+        g.ActiveId == id ? ImGuiCol_FrameBgActive
+                         : g.HoveredId == id ? ImGuiCol_FrameBgHovered : ImGuiCol_FrameBg);
+    RenderNavHighlight(frame_bb, id);
+    RenderFrame(frame_bb.Min, frame_bb.Max, frame_col, true, g.Style.FrameRounding);
+
+    // Slider behavior
+    ImRect grab_bb;
+    const bool value_changed = SliderBehavior(frame_bb, id, data_type, v, v_min, v_max, format,
+                                              power, ImGuiSliderFlags_None, &grab_bb);
+    if (value_changed)
+        MarkItemEdited(id);
+
+    // Render grab
+    if (grab_bb.Max.x > grab_bb.Min.x)
+        window->DrawList->AddRectFilled(
+            grab_bb.Min, grab_bb.Max,
+            GetColorU32(g.ActiveId == id ? ImGuiCol_SliderGrabActive : ImGuiCol_SliderGrab),
+            style.GrabRounding);
+
+    // Display value using user-provided display format so user can add prefix/suffix/decorations to
+    // the value.
+    char value_buf[64];
+    const char *value_buf_end =
+        value_buf + DataTypeFormatString(value_buf, IM_ARRAYSIZE(value_buf), data_type, v, format);
+    RenderTextClipped(frame_bb.Min, frame_bb.Max, value_buf, value_buf_end, NULL,
+                      ImVec2(0.5f, 0.5f));
+
+    if (label_size.x > 0.0f)
+        RenderText(ImVec2(frame_bb.Max.x + style.ItemInnerSpacing.x,
+                          frame_bb.Min.y + style.FramePadding.y),
+                   label);
+
+    IMGUI_TEST_ENGINE_ITEM_INFO(id, label, window->DC.ItemFlags);
+    return value_changed;
+}
+
+// Add multiple sliders on 1 line for compact edition of multiple components
+bool ImGui::SliderScalarN(const char *label,
+                          ImGuiDataType data_type,
+                          void *v,
+                          int components,
+                          const void *v_min,
+                          const void *v_max,
+                          const char *format,
+                          float power)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    ImGuiContext &g    = *GImGui;
+    bool value_changed = false;
+    BeginGroup();
+    PushID(label);
+    PushMultiItemsWidths(components, CalcItemWidth());
+    size_t type_size = GDataTypeInfo[data_type].Size;
+    for (int i = 0; i < components; i++)
+    {
+        PushID(i);
+        if (i > 0)
+            SameLine(0, g.Style.ItemInnerSpacing.x);
+        value_changed |= SliderScalar("", data_type, v, v_min, v_max, format, power);
+        PopID();
+        PopItemWidth();
+        v = (void *)((char *)v + type_size);
+    }
+    PopID();
+
+    const char *label_end = FindRenderedTextEnd(label);
+    if (label != label_end)
+    {
+        SameLine(0, g.Style.ItemInnerSpacing.x);
+        TextEx(label, label_end);
+    }
+
+    EndGroup();
+    return value_changed;
+}
+
+bool ImGui::SliderFloat(const char *label,
+                        float *v,
+                        float v_min,
+                        float v_max,
+                        const char *format,
+                        float power)
+{
+    return SliderScalar(label, ImGuiDataType_Float, v, &v_min, &v_max, format, power);
+}
+
+bool ImGui::SliderFloat2(const char *label,
+                         float v[2],
+                         float v_min,
+                         float v_max,
+                         const char *format,
+                         float power)
+{
+    return SliderScalarN(label, ImGuiDataType_Float, v, 2, &v_min, &v_max, format, power);
+}
+
+bool ImGui::SliderFloat3(const char *label,
+                         float v[3],
+                         float v_min,
+                         float v_max,
+                         const char *format,
+                         float power)
+{
+    return SliderScalarN(label, ImGuiDataType_Float, v, 3, &v_min, &v_max, format, power);
+}
+
+bool ImGui::SliderFloat4(const char *label,
+                         float v[4],
+                         float v_min,
+                         float v_max,
+                         const char *format,
+                         float power)
+{
+    return SliderScalarN(label, ImGuiDataType_Float, v, 4, &v_min, &v_max, format, power);
+}
+
+bool ImGui::SliderAngle(const char *label,
+                        float *v_rad,
+                        float v_degrees_min,
+                        float v_degrees_max,
+                        const char *format)
+{
+    if (format == NULL)
+        format = "%.0f deg";
+    float v_deg        = (*v_rad) * 360.0f / (2 * IM_PI);
+    bool value_changed = SliderFloat(label, &v_deg, v_degrees_min, v_degrees_max, format, 1.0f);
+    *v_rad             = v_deg * (2 * IM_PI) / 360.0f;
+    return value_changed;
+}
+
+bool ImGui::SliderInt(const char *label, int *v, int v_min, int v_max, const char *format)
+{
+    return SliderScalar(label, ImGuiDataType_S32, v, &v_min, &v_max, format);
+}
+
+bool ImGui::SliderInt2(const char *label, int v[2], int v_min, int v_max, const char *format)
+{
+    return SliderScalarN(label, ImGuiDataType_S32, v, 2, &v_min, &v_max, format);
+}
+
+bool ImGui::SliderInt3(const char *label, int v[3], int v_min, int v_max, const char *format)
+{
+    return SliderScalarN(label, ImGuiDataType_S32, v, 3, &v_min, &v_max, format);
+}
+
+bool ImGui::SliderInt4(const char *label, int v[4], int v_min, int v_max, const char *format)
+{
+    return SliderScalarN(label, ImGuiDataType_S32, v, 4, &v_min, &v_max, format);
+}
+
+bool ImGui::VSliderScalar(const char *label,
+                          const ImVec2 &size,
+                          ImGuiDataType data_type,
+                          void *v,
+                          const void *v_min,
+                          const void *v_max,
+                          const char *format,
+                          float power)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    ImGuiContext &g         = *GImGui;
+    const ImGuiStyle &style = g.Style;
+    const ImGuiID id        = window->GetID(label);
+
+    const ImVec2 label_size = CalcTextSize(label, NULL, true);
+    const ImRect frame_bb(window->DC.CursorPos, window->DC.CursorPos + size);
+    const ImRect bb(
+        frame_bb.Min,
+        frame_bb.Max +
+            ImVec2(label_size.x > 0.0f ? style.ItemInnerSpacing.x + label_size.x : 0.0f, 0.0f));
+
+    ItemSize(bb, style.FramePadding.y);
+    if (!ItemAdd(frame_bb, id))
+        return false;
+
+    // Default format string when passing NULL
+    if (format == NULL)
+        format = DataTypeGetInfo(data_type)->PrintFmt;
+    else if (data_type == ImGuiDataType_S32 &&
+             strcmp(format, "%d") != 0)  // (FIXME-LEGACY: Patch old "%.0f" format string to use
+                                         // "%d", read function more details.)
+        format = PatchFormatStringFloatToInt(format);
+
+    const bool hovered = ItemHoverable(frame_bb, id);
+    if ((hovered && g.IO.MouseClicked[0]) || g.NavActivateId == id || g.NavInputId == id)
+    {
+        SetActiveID(id, window);
+        SetFocusID(id, window);
+        FocusWindow(window);
+        g.ActiveIdAllowNavDirFlags = (1 << ImGuiDir_Left) | (1 << ImGuiDir_Right);
+    }
+
+    // Draw frame
+    const ImU32 frame_col = GetColorU32(
+        g.ActiveId == id ? ImGuiCol_FrameBgActive
+                         : g.HoveredId == id ? ImGuiCol_FrameBgHovered : ImGuiCol_FrameBg);
+    RenderNavHighlight(frame_bb, id);
+    RenderFrame(frame_bb.Min, frame_bb.Max, frame_col, true, g.Style.FrameRounding);
+
+    // Slider behavior
+    ImRect grab_bb;
+    const bool value_changed = SliderBehavior(frame_bb, id, data_type, v, v_min, v_max, format,
+                                              power, ImGuiSliderFlags_Vertical, &grab_bb);
+    if (value_changed)
+        MarkItemEdited(id);
+
+    // Render grab
+    if (grab_bb.Max.y > grab_bb.Min.y)
+        window->DrawList->AddRectFilled(
+            grab_bb.Min, grab_bb.Max,
+            GetColorU32(g.ActiveId == id ? ImGuiCol_SliderGrabActive : ImGuiCol_SliderGrab),
+            style.GrabRounding);
+
+    // Display value using user-provided display format so user can add prefix/suffix/decorations to
+    // the value. For the vertical slider we allow centered text to overlap the frame padding
+    char value_buf[64];
+    const char *value_buf_end =
+        value_buf + DataTypeFormatString(value_buf, IM_ARRAYSIZE(value_buf), data_type, v, format);
+    RenderTextClipped(ImVec2(frame_bb.Min.x, frame_bb.Min.y + style.FramePadding.y), frame_bb.Max,
+                      value_buf, value_buf_end, NULL, ImVec2(0.5f, 0.0f));
+    if (label_size.x > 0.0f)
+        RenderText(ImVec2(frame_bb.Max.x + style.ItemInnerSpacing.x,
+                          frame_bb.Min.y + style.FramePadding.y),
+                   label);
+
+    return value_changed;
+}
+
+bool ImGui::VSliderFloat(const char *label,
+                         const ImVec2 &size,
+                         float *v,
+                         float v_min,
+                         float v_max,
+                         const char *format,
+                         float power)
+{
+    return VSliderScalar(label, size, ImGuiDataType_Float, v, &v_min, &v_max, format, power);
+}
+
+bool ImGui::VSliderInt(const char *label,
+                       const ImVec2 &size,
+                       int *v,
+                       int v_min,
+                       int v_max,
+                       const char *format)
+{
+    return VSliderScalar(label, size, ImGuiDataType_S32, v, &v_min, &v_max, format);
+}
+
+//-------------------------------------------------------------------------
+// [SECTION] Widgets: InputScalar, InputFloat, InputInt, etc.
+//-------------------------------------------------------------------------
+// - ImParseFormatFindStart() [Internal]
+// - ImParseFormatFindEnd() [Internal]
+// - ImParseFormatTrimDecorations() [Internal]
+// - ImParseFormatPrecision() [Internal]
+// - TempInputTextScalar() [Internal]
+// - InputScalar()
+// - InputScalarN()
+// - InputFloat()
+// - InputFloat2()
+// - InputFloat3()
+// - InputFloat4()
+// - InputInt()
+// - InputInt2()
+// - InputInt3()
+// - InputInt4()
+// - InputDouble()
+//-------------------------------------------------------------------------
+
+// We don't use strchr() because our strings are usually very short and often start with '%'
+const char *ImParseFormatFindStart(const char *fmt)
+{
+    while (char c = fmt[0])
+    {
+        if (c == '%' && fmt[1] != '%')
+            return fmt;
+        else if (c == '%')
+            fmt++;
+        fmt++;
+    }
+    return fmt;
+}
+
+const char *ImParseFormatFindEnd(const char *fmt)
+{
+    // Printf/scanf types modifiers: I/L/h/j/l/t/w/z. Other uppercase letters qualify as types aka
+    // end of the format.
+    if (fmt[0] != '%')
+        return fmt;
+    const unsigned int ignored_uppercase_mask = (1 << ('I' - 'A')) | (1 << ('L' - 'A'));
+    const unsigned int ignored_lowercase_mask = (1 << ('h' - 'a')) | (1 << ('j' - 'a')) |
+                                                (1 << ('l' - 'a')) | (1 << ('t' - 'a')) |
+                                                (1 << ('w' - 'a')) | (1 << ('z' - 'a'));
+    for (char c; (c = *fmt) != 0; fmt++)
+    {
+        if (c >= 'A' && c <= 'Z' && ((1 << (c - 'A')) & ignored_uppercase_mask) == 0)
+            return fmt + 1;
+        if (c >= 'a' && c <= 'z' && ((1 << (c - 'a')) & ignored_lowercase_mask) == 0)
+            return fmt + 1;
+    }
+    return fmt;
+}
+
+// Extract the format out of a format string with leading or trailing decorations
+//  fmt = "blah blah"  -> return fmt
+//  fmt = "%.3f"       -> return fmt
+//  fmt = "hello %.3f" -> return fmt + 6
+//  fmt = "%.3f hello" -> return buf written with "%.3f"
+const char *ImParseFormatTrimDecorations(const char *fmt, char *buf, size_t buf_size)
+{
+    const char *fmt_start = ImParseFormatFindStart(fmt);
+    if (fmt_start[0] != '%')
+        return fmt;
+    const char *fmt_end = ImParseFormatFindEnd(fmt_start);
+    if (fmt_end[0] == 0)  // If we only have leading decoration, we don't need to copy the data.
+        return fmt_start;
+    ImStrncpy(buf, fmt_start, ImMin((size_t)(fmt_end - fmt_start) + 1, buf_size));
+    return buf;
+}
+
+// Parse display precision back from the display format string
+// FIXME: This is still used by some navigation code path to infer a minimum tweak step, but we
+// should aim to rework widgets so it isn't needed.
+int ImParseFormatPrecision(const char *fmt, int default_precision)
+{
+    fmt = ImParseFormatFindStart(fmt);
+    if (fmt[0] != '%')
+        return default_precision;
+    fmt++;
+    while (*fmt >= '0' && *fmt <= '9')
+        fmt++;
+    int precision = INT_MAX;
+    if (*fmt == '.')
+    {
+        fmt = ImAtoi<int>(fmt + 1, &precision);
+        if (precision < 0 || precision > 99)
+            precision = default_precision;
+    }
+    if (*fmt == 'e' || *fmt == 'E')  // Maximum precision with scientific notation
+        precision = -1;
+    if ((*fmt == 'g' || *fmt == 'G') && precision == INT_MAX)
+        precision = -1;
+    return (precision == INT_MAX) ? default_precision : precision;
+}
+
+// Create text input in place of another active widget (e.g. used when doing a CTRL+Click on
+// drag/slider widgets)
+// FIXME: Facilitate using this in variety of other situations.
+bool ImGui::TempInputTextScalar(const ImRect &bb,
+                                ImGuiID id,
+                                const char *label,
+                                ImGuiDataType data_type,
+                                void *data_ptr,
+                                const char *format)
+{
+    ImGuiContext &g = *GImGui;
+
+    // On the first frame, g.TempInputTextId == 0, then on subsequent frames it becomes == id.
+    // We clear ActiveID on the first frame to allow the InputText() taking it back.
+    const bool init = (g.TempInputTextId != id);
+    if (init)
+        ClearActiveID();
+
+    char fmt_buf[32];
+    char data_buf[32];
+    format = ImParseFormatTrimDecorations(format, fmt_buf, IM_ARRAYSIZE(fmt_buf));
+    DataTypeFormatString(data_buf, IM_ARRAYSIZE(data_buf), data_type, data_ptr, format);
+    ImStrTrimBlanks(data_buf);
+
+    g.CurrentWindow->DC.CursorPos = bb.Min;
+    ImGuiInputTextFlags flags =
+        ImGuiInputTextFlags_AutoSelectAll | ImGuiInputTextFlags_NoMarkEdited;
+    flags |= ((data_type == ImGuiDataType_Float || data_type == ImGuiDataType_Double)
+                  ? ImGuiInputTextFlags_CharsScientific
+                  : ImGuiInputTextFlags_CharsDecimal);
+    bool value_changed =
+        InputTextEx(label, NULL, data_buf, IM_ARRAYSIZE(data_buf), bb.GetSize(), flags);
+    if (init)
+    {
+        // First frame we started displaying the InputText widget, we expect it to take the active
+        // id.
+        IM_ASSERT(g.ActiveId == id);
+        g.TempInputTextId = g.ActiveId;
+    }
+    if (value_changed)
+    {
+        value_changed = DataTypeApplyOpFromText(data_buf, g.InputTextState.InitialTextA.Data,
+                                                data_type, data_ptr, NULL);
+        if (value_changed)
+            MarkItemEdited(id);
+    }
+    return value_changed;
+}
+
+bool ImGui::InputScalar(const char *label,
+                        ImGuiDataType data_type,
+                        void *data_ptr,
+                        const void *step,
+                        const void *step_fast,
+                        const char *format,
+                        ImGuiInputTextFlags flags)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    ImGuiContext &g   = *GImGui;
+    ImGuiStyle &style = g.Style;
+
+    if (format == NULL)
+        format = DataTypeGetInfo(data_type)->PrintFmt;
+
+    char buf[64];
+    DataTypeFormatString(buf, IM_ARRAYSIZE(buf), data_type, data_ptr, format);
+
+    bool value_changed = false;
+    if ((flags & (ImGuiInputTextFlags_CharsHexadecimal | ImGuiInputTextFlags_CharsScientific)) == 0)
+        flags |= ImGuiInputTextFlags_CharsDecimal;
+    flags |= ImGuiInputTextFlags_AutoSelectAll;
+    flags |= ImGuiInputTextFlags_NoMarkEdited;  // We call MarkItemEdited() ourselve by comparing
+                                                // the actual data rather than the string.
+
+    if (step != NULL)
+    {
+        const float button_size = GetFrameHeight();
+
+        BeginGroup();  // The only purpose of the group here is to allow the caller to query item
+                       // data e.g. IsItemActive()
+        PushID(label);
+        SetNextItemWidth(
+            ImMax(1.0f, CalcItemWidth() - (button_size + style.ItemInnerSpacing.x) * 2));
+        if (InputText(
+                "", buf, IM_ARRAYSIZE(buf),
+                flags))  // PushId(label) + "" gives us the expected ID from outside point of view
+            value_changed = DataTypeApplyOpFromText(buf, g.InputTextState.InitialTextA.Data,
+                                                    data_type, data_ptr, format);
+
+        // Step buttons
+        const ImVec2 backup_frame_padding = style.FramePadding;
+        style.FramePadding.x              = style.FramePadding.y;
+        ImGuiButtonFlags button_flags = ImGuiButtonFlags_Repeat | ImGuiButtonFlags_DontClosePopups;
+        if (flags & ImGuiInputTextFlags_ReadOnly)
+            button_flags |= ImGuiButtonFlags_Disabled;
+        SameLine(0, style.ItemInnerSpacing.x);
+        if (ButtonEx("-", ImVec2(button_size, button_size), button_flags))
+        {
+            DataTypeApplyOp(data_type, '-', data_ptr, data_ptr,
+                            g.IO.KeyCtrl && step_fast ? step_fast : step);
+            value_changed = true;
+        }
+        SameLine(0, style.ItemInnerSpacing.x);
+        if (ButtonEx("+", ImVec2(button_size, button_size), button_flags))
+        {
+            DataTypeApplyOp(data_type, '+', data_ptr, data_ptr,
+                            g.IO.KeyCtrl && step_fast ? step_fast : step);
+            value_changed = true;
+        }
+
+        const char *label_end = FindRenderedTextEnd(label);
+        if (label != label_end)
+        {
+            SameLine(0, style.ItemInnerSpacing.x);
+            TextEx(label, label_end);
+        }
+        style.FramePadding = backup_frame_padding;
+
+        PopID();
+        EndGroup();
+    }
+    else
+    {
+        if (InputText(label, buf, IM_ARRAYSIZE(buf), flags))
+            value_changed = DataTypeApplyOpFromText(buf, g.InputTextState.InitialTextA.Data,
+                                                    data_type, data_ptr, format);
+    }
+    if (value_changed)
+        MarkItemEdited(window->DC.LastItemId);
+
+    return value_changed;
+}
+
+bool ImGui::InputScalarN(const char *label,
+                         ImGuiDataType data_type,
+                         void *v,
+                         int components,
+                         const void *step,
+                         const void *step_fast,
+                         const char *format,
+                         ImGuiInputTextFlags flags)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    ImGuiContext &g    = *GImGui;
+    bool value_changed = false;
+    BeginGroup();
+    PushID(label);
+    PushMultiItemsWidths(components, CalcItemWidth());
+    size_t type_size = GDataTypeInfo[data_type].Size;
+    for (int i = 0; i < components; i++)
+    {
+        PushID(i);
+        if (i > 0)
+            SameLine(0, g.Style.ItemInnerSpacing.x);
+        value_changed |= InputScalar("", data_type, v, step, step_fast, format, flags);
+        PopID();
+        PopItemWidth();
+        v = (void *)((char *)v + type_size);
+    }
+    PopID();
+
+    const char *label_end = FindRenderedTextEnd(label);
+    if (label != label_end)
+    {
+        SameLine(0.0f, g.Style.ItemInnerSpacing.x);
+        TextEx(label, label_end);
+    }
+
+    EndGroup();
+    return value_changed;
+}
+
+bool ImGui::InputFloat(const char *label,
+                       float *v,
+                       float step,
+                       float step_fast,
+                       const char *format,
+                       ImGuiInputTextFlags flags)
+{
+    flags |= ImGuiInputTextFlags_CharsScientific;
+    return InputScalar(label, ImGuiDataType_Float, (void *)v, (void *)(step > 0.0f ? &step : NULL),
+                       (void *)(step_fast > 0.0f ? &step_fast : NULL), format, flags);
+}
+
+bool ImGui::InputFloat2(const char *label,
+                        float v[2],
+                        const char *format,
+                        ImGuiInputTextFlags flags)
+{
+    return InputScalarN(label, ImGuiDataType_Float, v, 2, NULL, NULL, format, flags);
+}
+
+bool ImGui::InputFloat3(const char *label,
+                        float v[3],
+                        const char *format,
+                        ImGuiInputTextFlags flags)
+{
+    return InputScalarN(label, ImGuiDataType_Float, v, 3, NULL, NULL, format, flags);
+}
+
+bool ImGui::InputFloat4(const char *label,
+                        float v[4],
+                        const char *format,
+                        ImGuiInputTextFlags flags)
+{
+    return InputScalarN(label, ImGuiDataType_Float, v, 4, NULL, NULL, format, flags);
+}
+
+// Prefer using "const char* format" directly, which is more flexible and consistent with other API.
+#ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+bool ImGui::InputFloat(const char *label,
+                       float *v,
+                       float step,
+                       float step_fast,
+                       int decimal_precision,
+                       ImGuiInputTextFlags flags)
+{
+    char format[16] = "%f";
+    if (decimal_precision >= 0)
+        ImFormatString(format, IM_ARRAYSIZE(format), "%%.%df", decimal_precision);
+    return InputFloat(label, v, step, step_fast, format, flags);
+}
+
+bool ImGui::InputFloat2(const char *label,
+                        float v[2],
+                        int decimal_precision,
+                        ImGuiInputTextFlags flags)
+{
+    char format[16] = "%f";
+    if (decimal_precision >= 0)
+        ImFormatString(format, IM_ARRAYSIZE(format), "%%.%df", decimal_precision);
+    return InputScalarN(label, ImGuiDataType_Float, v, 2, NULL, NULL, format, flags);
+}
+
+bool ImGui::InputFloat3(const char *label,
+                        float v[3],
+                        int decimal_precision,
+                        ImGuiInputTextFlags flags)
+{
+    char format[16] = "%f";
+    if (decimal_precision >= 0)
+        ImFormatString(format, IM_ARRAYSIZE(format), "%%.%df", decimal_precision);
+    return InputScalarN(label, ImGuiDataType_Float, v, 3, NULL, NULL, format, flags);
+}
+
+bool ImGui::InputFloat4(const char *label,
+                        float v[4],
+                        int decimal_precision,
+                        ImGuiInputTextFlags flags)
+{
+    char format[16] = "%f";
+    if (decimal_precision >= 0)
+        ImFormatString(format, IM_ARRAYSIZE(format), "%%.%df", decimal_precision);
+    return InputScalarN(label, ImGuiDataType_Float, v, 4, NULL, NULL, format, flags);
+}
+#endif  // IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+
+bool ImGui::InputInt(const char *label, int *v, int step, int step_fast, ImGuiInputTextFlags flags)
+{
+    // Hexadecimal input provided as a convenience but the flag name is awkward. Typically you'd use
+    // InputText() to parse your own data, if you want to handle prefixes.
+    const char *format = (flags & ImGuiInputTextFlags_CharsHexadecimal) ? "%08X" : "%d";
+    return InputScalar(label, ImGuiDataType_S32, (void *)v, (void *)(step > 0 ? &step : NULL),
+                       (void *)(step_fast > 0 ? &step_fast : NULL), format, flags);
+}
+
+bool ImGui::InputInt2(const char *label, int v[2], ImGuiInputTextFlags flags)
+{
+    return InputScalarN(label, ImGuiDataType_S32, v, 2, NULL, NULL, "%d", flags);
+}
+
+bool ImGui::InputInt3(const char *label, int v[3], ImGuiInputTextFlags flags)
+{
+    return InputScalarN(label, ImGuiDataType_S32, v, 3, NULL, NULL, "%d", flags);
+}
+
+bool ImGui::InputInt4(const char *label, int v[4], ImGuiInputTextFlags flags)
+{
+    return InputScalarN(label, ImGuiDataType_S32, v, 4, NULL, NULL, "%d", flags);
+}
+
+bool ImGui::InputDouble(const char *label,
+                        double *v,
+                        double step,
+                        double step_fast,
+                        const char *format,
+                        ImGuiInputTextFlags flags)
+{
+    flags |= ImGuiInputTextFlags_CharsScientific;
+    return InputScalar(label, ImGuiDataType_Double, (void *)v, (void *)(step > 0.0 ? &step : NULL),
+                       (void *)(step_fast > 0.0 ? &step_fast : NULL), format, flags);
+}
+
+//-------------------------------------------------------------------------
+// [SECTION] Widgets: InputText, InputTextMultiline, InputTextWithHint
+//-------------------------------------------------------------------------
+// - InputText()
+// - InputTextWithHint()
+// - InputTextMultiline()
+// - InputTextEx() [Internal]
+//-------------------------------------------------------------------------
+
+bool ImGui::InputText(const char *label,
+                      char *buf,
+                      size_t buf_size,
+                      ImGuiInputTextFlags flags,
+                      ImGuiInputTextCallback callback,
+                      void *user_data)
+{
+    IM_ASSERT(!(flags & ImGuiInputTextFlags_Multiline));  // call InputTextMultiline()
+    return InputTextEx(label, NULL, buf, (int)buf_size, ImVec2(0, 0), flags, callback, user_data);
+}
+
+bool ImGui::InputTextMultiline(const char *label,
+                               char *buf,
+                               size_t buf_size,
+                               const ImVec2 &size,
+                               ImGuiInputTextFlags flags,
+                               ImGuiInputTextCallback callback,
+                               void *user_data)
+{
+    return InputTextEx(label, NULL, buf, (int)buf_size, size, flags | ImGuiInputTextFlags_Multiline,
+                       callback, user_data);
+}
+
+bool ImGui::InputTextWithHint(const char *label,
+                              const char *hint,
+                              char *buf,
+                              size_t buf_size,
+                              ImGuiInputTextFlags flags,
+                              ImGuiInputTextCallback callback,
+                              void *user_data)
+{
+    IM_ASSERT(!(flags & ImGuiInputTextFlags_Multiline));  // call InputTextMultiline()
+    return InputTextEx(label, hint, buf, (int)buf_size, ImVec2(0, 0), flags, callback, user_data);
+}
+
+static int InputTextCalcTextLenAndLineCount(const char *text_begin, const char **out_text_end)
+{
+    int line_count = 0;
+    const char *s  = text_begin;
+    while (char c = *s++)  // We are only matching for \n so we can ignore UTF-8 decoding
+        if (c == '\n')
+            line_count++;
+    s--;
+    if (s[0] != '\n' && s[0] != '\r')
+        line_count++;
+    *out_text_end = s;
+    return line_count;
+}
+
+static ImVec2 InputTextCalcTextSizeW(const ImWchar *text_begin,
+                                     const ImWchar *text_end,
+                                     const ImWchar **remaining,
+                                     ImVec2 *out_offset,
+                                     bool stop_on_new_line)
+{
+    ImGuiContext &g         = *GImGui;
+    ImFont *font            = g.Font;
+    const float line_height = g.FontSize;
+    const float scale       = line_height / font->FontSize;
+
+    ImVec2 text_size = ImVec2(0, 0);
+    float line_width = 0.0f;
+
+    const ImWchar *s = text_begin;
+    while (s < text_end)
+    {
+        unsigned int c = (unsigned int)(*s++);
+        if (c == '\n')
+        {
+            text_size.x = ImMax(text_size.x, line_width);
+            text_size.y += line_height;
+            line_width = 0.0f;
+            if (stop_on_new_line)
+                break;
+            continue;
+        }
+        if (c == '\r')
+            continue;
+
+        const float char_width = font->GetCharAdvance((ImWchar)c) * scale;
+        line_width += char_width;
+    }
+
+    if (text_size.x < line_width)
+        text_size.x = line_width;
+
+    if (out_offset)
+        *out_offset = ImVec2(
+            line_width,
+            text_size.y +
+                line_height);  // offset allow for the possibility of sitting after a trailing \n
+
+    if (line_width > 0 || text_size.y == 0.0f)  // whereas size.y will ignore the trailing \n
+        text_size.y += line_height;
+
+    if (remaining)
+        *remaining = s;
+
+    return text_size;
+}
+
+// Wrapper for stb_textedit.h to edit text (our wrapper is for: statically sized buffer,
+// single-line, wchar characters. InputText converts between UTF-8 and wchar)
+namespace ImStb
+{
+
+static int STB_TEXTEDIT_STRINGLEN(const STB_TEXTEDIT_STRING *obj)
+{
+    return obj->CurLenW;
+}
+static ImWchar STB_TEXTEDIT_GETCHAR(const STB_TEXTEDIT_STRING *obj, int idx)
+{
+    return obj->TextW[idx];
+}
+static float STB_TEXTEDIT_GETWIDTH(STB_TEXTEDIT_STRING *obj, int line_start_idx, int char_idx)
+{
+    ImWchar c = obj->TextW[line_start_idx + char_idx];
+    if (c == '\n')
+        return STB_TEXTEDIT_GETWIDTH_NEWLINE;
+    return GImGui->Font->GetCharAdvance(c) * (GImGui->FontSize / GImGui->Font->FontSize);
+}
+static int STB_TEXTEDIT_KEYTOTEXT(int key)
+{
+    return key >= 0x10000 ? 0 : key;
+}
+static ImWchar STB_TEXTEDIT_NEWLINE = '\n';
+static void STB_TEXTEDIT_LAYOUTROW(StbTexteditRow *r, STB_TEXTEDIT_STRING *obj, int line_start_idx)
+{
+    const ImWchar *text           = obj->TextW.Data;
+    const ImWchar *text_remaining = NULL;
+    const ImVec2 size   = InputTextCalcTextSizeW(text + line_start_idx, text + obj->CurLenW,
+                                               &text_remaining, NULL, true);
+    r->x0               = 0.0f;
+    r->x1               = size.x;
+    r->baseline_y_delta = size.y;
+    r->ymin             = 0.0f;
+    r->ymax             = size.y;
+    r->num_chars        = (int)(text_remaining - (text + line_start_idx));
+}
+
+static bool is_separator(unsigned int c)
+{
+    return ImCharIsBlankW(c) || c == ',' || c == ';' || c == '(' || c == ')' || c == '{' ||
+           c == '}' || c == '[' || c == ']' || c == '|';
+}
+static int is_word_boundary_from_right(STB_TEXTEDIT_STRING *obj, int idx)
+{
+    return idx > 0 ? (is_separator(obj->TextW[idx - 1]) && !is_separator(obj->TextW[idx])) : 1;
+}
+static int STB_TEXTEDIT_MOVEWORDLEFT_IMPL(STB_TEXTEDIT_STRING *obj, int idx)
+{
+    idx--;
+    while (idx >= 0 && !is_word_boundary_from_right(obj, idx))
+        idx--;
+    return idx < 0 ? 0 : idx;
+}
+#ifdef __APPLE__  // FIXME: Move setting to IO structure
+static int is_word_boundary_from_left(STB_TEXTEDIT_STRING *obj, int idx)
+{
+    return idx > 0 ? (!is_separator(obj->TextW[idx - 1]) && is_separator(obj->TextW[idx])) : 1;
+}
+static int STB_TEXTEDIT_MOVEWORDRIGHT_IMPL(STB_TEXTEDIT_STRING *obj, int idx)
+{
+    idx++;
+    int len = obj->CurLenW;
+    while (idx < len && !is_word_boundary_from_left(obj, idx))
+        idx++;
+    return idx > len ? len : idx;
+}
+#else
+static int STB_TEXTEDIT_MOVEWORDRIGHT_IMPL(STB_TEXTEDIT_STRING *obj, int idx)
+{
+    idx++;
+    int len = obj->CurLenW;
+    while (idx < len && !is_word_boundary_from_right(obj, idx))
+        idx++;
+    return idx > len ? len : idx;
+}
+#endif
+#define STB_TEXTEDIT_MOVEWORDLEFT \
+    STB_TEXTEDIT_MOVEWORDLEFT_IMPL  // They need to be #define for stb_textedit.h
+#define STB_TEXTEDIT_MOVEWORDRIGHT STB_TEXTEDIT_MOVEWORDRIGHT_IMPL
+
+static void STB_TEXTEDIT_DELETECHARS(STB_TEXTEDIT_STRING *obj, int pos, int n)
+{
+    ImWchar *dst = obj->TextW.Data + pos;
+
+    // We maintain our buffer length in both UTF-8 and wchar formats
+    obj->CurLenA -= ImTextCountUtf8BytesFromStr(dst, dst + n);
+    obj->CurLenW -= n;
+
+    // Offset remaining text (FIXME-OPT: Use memmove)
+    const ImWchar *src = obj->TextW.Data + pos + n;
+    while (ImWchar c = *src++)
+        *dst++ = c;
+    *dst = '\0';
+}
+
+static bool STB_TEXTEDIT_INSERTCHARS(STB_TEXTEDIT_STRING *obj,
+                                     int pos,
+                                     const ImWchar *new_text,
+                                     int new_text_len)
+{
+    const bool is_resizable = (obj->UserFlags & ImGuiInputTextFlags_CallbackResize) != 0;
+    const int text_len      = obj->CurLenW;
+    IM_ASSERT(pos <= text_len);
+
+    const int new_text_len_utf8 = ImTextCountUtf8BytesFromStr(new_text, new_text + new_text_len);
+    if (!is_resizable && (new_text_len_utf8 + obj->CurLenA + 1 > obj->BufCapacityA))
+        return false;
+
+    // Grow internal buffer if needed
+    if (new_text_len + text_len + 1 > obj->TextW.Size)
+    {
+        if (!is_resizable)
+            return false;
+        IM_ASSERT(text_len < obj->TextW.Size);
+        obj->TextW.resize(text_len + ImClamp(new_text_len * 4, 32, ImMax(256, new_text_len)) + 1);
+    }
+
+    ImWchar *text = obj->TextW.Data;
+    if (pos != text_len)
+        memmove(text + pos + new_text_len, text + pos, (size_t)(text_len - pos) * sizeof(ImWchar));
+    memcpy(text + pos, new_text, (size_t)new_text_len * sizeof(ImWchar));
+
+    obj->CurLenW += new_text_len;
+    obj->CurLenA += new_text_len_utf8;
+    obj->TextW[obj->CurLenW] = '\0';
+
+    return true;
+}
+
+// We don't use an enum so we can build even with conflicting symbols (if another user of
+// stb_textedit.h leak their STB_TEXTEDIT_K_* symbols)
+#define STB_TEXTEDIT_K_LEFT 0x10000       // keyboard input to move cursor left
+#define STB_TEXTEDIT_K_RIGHT 0x10001      // keyboard input to move cursor right
+#define STB_TEXTEDIT_K_UP 0x10002         // keyboard input to move cursor up
+#define STB_TEXTEDIT_K_DOWN 0x10003       // keyboard input to move cursor down
+#define STB_TEXTEDIT_K_LINESTART 0x10004  // keyboard input to move cursor to start of line
+#define STB_TEXTEDIT_K_LINEEND 0x10005    // keyboard input to move cursor to end of line
+#define STB_TEXTEDIT_K_TEXTSTART 0x10006  // keyboard input to move cursor to start of text
+#define STB_TEXTEDIT_K_TEXTEND 0x10007    // keyboard input to move cursor to end of text
+#define STB_TEXTEDIT_K_DELETE \
+    0x10008  // keyboard input to delete selection or character under cursor
+#define STB_TEXTEDIT_K_BACKSPACE \
+    0x10009  // keyboard input to delete selection or character left of cursor
+#define STB_TEXTEDIT_K_UNDO 0x1000A       // keyboard input to perform undo
+#define STB_TEXTEDIT_K_REDO 0x1000B       // keyboard input to perform redo
+#define STB_TEXTEDIT_K_WORDLEFT 0x1000C   // keyboard input to move cursor left one word
+#define STB_TEXTEDIT_K_WORDRIGHT 0x1000D  // keyboard input to move cursor right one word
+#define STB_TEXTEDIT_K_SHIFT 0x20000
+
+#define STB_TEXTEDIT_IMPLEMENTATION
+#include "imstb_textedit.h"
+
+}  // namespace ImStb
+
+void ImGuiInputTextState::OnKeyPressed(int key)
+{
+    stb_textedit_key(this, &Stb, key);
+    CursorFollow = true;
+    CursorAnimReset();
+}
+
+ImGuiInputTextCallbackData::ImGuiInputTextCallbackData()
+{
+    memset(this, 0, sizeof(*this));
+}
+
+// Public API to manipulate UTF-8 text
+// We expose UTF-8 to the user (unlike the STB_TEXTEDIT_* functions which are manipulating wchar)
+// FIXME: The existence of this rarely exercised code path is a bit of a nuisance.
+void ImGuiInputTextCallbackData::DeleteChars(int pos, int bytes_count)
+{
+    IM_ASSERT(pos + bytes_count <= BufTextLen);
+    char *dst       = Buf + pos;
+    const char *src = Buf + pos + bytes_count;
+    while (char c = *src++)
+        *dst++ = c;
+    *dst = '\0';
+
+    if (CursorPos + bytes_count >= pos)
+        CursorPos -= bytes_count;
+    else if (CursorPos >= pos)
+        CursorPos = pos;
+    SelectionStart = SelectionEnd = CursorPos;
+    BufDirty                      = true;
+    BufTextLen -= bytes_count;
+}
+
+void ImGuiInputTextCallbackData::InsertChars(int pos,
+                                             const char *new_text,
+                                             const char *new_text_end)
+{
+    const bool is_resizable = (Flags & ImGuiInputTextFlags_CallbackResize) != 0;
+    const int new_text_len  = new_text_end ? (int)(new_text_end - new_text) : (int)strlen(new_text);
+    if (new_text_len + BufTextLen >= BufSize)
+    {
+        if (!is_resizable)
+            return;
+
+        // Contrary to STB_TEXTEDIT_INSERTCHARS() this is working in the UTF8 buffer, hence the
+        // midly similar code (until we remove the U16 buffer alltogether!)
+        ImGuiContext &g                 = *GImGui;
+        ImGuiInputTextState *edit_state = &g.InputTextState;
+        IM_ASSERT(edit_state->ID != 0 && g.ActiveId == edit_state->ID);
+        IM_ASSERT(Buf == edit_state->TextA.Data);
+        int new_buf_size = BufTextLen + ImClamp(new_text_len * 4, 32, ImMax(256, new_text_len)) + 1;
+        edit_state->TextA.reserve(new_buf_size + 1);
+        Buf     = edit_state->TextA.Data;
+        BufSize = edit_state->BufCapacityA = new_buf_size;
+    }
+
+    if (BufTextLen != pos)
+        memmove(Buf + pos + new_text_len, Buf + pos, (size_t)(BufTextLen - pos));
+    memcpy(Buf + pos, new_text, (size_t)new_text_len * sizeof(char));
+    Buf[BufTextLen + new_text_len] = '\0';
+
+    if (CursorPos >= pos)
+        CursorPos += new_text_len;
+    SelectionStart = SelectionEnd = CursorPos;
+    BufDirty                      = true;
+    BufTextLen += new_text_len;
+}
+
+// Return false to discard a character.
+static bool InputTextFilterCharacter(unsigned int *p_char,
+                                     ImGuiInputTextFlags flags,
+                                     ImGuiInputTextCallback callback,
+                                     void *user_data)
+{
+    unsigned int c = *p_char;
+
+    // Filter non-printable (NB: isprint is unreliable! see #2467)
+    if (c < 0x20)
+    {
+        bool pass = false;
+        pass |= (c == '\n' && (flags & ImGuiInputTextFlags_Multiline));
+        pass |= (c == '\t' && (flags & ImGuiInputTextFlags_AllowTabInput));
+        if (!pass)
+            return false;
+    }
+
+    // Filter private Unicode range. GLFW on OSX seems to send private characters for special keys
+    // like arrow keys (FIXME)
+    if (c >= 0xE000 && c <= 0xF8FF)
+        return false;
+
+    // Generic named filters
+    if (flags & (ImGuiInputTextFlags_CharsDecimal | ImGuiInputTextFlags_CharsHexadecimal |
+                 ImGuiInputTextFlags_CharsUppercase | ImGuiInputTextFlags_CharsNoBlank |
+                 ImGuiInputTextFlags_CharsScientific))
+    {
+        if (flags & ImGuiInputTextFlags_CharsDecimal)
+            if (!(c >= '0' && c <= '9') && (c != '.') && (c != '-') && (c != '+') && (c != '*') &&
+                (c != '/'))
+                return false;
+
+        if (flags & ImGuiInputTextFlags_CharsScientific)
+            if (!(c >= '0' && c <= '9') && (c != '.') && (c != '-') && (c != '+') && (c != '*') &&
+                (c != '/') && (c != 'e') && (c != 'E'))
+                return false;
+
+        if (flags & ImGuiInputTextFlags_CharsHexadecimal)
+            if (!(c >= '0' && c <= '9') && !(c >= 'a' && c <= 'f') && !(c >= 'A' && c <= 'F'))
+                return false;
+
+        if (flags & ImGuiInputTextFlags_CharsUppercase)
+            if (c >= 'a' && c <= 'z')
+                *p_char = (c += (unsigned int)('A' - 'a'));
+
+        if (flags & ImGuiInputTextFlags_CharsNoBlank)
+            if (ImCharIsBlankW(c))
+                return false;
+    }
+
+    // Custom callback filter
+    if (flags & ImGuiInputTextFlags_CallbackCharFilter)
+    {
+        ImGuiInputTextCallbackData callback_data;
+        memset(&callback_data, 0, sizeof(ImGuiInputTextCallbackData));
+        callback_data.EventFlag = ImGuiInputTextFlags_CallbackCharFilter;
+        callback_data.EventChar = (ImWchar)c;
+        callback_data.Flags     = flags;
+        callback_data.UserData  = user_data;
+        if (callback(&callback_data) != 0)
+            return false;
+        *p_char = callback_data.EventChar;
+        if (!callback_data.EventChar)
+            return false;
+    }
+
+    return true;
+}
+
+// Edit a string of text
+// - buf_size account for the zero-terminator, so a buf_size of 6 can hold "Hello" but not "Hello!".
+//   This is so we can easily call InputText() on static arrays using ARRAYSIZE() and to match
+//   Note that in std::string world, capacity() would omit 1 byte used by the zero-terminator.
+// - When active, hold on a privately held copy of the text (and apply back to 'buf'). So changing
+// 'buf' while the InputText is active has no effect.
+// - If you want to use ImGui::InputText() with std::string, see misc/cpp/imgui_stdlib.h
+// (FIXME: Rather confusing and messy function, among the worse part of our codebase, expecting to
+// rewrite a V2 at some point.. Partly because we are
+//  doing UTF8 > U16 > UTF8 conversions on the go to easily interface with stb_textedit. Ideally
+//  should stay in UTF-8 all the time. See https://github.com/nothings/stb/issues/188)
+bool ImGui::InputTextEx(const char *label,
+                        const char *hint,
+                        char *buf,
+                        int buf_size,
+                        const ImVec2 &size_arg,
+                        ImGuiInputTextFlags flags,
+                        ImGuiInputTextCallback callback,
+                        void *callback_user_data)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    IM_ASSERT(!(
+        (flags & ImGuiInputTextFlags_CallbackHistory) &&
+        (flags &
+         ImGuiInputTextFlags_Multiline)));  // Can't use both together (they both use up/down keys)
+    IM_ASSERT(
+        !((flags & ImGuiInputTextFlags_CallbackCompletion) &&
+          (flags &
+           ImGuiInputTextFlags_AllowTabInput)));  // Can't use both together (they both use tab key)
+
+    ImGuiContext &g         = *GImGui;
+    ImGuiIO &io             = g.IO;
+    const ImGuiStyle &style = g.Style;
+
+    const bool RENDER_SELECTION_WHEN_INACTIVE = false;
+    const bool is_multiline                   = (flags & ImGuiInputTextFlags_Multiline) != 0;
+    const bool is_readonly                    = (flags & ImGuiInputTextFlags_ReadOnly) != 0;
+    const bool is_password                    = (flags & ImGuiInputTextFlags_Password) != 0;
+    const bool is_undoable                    = (flags & ImGuiInputTextFlags_NoUndoRedo) == 0;
+    const bool is_resizable                   = (flags & ImGuiInputTextFlags_CallbackResize) != 0;
+    if (is_resizable)
+        IM_ASSERT(callback != NULL);  // Must provide a callback if you set the
+                                      // ImGuiInputTextFlags_CallbackResize flag!
+
+    if (is_multiline)  // Open group before calling GetID() because groups tracks id created within
+                       // their scope,
+        BeginGroup();
+    const ImGuiID id        = window->GetID(label);
+    const ImVec2 label_size = CalcTextSize(label, NULL, true);
+    ImVec2 size             = CalcItemSize(
+        size_arg, CalcItemWidth(),
+        (is_multiline ? GetTextLineHeight() * 8.0f : label_size.y) +
+            style.FramePadding.y * 2.0f);  // Arbitrary default of 8 lines high for multi-line
+    const ImRect frame_bb(window->DC.CursorPos, window->DC.CursorPos + size);
+    const ImRect total_bb(
+        frame_bb.Min,
+        frame_bb.Max +
+            ImVec2(label_size.x > 0.0f ? (style.ItemInnerSpacing.x + label_size.x) : 0.0f, 0.0f));
+
+    ImGuiWindow *draw_window = window;
+    if (is_multiline)
+    {
+        if (!ItemAdd(total_bb, id, &frame_bb))
+        {
+            ItemSize(total_bb, style.FramePadding.y);
+            EndGroup();
+            return false;
+        }
+        if (!BeginChildFrame(id, frame_bb.GetSize()))
+        {
+            EndChildFrame();
+            EndGroup();
+            return false;
+        }
+        draw_window = GetCurrentWindow();
+        draw_window->DC.NavLayerActiveMaskNext |=
+            draw_window->DC.NavLayerCurrentMask;  // This is to ensure that EndChild() will display
+                                                  // a navigation highlight
+        size.x -= draw_window->ScrollbarSizes.x;
+    }
+    else
+    {
+        ItemSize(total_bb, style.FramePadding.y);
+        if (!ItemAdd(total_bb, id, &frame_bb))
+            return false;
+    }
+    const bool hovered = ItemHoverable(frame_bb, id);
+    if (hovered)
+        g.MouseCursor = ImGuiMouseCursor_TextInput;
+
+    // NB: we are only allowed to access 'edit_state' if we are the active widget.
+    ImGuiInputTextState *state = NULL;
+    if (g.InputTextState.ID == id)
+        state = &g.InputTextState;
+
+    const bool focus_requested = FocusableItemRegister(window, id);
+    const bool focus_requested_by_code =
+        focus_requested && (g.FocusRequestCurrWindow == window &&
+                            g.FocusRequestCurrCounterAll == window->DC.FocusCounterAll);
+    const bool focus_requested_by_tab = focus_requested && !focus_requested_by_code;
+
+    const bool user_clicked = hovered && io.MouseClicked[0];
+    const bool user_nav_input_start =
+        (g.ActiveId != id) &&
+        ((g.NavInputId == id) ||
+         (g.NavActivateId == id && g.NavInputSource == ImGuiInputSource_NavKeyboard));
+    const bool user_scroll_finish =
+        is_multiline && state != NULL && g.ActiveId == 0 &&
+        g.ActiveIdPreviousFrame == GetScrollbarID(draw_window, ImGuiAxis_Y);
+    const bool user_scroll_active =
+        is_multiline && state != NULL && g.ActiveId == GetScrollbarID(draw_window, ImGuiAxis_Y);
+
+    bool clear_active_id = false;
+    bool select_all      = (g.ActiveId != id) &&
+                      ((flags & ImGuiInputTextFlags_AutoSelectAll) != 0 || user_nav_input_start) &&
+                      (!is_multiline);
+
+    const bool init_make_active =
+        (focus_requested || user_clicked || user_scroll_finish || user_nav_input_start);
+    const bool init_state = (init_make_active || user_scroll_active);
+    if (init_state && g.ActiveId != id)
+    {
+        // Access state even if we don't own it yet.
+        state = &g.InputTextState;
+        state->CursorAnimReset();
+
+        // Take a copy of the initial buffer value (both in original UTF-8 format and converted to
+        // wchar) From the moment we focused we are ignoring the content of 'buf' (unless we are in
+        // read-only mode)
+        const int buf_len = (int)strlen(buf);
+        state->InitialTextA.resize(buf_len + 1);  // UTF-8. we use +1 to make sure that .Data is
+                                                  // always pointing to at least an empty string.
+        memcpy(state->InitialTextA.Data, buf, buf_len + 1);
+
+        // Start edition
+        const char *buf_end = NULL;
+        state->TextW.resize(buf_size +
+                            1);  // wchar count <= UTF-8 count. we use +1 to make sure that .Data is
+                                 // always pointing to at least an empty string.
+        state->TextA.resize(0);
+        state->TextAIsValid = false;  // TextA is not valid yet (we will display buf until then)
+        state->CurLenW      = ImTextStrFromUtf8(state->TextW.Data, buf_size, buf, NULL, &buf_end);
+        state->CurLenA =
+            (int)(buf_end - buf);  // We can't get the result from ImStrncpy() above because it is
+                                   // not UTF-8 aware. Here we'll cut off malformed UTF-8.
+
+        // Preserve cursor position and undo/redo stack if we come back to same widget
+        // FIXME: For non-readonly widgets we might be able to require that TextAIsValid && TextA ==
+        // buf ? (untested) and discard undo stack if user buffer has changed.
+        const bool recycle_state = (state->ID == id);
+        if (recycle_state)
+        {
+            // Recycle existing cursor/selection/undo stack but clamp position
+            // Note a single mouse click will override the cursor/position immediately by calling
+            // stb_textedit_click handler.
+            state->CursorClamp();
+        }
+        else
+        {
+            state->ID      = id;
+            state->ScrollX = 0.0f;
+            stb_textedit_initialize_state(&state->Stb, !is_multiline);
+            if (!is_multiline && focus_requested_by_code)
+                select_all = true;
+        }
+        if (flags & ImGuiInputTextFlags_AlwaysInsertMode)
+            state->Stb.insert_mode = 1;
+        if (!is_multiline && (focus_requested_by_tab || (user_clicked && io.KeyCtrl)))
+            select_all = true;
+    }
+
+    if (g.ActiveId != id && init_make_active)
+    {
+        IM_ASSERT(state && state->ID == id);
+        SetActiveID(id, window);
+        SetFocusID(id, window);
+        FocusWindow(window);
+        IM_ASSERT(ImGuiNavInput_COUNT < 32);
+        g.ActiveIdBlockNavInputFlags = (1 << ImGuiNavInput_Cancel);
+        if (flags & (ImGuiInputTextFlags_CallbackCompletion |
+                     ImGuiInputTextFlags_AllowTabInput))  // Disable keyboard tabbing out as we will
+                                                          // use the \t character.
+            g.ActiveIdBlockNavInputFlags |= (1 << ImGuiNavInput_KeyTab_);
+        if (!is_multiline && !(flags & ImGuiInputTextFlags_CallbackHistory))
+            g.ActiveIdAllowNavDirFlags = ((1 << ImGuiDir_Up) | (1 << ImGuiDir_Down));
+    }
+
+    // We have an edge case if ActiveId was set through another widget (e.g. widget being swapped),
+    // clear id immediately (don't wait until the end of the function)
+    if (g.ActiveId == id && state == NULL)
+        ClearActiveID();
+
+    // Release focus when we click outside
+    if (g.ActiveId == id && io.MouseClicked[0] && !init_state && !init_make_active)  //-V560
+        clear_active_id = true;
+
+    // Lock the decision of whether we are going to take the path displaying the cursor or selection
+    const bool render_cursor = (g.ActiveId == id) || (state && user_scroll_active);
+    bool render_selection =
+        state && state->HasSelection() && (RENDER_SELECTION_WHEN_INACTIVE || render_cursor);
+    bool value_changed = false;
+    bool enter_pressed = false;
+
+    // When read-only we always use the live data passed to the function
+    // FIXME-OPT: Because our selection/cursor code currently needs the wide text we need to convert
+    // it when active, which is not ideal :(
+    if (is_readonly && state != NULL && (render_cursor || render_selection))
+    {
+        const char *buf_end = NULL;
+        state->TextW.resize(buf_size + 1);
+        state->CurLenW =
+            ImTextStrFromUtf8(state->TextW.Data, state->TextW.Size, buf, NULL, &buf_end);
+        state->CurLenA = (int)(buf_end - buf);
+        state->CursorClamp();
+        render_selection &= state->HasSelection();
+    }
+
+    // Select the buffer to render.
+    const bool buf_display_from_state = (render_cursor || render_selection || g.ActiveId == id) &&
+                                        !is_readonly && state && state->TextAIsValid;
+    const bool is_displaying_hint =
+        (hint != NULL && (buf_display_from_state ? state->TextA.Data : buf)[0] == 0);
+
+    // Password pushes a temporary font with only a fallback glyph
+    if (is_password && !is_displaying_hint)
+    {
+        const ImFontGlyph *glyph        = g.Font->FindGlyph('*');
+        ImFont *password_font           = &g.InputTextPasswordFont;
+        password_font->FontSize         = g.Font->FontSize;
+        password_font->Scale            = g.Font->Scale;
+        password_font->DisplayOffset    = g.Font->DisplayOffset;
+        password_font->Ascent           = g.Font->Ascent;
+        password_font->Descent          = g.Font->Descent;
+        password_font->ContainerAtlas   = g.Font->ContainerAtlas;
+        password_font->FallbackGlyph    = glyph;
+        password_font->FallbackAdvanceX = glyph->AdvanceX;
+        IM_ASSERT(password_font->Glyphs.empty() && password_font->IndexAdvanceX.empty() &&
+                  password_font->IndexLookup.empty());
+        PushFont(password_font);
+    }
+
+    // Process mouse inputs and character inputs
+    int backup_current_text_length = 0;
+    if (g.ActiveId == id)
+    {
+        IM_ASSERT(state != NULL);
+        backup_current_text_length = state->CurLenA;
+        state->BufCapacityA        = buf_size;
+        state->UserFlags           = flags;
+        state->UserCallback        = callback;
+        state->UserCallbackData    = callback_user_data;
+
+        // Although we are active we don't prevent mouse from hovering other elements unless we are
+        // interacting right now with the widget. Down the line we should have a cleaner
+        // library-wide concept of Selected vs Active.
+        g.ActiveIdAllowOverlap   = !io.MouseDown[0];
+        g.WantTextInputNextFrame = 1;
+
+        // Edit in progress
+        const float mouse_x =
+            (io.MousePos.x - frame_bb.Min.x - style.FramePadding.x) + state->ScrollX;
+        const float mouse_y =
+            (is_multiline ? (io.MousePos.y - draw_window->DC.CursorPos.y - style.FramePadding.y)
+                          : (g.FontSize * 0.5f));
+
+        const bool is_osx = io.ConfigMacOSXBehaviors;
+        if (select_all || (hovered && !is_osx && io.MouseDoubleClicked[0]))
+        {
+            state->SelectAll();
+            state->SelectedAllMouseLock = true;
+        }
+        else if (hovered && is_osx && io.MouseDoubleClicked[0])
+        {
+            // Double-click select a word only, OS X style (by simulating keystrokes)
+            state->OnKeyPressed(STB_TEXTEDIT_K_WORDLEFT);
+            state->OnKeyPressed(STB_TEXTEDIT_K_WORDRIGHT | STB_TEXTEDIT_K_SHIFT);
+        }
+        else if (io.MouseClicked[0] && !state->SelectedAllMouseLock)
+        {
+            if (hovered)
+            {
+                stb_textedit_click(state, &state->Stb, mouse_x, mouse_y);
+                state->CursorAnimReset();
+            }
+        }
+        else if (io.MouseDown[0] && !state->SelectedAllMouseLock &&
+                 (io.MouseDelta.x != 0.0f || io.MouseDelta.y != 0.0f))
+        {
+            stb_textedit_drag(state, &state->Stb, mouse_x, mouse_y);
+            state->CursorAnimReset();
+            state->CursorFollow = true;
+        }
+        if (state->SelectedAllMouseLock && !io.MouseDown[0])
+            state->SelectedAllMouseLock = false;
+
+        // It is ill-defined whether the back-end needs to send a \t character when pressing the TAB
+        // keys. Win32 and GLFW naturally do it but not SDL.
+        const bool ignore_char_inputs = (io.KeyCtrl && !io.KeyAlt) || (is_osx && io.KeySuper);
+        if ((flags & ImGuiInputTextFlags_AllowTabInput) && IsKeyPressedMap(ImGuiKey_Tab) &&
+            !ignore_char_inputs && !io.KeyShift && !is_readonly)
+            if (!io.InputQueueCharacters.contains('\t'))
+            {
+                unsigned int c = '\t';  // Insert TAB
+                if (InputTextFilterCharacter(&c, flags, callback, callback_user_data))
+                    state->OnKeyPressed((int)c);
+            }
+
+        // Process regular text input (before we check for Return because using some IME will
+        // effectively send a Return?) We ignore CTRL inputs, but need to allow ALT+CTRL as some
+        // keyboards (e.g. German) use AltGR (which _is_ Alt+Ctrl) to input certain characters.
+        if (io.InputQueueCharacters.Size > 0)
+        {
+            if (!ignore_char_inputs && !is_readonly && !user_nav_input_start)
+                for (int n = 0; n < io.InputQueueCharacters.Size; n++)
+                {
+                    // Insert character if they pass filtering
+                    unsigned int c = (unsigned int)io.InputQueueCharacters[n];
+                    if (c == '\t' && io.KeyShift)
+                        continue;
+                    if (InputTextFilterCharacter(&c, flags, callback, callback_user_data))
+                        state->OnKeyPressed((int)c);
+                }
+
+            // Consume characters
+            io.InputQueueCharacters.resize(0);
+        }
+    }
+
+    // Process other shortcuts/key-presses
+    bool cancel_edit = false;
+    if (g.ActiveId == id && !g.ActiveIdIsJustActivated && !clear_active_id)
+    {
+        IM_ASSERT(state != NULL);
+        const int k_mask  = (io.KeyShift ? STB_TEXTEDIT_K_SHIFT : 0);
+        const bool is_osx = io.ConfigMacOSXBehaviors;
+        const bool is_shortcut_key =
+            (is_osx ? (io.KeySuper && !io.KeyCtrl) : (io.KeyCtrl && !io.KeySuper)) && !io.KeyAlt &&
+            !io.KeyShift;  // OS X style: Shortcuts using Cmd/Super instead of Ctrl
+        const bool is_osx_shift_shortcut =
+            is_osx && io.KeySuper && io.KeyShift && !io.KeyCtrl && !io.KeyAlt;
+        const bool is_wordmove_key_down =
+            is_osx
+                ? io.KeyAlt
+                : io.KeyCtrl;  // OS X style: Text editing cursor movement using Alt instead of Ctrl
+        const bool is_startend_key_down =
+            is_osx && io.KeySuper && !io.KeyCtrl &&
+            !io.KeyAlt;  // OS X style: Line/Text Start and End using Cmd+Arrows instead of Home/End
+        const bool is_ctrl_key_only  = io.KeyCtrl && !io.KeyShift && !io.KeyAlt && !io.KeySuper;
+        const bool is_shift_key_only = io.KeyShift && !io.KeyCtrl && !io.KeyAlt && !io.KeySuper;
+
+        const bool is_cut = ((is_shortcut_key && IsKeyPressedMap(ImGuiKey_X)) ||
+                             (is_shift_key_only && IsKeyPressedMap(ImGuiKey_Delete))) &&
+                            !is_readonly && !is_password &&
+                            (!is_multiline || state->HasSelection());
+        const bool is_copy = ((is_shortcut_key && IsKeyPressedMap(ImGuiKey_C)) ||
+                              (is_ctrl_key_only && IsKeyPressedMap(ImGuiKey_Insert))) &&
+                             !is_password && (!is_multiline || state->HasSelection());
+        const bool is_paste = ((is_shortcut_key && IsKeyPressedMap(ImGuiKey_V)) ||
+                               (is_shift_key_only && IsKeyPressedMap(ImGuiKey_Insert))) &&
+                              !is_readonly;
+        const bool is_undo =
+            ((is_shortcut_key && IsKeyPressedMap(ImGuiKey_Z)) && !is_readonly && is_undoable);
+        const bool is_redo = ((is_shortcut_key && IsKeyPressedMap(ImGuiKey_Y)) ||
+                              (is_osx_shift_shortcut && IsKeyPressedMap(ImGuiKey_Z))) &&
+                             !is_readonly && is_undoable;
+
+        if (IsKeyPressedMap(ImGuiKey_LeftArrow))
+        {
+            state->OnKeyPressed(
+                (is_startend_key_down
+                     ? STB_TEXTEDIT_K_LINESTART
+                     : is_wordmove_key_down ? STB_TEXTEDIT_K_WORDLEFT : STB_TEXTEDIT_K_LEFT) |
+                k_mask);
+        }
+        else if (IsKeyPressedMap(ImGuiKey_RightArrow))
+        {
+            state->OnKeyPressed(
+                (is_startend_key_down
+                     ? STB_TEXTEDIT_K_LINEEND
+                     : is_wordmove_key_down ? STB_TEXTEDIT_K_WORDRIGHT : STB_TEXTEDIT_K_RIGHT) |
+                k_mask);
+        }
+        else if (IsKeyPressedMap(ImGuiKey_UpArrow) && is_multiline)
+        {
+            if (io.KeyCtrl)
+                SetWindowScrollY(draw_window, ImMax(draw_window->Scroll.y - g.FontSize, 0.0f));
+            else
+                state->OnKeyPressed(
+                    (is_startend_key_down ? STB_TEXTEDIT_K_TEXTSTART : STB_TEXTEDIT_K_UP) | k_mask);
+        }
+        else if (IsKeyPressedMap(ImGuiKey_DownArrow) && is_multiline)
+        {
+            if (io.KeyCtrl)
+                SetWindowScrollY(draw_window,
+                                 ImMin(draw_window->Scroll.y + g.FontSize, GetScrollMaxY()));
+            else
+                state->OnKeyPressed(
+                    (is_startend_key_down ? STB_TEXTEDIT_K_TEXTEND : STB_TEXTEDIT_K_DOWN) | k_mask);
+        }
+        else if (IsKeyPressedMap(ImGuiKey_Home))
+        {
+            state->OnKeyPressed(io.KeyCtrl ? STB_TEXTEDIT_K_TEXTSTART | k_mask
+                                           : STB_TEXTEDIT_K_LINESTART | k_mask);
+        }
+        else if (IsKeyPressedMap(ImGuiKey_End))
+        {
+            state->OnKeyPressed(io.KeyCtrl ? STB_TEXTEDIT_K_TEXTEND | k_mask
+                                           : STB_TEXTEDIT_K_LINEEND | k_mask);
+        }
+        else if (IsKeyPressedMap(ImGuiKey_Delete) && !is_readonly)
+        {
+            state->OnKeyPressed(STB_TEXTEDIT_K_DELETE | k_mask);
+        }
+        else if (IsKeyPressedMap(ImGuiKey_Backspace) && !is_readonly)
+        {
+            if (!state->HasSelection())
+            {
+                if (is_wordmove_key_down)
+                    state->OnKeyPressed(STB_TEXTEDIT_K_WORDLEFT | STB_TEXTEDIT_K_SHIFT);
+                else if (is_osx && io.KeySuper && !io.KeyAlt && !io.KeyCtrl)
+                    state->OnKeyPressed(STB_TEXTEDIT_K_LINESTART | STB_TEXTEDIT_K_SHIFT);
+            }
+            state->OnKeyPressed(STB_TEXTEDIT_K_BACKSPACE | k_mask);
+        }
+        else if (IsKeyPressedMap(ImGuiKey_Enter))
+        {
+            bool ctrl_enter_for_new_line = (flags & ImGuiInputTextFlags_CtrlEnterForNewLine) != 0;
+            if (!is_multiline || (ctrl_enter_for_new_line && !io.KeyCtrl) ||
+                (!ctrl_enter_for_new_line && io.KeyCtrl))
+            {
+                enter_pressed = clear_active_id = true;
+            }
+            else if (!is_readonly)
+            {
+                unsigned int c = '\n';  // Insert new line
+                if (InputTextFilterCharacter(&c, flags, callback, callback_user_data))
+                    state->OnKeyPressed((int)c);
+            }
+        }
+        else if (IsKeyPressedMap(ImGuiKey_Escape))
+        {
+            clear_active_id = cancel_edit = true;
+        }
+        else if (is_undo || is_redo)
+        {
+            state->OnKeyPressed(is_undo ? STB_TEXTEDIT_K_UNDO : STB_TEXTEDIT_K_REDO);
+            state->ClearSelection();
+        }
+        else if (is_shortcut_key && IsKeyPressedMap(ImGuiKey_A))
+        {
+            state->SelectAll();
+            state->CursorFollow = true;
+        }
+        else if (is_cut || is_copy)
+        {
+            // Cut, Copy
+            if (io.SetClipboardTextFn)
+            {
+                const int ib = state->HasSelection()
+                                   ? ImMin(state->Stb.select_start, state->Stb.select_end)
+                                   : 0;
+                const int ie = state->HasSelection()
+                                   ? ImMax(state->Stb.select_start, state->Stb.select_end)
+                                   : state->CurLenW;
+                const int clipboard_data_len =
+                    ImTextCountUtf8BytesFromStr(state->TextW.Data + ib, state->TextW.Data + ie) + 1;
+                char *clipboard_data = (char *)IM_ALLOC(clipboard_data_len * sizeof(char));
+                ImTextStrToUtf8(clipboard_data, clipboard_data_len, state->TextW.Data + ib,
+                                state->TextW.Data + ie);
+                SetClipboardText(clipboard_data);
+                MemFree(clipboard_data);
+            }
+            if (is_cut)
+            {
+                if (!state->HasSelection())
+                    state->SelectAll();
+                state->CursorFollow = true;
+                stb_textedit_cut(state, &state->Stb);
+            }
+        }
+        else if (is_paste)
+        {
+            if (const char *clipboard = GetClipboardText())
+            {
+                // Filter pasted buffer
+                const int clipboard_len = (int)strlen(clipboard);
+                ImWchar *clipboard_filtered =
+                    (ImWchar *)IM_ALLOC((clipboard_len + 1) * sizeof(ImWchar));
+                int clipboard_filtered_len = 0;
+                for (const char *s = clipboard; *s;)
+                {
+                    unsigned int c;
+                    s += ImTextCharFromUtf8(&c, s, NULL);
+                    if (c == 0)
+                        break;
+                    if (c >= 0x10000 ||
+                        !InputTextFilterCharacter(&c, flags, callback, callback_user_data))
+                        continue;
+                    clipboard_filtered[clipboard_filtered_len++] = (ImWchar)c;
+                }
+                clipboard_filtered[clipboard_filtered_len] = 0;
+                if (clipboard_filtered_len >
+                    0)  // If everything was filtered, ignore the pasting operation
+                {
+                    stb_textedit_paste(state, &state->Stb, clipboard_filtered,
+                                       clipboard_filtered_len);
+                    state->CursorFollow = true;
+                }
+                MemFree(clipboard_filtered);
+            }
+        }
+
+        // Update render selection flag after events have been handled, so selection highlight can
+        // be displayed during the same frame.
+        render_selection |=
+            state->HasSelection() && (RENDER_SELECTION_WHEN_INACTIVE || render_cursor);
+    }
+
+    // Process callbacks and apply result back to user's buffer.
+    if (g.ActiveId == id)
+    {
+        IM_ASSERT(state != NULL);
+        const char *apply_new_text = NULL;
+        int apply_new_text_length  = 0;
+        if (cancel_edit)
+        {
+            // Restore initial value. Only return true if restoring to the initial value changes the
+            // current buffer contents.
+            if (!is_readonly && strcmp(buf, state->InitialTextA.Data) != 0)
+            {
+                apply_new_text        = state->InitialTextA.Data;
+                apply_new_text_length = state->InitialTextA.Size - 1;
+            }
+        }
+
+        // When using 'ImGuiInputTextFlags_EnterReturnsTrue' as a special case we reapply the live
+        // buffer back to the input buffer before clearing ActiveId, even though strictly speaking
+        // it wasn't modified on this frame. If we didn't do that, code like InputInt() with
+        // ImGuiInputTextFlags_EnterReturnsTrue would fail. Also this allows the user to use
+        // InputText() with ImGuiInputTextFlags_EnterReturnsTrue without maintaining any user-side
+        // storage.
+        bool apply_edit_back_to_user_buffer =
+            !cancel_edit || (enter_pressed && (flags & ImGuiInputTextFlags_EnterReturnsTrue) != 0);
+        if (apply_edit_back_to_user_buffer)
+        {
+            // Apply new value immediately - copy modified buffer back
+            // Note that as soon as the input box is active, the in-widget value gets priority over
+            // any underlying modification of the input buffer
+            // FIXME: We actually always render 'buf' when calling DrawList->AddText, making the
+            // comment above incorrect.
+            // FIXME-OPT: CPU waste to do this every time the widget is active, should mark dirty
+            // state from the stb_textedit callbacks.
+            if (!is_readonly)
+            {
+                state->TextAIsValid = true;
+                state->TextA.resize(state->TextW.Size * 4 + 1);
+                ImTextStrToUtf8(state->TextA.Data, state->TextA.Size, state->TextW.Data, NULL);
+            }
+
+            // User callback
+            if ((flags &
+                 (ImGuiInputTextFlags_CallbackCompletion | ImGuiInputTextFlags_CallbackHistory |
+                  ImGuiInputTextFlags_CallbackAlways)) != 0)
+            {
+                IM_ASSERT(callback != NULL);
+
+                // The reason we specify the usage semantic (Completion/History) is that Completion
+                // needs to disable keyboard TABBING at the moment.
+                ImGuiInputTextFlags event_flag = 0;
+                ImGuiKey event_key             = ImGuiKey_COUNT;
+                if ((flags & ImGuiInputTextFlags_CallbackCompletion) != 0 &&
+                    IsKeyPressedMap(ImGuiKey_Tab))
+                {
+                    event_flag = ImGuiInputTextFlags_CallbackCompletion;
+                    event_key  = ImGuiKey_Tab;
+                }
+                else if ((flags & ImGuiInputTextFlags_CallbackHistory) != 0 &&
+                         IsKeyPressedMap(ImGuiKey_UpArrow))
+                {
+                    event_flag = ImGuiInputTextFlags_CallbackHistory;
+                    event_key  = ImGuiKey_UpArrow;
+                }
+                else if ((flags & ImGuiInputTextFlags_CallbackHistory) != 0 &&
+                         IsKeyPressedMap(ImGuiKey_DownArrow))
+                {
+                    event_flag = ImGuiInputTextFlags_CallbackHistory;
+                    event_key  = ImGuiKey_DownArrow;
+                }
+                else if (flags & ImGuiInputTextFlags_CallbackAlways)
+                    event_flag = ImGuiInputTextFlags_CallbackAlways;
+
+                if (event_flag)
+                {
+                    ImGuiInputTextCallbackData callback_data;
+                    memset(&callback_data, 0, sizeof(ImGuiInputTextCallbackData));
+                    callback_data.EventFlag = event_flag;
+                    callback_data.Flags     = flags;
+                    callback_data.UserData  = callback_user_data;
+
+                    callback_data.EventKey   = event_key;
+                    callback_data.Buf        = state->TextA.Data;
+                    callback_data.BufTextLen = state->CurLenA;
+                    callback_data.BufSize    = state->BufCapacityA;
+                    callback_data.BufDirty   = false;
+
+                    // We have to convert from wchar-positions to UTF-8-positions, which can be
+                    // pretty slow (an incentive to ditch the ImWchar buffer, see
+                    // https://github.com/nothings/stb/issues/188)
+                    ImWchar *text             = state->TextW.Data;
+                    const int utf8_cursor_pos = callback_data.CursorPos =
+                        ImTextCountUtf8BytesFromStr(text, text + state->Stb.cursor);
+                    const int utf8_selection_start = callback_data.SelectionStart =
+                        ImTextCountUtf8BytesFromStr(text, text + state->Stb.select_start);
+                    const int utf8_selection_end = callback_data.SelectionEnd =
+                        ImTextCountUtf8BytesFromStr(text, text + state->Stb.select_end);
+
+                    // Call user code
+                    callback(&callback_data);
+
+                    // Read back what user may have modified
+                    IM_ASSERT(callback_data.Buf ==
+                              state->TextA.Data);  // Invalid to modify those fields
+                    IM_ASSERT(callback_data.BufSize == state->BufCapacityA);
+                    IM_ASSERT(callback_data.Flags == flags);
+                    if (callback_data.CursorPos != utf8_cursor_pos)
+                    {
+                        state->Stb.cursor = ImTextCountCharsFromUtf8(
+                            callback_data.Buf, callback_data.Buf + callback_data.CursorPos);
+                        state->CursorFollow = true;
+                    }
+                    if (callback_data.SelectionStart != utf8_selection_start)
+                    {
+                        state->Stb.select_start = ImTextCountCharsFromUtf8(
+                            callback_data.Buf, callback_data.Buf + callback_data.SelectionStart);
+                    }
+                    if (callback_data.SelectionEnd != utf8_selection_end)
+                    {
+                        state->Stb.select_end = ImTextCountCharsFromUtf8(
+                            callback_data.Buf, callback_data.Buf + callback_data.SelectionEnd);
+                    }
+                    if (callback_data.BufDirty)
+                    {
+                        IM_ASSERT(
+                            callback_data.BufTextLen ==
+                            (int)strlen(callback_data.Buf));  // You need to maintain BufTextLen if
+                                                              // you change the text!
+                        if (callback_data.BufTextLen > backup_current_text_length && is_resizable)
+                            state->TextW.resize(state->TextW.Size + (callback_data.BufTextLen -
+                                                                     backup_current_text_length));
+                        state->CurLenW = ImTextStrFromUtf8(state->TextW.Data, state->TextW.Size,
+                                                           callback_data.Buf, NULL);
+                        state->CurLenA =
+                            callback_data.BufTextLen;  // Assume correct length and valid UTF-8 from
+                                                       // user, saves us an extra strlen()
+                        state->CursorAnimReset();
+                    }
+                }
+            }
+
+            // Will copy result string if modified
+            if (!is_readonly && strcmp(state->TextA.Data, buf) != 0)
+            {
+                apply_new_text        = state->TextA.Data;
+                apply_new_text_length = state->CurLenA;
+            }
+        }
+
+        // Copy result to user buffer
+        if (apply_new_text)
+        {
+            IM_ASSERT(apply_new_text_length >= 0);
+            if (backup_current_text_length != apply_new_text_length && is_resizable)
+            {
+                ImGuiInputTextCallbackData callback_data;
+                callback_data.EventFlag  = ImGuiInputTextFlags_CallbackResize;
+                callback_data.Flags      = flags;
+                callback_data.Buf        = buf;
+                callback_data.BufTextLen = apply_new_text_length;
+                callback_data.BufSize    = ImMax(buf_size, apply_new_text_length + 1);
+                callback_data.UserData   = callback_user_data;
+                callback(&callback_data);
+                buf                   = callback_data.Buf;
+                buf_size              = callback_data.BufSize;
+                apply_new_text_length = ImMin(callback_data.BufTextLen, buf_size - 1);
+                IM_ASSERT(apply_new_text_length <= buf_size);
+            }
+
+            // If the underlying buffer resize was denied or not carried to the next frame,
+            // apply_new_text_length+1 may be >= buf_size.
+            ImStrncpy(buf, apply_new_text, ImMin(apply_new_text_length + 1, buf_size));
+            value_changed = true;
+        }
+
+        // Clear temporary user storage
+        state->UserFlags        = 0;
+        state->UserCallback     = NULL;
+        state->UserCallbackData = NULL;
+    }
+
+    // Release active ID at the end of the function (so e.g. pressing Return still does a final
+    // application of the value)
+    if (clear_active_id && g.ActiveId == id)
+        ClearActiveID();
+
+    // Render frame
+    if (!is_multiline)
+    {
+        RenderNavHighlight(frame_bb, id);
+        RenderFrame(frame_bb.Min, frame_bb.Max, GetColorU32(ImGuiCol_FrameBg), true,
+                    style.FrameRounding);
+    }
+
+    const ImVec4 clip_rect(
+        frame_bb.Min.x, frame_bb.Min.y, frame_bb.Min.x + size.x,
+        frame_bb.Min.y + size.y);  // Not using frame_bb.Max because we have adjusted size
+    ImVec2 draw_pos = is_multiline ? draw_window->DC.CursorPos : frame_bb.Min + style.FramePadding;
+    ImVec2 text_size(0.0f, 0.0f);
+
+    // Set upper limit of single-line InputTextEx() at 2 million characters strings. The current
+    // pathological worst case is a long line without any carriage return, which would makes
+    // ImFont::RenderText() reserve too many vertices and probably crash. Avoid it altogether. Note
+    // that we only use this limit on single-line InputText(), so a pathologically large line on a
+    // InputTextMultiline() would still crash.
+    const int buf_display_max_length = 2 * 1024 * 1024;
+    const char *buf_display          = buf_display_from_state ? state->TextA.Data : buf;  //-V595
+    const char *buf_display_end = NULL;  // We have specialized paths below for setting the length
+    if (is_displaying_hint)
+    {
+        buf_display     = hint;
+        buf_display_end = hint + strlen(hint);
+    }
+
+    // Render text. We currently only render selection when the widget is active or while scrolling.
+    // FIXME: We could remove the '&& render_cursor' to keep rendering selection when inactive.
+    if (render_cursor || render_selection)
+    {
+        IM_ASSERT(state != NULL);
+        if (!is_displaying_hint)
+            buf_display_end = buf_display + state->CurLenA;
+
+        // Render text (with cursor and selection)
+        // This is going to be messy. We need to:
+        // - Display the text (this alone can be more easily clipped)
+        // - Handle scrolling, highlight selection, display cursor (those all requires some form of
+        // 1d->2d cursor position calculation)
+        // - Measure text height (for scrollbar)
+        // We are attempting to do most of that in **one main pass** to minimize the computation
+        // cost (non-negligible for large amount of text) + 2nd pass for selection rendering (we
+        // could merge them by an extra refactoring effort)
+        // FIXME: This should occur on buf_display but we'd need to maintain
+        // cursor/select_start/select_end for UTF-8.
+        const ImWchar *text_begin = state->TextW.Data;
+        ImVec2 cursor_offset, select_start_offset;
+
+        {
+            // Find lines numbers straddling 'cursor' (slot 0) and 'select_start' (slot 1)
+            // positions.
+            const ImWchar *searches_input_ptr[2] = {NULL, NULL};
+            int searches_result_line_no[2]       = {-1000, -1000};
+            int searches_remaining               = 0;
+            if (render_cursor)
+            {
+                searches_input_ptr[0]      = text_begin + state->Stb.cursor;
+                searches_result_line_no[0] = -1;
+                searches_remaining++;
+            }
+            if (render_selection)
+            {
+                searches_input_ptr[1] =
+                    text_begin + ImMin(state->Stb.select_start, state->Stb.select_end);
+                searches_result_line_no[1] = -1;
+                searches_remaining++;
+            }
+
+            // Iterate all lines to find our line numbers
+            // In multi-line mode, we never exit the loop until all lines are counted, so add one
+            // extra to the searches_remaining counter.
+            searches_remaining += is_multiline ? 1 : 0;
+            int line_count = 0;
+            // for (const ImWchar* s = text_begin; (s = (const ImWchar*)wcschr((const wchar_t*)s,
+            // (wchar_t)'\n')) != NULL; s++)  // FIXME-OPT: Could use this when wchar_t are 16-bits
+            for (const ImWchar *s = text_begin; *s != 0; s++)
+                if (*s == '\n')
+                {
+                    line_count++;
+                    if (searches_result_line_no[0] == -1 && s >= searches_input_ptr[0])
+                    {
+                        searches_result_line_no[0] = line_count;
+                        if (--searches_remaining <= 0)
+                            break;
+                    }
+                    if (searches_result_line_no[1] == -1 && s >= searches_input_ptr[1])
+                    {
+                        searches_result_line_no[1] = line_count;
+                        if (--searches_remaining <= 0)
+                            break;
+                    }
+                }
+            line_count++;
+            if (searches_result_line_no[0] == -1)
+                searches_result_line_no[0] = line_count;
+            if (searches_result_line_no[1] == -1)
+                searches_result_line_no[1] = line_count;
+
+            // Calculate 2d position by finding the beginning of the line and measuring distance
+            cursor_offset.x = InputTextCalcTextSizeW(ImStrbolW(searches_input_ptr[0], text_begin),
+                                                     searches_input_ptr[0])
+                                  .x;
+            cursor_offset.y = searches_result_line_no[0] * g.FontSize;
+            if (searches_result_line_no[1] >= 0)
+            {
+                select_start_offset.x =
+                    InputTextCalcTextSizeW(ImStrbolW(searches_input_ptr[1], text_begin),
+                                           searches_input_ptr[1])
+                        .x;
+                select_start_offset.y = searches_result_line_no[1] * g.FontSize;
+            }
+
+            // Store text height (note that we haven't calculated text width at all, see GitHub
+            // issues #383, #1224)
+            if (is_multiline)
+                text_size = ImVec2(size.x, line_count * g.FontSize);
+        }
+
+        // Scroll
+        if (render_cursor && state->CursorFollow)
+        {
+            // Horizontal scroll in chunks of quarter width
+            if (!(flags & ImGuiInputTextFlags_NoHorizontalScroll))
+            {
+                const float scroll_increment_x = size.x * 0.25f;
+                if (cursor_offset.x < state->ScrollX)
+                    state->ScrollX = (float)(int)ImMax(0.0f, cursor_offset.x - scroll_increment_x);
+                else if (cursor_offset.x - size.x >= state->ScrollX)
+                    state->ScrollX = (float)(int)(cursor_offset.x - size.x + scroll_increment_x);
+            }
+            else
+            {
+                state->ScrollX = 0.0f;
+            }
+
+            // Vertical scroll
+            if (is_multiline)
+            {
+                float scroll_y = draw_window->Scroll.y;
+                if (cursor_offset.y - g.FontSize < scroll_y)
+                    scroll_y = ImMax(0.0f, cursor_offset.y - g.FontSize);
+                else if (cursor_offset.y - size.y >= scroll_y)
+                    scroll_y = cursor_offset.y - size.y;
+                draw_window->DC.CursorPos.y +=
+                    (draw_window->Scroll.y -
+                     scroll_y);  // Manipulate cursor pos immediately avoid a frame of lag
+                draw_window->Scroll.y = scroll_y;
+                draw_pos.y            = draw_window->DC.CursorPos.y;
+            }
+
+            state->CursorFollow = false;
+        }
+
+        // Draw selection
+        const ImVec2 draw_scroll = ImVec2(state->ScrollX, 0.0f);
+        if (render_selection)
+        {
+            const ImWchar *text_selected_begin =
+                text_begin + ImMin(state->Stb.select_start, state->Stb.select_end);
+            const ImWchar *text_selected_end =
+                text_begin + ImMax(state->Stb.select_start, state->Stb.select_end);
+
+            ImU32 bg_color = GetColorU32(
+                ImGuiCol_TextSelectedBg,
+                render_cursor
+                    ? 1.0f
+                    : 0.6f);  // FIXME: current code flow mandate that render_cursor is always true
+                              // here, we are leaving the transparent one for tests.
+            float bg_offy_up =
+                is_multiline ? 0.0f : -1.0f;  // FIXME: those offsets should be part of the style?
+                                              // they don't play so well with multi-line selection.
+            float bg_offy_dn = is_multiline ? 0.0f : 2.0f;
+            ImVec2 rect_pos  = draw_pos + select_start_offset - draw_scroll;
+            for (const ImWchar *p = text_selected_begin; p < text_selected_end;)
+            {
+                if (rect_pos.y > clip_rect.w + g.FontSize)
+                    break;
+                if (rect_pos.y < clip_rect.y)
+                {
+                    // p = (const ImWchar*)wmemchr((const wchar_t*)p, '\n', text_selected_end - p);
+                    // // FIXME-OPT: Could use this when wchar_t are 16-bits p = p ? p + 1 :
+                    // text_selected_end;
+                    while (p < text_selected_end)
+                        if (*p++ == '\n')
+                            break;
+                }
+                else
+                {
+                    ImVec2 rect_size = InputTextCalcTextSizeW(p, text_selected_end, &p, NULL, true);
+                    if (rect_size.x <= 0.0f)
+                        rect_size.x = (float)(int)(g.Font->GetCharAdvance((ImWchar)' ') *
+                                                   0.50f);  // So we can see selected empty lines
+                    ImRect rect(rect_pos + ImVec2(0.0f, bg_offy_up - g.FontSize),
+                                rect_pos + ImVec2(rect_size.x, bg_offy_dn));
+                    rect.ClipWith(clip_rect);
+                    if (rect.Overlaps(clip_rect))
+                        draw_window->DrawList->AddRectFilled(rect.Min, rect.Max, bg_color);
+                }
+                rect_pos.x = draw_pos.x - draw_scroll.x;
+                rect_pos.y += g.FontSize;
+            }
+        }
+
+        // We test for 'buf_display_max_length' as a way to avoid some pathological cases (e.g.
+        // single-line 1 MB string) which would make ImDrawList crash.
+        if (is_multiline || (buf_display_end - buf_display) < buf_display_max_length)
+        {
+            ImU32 col = GetColorU32(is_displaying_hint ? ImGuiCol_TextDisabled : ImGuiCol_Text);
+            draw_window->DrawList->AddText(g.Font, g.FontSize, draw_pos - draw_scroll, col,
+                                           buf_display, buf_display_end, 0.0f,
+                                           is_multiline ? NULL : &clip_rect);
+        }
+
+        // Draw blinking cursor
+        if (render_cursor)
+        {
+            state->CursorAnim += io.DeltaTime;
+            bool cursor_is_visible = (!g.IO.ConfigInputTextCursorBlink) ||
+                                     (state->CursorAnim <= 0.0f) ||
+                                     ImFmod(state->CursorAnim, 1.20f) <= 0.80f;
+            ImVec2 cursor_screen_pos = draw_pos + cursor_offset - draw_scroll;
+            ImRect cursor_screen_rect(cursor_screen_pos.x, cursor_screen_pos.y - g.FontSize + 0.5f,
+                                      cursor_screen_pos.x + 1.0f, cursor_screen_pos.y - 1.5f);
+            if (cursor_is_visible && cursor_screen_rect.Overlaps(clip_rect))
+                draw_window->DrawList->AddLine(cursor_screen_rect.Min, cursor_screen_rect.GetBL(),
+                                               GetColorU32(ImGuiCol_Text));
+
+            // Notify OS of text input position for advanced IME (-1 x offset so that Windows IME
+            // can cover our cursor. Bit of an extra nicety.)
+            if (!is_readonly)
+                g.PlatformImePos =
+                    ImVec2(cursor_screen_pos.x - 1.0f, cursor_screen_pos.y - g.FontSize);
+        }
+    }
+    else
+    {
+        // Render text only (no selection, no cursor)
+        if (is_multiline)
+            text_size =
+                ImVec2(size.x, InputTextCalcTextLenAndLineCount(buf_display, &buf_display_end) *
+                                   g.FontSize);  // We don't need width
+        else if (!is_displaying_hint && g.ActiveId == id)
+            buf_display_end = buf_display + state->CurLenA;
+        else if (!is_displaying_hint)
+            buf_display_end = buf_display + strlen(buf_display);
+
+        if (is_multiline || (buf_display_end - buf_display) < buf_display_max_length)
+        {
+            ImU32 col = GetColorU32(is_displaying_hint ? ImGuiCol_TextDisabled : ImGuiCol_Text);
+            draw_window->DrawList->AddText(g.Font, g.FontSize, draw_pos, col, buf_display,
+                                           buf_display_end, 0.0f, is_multiline ? NULL : &clip_rect);
+        }
+    }
+
+    if (is_multiline)
+    {
+        Dummy(text_size + ImVec2(0.0f, g.FontSize));  // Always add room to scroll an extra line
+        EndChildFrame();
+        EndGroup();
+    }
+
+    if (is_password && !is_displaying_hint)
+        PopFont();
+
+    // Log as text
+    if (g.LogEnabled && !(is_password && !is_displaying_hint))
+        LogRenderedText(&draw_pos, buf_display, buf_display_end);
+
+    if (label_size.x > 0)
+        RenderText(ImVec2(frame_bb.Max.x + style.ItemInnerSpacing.x,
+                          frame_bb.Min.y + style.FramePadding.y),
+                   label);
+
+    if (value_changed && !(flags & ImGuiInputTextFlags_NoMarkEdited))
+        MarkItemEdited(id);
+
+    IMGUI_TEST_ENGINE_ITEM_INFO(id, label, window->DC.ItemFlags);
+    if ((flags & ImGuiInputTextFlags_EnterReturnsTrue) != 0)
+        return enter_pressed;
+    else
+        return value_changed;
+}
+
+//-------------------------------------------------------------------------
+// [SECTION] Widgets: ColorEdit, ColorPicker, ColorButton, etc.
+//-------------------------------------------------------------------------
+// - ColorEdit3()
+// - ColorEdit4()
+// - ColorPicker3()
+// - RenderColorRectWithAlphaCheckerboard() [Internal]
+// - ColorPicker4()
+// - ColorButton()
+// - SetColorEditOptions()
+// - ColorTooltip() [Internal]
+// - ColorEditOptionsPopup() [Internal]
+// - ColorPickerOptionsPopup() [Internal]
+//-------------------------------------------------------------------------
+
+bool ImGui::ColorEdit3(const char *label, float col[3], ImGuiColorEditFlags flags)
+{
+    return ColorEdit4(label, col, flags | ImGuiColorEditFlags_NoAlpha);
+}
+
+// Edit colors components (each component in 0.0f..1.0f range).
+// See enum ImGuiColorEditFlags_ for available options. e.g. Only access 3 floats if
+// ImGuiColorEditFlags_NoAlpha flag is set. With typical options: Left-click on colored square to
+// open color picker. Right-click to open option menu. CTRL-Click over input fields to edit them and
+// TAB to go to next item.
+bool ImGui::ColorEdit4(const char *label, float col[4], ImGuiColorEditFlags flags)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    ImGuiContext &g         = *GImGui;
+    const ImGuiStyle &style = g.Style;
+    const float square_sz   = GetFrameHeight();
+    const float w_extra     = (flags & ImGuiColorEditFlags_NoSmallPreview)
+                              ? 0.0f
+                              : (square_sz + style.ItemInnerSpacing.x);
+    const float w_items_all       = CalcItemWidth() - w_extra;
+    const char *label_display_end = FindRenderedTextEnd(label);
+    g.NextItemData.ClearFlags();
+
+    BeginGroup();
+    PushID(label);
+
+    // If we're not showing any slider there's no point in doing any HSV conversions
+    const ImGuiColorEditFlags flags_untouched = flags;
+    if (flags & ImGuiColorEditFlags_NoInputs)
+        flags = (flags & (~ImGuiColorEditFlags__DisplayMask)) | ImGuiColorEditFlags_DisplayRGB |
+                ImGuiColorEditFlags_NoOptions;
+
+    // Context menu: display and modify options (before defaults are applied)
+    if (!(flags & ImGuiColorEditFlags_NoOptions))
+        ColorEditOptionsPopup(col, flags);
+
+    // Read stored options
+    if (!(flags & ImGuiColorEditFlags__DisplayMask))
+        flags |= (g.ColorEditOptions & ImGuiColorEditFlags__DisplayMask);
+    if (!(flags & ImGuiColorEditFlags__DataTypeMask))
+        flags |= (g.ColorEditOptions & ImGuiColorEditFlags__DataTypeMask);
+    if (!(flags & ImGuiColorEditFlags__PickerMask))
+        flags |= (g.ColorEditOptions & ImGuiColorEditFlags__PickerMask);
+    if (!(flags & ImGuiColorEditFlags__InputMask))
+        flags |= (g.ColorEditOptions & ImGuiColorEditFlags__InputMask);
+    flags |= (g.ColorEditOptions &
+              ~(ImGuiColorEditFlags__DisplayMask | ImGuiColorEditFlags__DataTypeMask |
+                ImGuiColorEditFlags__PickerMask | ImGuiColorEditFlags__InputMask));
+    IM_ASSERT(
+        ImIsPowerOfTwo(flags & ImGuiColorEditFlags__DisplayMask));  // Check that only 1 is selected
+    IM_ASSERT(
+        ImIsPowerOfTwo(flags & ImGuiColorEditFlags__InputMask));  // Check that only 1 is selected
+
+    const bool alpha     = (flags & ImGuiColorEditFlags_NoAlpha) == 0;
+    const bool hdr       = (flags & ImGuiColorEditFlags_HDR) != 0;
+    const int components = alpha ? 4 : 3;
+
+    // Convert to the formats we need
+    float f[4] = {col[0], col[1], col[2], alpha ? col[3] : 1.0f};
+    if ((flags & ImGuiColorEditFlags_InputHSV) && (flags & ImGuiColorEditFlags_DisplayRGB))
+        ColorConvertHSVtoRGB(f[0], f[1], f[2], f[0], f[1], f[2]);
+    else if ((flags & ImGuiColorEditFlags_InputRGB) && (flags & ImGuiColorEditFlags_DisplayHSV))
+        ColorConvertRGBtoHSV(f[0], f[1], f[2], f[0], f[1], f[2]);
+    int i[4] = {IM_F32_TO_INT8_UNBOUND(f[0]), IM_F32_TO_INT8_UNBOUND(f[1]),
+                IM_F32_TO_INT8_UNBOUND(f[2]), IM_F32_TO_INT8_UNBOUND(f[3])};
+
+    bool value_changed          = false;
+    bool value_changed_as_float = false;
+
+    if ((flags & (ImGuiColorEditFlags_DisplayRGB | ImGuiColorEditFlags_DisplayHSV)) != 0 &&
+        (flags & ImGuiColorEditFlags_NoInputs) == 0)
+    {
+        // RGB/HSV 0..255 Sliders
+        const float w_item_one =
+            ImMax(1.0f, (float)(int)((w_items_all - (style.ItemInnerSpacing.x) * (components - 1)) /
+                                     (float)components));
+        const float w_item_last = ImMax(
+            1.0f,
+            (float)(int)(w_items_all - (w_item_one + style.ItemInnerSpacing.x) * (components - 1)));
+
+        const bool hide_prefix =
+            (w_item_one <=
+             CalcTextSize((flags & ImGuiColorEditFlags_Float) ? "M:0.000" : "M:000").x);
+        static const char *ids[4]              = {"##X", "##Y", "##Z", "##W"};
+        static const char *fmt_table_int[3][4] = {
+            {"%3d", "%3d", "%3d", "%3d"},          // Short display
+            {"R:%3d", "G:%3d", "B:%3d", "A:%3d"},  // Long display for RGBA
+            {"H:%3d", "S:%3d", "V:%3d", "A:%3d"}   // Long display for HSVA
+        };
+        static const char *fmt_table_float[3][4] = {
+            {"%0.3f", "%0.3f", "%0.3f", "%0.3f"},          // Short display
+            {"R:%0.3f", "G:%0.3f", "B:%0.3f", "A:%0.3f"},  // Long display for RGBA
+            {"H:%0.3f", "S:%0.3f", "V:%0.3f", "A:%0.3f"}   // Long display for HSVA
+        };
+        const int fmt_idx = hide_prefix ? 0 : (flags & ImGuiColorEditFlags_DisplayHSV) ? 2 : 1;
+
+        for (int n = 0; n < components; n++)
+        {
+            if (n > 0)
+                SameLine(0, style.ItemInnerSpacing.x);
+            SetNextItemWidth((n + 1 < components) ? w_item_one : w_item_last);
+            if (flags & ImGuiColorEditFlags_Float)
+            {
+                value_changed |= DragFloat(ids[n], &f[n], 1.0f / 255.0f, 0.0f, hdr ? 0.0f : 1.0f,
+                                           fmt_table_float[fmt_idx][n]);
+                value_changed_as_float |= value_changed;
+            }
+            else
+            {
+                value_changed |=
+                    DragInt(ids[n], &i[n], 1.0f, 0, hdr ? 0 : 255, fmt_table_int[fmt_idx][n]);
+            }
+            if (!(flags & ImGuiColorEditFlags_NoOptions))
+                OpenPopupOnItemClick("context");
+        }
+    }
+    else if ((flags & ImGuiColorEditFlags_DisplayHex) != 0 &&
+             (flags & ImGuiColorEditFlags_NoInputs) == 0)
+    {
+        // RGB Hexadecimal Input
+        char buf[64];
+        if (alpha)
+            ImFormatString(buf, IM_ARRAYSIZE(buf), "#%02X%02X%02X%02X", ImClamp(i[0], 0, 255),
+                           ImClamp(i[1], 0, 255), ImClamp(i[2], 0, 255), ImClamp(i[3], 0, 255));
+        else
+            ImFormatString(buf, IM_ARRAYSIZE(buf), "#%02X%02X%02X", ImClamp(i[0], 0, 255),
+                           ImClamp(i[1], 0, 255), ImClamp(i[2], 0, 255));
+        SetNextItemWidth(w_items_all);
+        if (InputText("##Text", buf, IM_ARRAYSIZE(buf),
+                      ImGuiInputTextFlags_CharsHexadecimal | ImGuiInputTextFlags_CharsUppercase))
+        {
+            value_changed = true;
+            char *p       = buf;
+            while (*p == '#' || ImCharIsBlankA(*p))
+                p++;
+            i[0] = i[1] = i[2] = i[3] = 0;
+            if (alpha)
+                sscanf(p, "%02X%02X%02X%02X", (unsigned int *)&i[0], (unsigned int *)&i[1],
+                       (unsigned int *)&i[2],
+                       (unsigned int *)&i[3]);  // Treat at unsigned (%X is unsigned)
+            else
+                sscanf(p, "%02X%02X%02X", (unsigned int *)&i[0], (unsigned int *)&i[1],
+                       (unsigned int *)&i[2]);
+        }
+        if (!(flags & ImGuiColorEditFlags_NoOptions))
+            OpenPopupOnItemClick("context");
+    }
+
+    ImGuiWindow *picker_active_window = NULL;
+    if (!(flags & ImGuiColorEditFlags_NoSmallPreview))
+    {
+        if (!(flags & ImGuiColorEditFlags_NoInputs))
+            SameLine(0, style.ItemInnerSpacing.x);
+
+        const ImVec4 col_v4(col[0], col[1], col[2], alpha ? col[3] : 1.0f);
+        if (ColorButton("##ColorButton", col_v4, flags))
+        {
+            if (!(flags & ImGuiColorEditFlags_NoPicker))
+            {
+                // Store current color and open a picker
+                g.ColorPickerRef = col_v4;
+                OpenPopup("picker");
+                SetNextWindowPos(window->DC.LastItemRect.GetBL() + ImVec2(-1, style.ItemSpacing.y));
+            }
+        }
+        if (!(flags & ImGuiColorEditFlags_NoOptions))
+            OpenPopupOnItemClick("context");
+
+        if (BeginPopup("picker"))
+        {
+            picker_active_window = g.CurrentWindow;
+            if (label != label_display_end)
+            {
+                TextEx(label, label_display_end);
+                Spacing();
+            }
+            ImGuiColorEditFlags picker_flags_to_forward =
+                ImGuiColorEditFlags__DataTypeMask | ImGuiColorEditFlags__PickerMask |
+                ImGuiColorEditFlags__InputMask | ImGuiColorEditFlags_HDR |
+                ImGuiColorEditFlags_NoAlpha | ImGuiColorEditFlags_AlphaBar;
+            ImGuiColorEditFlags picker_flags =
+                (flags_untouched & picker_flags_to_forward) | ImGuiColorEditFlags__DisplayMask |
+                ImGuiColorEditFlags_NoLabel | ImGuiColorEditFlags_AlphaPreviewHalf;
+            SetNextItemWidth(square_sz * 12.0f);  // Use 256 + bar sizes?
+            value_changed |= ColorPicker4("##picker", col, picker_flags, &g.ColorPickerRef.x);
+            EndPopup();
+        }
+    }
+
+    if (label != label_display_end && !(flags & ImGuiColorEditFlags_NoLabel))
+    {
+        SameLine(0, style.ItemInnerSpacing.x);
+        TextEx(label, label_display_end);
+    }
+
+    // Convert back
+    if (value_changed && picker_active_window == NULL)
+    {
+        if (!value_changed_as_float)
+            for (int n = 0; n < 4; n++)
+                f[n] = i[n] / 255.0f;
+        if ((flags & ImGuiColorEditFlags_DisplayHSV) && (flags & ImGuiColorEditFlags_InputRGB))
+            ColorConvertHSVtoRGB(f[0], f[1], f[2], f[0], f[1], f[2]);
+        if ((flags & ImGuiColorEditFlags_DisplayRGB) && (flags & ImGuiColorEditFlags_InputHSV))
+            ColorConvertRGBtoHSV(f[0], f[1], f[2], f[0], f[1], f[2]);
+
+        col[0] = f[0];
+        col[1] = f[1];
+        col[2] = f[2];
+        if (alpha)
+            col[3] = f[3];
+    }
+
+    PopID();
+    EndGroup();
+
+    // Drag and Drop Target
+    // NB: The flag test is merely an optional micro-optimization, BeginDragDropTarget() does the
+    // same test.
+    if ((window->DC.LastItemStatusFlags & ImGuiItemStatusFlags_HoveredRect) &&
+        !(flags & ImGuiColorEditFlags_NoDragDrop) && BeginDragDropTarget())
+    {
+        bool accepted_drag_drop = false;
+        if (const ImGuiPayload *payload = AcceptDragDropPayload(IMGUI_PAYLOAD_TYPE_COLOR_3F))
+        {
+            memcpy((float *)col, payload->Data,
+                   sizeof(float) * 3);  // Preserve alpha if any //-V512
+            value_changed = accepted_drag_drop = true;
+        }
+        if (const ImGuiPayload *payload = AcceptDragDropPayload(IMGUI_PAYLOAD_TYPE_COLOR_4F))
+        {
+            memcpy((float *)col, payload->Data, sizeof(float) * components);
+            value_changed = accepted_drag_drop = true;
+        }
+
+        // Drag-drop payloads are always RGB
+        if (accepted_drag_drop && (flags & ImGuiColorEditFlags_InputHSV))
+            ColorConvertRGBtoHSV(col[0], col[1], col[2], col[0], col[1], col[2]);
+        EndDragDropTarget();
+    }
+
+    // When picker is being actively used, use its active id so IsItemActive() will function on
+    // ColorEdit4().
+    if (picker_active_window && g.ActiveId != 0 && g.ActiveIdWindow == picker_active_window)
+        window->DC.LastItemId = g.ActiveId;
+
+    if (value_changed)
+        MarkItemEdited(window->DC.LastItemId);
+
+    return value_changed;
+}
+
+bool ImGui::ColorPicker3(const char *label, float col[3], ImGuiColorEditFlags flags)
+{
+    float col4[4] = {col[0], col[1], col[2], 1.0f};
+    if (!ColorPicker4(label, col4, flags | ImGuiColorEditFlags_NoAlpha))
+        return false;
+    col[0] = col4[0];
+    col[1] = col4[1];
+    col[2] = col4[2];
+    return true;
+}
+
+static inline ImU32 ImAlphaBlendColor(ImU32 col_a, ImU32 col_b)
+{
+    float t = ((col_b >> IM_COL32_A_SHIFT) & 0xFF) / 255.f;
+    int r =
+        ImLerp((int)(col_a >> IM_COL32_R_SHIFT) & 0xFF, (int)(col_b >> IM_COL32_R_SHIFT) & 0xFF, t);
+    int g =
+        ImLerp((int)(col_a >> IM_COL32_G_SHIFT) & 0xFF, (int)(col_b >> IM_COL32_G_SHIFT) & 0xFF, t);
+    int b =
+        ImLerp((int)(col_a >> IM_COL32_B_SHIFT) & 0xFF, (int)(col_b >> IM_COL32_B_SHIFT) & 0xFF, t);
+    return IM_COL32(r, g, b, 0xFF);
+}
+
+// Helper for ColorPicker4()
+// NB: This is rather brittle and will show artifact when rounding this enabled if rounded corners
+// overlap multiple cells. Caller currently responsible for avoiding that. I spent a non reasonable
+// amount of time trying to getting this right for ColorButton with
+// rounding+anti-aliasing+ImGuiColorEditFlags_HalfAlphaPreview flag + various grid sizes and
+// offsets, and eventually gave up... probably more reasonable to disable rounding alltogether.
+void ImGui::RenderColorRectWithAlphaCheckerboard(ImVec2 p_min,
+                                                 ImVec2 p_max,
+                                                 ImU32 col,
+                                                 float grid_step,
+                                                 ImVec2 grid_off,
+                                                 float rounding,
+                                                 int rounding_corners_flags)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (((col & IM_COL32_A_MASK) >> IM_COL32_A_SHIFT) < 0xFF)
+    {
+        ImU32 col_bg1 = GetColorU32(ImAlphaBlendColor(IM_COL32(204, 204, 204, 255), col));
+        ImU32 col_bg2 = GetColorU32(ImAlphaBlendColor(IM_COL32(128, 128, 128, 255), col));
+        window->DrawList->AddRectFilled(p_min, p_max, col_bg1, rounding, rounding_corners_flags);
+
+        int yi = 0;
+        for (float y = p_min.y + grid_off.y; y < p_max.y; y += grid_step, yi++)
+        {
+            float y1 = ImClamp(y, p_min.y, p_max.y), y2 = ImMin(y + grid_step, p_max.y);
+            if (y2 <= y1)
+                continue;
+            for (float x = p_min.x + grid_off.x + (yi & 1) * grid_step; x < p_max.x;
+                 x += grid_step * 2.0f)
+            {
+                float x1 = ImClamp(x, p_min.x, p_max.x), x2 = ImMin(x + grid_step, p_max.x);
+                if (x2 <= x1)
+                    continue;
+                int rounding_corners_flags_cell = 0;
+                if (y1 <= p_min.y)
+                {
+                    if (x1 <= p_min.x)
+                        rounding_corners_flags_cell |= ImDrawCornerFlags_TopLeft;
+                    if (x2 >= p_max.x)
+                        rounding_corners_flags_cell |= ImDrawCornerFlags_TopRight;
+                }
+                if (y2 >= p_max.y)
+                {
+                    if (x1 <= p_min.x)
+                        rounding_corners_flags_cell |= ImDrawCornerFlags_BotLeft;
+                    if (x2 >= p_max.x)
+                        rounding_corners_flags_cell |= ImDrawCornerFlags_BotRight;
+                }
+                rounding_corners_flags_cell &= rounding_corners_flags;
+                window->DrawList->AddRectFilled(ImVec2(x1, y1), ImVec2(x2, y2), col_bg2,
+                                                rounding_corners_flags_cell ? rounding : 0.0f,
+                                                rounding_corners_flags_cell);
+            }
+        }
+    }
+    else
+    {
+        window->DrawList->AddRectFilled(p_min, p_max, col, rounding, rounding_corners_flags);
+    }
+}
+
+// Helper for ColorPicker4()
+static void RenderArrowsForVerticalBar(ImDrawList *draw_list,
+                                       ImVec2 pos,
+                                       ImVec2 half_sz,
+                                       float bar_w)
+{
+    ImGui::RenderArrowPointingAt(draw_list, ImVec2(pos.x + half_sz.x + 1, pos.y),
+                                 ImVec2(half_sz.x + 2, half_sz.y + 1), ImGuiDir_Right,
+                                 IM_COL32_BLACK);
+    ImGui::RenderArrowPointingAt(draw_list, ImVec2(pos.x + half_sz.x, pos.y), half_sz,
+                                 ImGuiDir_Right, IM_COL32_WHITE);
+    ImGui::RenderArrowPointingAt(draw_list, ImVec2(pos.x + bar_w - half_sz.x - 1, pos.y),
+                                 ImVec2(half_sz.x + 2, half_sz.y + 1), ImGuiDir_Left,
+                                 IM_COL32_BLACK);
+    ImGui::RenderArrowPointingAt(draw_list, ImVec2(pos.x + bar_w - half_sz.x, pos.y), half_sz,
+                                 ImGuiDir_Left, IM_COL32_WHITE);
+}
+
+// Note: ColorPicker4() only accesses 3 floats if ImGuiColorEditFlags_NoAlpha flag is set.
+// (In C++ the 'float col[4]' notation for a function argument is equivalent to 'float* col', we
+// only specify a size to facilitate understanding of the code.)
+// FIXME: we adjust the big color square height based on item width, which may cause a flickering
+// feedback loop (if automatic height makes a vertical scrollbar appears, affecting automatic
+// width..)
+bool ImGui::ColorPicker4(const char *label,
+                         float col[4],
+                         ImGuiColorEditFlags flags,
+                         const float *ref_col)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    ImDrawList *draw_list = window->DrawList;
+    ImGuiStyle &style     = g.Style;
+    ImGuiIO &io           = g.IO;
+
+    const float width = CalcItemWidth();
+    g.NextItemData.ClearFlags();
+
+    PushID(label);
+    BeginGroup();
+
+    if (!(flags & ImGuiColorEditFlags_NoSidePreview))
+        flags |= ImGuiColorEditFlags_NoSmallPreview;
+
+    // Context menu: display and store options.
+    if (!(flags & ImGuiColorEditFlags_NoOptions))
+        ColorPickerOptionsPopup(col, flags);
+
+    // Read stored options
+    if (!(flags & ImGuiColorEditFlags__PickerMask))
+        flags |= ((g.ColorEditOptions & ImGuiColorEditFlags__PickerMask)
+                      ? g.ColorEditOptions
+                      : ImGuiColorEditFlags__OptionsDefault) &
+                 ImGuiColorEditFlags__PickerMask;
+    if (!(flags & ImGuiColorEditFlags__InputMask))
+        flags |= ((g.ColorEditOptions & ImGuiColorEditFlags__InputMask)
+                      ? g.ColorEditOptions
+                      : ImGuiColorEditFlags__OptionsDefault) &
+                 ImGuiColorEditFlags__InputMask;
+    IM_ASSERT(
+        ImIsPowerOfTwo(flags & ImGuiColorEditFlags__PickerMask));  // Check that only 1 is selected
+    IM_ASSERT(
+        ImIsPowerOfTwo(flags & ImGuiColorEditFlags__InputMask));  // Check that only 1 is selected
+    if (!(flags & ImGuiColorEditFlags_NoOptions))
+        flags |= (g.ColorEditOptions & ImGuiColorEditFlags_AlphaBar);
+
+    // Setup
+    int components = (flags & ImGuiColorEditFlags_NoAlpha) ? 3 : 4;
+    bool alpha_bar =
+        (flags & ImGuiColorEditFlags_AlphaBar) && !(flags & ImGuiColorEditFlags_NoAlpha);
+    ImVec2 picker_pos = window->DC.CursorPos;
+    float square_sz   = GetFrameHeight();
+    float bars_width  = square_sz;  // Arbitrary smallish width of Hue/Alpha picking bars
+    float sv_picker_size =
+        ImMax(bars_width * 1,
+              width - (alpha_bar ? 2 : 1) *
+                          (bars_width + style.ItemInnerSpacing.x));  // Saturation/Value picking box
+    float bar0_pos_x             = picker_pos.x + sv_picker_size + style.ItemInnerSpacing.x;
+    float bar1_pos_x             = bar0_pos_x + bars_width + style.ItemInnerSpacing.x;
+    float bars_triangles_half_sz = (float)(int)(bars_width * 0.20f);
+
+    float backup_initial_col[4];
+    memcpy(backup_initial_col, col, components * sizeof(float));
+
+    float wheel_thickness = sv_picker_size * 0.08f;
+    float wheel_r_outer   = sv_picker_size * 0.50f;
+    float wheel_r_inner   = wheel_r_outer - wheel_thickness;
+    ImVec2 wheel_center(picker_pos.x + (sv_picker_size + bars_width) * 0.5f,
+                        picker_pos.y + sv_picker_size * 0.5f);
+
+    // Note: the triangle is displayed rotated with triangle_pa pointing to Hue, but most
+    // coordinates stays unrotated for logic.
+    float triangle_r   = wheel_r_inner - (int)(sv_picker_size * 0.027f);
+    ImVec2 triangle_pa = ImVec2(triangle_r, 0.0f);                             // Hue point.
+    ImVec2 triangle_pb = ImVec2(triangle_r * -0.5f, triangle_r * -0.866025f);  // Black point.
+    ImVec2 triangle_pc = ImVec2(triangle_r * -0.5f, triangle_r * +0.866025f);  // White point.
+
+    float H = col[0], S = col[1], V = col[2];
+    float R = col[0], G = col[1], B = col[2];
+    if (flags & ImGuiColorEditFlags_InputRGB)
+        ColorConvertRGBtoHSV(R, G, B, H, S, V);
+    else if (flags & ImGuiColorEditFlags_InputHSV)
+        ColorConvertHSVtoRGB(H, S, V, R, G, B);
+
+    bool value_changed = false, value_changed_h = false, value_changed_sv = false;
+
+    PushItemFlag(ImGuiItemFlags_NoNav, true);
+    if (flags & ImGuiColorEditFlags_PickerHueWheel)
+    {
+        // Hue wheel + SV triangle logic
+        InvisibleButton(
+            "hsv", ImVec2(sv_picker_size + style.ItemInnerSpacing.x + bars_width, sv_picker_size));
+        if (IsItemActive())
+        {
+            ImVec2 initial_off  = g.IO.MouseClickedPos[0] - wheel_center;
+            ImVec2 current_off  = g.IO.MousePos - wheel_center;
+            float initial_dist2 = ImLengthSqr(initial_off);
+            if (initial_dist2 >= (wheel_r_inner - 1) * (wheel_r_inner - 1) &&
+                initial_dist2 <= (wheel_r_outer + 1) * (wheel_r_outer + 1))
+            {
+                // Interactive with Hue wheel
+                H = ImAtan2(current_off.y, current_off.x) / IM_PI * 0.5f;
+                if (H < 0.0f)
+                    H += 1.0f;
+                value_changed = value_changed_h = true;
+            }
+            float cos_hue_angle = ImCos(-H * 2.0f * IM_PI);
+            float sin_hue_angle = ImSin(-H * 2.0f * IM_PI);
+            if (ImTriangleContainsPoint(triangle_pa, triangle_pb, triangle_pc,
+                                        ImRotate(initial_off, cos_hue_angle, sin_hue_angle)))
+            {
+                // Interacting with SV triangle
+                ImVec2 current_off_unrotated = ImRotate(current_off, cos_hue_angle, sin_hue_angle);
+                if (!ImTriangleContainsPoint(triangle_pa, triangle_pb, triangle_pc,
+                                             current_off_unrotated))
+                    current_off_unrotated = ImTriangleClosestPoint(
+                        triangle_pa, triangle_pb, triangle_pc, current_off_unrotated);
+                float uu, vv, ww;
+                ImTriangleBarycentricCoords(triangle_pa, triangle_pb, triangle_pc,
+                                            current_off_unrotated, uu, vv, ww);
+                V             = ImClamp(1.0f - vv, 0.0001f, 1.0f);
+                S             = ImClamp(uu / V, 0.0001f, 1.0f);
+                value_changed = value_changed_sv = true;
+            }
+        }
+        if (!(flags & ImGuiColorEditFlags_NoOptions))
+            OpenPopupOnItemClick("context");
+    }
+    else if (flags & ImGuiColorEditFlags_PickerHueBar)
+    {
+        // SV rectangle logic
+        InvisibleButton("sv", ImVec2(sv_picker_size, sv_picker_size));
+        if (IsItemActive())
+        {
+            S = ImSaturate((io.MousePos.x - picker_pos.x) / (sv_picker_size - 1));
+            V = 1.0f - ImSaturate((io.MousePos.y - picker_pos.y) / (sv_picker_size - 1));
+            value_changed = value_changed_sv = true;
+        }
+        if (!(flags & ImGuiColorEditFlags_NoOptions))
+            OpenPopupOnItemClick("context");
+
+        // Hue bar logic
+        SetCursorScreenPos(ImVec2(bar0_pos_x, picker_pos.y));
+        InvisibleButton("hue", ImVec2(bars_width, sv_picker_size));
+        if (IsItemActive())
+        {
+            H             = ImSaturate((io.MousePos.y - picker_pos.y) / (sv_picker_size - 1));
+            value_changed = value_changed_h = true;
+        }
+    }
+
+    // Alpha bar logic
+    if (alpha_bar)
+    {
+        SetCursorScreenPos(ImVec2(bar1_pos_x, picker_pos.y));
+        InvisibleButton("alpha", ImVec2(bars_width, sv_picker_size));
+        if (IsItemActive())
+        {
+            col[3] = 1.0f - ImSaturate((io.MousePos.y - picker_pos.y) / (sv_picker_size - 1));
+            value_changed = true;
+        }
+    }
+    PopItemFlag();  // ImGuiItemFlags_NoNav
+
+    if (!(flags & ImGuiColorEditFlags_NoSidePreview))
+    {
+        SameLine(0, style.ItemInnerSpacing.x);
+        BeginGroup();
+    }
+
+    if (!(flags & ImGuiColorEditFlags_NoLabel))
+    {
+        const char *label_display_end = FindRenderedTextEnd(label);
+        if (label != label_display_end)
+        {
+            if ((flags & ImGuiColorEditFlags_NoSidePreview))
+                SameLine(0, style.ItemInnerSpacing.x);
+            TextEx(label, label_display_end);
+        }
+    }
+
+    if (!(flags & ImGuiColorEditFlags_NoSidePreview))
+    {
+        PushItemFlag(ImGuiItemFlags_NoNavDefaultFocus, true);
+        ImVec4 col_v4(col[0], col[1], col[2],
+                      (flags & ImGuiColorEditFlags_NoAlpha) ? 1.0f : col[3]);
+        if ((flags & ImGuiColorEditFlags_NoLabel))
+            Text("Current");
+
+        ImGuiColorEditFlags sub_flags_to_forward =
+            ImGuiColorEditFlags__InputMask | ImGuiColorEditFlags_HDR |
+            ImGuiColorEditFlags_AlphaPreview | ImGuiColorEditFlags_AlphaPreviewHalf |
+            ImGuiColorEditFlags_NoTooltip;
+        ColorButton("##current", col_v4, (flags & sub_flags_to_forward),
+                    ImVec2(square_sz * 3, square_sz * 2));
+        if (ref_col != NULL)
+        {
+            Text("Original");
+            ImVec4 ref_col_v4(ref_col[0], ref_col[1], ref_col[2],
+                              (flags & ImGuiColorEditFlags_NoAlpha) ? 1.0f : ref_col[3]);
+            if (ColorButton("##original", ref_col_v4, (flags & sub_flags_to_forward),
+                            ImVec2(square_sz * 3, square_sz * 2)))
+            {
+                memcpy(col, ref_col, components * sizeof(float));
+                value_changed = true;
+            }
+        }
+        PopItemFlag();
+        EndGroup();
+    }
+
+    // Convert back color to RGB
+    if (value_changed_h || value_changed_sv)
+    {
+        if (flags & ImGuiColorEditFlags_InputRGB)
+        {
+            ColorConvertHSVtoRGB(H >= 1.0f ? H - 10 * 1e-6f : H, S > 0.0f ? S : 10 * 1e-6f,
+                                 V > 0.0f ? V : 1e-6f, col[0], col[1], col[2]);
+        }
+        else if (flags & ImGuiColorEditFlags_InputHSV)
+        {
+            col[0] = H;
+            col[1] = S;
+            col[2] = V;
+        }
+    }
+
+    // R,G,B and H,S,V slider color editor
+    bool value_changed_fix_hue_wrap = false;
+    if ((flags & ImGuiColorEditFlags_NoInputs) == 0)
+    {
+        PushItemWidth((alpha_bar ? bar1_pos_x : bar0_pos_x) + bars_width - picker_pos.x);
+        ImGuiColorEditFlags sub_flags_to_forward =
+            ImGuiColorEditFlags__DataTypeMask | ImGuiColorEditFlags__InputMask |
+            ImGuiColorEditFlags_HDR | ImGuiColorEditFlags_NoAlpha | ImGuiColorEditFlags_NoOptions |
+            ImGuiColorEditFlags_NoSmallPreview | ImGuiColorEditFlags_AlphaPreview |
+            ImGuiColorEditFlags_AlphaPreviewHalf;
+        ImGuiColorEditFlags sub_flags =
+            (flags & sub_flags_to_forward) | ImGuiColorEditFlags_NoPicker;
+        if (flags & ImGuiColorEditFlags_DisplayRGB ||
+            (flags & ImGuiColorEditFlags__DisplayMask) == 0)
+            if (ColorEdit4("##rgb", col, sub_flags | ImGuiColorEditFlags_DisplayRGB))
+            {
+                // FIXME: Hackily differenciating using the DragInt (ActiveId != 0 &&
+                // !ActiveIdAllowOverlap) vs. using the InputText or DropTarget. For the later we
+                // don't want to run the hue-wrap canceling code. If you are well versed in HSV
+                // picker please provide your input! (See #2050)
+                value_changed_fix_hue_wrap = (g.ActiveId != 0 && !g.ActiveIdAllowOverlap);
+                value_changed              = true;
+            }
+        if (flags & ImGuiColorEditFlags_DisplayHSV ||
+            (flags & ImGuiColorEditFlags__DisplayMask) == 0)
+            value_changed |= ColorEdit4("##hsv", col, sub_flags | ImGuiColorEditFlags_DisplayHSV);
+        if (flags & ImGuiColorEditFlags_DisplayHex ||
+            (flags & ImGuiColorEditFlags__DisplayMask) == 0)
+            value_changed |= ColorEdit4("##hex", col, sub_flags | ImGuiColorEditFlags_DisplayHex);
+        PopItemWidth();
+    }
+
+    // Try to cancel hue wrap (after ColorEdit4 call), if any
+    if (value_changed_fix_hue_wrap && (flags & ImGuiColorEditFlags_InputRGB))
+    {
+        float new_H, new_S, new_V;
+        ColorConvertRGBtoHSV(col[0], col[1], col[2], new_H, new_S, new_V);
+        if (new_H <= 0 && H > 0)
+        {
+            if (new_V <= 0 && V != new_V)
+                ColorConvertHSVtoRGB(H, S, new_V <= 0 ? V * 0.5f : new_V, col[0], col[1], col[2]);
+            else if (new_S <= 0)
+                ColorConvertHSVtoRGB(H, new_S <= 0 ? S * 0.5f : new_S, new_V, col[0], col[1],
+                                     col[2]);
+        }
+    }
+
+    if (value_changed)
+    {
+        if (flags & ImGuiColorEditFlags_InputRGB)
+        {
+            R = col[0];
+            G = col[1];
+            B = col[2];
+            ColorConvertRGBtoHSV(R, G, B, H, S, V);
+        }
+        else if (flags & ImGuiColorEditFlags_InputHSV)
+        {
+            H = col[0];
+            S = col[1];
+            V = col[2];
+            ColorConvertHSVtoRGB(H, S, V, R, G, B);
+        }
+    }
+
+    ImVec4 hue_color_f(1, 1, 1, 1);
+    ColorConvertHSVtoRGB(H, 1, 1, hue_color_f.x, hue_color_f.y, hue_color_f.z);
+    ImU32 hue_color32    = ColorConvertFloat4ToU32(hue_color_f);
+    ImU32 col32_no_alpha = ColorConvertFloat4ToU32(ImVec4(R, G, B, 1.0f));
+
+    const ImU32 hue_colors[6 + 1] = {IM_COL32(255, 0, 0, 255), IM_COL32(255, 255, 0, 255),
+                                     IM_COL32(0, 255, 0, 255), IM_COL32(0, 255, 255, 255),
+                                     IM_COL32(0, 0, 255, 255), IM_COL32(255, 0, 255, 255),
+                                     IM_COL32(255, 0, 0, 255)};
+    ImVec2 sv_cursor_pos;
+
+    if (flags & ImGuiColorEditFlags_PickerHueWheel)
+    {
+        // Render Hue Wheel
+        const float aeps =
+            1.5f / wheel_r_outer;  // Half a pixel arc length in radians (2pi cancels out).
+        const int segment_per_arc = ImMax(4, (int)wheel_r_outer / 12);
+        for (int n = 0; n < 6; n++)
+        {
+            const float a0           = (n) / 6.0f * 2.0f * IM_PI - aeps;
+            const float a1           = (n + 1.0f) / 6.0f * 2.0f * IM_PI + aeps;
+            const int vert_start_idx = draw_list->VtxBuffer.Size;
+            draw_list->PathArcTo(wheel_center, (wheel_r_inner + wheel_r_outer) * 0.5f, a0, a1,
+                                 segment_per_arc);
+            draw_list->PathStroke(IM_COL32_WHITE, false, wheel_thickness);
+            const int vert_end_idx = draw_list->VtxBuffer.Size;
+
+            // Paint colors over existing vertices
+            ImVec2 gradient_p0(wheel_center.x + ImCos(a0) * wheel_r_inner,
+                               wheel_center.y + ImSin(a0) * wheel_r_inner);
+            ImVec2 gradient_p1(wheel_center.x + ImCos(a1) * wheel_r_inner,
+                               wheel_center.y + ImSin(a1) * wheel_r_inner);
+            ShadeVertsLinearColorGradientKeepAlpha(draw_list, vert_start_idx, vert_end_idx,
+                                                   gradient_p0, gradient_p1, hue_colors[n],
+                                                   hue_colors[n + 1]);
+        }
+
+        // Render Cursor + preview on Hue Wheel
+        float cos_hue_angle = ImCos(H * 2.0f * IM_PI);
+        float sin_hue_angle = ImSin(H * 2.0f * IM_PI);
+        ImVec2 hue_cursor_pos(
+            wheel_center.x + cos_hue_angle * (wheel_r_inner + wheel_r_outer) * 0.5f,
+            wheel_center.y + sin_hue_angle * (wheel_r_inner + wheel_r_outer) * 0.5f);
+        float hue_cursor_rad = value_changed_h ? wheel_thickness * 0.65f : wheel_thickness * 0.55f;
+        int hue_cursor_segments = ImClamp((int)(hue_cursor_rad / 1.4f), 9, 32);
+        draw_list->AddCircleFilled(hue_cursor_pos, hue_cursor_rad, hue_color32,
+                                   hue_cursor_segments);
+        draw_list->AddCircle(hue_cursor_pos, hue_cursor_rad + 1, IM_COL32(128, 128, 128, 255),
+                             hue_cursor_segments);
+        draw_list->AddCircle(hue_cursor_pos, hue_cursor_rad, IM_COL32_WHITE, hue_cursor_segments);
+
+        // Render SV triangle (rotated according to hue)
+        ImVec2 tra      = wheel_center + ImRotate(triangle_pa, cos_hue_angle, sin_hue_angle);
+        ImVec2 trb      = wheel_center + ImRotate(triangle_pb, cos_hue_angle, sin_hue_angle);
+        ImVec2 trc      = wheel_center + ImRotate(triangle_pc, cos_hue_angle, sin_hue_angle);
+        ImVec2 uv_white = GetFontTexUvWhitePixel();
+        draw_list->PrimReserve(6, 6);
+        draw_list->PrimVtx(tra, uv_white, hue_color32);
+        draw_list->PrimVtx(trb, uv_white, hue_color32);
+        draw_list->PrimVtx(trc, uv_white, IM_COL32_WHITE);
+        draw_list->PrimVtx(tra, uv_white, IM_COL32_BLACK_TRANS);
+        draw_list->PrimVtx(trb, uv_white, IM_COL32_BLACK);
+        draw_list->PrimVtx(trc, uv_white, IM_COL32_BLACK_TRANS);
+        draw_list->AddTriangle(tra, trb, trc, IM_COL32(128, 128, 128, 255), 1.5f);
+        sv_cursor_pos = ImLerp(ImLerp(trc, tra, ImSaturate(S)), trb, ImSaturate(1 - V));
+    }
+    else if (flags & ImGuiColorEditFlags_PickerHueBar)
+    {
+        // Render SV Square
+        draw_list->AddRectFilledMultiColor(
+            picker_pos, picker_pos + ImVec2(sv_picker_size, sv_picker_size), IM_COL32_WHITE,
+            hue_color32, hue_color32, IM_COL32_WHITE);
+        draw_list->AddRectFilledMultiColor(
+            picker_pos, picker_pos + ImVec2(sv_picker_size, sv_picker_size), IM_COL32_BLACK_TRANS,
+            IM_COL32_BLACK_TRANS, IM_COL32_BLACK, IM_COL32_BLACK);
+        RenderFrameBorder(picker_pos, picker_pos + ImVec2(sv_picker_size, sv_picker_size), 0.0f);
+        sv_cursor_pos.x = ImClamp(
+            (float)(int)(picker_pos.x + ImSaturate(S) * sv_picker_size + 0.5f), picker_pos.x + 2,
+            picker_pos.x + sv_picker_size -
+                2);  // Sneakily prevent the circle to stick out too much
+        sv_cursor_pos.y =
+            ImClamp((float)(int)(picker_pos.y + ImSaturate(1 - V) * sv_picker_size + 0.5f),
+                    picker_pos.y + 2, picker_pos.y + sv_picker_size - 2);
+
+        // Render Hue Bar
+        for (int i = 0; i < 6; ++i)
+            draw_list->AddRectFilledMultiColor(
+                ImVec2(bar0_pos_x, picker_pos.y + i * (sv_picker_size / 6)),
+                ImVec2(bar0_pos_x + bars_width, picker_pos.y + (i + 1) * (sv_picker_size / 6)),
+                hue_colors[i], hue_colors[i], hue_colors[i + 1], hue_colors[i + 1]);
+        float bar0_line_y = (float)(int)(picker_pos.y + H * sv_picker_size + 0.5f);
+        RenderFrameBorder(ImVec2(bar0_pos_x, picker_pos.y),
+                          ImVec2(bar0_pos_x + bars_width, picker_pos.y + sv_picker_size), 0.0f);
+        RenderArrowsForVerticalBar(draw_list, ImVec2(bar0_pos_x - 1, bar0_line_y),
+                                   ImVec2(bars_triangles_half_sz + 1, bars_triangles_half_sz),
+                                   bars_width + 2.0f);
+    }
+
+    // Render cursor/preview circle (clamp S/V within 0..1 range because floating points colors may
+    // lead HSV values to be out of range)
+    float sv_cursor_rad = value_changed_sv ? 10.0f : 6.0f;
+    draw_list->AddCircleFilled(sv_cursor_pos, sv_cursor_rad, col32_no_alpha, 12);
+    draw_list->AddCircle(sv_cursor_pos, sv_cursor_rad + 1, IM_COL32(128, 128, 128, 255), 12);
+    draw_list->AddCircle(sv_cursor_pos, sv_cursor_rad, IM_COL32_WHITE, 12);
+
+    // Render alpha bar
+    if (alpha_bar)
+    {
+        float alpha = ImSaturate(col[3]);
+        ImRect bar1_bb(bar1_pos_x, picker_pos.y, bar1_pos_x + bars_width,
+                       picker_pos.y + sv_picker_size);
+        RenderColorRectWithAlphaCheckerboard(bar1_bb.Min, bar1_bb.Max, IM_COL32(0, 0, 0, 0),
+                                             bar1_bb.GetWidth() / 2.0f, ImVec2(0.0f, 0.0f));
+        draw_list->AddRectFilledMultiColor(bar1_bb.Min, bar1_bb.Max, col32_no_alpha, col32_no_alpha,
+                                           col32_no_alpha & ~IM_COL32_A_MASK,
+                                           col32_no_alpha & ~IM_COL32_A_MASK);
+        float bar1_line_y = (float)(int)(picker_pos.y + (1.0f - alpha) * sv_picker_size + 0.5f);
+        RenderFrameBorder(bar1_bb.Min, bar1_bb.Max, 0.0f);
+        RenderArrowsForVerticalBar(draw_list, ImVec2(bar1_pos_x - 1, bar1_line_y),
+                                   ImVec2(bars_triangles_half_sz + 1, bars_triangles_half_sz),
+                                   bars_width + 2.0f);
+    }
+
+    EndGroup();
+
+    if (value_changed && memcmp(backup_initial_col, col, components * sizeof(float)) == 0)
+        value_changed = false;
+    if (value_changed)
+        MarkItemEdited(window->DC.LastItemId);
+
+    PopID();
+
+    return value_changed;
+}
+
+// A little colored square. Return true when clicked.
+// FIXME: May want to display/ignore the alpha component in the color display? Yet show it in the
+// tooltip. 'desc_id' is not called 'label' because we don't display it next to the button, but only
+// in the tooltip. Note that 'col' may be encoded in HSV if ImGuiColorEditFlags_InputHSV is set.
+bool ImGui::ColorButton(const char *desc_id,
+                        const ImVec4 &col,
+                        ImGuiColorEditFlags flags,
+                        ImVec2 size)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    ImGuiContext &g    = *GImGui;
+    const ImGuiID id   = window->GetID(desc_id);
+    float default_size = GetFrameHeight();
+    if (size.x == 0.0f)
+        size.x = default_size;
+    if (size.y == 0.0f)
+        size.y = default_size;
+    const ImRect bb(window->DC.CursorPos, window->DC.CursorPos + size);
+    ItemSize(bb, (size.y >= default_size) ? g.Style.FramePadding.y : 0.0f);
+    if (!ItemAdd(bb, id))
+        return false;
+
+    bool hovered, held;
+    bool pressed = ButtonBehavior(bb, id, &hovered, &held);
+
+    if (flags & ImGuiColorEditFlags_NoAlpha)
+        flags &= ~(ImGuiColorEditFlags_AlphaPreview | ImGuiColorEditFlags_AlphaPreviewHalf);
+
+    ImVec4 col_rgb = col;
+    if (flags & ImGuiColorEditFlags_InputHSV)
+        ColorConvertHSVtoRGB(col_rgb.x, col_rgb.y, col_rgb.z, col_rgb.x, col_rgb.y, col_rgb.z);
+
+    ImVec4 col_rgb_without_alpha(col_rgb.x, col_rgb.y, col_rgb.z, 1.0f);
+    float grid_step = ImMin(size.x, size.y) / 2.99f;
+    float rounding  = ImMin(g.Style.FrameRounding, grid_step * 0.5f);
+    ImRect bb_inner = bb;
+    float off       = -0.75f;  // The border (using Col_FrameBg) tends to look off when color is
+                         // near-opaque and rounding is enabled. This offset seemed like a good
+                         // middle ground to reduce those artifacts.
+    bb_inner.Expand(off);
+    if ((flags & ImGuiColorEditFlags_AlphaPreviewHalf) && col_rgb.w < 1.0f)
+    {
+        float mid_x = (float)(int)((bb_inner.Min.x + bb_inner.Max.x) * 0.5f + 0.5f);
+        RenderColorRectWithAlphaCheckerboard(
+            ImVec2(bb_inner.Min.x + grid_step, bb_inner.Min.y), bb_inner.Max, GetColorU32(col_rgb),
+            grid_step, ImVec2(-grid_step + off, off), rounding,
+            ImDrawCornerFlags_TopRight | ImDrawCornerFlags_BotRight);
+        window->DrawList->AddRectFilled(bb_inner.Min, ImVec2(mid_x, bb_inner.Max.y),
+                                        GetColorU32(col_rgb_without_alpha), rounding,
+                                        ImDrawCornerFlags_TopLeft | ImDrawCornerFlags_BotLeft);
+    }
+    else
+    {
+        // Because GetColorU32() multiplies by the global style Alpha and we don't want to display a
+        // checkerboard if the source code had no alpha
+        ImVec4 col_source =
+            (flags & ImGuiColorEditFlags_AlphaPreview) ? col_rgb : col_rgb_without_alpha;
+        if (col_source.w < 1.0f)
+            RenderColorRectWithAlphaCheckerboard(bb_inner.Min, bb_inner.Max,
+                                                 GetColorU32(col_source), grid_step,
+                                                 ImVec2(off, off), rounding);
+        else
+            window->DrawList->AddRectFilled(bb_inner.Min, bb_inner.Max, GetColorU32(col_source),
+                                            rounding, ImDrawCornerFlags_All);
+    }
+    RenderNavHighlight(bb, id);
+    if (g.Style.FrameBorderSize > 0.0f)
+        RenderFrameBorder(bb.Min, bb.Max, rounding);
+    else
+        window->DrawList->AddRect(
+            bb.Min, bb.Max, GetColorU32(ImGuiCol_FrameBg),
+            rounding);  // Color button are often in need of some sort of border
+
+    // Drag and Drop Source
+    // NB: The ActiveId test is merely an optional micro-optimization, BeginDragDropSource() does
+    // the same test.
+    if (g.ActiveId == id && !(flags & ImGuiColorEditFlags_NoDragDrop) && BeginDragDropSource())
+    {
+        if (flags & ImGuiColorEditFlags_NoAlpha)
+            SetDragDropPayload(IMGUI_PAYLOAD_TYPE_COLOR_3F, &col_rgb, sizeof(float) * 3,
+                               ImGuiCond_Once);
+        else
+            SetDragDropPayload(IMGUI_PAYLOAD_TYPE_COLOR_4F, &col_rgb, sizeof(float) * 4,
+                               ImGuiCond_Once);
+        ColorButton(desc_id, col, flags);
+        SameLine();
+        TextEx("Color");
+        EndDragDropSource();
+    }
+
+    // Tooltip
+    if (!(flags & ImGuiColorEditFlags_NoTooltip) && hovered)
+        ColorTooltip(
+            desc_id, &col.x,
+            flags & (ImGuiColorEditFlags__InputMask | ImGuiColorEditFlags_NoAlpha |
+                     ImGuiColorEditFlags_AlphaPreview | ImGuiColorEditFlags_AlphaPreviewHalf));
+
+    if (pressed)
+        MarkItemEdited(id);
+
+    return pressed;
+}
+
+// Initialize/override default color options
+void ImGui::SetColorEditOptions(ImGuiColorEditFlags flags)
+{
+    ImGuiContext &g = *GImGui;
+    if ((flags & ImGuiColorEditFlags__DisplayMask) == 0)
+        flags |= ImGuiColorEditFlags__OptionsDefault & ImGuiColorEditFlags__DisplayMask;
+    if ((flags & ImGuiColorEditFlags__DataTypeMask) == 0)
+        flags |= ImGuiColorEditFlags__OptionsDefault & ImGuiColorEditFlags__DataTypeMask;
+    if ((flags & ImGuiColorEditFlags__PickerMask) == 0)
+        flags |= ImGuiColorEditFlags__OptionsDefault & ImGuiColorEditFlags__PickerMask;
+    if ((flags & ImGuiColorEditFlags__InputMask) == 0)
+        flags |= ImGuiColorEditFlags__OptionsDefault & ImGuiColorEditFlags__InputMask;
+    IM_ASSERT(ImIsPowerOfTwo(flags &
+                             ImGuiColorEditFlags__DisplayMask));  // Check only 1 option is selected
+    IM_ASSERT(ImIsPowerOfTwo(
+        flags & ImGuiColorEditFlags__DataTypeMask));  // Check only 1 option is selected
+    IM_ASSERT(ImIsPowerOfTwo(flags &
+                             ImGuiColorEditFlags__PickerMask));  // Check only 1 option is selected
+    IM_ASSERT(
+        ImIsPowerOfTwo(flags & ImGuiColorEditFlags__InputMask));  // Check only 1 option is selected
+    g.ColorEditOptions = flags;
+}
+
+// Note: only access 3 floats if ImGuiColorEditFlags_NoAlpha flag is set.
+void ImGui::ColorTooltip(const char *text, const float *col, ImGuiColorEditFlags flags)
+{
+    ImGuiContext &g = *GImGui;
+
+    BeginTooltipEx(0, true);
+    const char *text_end = text ? FindRenderedTextEnd(text, NULL) : text;
+    if (text_end > text)
+    {
+        TextEx(text, text_end);
+        Separator();
+    }
+
+    ImVec2 sz(g.FontSize * 3 + g.Style.FramePadding.y * 2,
+              g.FontSize * 3 + g.Style.FramePadding.y * 2);
+    ImVec4 cf(col[0], col[1], col[2], (flags & ImGuiColorEditFlags_NoAlpha) ? 1.0f : col[3]);
+    int cr = IM_F32_TO_INT8_SAT(col[0]), cg = IM_F32_TO_INT8_SAT(col[1]),
+        cb = IM_F32_TO_INT8_SAT(col[2]),
+        ca = (flags & ImGuiColorEditFlags_NoAlpha) ? 255 : IM_F32_TO_INT8_SAT(col[3]);
+    ColorButton(
+        "##preview", cf,
+        (flags & (ImGuiColorEditFlags__InputMask | ImGuiColorEditFlags_NoAlpha |
+                  ImGuiColorEditFlags_AlphaPreview | ImGuiColorEditFlags_AlphaPreviewHalf)) |
+            ImGuiColorEditFlags_NoTooltip,
+        sz);
+    SameLine();
+    if ((flags & ImGuiColorEditFlags_InputRGB) || !(flags & ImGuiColorEditFlags__InputMask))
+    {
+        if (flags & ImGuiColorEditFlags_NoAlpha)
+            Text("#%02X%02X%02X\nR: %d, G: %d, B: %d\n(%.3f, %.3f, %.3f)", cr, cg, cb, cr, cg, cb,
+                 col[0], col[1], col[2]);
+        else
+            Text("#%02X%02X%02X%02X\nR:%d, G:%d, B:%d, A:%d\n(%.3f, %.3f, %.3f, %.3f)", cr, cg, cb,
+                 ca, cr, cg, cb, ca, col[0], col[1], col[2], col[3]);
+    }
+    else if (flags & ImGuiColorEditFlags_InputHSV)
+    {
+        if (flags & ImGuiColorEditFlags_NoAlpha)
+            Text("H: %.3f, S: %.3f, V: %.3f", col[0], col[1], col[2]);
+        else
+            Text("H: %.3f, S: %.3f, V: %.3f, A: %.3f", col[0], col[1], col[2], col[3]);
+    }
+    EndTooltip();
+}
+
+void ImGui::ColorEditOptionsPopup(const float *col, ImGuiColorEditFlags flags)
+{
+    bool allow_opt_inputs   = !(flags & ImGuiColorEditFlags__DisplayMask);
+    bool allow_opt_datatype = !(flags & ImGuiColorEditFlags__DataTypeMask);
+    if ((!allow_opt_inputs && !allow_opt_datatype) || !BeginPopup("context"))
+        return;
+    ImGuiContext &g          = *GImGui;
+    ImGuiColorEditFlags opts = g.ColorEditOptions;
+    if (allow_opt_inputs)
+    {
+        if (RadioButton("RGB", (opts & ImGuiColorEditFlags_DisplayRGB) != 0))
+            opts = (opts & ~ImGuiColorEditFlags__DisplayMask) | ImGuiColorEditFlags_DisplayRGB;
+        if (RadioButton("HSV", (opts & ImGuiColorEditFlags_DisplayHSV) != 0))
+            opts = (opts & ~ImGuiColorEditFlags__DisplayMask) | ImGuiColorEditFlags_DisplayHSV;
+        if (RadioButton("Hex", (opts & ImGuiColorEditFlags_DisplayHex) != 0))
+            opts = (opts & ~ImGuiColorEditFlags__DisplayMask) | ImGuiColorEditFlags_DisplayHex;
+    }
+    if (allow_opt_datatype)
+    {
+        if (allow_opt_inputs)
+            Separator();
+        if (RadioButton("0..255", (opts & ImGuiColorEditFlags_Uint8) != 0))
+            opts = (opts & ~ImGuiColorEditFlags__DataTypeMask) | ImGuiColorEditFlags_Uint8;
+        if (RadioButton("0.00..1.00", (opts & ImGuiColorEditFlags_Float) != 0))
+            opts = (opts & ~ImGuiColorEditFlags__DataTypeMask) | ImGuiColorEditFlags_Float;
+    }
+
+    if (allow_opt_inputs || allow_opt_datatype)
+        Separator();
+    if (Button("Copy as..", ImVec2(-1, 0)))
+        OpenPopup("Copy");
+    if (BeginPopup("Copy"))
+    {
+        int cr = IM_F32_TO_INT8_SAT(col[0]), cg = IM_F32_TO_INT8_SAT(col[1]),
+            cb = IM_F32_TO_INT8_SAT(col[2]),
+            ca = (flags & ImGuiColorEditFlags_NoAlpha) ? 255 : IM_F32_TO_INT8_SAT(col[3]);
+        char buf[64];
+        ImFormatString(buf, IM_ARRAYSIZE(buf), "(%.3ff, %.3ff, %.3ff, %.3ff)", col[0], col[1],
+                       col[2], (flags & ImGuiColorEditFlags_NoAlpha) ? 1.0f : col[3]);
+        if (Selectable(buf))
+            SetClipboardText(buf);
+        ImFormatString(buf, IM_ARRAYSIZE(buf), "(%d,%d,%d,%d)", cr, cg, cb, ca);
+        if (Selectable(buf))
+            SetClipboardText(buf);
+        if (flags & ImGuiColorEditFlags_NoAlpha)
+            ImFormatString(buf, IM_ARRAYSIZE(buf), "0x%02X%02X%02X", cr, cg, cb);
+        else
+            ImFormatString(buf, IM_ARRAYSIZE(buf), "0x%02X%02X%02X%02X", cr, cg, cb, ca);
+        if (Selectable(buf))
+            SetClipboardText(buf);
+        EndPopup();
+    }
+
+    g.ColorEditOptions = opts;
+    EndPopup();
+}
+
+void ImGui::ColorPickerOptionsPopup(const float *ref_col, ImGuiColorEditFlags flags)
+{
+    bool allow_opt_picker = !(flags & ImGuiColorEditFlags__PickerMask);
+    bool allow_opt_alpha_bar =
+        !(flags & ImGuiColorEditFlags_NoAlpha) && !(flags & ImGuiColorEditFlags_AlphaBar);
+    if ((!allow_opt_picker && !allow_opt_alpha_bar) || !BeginPopup("context"))
+        return;
+    ImGuiContext &g = *GImGui;
+    if (allow_opt_picker)
+    {
+        ImVec2 picker_size(g.FontSize * 8,
+                           ImMax(g.FontSize * 8 - (GetFrameHeight() + g.Style.ItemInnerSpacing.x),
+                                 1.0f));  // FIXME: Picker size copied from main picker function
+        PushItemWidth(picker_size.x);
+        for (int picker_type = 0; picker_type < 2; picker_type++)
+        {
+            // Draw small/thumbnail version of each picker type (over an invisible button for
+            // selection)
+            if (picker_type > 0)
+                Separator();
+            PushID(picker_type);
+            ImGuiColorEditFlags picker_flags =
+                ImGuiColorEditFlags_NoInputs | ImGuiColorEditFlags_NoOptions |
+                ImGuiColorEditFlags_NoLabel | ImGuiColorEditFlags_NoSidePreview |
+                (flags & ImGuiColorEditFlags_NoAlpha);
+            if (picker_type == 0)
+                picker_flags |= ImGuiColorEditFlags_PickerHueBar;
+            if (picker_type == 1)
+                picker_flags |= ImGuiColorEditFlags_PickerHueWheel;
+            ImVec2 backup_pos = GetCursorScreenPos();
+            if (Selectable("##selectable", false, 0,
+                           picker_size))  // By default, Selectable() is closing popup
+                g.ColorEditOptions = (g.ColorEditOptions & ~ImGuiColorEditFlags__PickerMask) |
+                                     (picker_flags & ImGuiColorEditFlags__PickerMask);
+            SetCursorScreenPos(backup_pos);
+            ImVec4 dummy_ref_col;
+            memcpy(&dummy_ref_col, ref_col,
+                   sizeof(float) * ((picker_flags & ImGuiColorEditFlags_NoAlpha) ? 3 : 4));
+            ColorPicker4("##dummypicker", &dummy_ref_col.x, picker_flags);
+            PopID();
+        }
+        PopItemWidth();
+    }
+    if (allow_opt_alpha_bar)
+    {
+        if (allow_opt_picker)
+            Separator();
+        CheckboxFlags("Alpha Bar", (unsigned int *)&g.ColorEditOptions,
+                      ImGuiColorEditFlags_AlphaBar);
+    }
+    EndPopup();
+}
+
+//-------------------------------------------------------------------------
+// [SECTION] Widgets: TreeNode, CollapsingHeader, etc.
+//-------------------------------------------------------------------------
+// - TreeNode()
+// - TreeNodeV()
+// - TreeNodeEx()
+// - TreeNodeExV()
+// - TreeNodeBehavior() [Internal]
+// - TreePush()
+// - TreePop()
+// - TreeAdvanceToLabelPos()
+// - GetTreeNodeToLabelSpacing()
+// - SetNextItemOpen()
+// - CollapsingHeader()
+//-------------------------------------------------------------------------
+
+bool ImGui::TreeNode(const char *str_id, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    bool is_open = TreeNodeExV(str_id, 0, fmt, args);
+    va_end(args);
+    return is_open;
+}
+
+bool ImGui::TreeNode(const void *ptr_id, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    bool is_open = TreeNodeExV(ptr_id, 0, fmt, args);
+    va_end(args);
+    return is_open;
+}
+
+bool ImGui::TreeNode(const char *label)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+    return TreeNodeBehavior(window->GetID(label), 0, label, NULL);
+}
+
+bool ImGui::TreeNodeV(const char *str_id, const char *fmt, va_list args)
+{
+    return TreeNodeExV(str_id, 0, fmt, args);
+}
+
+bool ImGui::TreeNodeV(const void *ptr_id, const char *fmt, va_list args)
+{
+    return TreeNodeExV(ptr_id, 0, fmt, args);
+}
+
+bool ImGui::TreeNodeEx(const char *label, ImGuiTreeNodeFlags flags)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    return TreeNodeBehavior(window->GetID(label), flags, label, NULL);
+}
+
+bool ImGui::TreeNodeEx(const char *str_id, ImGuiTreeNodeFlags flags, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    bool is_open = TreeNodeExV(str_id, flags, fmt, args);
+    va_end(args);
+    return is_open;
+}
+
+bool ImGui::TreeNodeEx(const void *ptr_id, ImGuiTreeNodeFlags flags, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    bool is_open = TreeNodeExV(ptr_id, flags, fmt, args);
+    va_end(args);
+    return is_open;
+}
+
+bool ImGui::TreeNodeExV(const char *str_id, ImGuiTreeNodeFlags flags, const char *fmt, va_list args)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    ImGuiContext &g = *GImGui;
+    const char *label_end =
+        g.TempBuffer + ImFormatStringV(g.TempBuffer, IM_ARRAYSIZE(g.TempBuffer), fmt, args);
+    return TreeNodeBehavior(window->GetID(str_id), flags, g.TempBuffer, label_end);
+}
+
+bool ImGui::TreeNodeExV(const void *ptr_id, ImGuiTreeNodeFlags flags, const char *fmt, va_list args)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    ImGuiContext &g = *GImGui;
+    const char *label_end =
+        g.TempBuffer + ImFormatStringV(g.TempBuffer, IM_ARRAYSIZE(g.TempBuffer), fmt, args);
+    return TreeNodeBehavior(window->GetID(ptr_id), flags, g.TempBuffer, label_end);
+}
+
+bool ImGui::TreeNodeBehaviorIsOpen(ImGuiID id, ImGuiTreeNodeFlags flags)
+{
+    if (flags & ImGuiTreeNodeFlags_Leaf)
+        return true;
+
+    // We only write to the tree storage if the user clicks (or explicitly use the SetNextItemOpen
+    // function)
+    ImGuiContext &g       = *GImGui;
+    ImGuiWindow *window   = g.CurrentWindow;
+    ImGuiStorage *storage = window->DC.StateStorage;
+
+    bool is_open;
+    if (g.NextItemData.Flags & ImGuiNextItemDataFlags_HasOpen)
+    {
+        if (g.NextItemData.OpenCond & ImGuiCond_Always)
+        {
+            is_open = g.NextItemData.OpenVal;
+            storage->SetInt(id, is_open);
+        }
+        else
+        {
+            // We treat ImGuiCond_Once and ImGuiCond_FirstUseEver the same because tree node state
+            // are not saved persistently.
+            const int stored_value = storage->GetInt(id, -1);
+            if (stored_value == -1)
+            {
+                is_open = g.NextItemData.OpenVal;
+                storage->SetInt(id, is_open);
+            }
+            else
+            {
+                is_open = stored_value != 0;
+            }
+        }
+    }
+    else
+    {
+        is_open = storage->GetInt(id, (flags & ImGuiTreeNodeFlags_DefaultOpen) ? 1 : 0) != 0;
+    }
+
+    // When logging is enabled, we automatically expand tree nodes (but *NOT* collapsing headers..
+    // seems like sensible behavior). NB- If we are above max depth we still allow manually opened
+    // nodes to be logged.
+    if (g.LogEnabled && !(flags & ImGuiTreeNodeFlags_NoAutoOpenOnLog) &&
+        (window->DC.TreeDepth - g.LogDepthRef) < g.LogDepthToExpand)
+        is_open = true;
+
+    return is_open;
+}
+
+bool ImGui::TreeNodeBehavior(ImGuiID id,
+                             ImGuiTreeNodeFlags flags,
+                             const char *label,
+                             const char *label_end)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    ImGuiContext &g          = *GImGui;
+    const ImGuiStyle &style  = g.Style;
+    const bool display_frame = (flags & ImGuiTreeNodeFlags_Framed) != 0;
+    const ImVec2 padding     = (display_frame || (flags & ImGuiTreeNodeFlags_FramePadding))
+                               ? style.FramePadding
+                               : ImVec2(style.FramePadding.x, 0.0f);
+
+    if (!label_end)
+        label_end = FindRenderedTextEnd(label);
+    const ImVec2 label_size = CalcTextSize(label, label_end, false);
+
+    // We vertically grow up to current line height up the typical widget height.
+    const float text_base_offset_y =
+        ImMax(padding.y, window->DC.CurrLineTextBaseOffset);  // Latch before ItemSize changes it
+    const float frame_height =
+        ImMax(ImMin(window->DC.CurrLineSize.y, g.FontSize + style.FramePadding.y * 2),
+              label_size.y + padding.y * 2);
+    ImRect frame_bb = ImRect(window->DC.CursorPos,
+                             ImVec2(window->WorkRect.Max.x, window->DC.CursorPos.y + frame_height));
+    if (display_frame)
+    {
+        // Framed header expand a little outside the default padding
+        frame_bb.Min.x -= (float)(int)(window->WindowPadding.x * 0.5f - 1.0f);
+        frame_bb.Max.x += (float)(int)(window->WindowPadding.x * 0.5f);
+    }
+
+    const float text_offset_x =
+        (g.FontSize +
+         (display_frame ? padding.x * 3 : padding.x * 2));  // Collapser arrow width + Spacing
+    const float text_width = g.FontSize + (label_size.x > 0.0f ? label_size.x + padding.x * 2
+                                                               : 0.0f);  // Include collapser
+    ItemSize(ImVec2(text_width, frame_height), text_base_offset_y);
+
+    // For regular tree nodes, we arbitrary allow to click past 2 worth of ItemSpacing
+    // (Ideally we'd want to add a flag for the user to specify if we want the hit test to be done
+    // up to the right side of the content or not)
+    const ImRect interact_bb =
+        display_frame
+            ? frame_bb
+            : ImRect(frame_bb.Min.x, frame_bb.Min.y,
+                     frame_bb.Min.x + text_width + style.ItemSpacing.x * 2, frame_bb.Max.y);
+    bool is_open = TreeNodeBehaviorIsOpen(id, flags);
+    bool is_leaf = (flags & ImGuiTreeNodeFlags_Leaf) != 0;
+
+    // Store a flag for the current depth to tell if we will allow closing this node when navigating
+    // one of its child. For this purpose we essentially compare if g.NavIdIsAlive went from 0 to 1
+    // between TreeNode() and TreePop(). This is currently only support 32 level deep and we are
+    // fine with (1 << Depth) overflowing into a zero.
+    if (is_open && !g.NavIdIsAlive && (flags & ImGuiTreeNodeFlags_NavLeftJumpsBackHere) &&
+        !(flags & ImGuiTreeNodeFlags_NoTreePushOnOpen))
+        window->DC.TreeStoreMayJumpToParentOnPop |= (1 << window->DC.TreeDepth);
+
+    bool item_add = ItemAdd(interact_bb, id);
+    window->DC.LastItemStatusFlags |= ImGuiItemStatusFlags_HasDisplayRect;
+    window->DC.LastItemDisplayRect = frame_bb;
+
+    if (!item_add)
+    {
+        if (is_open && !(flags & ImGuiTreeNodeFlags_NoTreePushOnOpen))
+            TreePushOverrideID(id);
+        IMGUI_TEST_ENGINE_ITEM_INFO(window->DC.LastItemId, label,
+                                    window->DC.ItemFlags |
+                                        (is_leaf ? 0 : ImGuiItemStatusFlags_Openable) |
+                                        (is_open ? ImGuiItemStatusFlags_Opened : 0));
+        return is_open;
+    }
+
+    // Flags that affects opening behavior:
+    // - 0 (default) .................... single-click anywhere to open
+    // - OpenOnDoubleClick .............. double-click anywhere to open
+    // - OpenOnArrow .................... single-click on arrow to open
+    // - OpenOnDoubleClick|OpenOnArrow .. single-click on arrow or double-click anywhere to open
+    ImGuiButtonFlags button_flags = ImGuiButtonFlags_NoKeyModifiers;
+    if (flags & ImGuiTreeNodeFlags_AllowItemOverlap)
+        button_flags |= ImGuiButtonFlags_AllowItemOverlap;
+    if (flags & ImGuiTreeNodeFlags_OpenOnDoubleClick)
+        button_flags |=
+            ImGuiButtonFlags_PressedOnDoubleClick |
+            ((flags & ImGuiTreeNodeFlags_OpenOnArrow) ? ImGuiButtonFlags_PressedOnClickRelease : 0);
+    if (!is_leaf)
+        button_flags |= ImGuiButtonFlags_PressedOnDragDropHold;
+
+    bool selected           = (flags & ImGuiTreeNodeFlags_Selected) != 0;
+    const bool was_selected = selected;
+
+    bool hovered, held;
+    bool pressed = ButtonBehavior(interact_bb, id, &hovered, &held, button_flags);
+    bool toggled = false;
+    if (!is_leaf)
+    {
+        if (pressed)
+        {
+            toggled = !(flags &
+                        (ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick)) ||
+                      (g.NavActivateId == id);
+            if (flags & ImGuiTreeNodeFlags_OpenOnArrow)
+                toggled |= IsMouseHoveringRect(
+                               interact_bb.Min,
+                               ImVec2(interact_bb.Min.x + text_offset_x, interact_bb.Max.y)) &&
+                           (!g.NavDisableMouseHover);
+            if (flags & ImGuiTreeNodeFlags_OpenOnDoubleClick)
+                toggled |= g.IO.MouseDoubleClicked[0];
+            if (g.DragDropActive &&
+                is_open)  // When using Drag and Drop "hold to open" we keep the node highlighted
+                          // after opening, but never close it again.
+                toggled = false;
+        }
+
+        if (g.NavId == id && g.NavMoveRequest && g.NavMoveDir == ImGuiDir_Left && is_open)
+        {
+            toggled = true;
+            NavMoveRequestCancel();
+        }
+        if (g.NavId == id && g.NavMoveRequest && g.NavMoveDir == ImGuiDir_Right &&
+            !is_open)  // If there's something upcoming on the line we may want to give it the
+                       // priority?
+        {
+            toggled = true;
+            NavMoveRequestCancel();
+        }
+
+        if (toggled)
+        {
+            is_open = !is_open;
+            window->DC.StateStorage->SetInt(id, is_open);
+        }
+    }
+    if (flags & ImGuiTreeNodeFlags_AllowItemOverlap)
+        SetItemAllowOverlap();
+
+    // In this branch, TreeNodeBehavior() cannot toggle the selection so this will never trigger.
+    if (selected != was_selected)  //-V547
+        window->DC.LastItemStatusFlags |= ImGuiItemStatusFlags_ToggledSelection;
+
+    // Render
+    const ImU32 bg_col =
+        GetColorU32((held && hovered) ? ImGuiCol_HeaderActive
+                                      : hovered ? ImGuiCol_HeaderHovered : ImGuiCol_Header);
+    const ImU32 text_col  = GetColorU32(ImGuiCol_Text);
+    const ImVec2 text_pos = frame_bb.Min + ImVec2(text_offset_x, text_base_offset_y);
+    ImGuiNavHighlightFlags nav_highlight_flags = ImGuiNavHighlightFlags_TypeThin;
+    if (display_frame)
+    {
+        // Framed type
+        RenderFrame(frame_bb.Min, frame_bb.Max, bg_col, true, style.FrameRounding);
+        RenderNavHighlight(frame_bb, id, nav_highlight_flags);
+        RenderArrow(window->DrawList, frame_bb.Min + ImVec2(padding.x, text_base_offset_y),
+                    text_col, is_open ? ImGuiDir_Down : ImGuiDir_Right, 1.0f);
+        if (flags & ImGuiTreeNodeFlags_ClipLabelForTrailingButton)
+            frame_bb.Max.x -= g.FontSize + style.FramePadding.x;
+        if (g.LogEnabled)
+        {
+            // NB: '##' is normally used to hide text (as a library-wide feature), so we need to
+            // specify the text range to make sure the ## aren't stripped out here.
+            const char log_prefix[] = "\n##";
+            const char log_suffix[] = "##";
+            LogRenderedText(&text_pos, log_prefix, log_prefix + 3);
+            RenderTextClipped(text_pos, frame_bb.Max, label, label_end, &label_size);
+            LogRenderedText(&text_pos, log_suffix, log_suffix + 2);
+        }
+        else
+        {
+            RenderTextClipped(text_pos, frame_bb.Max, label, label_end, &label_size);
+        }
+    }
+    else
+    {
+        // Unframed typed for tree nodes
+        if (hovered || selected)
+        {
+            RenderFrame(frame_bb.Min, frame_bb.Max, bg_col, false);
+            RenderNavHighlight(frame_bb, id, nav_highlight_flags);
+        }
+
+        if (flags & ImGuiTreeNodeFlags_Bullet)
+            RenderBullet(window->DrawList,
+                         frame_bb.Min +
+                             ImVec2(text_offset_x * 0.5f, g.FontSize * 0.50f + text_base_offset_y),
+                         text_col);
+        else if (!is_leaf)
+            RenderArrow(window->DrawList,
+                        frame_bb.Min + ImVec2(padding.x, g.FontSize * 0.15f + text_base_offset_y),
+                        text_col, is_open ? ImGuiDir_Down : ImGuiDir_Right, 0.70f);
+        if (g.LogEnabled)
+            LogRenderedText(&text_pos, ">");
+        RenderText(text_pos, label, label_end, false);
+    }
+
+    if (is_open && !(flags & ImGuiTreeNodeFlags_NoTreePushOnOpen))
+        TreePushOverrideID(id);
+    IMGUI_TEST_ENGINE_ITEM_INFO(id, label,
+                                window->DC.ItemFlags |
+                                    (is_leaf ? 0 : ImGuiItemStatusFlags_Openable) |
+                                    (is_open ? ImGuiItemStatusFlags_Opened : 0));
+    return is_open;
+}
+
+void ImGui::TreePush(const char *str_id)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    Indent();
+    window->DC.TreeDepth++;
+    PushID(str_id ? str_id : "#TreePush");
+}
+
+void ImGui::TreePush(const void *ptr_id)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    Indent();
+    window->DC.TreeDepth++;
+    PushID(ptr_id ? ptr_id : (const void *)"#TreePush");
+}
+
+void ImGui::TreePushOverrideID(ImGuiID id)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    Indent();
+    window->DC.TreeDepth++;
+    window->IDStack.push_back(id);
+}
+
+void ImGui::TreePop()
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+    Unindent();
+
+    window->DC.TreeDepth--;
+    if (g.NavMoveDir == ImGuiDir_Left && g.NavWindow == window && NavMoveRequestButNoResultYet())
+        if (g.NavIdIsAlive &&
+            (window->DC.TreeStoreMayJumpToParentOnPop & (1 << window->DC.TreeDepth)))
+        {
+            SetNavID(window->IDStack.back(), g.NavLayer);
+            NavMoveRequestCancel();
+        }
+    window->DC.TreeStoreMayJumpToParentOnPop &= (1 << window->DC.TreeDepth) - 1;
+
+    IM_ASSERT(window->IDStack.Size >
+              1);  // There should always be 1 element in the IDStack (pushed during window
+                   // creation). If this triggers you called TreePop/PopID too much.
+    PopID();
+}
+
+void ImGui::TreeAdvanceToLabelPos()
+{
+    ImGuiContext &g = *GImGui;
+    g.CurrentWindow->DC.CursorPos.x += GetTreeNodeToLabelSpacing();
+}
+
+// Horizontal distance preceding label when using TreeNode() or Bullet()
+float ImGui::GetTreeNodeToLabelSpacing()
+{
+    ImGuiContext &g = *GImGui;
+    return g.FontSize + (g.Style.FramePadding.x * 2.0f);
+}
+
+// Set next TreeNode/CollapsingHeader open state.
+void ImGui::SetNextItemOpen(bool is_open, ImGuiCond cond)
+{
+    ImGuiContext &g = *GImGui;
+    if (g.CurrentWindow->SkipItems)
+        return;
+    g.NextItemData.Flags |= ImGuiNextItemDataFlags_HasOpen;
+    g.NextItemData.OpenVal  = is_open;
+    g.NextItemData.OpenCond = cond ? cond : ImGuiCond_Always;
+}
+
+// CollapsingHeader returns true when opened but do not indent nor push into the ID stack (because
+// of the ImGuiTreeNodeFlags_NoTreePushOnOpen flag). This is basically the same as calling
+// TreeNodeEx(label, ImGuiTreeNodeFlags_CollapsingHeader). You can remove the _NoTreePushOnOpen flag
+// if you want behavior closer to normal TreeNode().
+bool ImGui::CollapsingHeader(const char *label, ImGuiTreeNodeFlags flags)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    return TreeNodeBehavior(window->GetID(label), flags | ImGuiTreeNodeFlags_CollapsingHeader,
+                            label);
+}
+
+bool ImGui::CollapsingHeader(const char *label, bool *p_open, ImGuiTreeNodeFlags flags)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    if (p_open && !*p_open)
+        return false;
+
+    ImGuiID id = window->GetID(label);
+    flags |= ImGuiTreeNodeFlags_CollapsingHeader |
+             (p_open ? ImGuiTreeNodeFlags_AllowItemOverlap |
+                           ImGuiTreeNodeFlags_ClipLabelForTrailingButton
+                     : 0);
+    bool is_open = TreeNodeBehavior(id, flags, label);
+    if (p_open)
+    {
+        // Create a small overlapping close button
+        // FIXME: We can evolve this into user accessible helpers to add extra buttons on title
+        // bars, headers, etc.
+        // FIXME: CloseButton can overlap into text, need find a way to clip the text somehow.
+        ImGuiContext &g = *GImGui;
+        ImGuiItemHoveredDataBackup last_item_backup;
+        float button_size = g.FontSize;
+        float button_x =
+            ImMax(window->DC.LastItemRect.Min.x,
+                  window->DC.LastItemRect.Max.x - g.Style.FramePadding.x * 2.0f - button_size);
+        float button_y = window->DC.LastItemRect.Min.y;
+        if (CloseButton(window->GetID((void *)((intptr_t)id + 1)), ImVec2(button_x, button_y)))
+            *p_open = false;
+        last_item_backup.Restore();
+    }
+
+    return is_open;
+}
+
+//-------------------------------------------------------------------------
+// [SECTION] Widgets: Selectable
+//-------------------------------------------------------------------------
+// - Selectable()
+//-------------------------------------------------------------------------
+
+// Tip: pass a non-visible label (e.g. "##dummy") then you can use the space to draw other text or
+// image. But you need to make sure the ID is unique, e.g. enclose calls in PushID/PopID or use
+// ##unique_id.
+bool ImGui::Selectable(const char *label,
+                       bool selected,
+                       ImGuiSelectableFlags flags,
+                       const ImVec2 &size_arg)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    ImGuiContext &g         = *GImGui;
+    const ImGuiStyle &style = g.Style;
+
+    if ((flags & ImGuiSelectableFlags_SpanAllColumns) &&
+        window->DC.CurrentColumns)  // FIXME-OPT: Avoid if vertically clipped.
+        PushColumnsBackground();
+
+    ImGuiID id        = window->GetID(label);
+    ImVec2 label_size = CalcTextSize(label, NULL, true);
+    ImVec2 size(size_arg.x != 0.0f ? size_arg.x : label_size.x,
+                size_arg.y != 0.0f ? size_arg.y : label_size.y);
+    ImVec2 pos = window->DC.CursorPos;
+    pos.y += window->DC.CurrLineTextBaseOffset;
+    ImRect bb_inner(pos, pos + size);
+    ItemSize(size);
+
+    // Fill horizontal space.
+    ImVec2 window_padding = window->WindowPadding;
+    float max_x = (flags & ImGuiSelectableFlags_SpanAllColumns) ? GetWindowContentRegionMax().x
+                                                                : GetContentRegionMax().x;
+    float w_draw = ImMax(label_size.x, window->Pos.x + max_x - window_padding.x - pos.x);
+    ImVec2 size_draw((size_arg.x != 0 && !(flags & ImGuiSelectableFlags_DrawFillAvailWidth))
+                         ? size_arg.x
+                         : w_draw,
+                     size_arg.y != 0.0f ? size_arg.y : size.y);
+    ImRect bb(pos, pos + size_draw);
+    if (size_arg.x == 0.0f || (flags & ImGuiSelectableFlags_DrawFillAvailWidth))
+        bb.Max.x += window_padding.x;
+
+    // Selectables are tightly packed together so we extend the box to cover spacing between
+    // selectable.
+    const float spacing_x = style.ItemSpacing.x;
+    const float spacing_y = style.ItemSpacing.y;
+    const float spacing_L = (float)(int)(spacing_x * 0.50f);
+    const float spacing_U = (float)(int)(spacing_y * 0.50f);
+    bb.Min.x -= spacing_L;
+    bb.Min.y -= spacing_U;
+    bb.Max.x += (spacing_x - spacing_L);
+    bb.Max.y += (spacing_y - spacing_U);
+
+    bool item_add;
+    if (flags & ImGuiSelectableFlags_Disabled)
+    {
+        ImGuiItemFlags backup_item_flags = window->DC.ItemFlags;
+        window->DC.ItemFlags |= ImGuiItemFlags_Disabled | ImGuiItemFlags_NoNavDefaultFocus;
+        item_add             = ItemAdd(bb, id);
+        window->DC.ItemFlags = backup_item_flags;
+    }
+    else
+    {
+        item_add = ItemAdd(bb, id);
+    }
+    if (!item_add)
+    {
+        if ((flags & ImGuiSelectableFlags_SpanAllColumns) && window->DC.CurrentColumns)
+            PopColumnsBackground();
+        return false;
+    }
+
+    // We use NoHoldingActiveID on menus so user can click and _hold_ on a menu then drag to browse
+    // child entries
+    ImGuiButtonFlags button_flags = 0;
+    if (flags & ImGuiSelectableFlags_NoHoldingActiveID)
+        button_flags |= ImGuiButtonFlags_NoHoldingActiveID;
+    if (flags & ImGuiSelectableFlags_PressedOnClick)
+        button_flags |= ImGuiButtonFlags_PressedOnClick;
+    if (flags & ImGuiSelectableFlags_PressedOnRelease)
+        button_flags |= ImGuiButtonFlags_PressedOnRelease;
+    if (flags & ImGuiSelectableFlags_Disabled)
+        button_flags |= ImGuiButtonFlags_Disabled;
+    if (flags & ImGuiSelectableFlags_AllowDoubleClick)
+        button_flags |=
+            ImGuiButtonFlags_PressedOnClickRelease | ImGuiButtonFlags_PressedOnDoubleClick;
+    if (flags & ImGuiSelectableFlags_AllowItemOverlap)
+        button_flags |= ImGuiButtonFlags_AllowItemOverlap;
+
+    if (flags & ImGuiSelectableFlags_Disabled)
+        selected = false;
+
+    const bool was_selected = selected;
+    bool hovered, held;
+    bool pressed = ButtonBehavior(bb, id, &hovered, &held, button_flags);
+    // Hovering selectable with mouse updates NavId accordingly so navigation can be resumed with
+    // gamepad/keyboard (this doesn't happen on most widgets)
+    if (pressed || hovered)
+        if (!g.NavDisableMouseHover && g.NavWindow == window &&
+            g.NavLayer == window->DC.NavLayerCurrent)
+        {
+            g.NavDisableHighlight = true;
+            SetNavID(id, window->DC.NavLayerCurrent);
+        }
+    if (pressed)
+        MarkItemEdited(id);
+
+    if (flags & ImGuiSelectableFlags_AllowItemOverlap)
+        SetItemAllowOverlap();
+
+    // In this branch, Selectable() cannot toggle the selection so this will never trigger.
+    if (selected != was_selected)  //-V547
+        window->DC.LastItemStatusFlags |= ImGuiItemStatusFlags_ToggledSelection;
+
+    // Render
+    if (hovered || selected)
+    {
+        const ImU32 col =
+            GetColorU32((held && hovered) ? ImGuiCol_HeaderActive
+                                          : hovered ? ImGuiCol_HeaderHovered : ImGuiCol_Header);
+        RenderFrame(bb.Min, bb.Max, col, false, 0.0f);
+        RenderNavHighlight(bb, id,
+                           ImGuiNavHighlightFlags_TypeThin | ImGuiNavHighlightFlags_NoRounding);
+    }
+
+    if ((flags & ImGuiSelectableFlags_SpanAllColumns) && window->DC.CurrentColumns)
+    {
+        PopColumnsBackground();
+        bb.Max.x -= (GetContentRegionMax().x - max_x);
+    }
+
+    if (flags & ImGuiSelectableFlags_Disabled)
+        PushStyleColor(ImGuiCol_Text, style.Colors[ImGuiCol_TextDisabled]);
+    RenderTextClipped(bb_inner.Min, bb_inner.Max, label, NULL, &label_size,
+                      style.SelectableTextAlign, &bb);
+    if (flags & ImGuiSelectableFlags_Disabled)
+        PopStyleColor();
+
+    // Automatically close popups
+    if (pressed && (window->Flags & ImGuiWindowFlags_Popup) &&
+        !(flags & ImGuiSelectableFlags_DontClosePopups) &&
+        !(window->DC.ItemFlags & ImGuiItemFlags_SelectableDontClosePopup))
+        CloseCurrentPopup();
+
+    IMGUI_TEST_ENGINE_ITEM_INFO(id, label, window->DC.ItemFlags);
+    return pressed;
+}
+
+bool ImGui::Selectable(const char *label,
+                       bool *p_selected,
+                       ImGuiSelectableFlags flags,
+                       const ImVec2 &size_arg)
+{
+    if (Selectable(label, *p_selected, flags, size_arg))
+    {
+        *p_selected = !*p_selected;
+        return true;
+    }
+    return false;
+}
+
+//-------------------------------------------------------------------------
+// [SECTION] Widgets: ListBox
+//-------------------------------------------------------------------------
+// - ListBox()
+// - ListBoxHeader()
+// - ListBoxFooter()
+//-------------------------------------------------------------------------
+// FIXME: This is an old API. We should redesign some of it, rename ListBoxHeader->BeginListBox,
+// ListBoxFooter->EndListBox and promote using them over existing ListBox() functions, similarly to
+// change with combo boxes.
+//-------------------------------------------------------------------------
+
+// FIXME: In principle this function should be called BeginListBox(). We should rename it after
+// re-evaluating if we want to keep the same signature. Helper to calculate the size of a listbox
+// and display a label on the right. Tip: To have a list filling the entire window width,
+// PushItemWidth(-1) and pass an non-visible label e.g. "##empty"
+bool ImGui::ListBoxHeader(const char *label, const ImVec2 &size_arg)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    const ImGuiStyle &style = g.Style;
+    const ImGuiID id        = GetID(label);
+    const ImVec2 label_size = CalcTextSize(label, NULL, true);
+
+    // Size default to hold ~7 items. Fractional number of items helps seeing that we can scroll
+    // down/up without looking at scrollbar.
+    ImVec2 size       = CalcItemSize(size_arg, CalcItemWidth(),
+                               GetTextLineHeightWithSpacing() * 7.4f + style.ItemSpacing.y);
+    ImVec2 frame_size = ImVec2(size.x, ImMax(size.y, label_size.y));
+    ImRect frame_bb(window->DC.CursorPos, window->DC.CursorPos + frame_size);
+    ImRect bb(
+        frame_bb.Min,
+        frame_bb.Max +
+            ImVec2(label_size.x > 0.0f ? style.ItemInnerSpacing.x + label_size.x : 0.0f, 0.0f));
+    window->DC.LastItemRect = bb;  // Forward storage for ListBoxFooter.. dodgy.
+    g.NextItemData.ClearFlags();
+
+    if (!IsRectVisible(bb.Min, bb.Max))
+    {
+        ItemSize(bb.GetSize(), style.FramePadding.y);
+        ItemAdd(bb, 0, &frame_bb);
+        return false;
+    }
+
+    BeginGroup();
+    if (label_size.x > 0)
+        RenderText(ImVec2(frame_bb.Max.x + style.ItemInnerSpacing.x,
+                          frame_bb.Min.y + style.FramePadding.y),
+                   label);
+
+    BeginChildFrame(id, frame_bb.GetSize());
+    return true;
+}
+
+// FIXME: In principle this function should be called EndListBox(). We should rename it after
+// re-evaluating if we want to keep the same signature.
+bool ImGui::ListBoxHeader(const char *label, int items_count, int height_in_items)
+{
+    // Size default to hold ~7.25 items.
+    // We add +25% worth of item height to allow the user to see at a glance if there are more items
+    // up/down, without looking at the scrollbar. We don't add this extra bit if items_count <=
+    // height_in_items. It is slightly dodgy, because it means a dynamic list of items will make the
+    // widget resize occasionally when it crosses that size. I am expecting that someone will come
+    // and complain about this behavior in a remote future, then we can advise on a better solution.
+    if (height_in_items < 0)
+        height_in_items = ImMin(items_count, 7);
+    const ImGuiStyle &style = GetStyle();
+    float height_in_items_f =
+        (height_in_items < items_count) ? (height_in_items + 0.25f) : (height_in_items + 0.00f);
+
+    // We include ItemSpacing.y so that a list sized for the exact number of items doesn't make a
+    // scrollbar appears. We could also enforce that by passing a flag to BeginChild().
+    ImVec2 size;
+    size.x = 0.0f;
+    size.y = GetTextLineHeightWithSpacing() * height_in_items_f + style.FramePadding.y * 2.0f;
+    return ListBoxHeader(label, size);
+}
+
+// FIXME: In principle this function should be called EndListBox(). We should rename it after
+// re-evaluating if we want to keep the same signature.
+void ImGui::ListBoxFooter()
+{
+    ImGuiWindow *parent_window = GetCurrentWindow()->ParentWindow;
+    const ImRect bb            = parent_window->DC.LastItemRect;
+    const ImGuiStyle &style    = GetStyle();
+
+    EndChildFrame();
+
+    // Redeclare item size so that it includes the label (we have stored the full size in
+    // LastItemRect) We call SameLine() to restore DC.CurrentLine* data
+    SameLine();
+    parent_window->DC.CursorPos = bb.Min;
+    ItemSize(bb, style.FramePadding.y);
+    EndGroup();
+}
+
+bool ImGui::ListBox(const char *label,
+                    int *current_item,
+                    const char *const items[],
+                    int items_count,
+                    int height_items)
+{
+    const bool value_changed =
+        ListBox(label, current_item, Items_ArrayGetter, (void *)items, items_count, height_items);
+    return value_changed;
+}
+
+bool ImGui::ListBox(const char *label,
+                    int *current_item,
+                    bool (*items_getter)(void *, int, const char **),
+                    void *data,
+                    int items_count,
+                    int height_in_items)
+{
+    if (!ListBoxHeader(label, items_count, height_in_items))
+        return false;
+
+    // Assume all items have even height (= 1 line of text). If you need items of different or
+    // variable sizes you can create a custom version of ListBox() in your code without using the
+    // clipper.
+    ImGuiContext &g    = *GImGui;
+    bool value_changed = false;
+    ImGuiListClipper clipper(
+        items_count,
+        GetTextLineHeightWithSpacing());  // We know exactly our line height here so we pass it as a
+                                          // minor optimization, but generally you don't need to.
+    while (clipper.Step())
+        for (int i = clipper.DisplayStart; i < clipper.DisplayEnd; i++)
+        {
+            const bool item_selected = (i == *current_item);
+            const char *item_text;
+            if (!items_getter(data, i, &item_text))
+                item_text = "*Unknown item*";
+
+            PushID(i);
+            if (Selectable(item_text, item_selected))
+            {
+                *current_item = i;
+                value_changed = true;
+            }
+            if (item_selected)
+                SetItemDefaultFocus();
+            PopID();
+        }
+    ListBoxFooter();
+    if (value_changed)
+        MarkItemEdited(g.CurrentWindow->DC.LastItemId);
+
+    return value_changed;
+}
+
+//-------------------------------------------------------------------------
+// [SECTION] Widgets: PlotLines, PlotHistogram
+//-------------------------------------------------------------------------
+// - PlotEx() [Internal]
+// - PlotLines()
+// - PlotHistogram()
+//-------------------------------------------------------------------------
+
+void ImGui::PlotEx(ImGuiPlotType plot_type,
+                   const char *label,
+                   float (*values_getter)(void *data, int idx),
+                   void *data,
+                   int values_count,
+                   int values_offset,
+                   const char *overlay_text,
+                   float scale_min,
+                   float scale_max,
+                   ImVec2 frame_size)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return;
+
+    ImGuiContext &g         = *GImGui;
+    const ImGuiStyle &style = g.Style;
+    const ImGuiID id        = window->GetID(label);
+
+    const ImVec2 label_size = CalcTextSize(label, NULL, true);
+    if (frame_size.x == 0.0f)
+        frame_size.x = CalcItemWidth();
+    if (frame_size.y == 0.0f)
+        frame_size.y = label_size.y + (style.FramePadding.y * 2);
+
+    const ImRect frame_bb(window->DC.CursorPos, window->DC.CursorPos + frame_size);
+    const ImRect inner_bb(frame_bb.Min + style.FramePadding, frame_bb.Max - style.FramePadding);
+    const ImRect total_bb(
+        frame_bb.Min,
+        frame_bb.Max +
+            ImVec2(label_size.x > 0.0f ? style.ItemInnerSpacing.x + label_size.x : 0.0f, 0));
+    ItemSize(total_bb, style.FramePadding.y);
+    if (!ItemAdd(total_bb, 0, &frame_bb))
+        return;
+    const bool hovered = ItemHoverable(frame_bb, id);
+
+    // Determine scale from values if not specified
+    if (scale_min == FLT_MAX || scale_max == FLT_MAX)
+    {
+        float v_min = FLT_MAX;
+        float v_max = -FLT_MAX;
+        for (int i = 0; i < values_count; i++)
+        {
+            const float v = values_getter(data, i);
+            if (v != v)  // Ignore NaN values
+                continue;
+            v_min = ImMin(v_min, v);
+            v_max = ImMax(v_max, v);
+        }
+        if (scale_min == FLT_MAX)
+            scale_min = v_min;
+        if (scale_max == FLT_MAX)
+            scale_max = v_max;
+    }
+
+    RenderFrame(frame_bb.Min, frame_bb.Max, GetColorU32(ImGuiCol_FrameBg), true,
+                style.FrameRounding);
+
+    const int values_count_min = (plot_type == ImGuiPlotType_Lines) ? 2 : 1;
+    if (values_count >= values_count_min)
+    {
+        int res_w =
+            ImMin((int)frame_size.x, values_count) + ((plot_type == ImGuiPlotType_Lines) ? -1 : 0);
+        int item_count = values_count + ((plot_type == ImGuiPlotType_Lines) ? -1 : 0);
+
+        // Tooltip on hover
+        int v_hovered = -1;
+        if (hovered && inner_bb.Contains(g.IO.MousePos))
+        {
+            const float t =
+                ImClamp((g.IO.MousePos.x - inner_bb.Min.x) / (inner_bb.Max.x - inner_bb.Min.x),
+                        0.0f, 0.9999f);
+            const int v_idx = (int)(t * item_count);
+            IM_ASSERT(v_idx >= 0 && v_idx < values_count);
+
+            const float v0 = values_getter(data, (v_idx + values_offset) % values_count);
+            const float v1 = values_getter(data, (v_idx + 1 + values_offset) % values_count);
+            if (plot_type == ImGuiPlotType_Lines)
+                SetTooltip("%d: %8.4g\n%d: %8.4g", v_idx, v0, v_idx + 1, v1);
+            else if (plot_type == ImGuiPlotType_Histogram)
+                SetTooltip("%d: %8.4g", v_idx, v0);
+            v_hovered = v_idx;
+        }
+
+        const float t_step    = 1.0f / (float)res_w;
+        const float inv_scale = (scale_min == scale_max) ? 0.0f : (1.0f / (scale_max - scale_min));
+
+        float v0   = values_getter(data, (0 + values_offset) % values_count);
+        float t0   = 0.0f;
+        ImVec2 tp0 = ImVec2(
+            t0,
+            1.0f - ImSaturate((v0 - scale_min) *
+                              inv_scale));  // Point in the normalized space of our target rectangle
+        float histogram_zero_line_t =
+            (scale_min * scale_max < 0.0f)
+                ? (-scale_min * inv_scale)
+                : (scale_min < 0.0f ? 0.0f : 1.0f);  // Where does the zero line stands
+
+        const ImU32 col_base = GetColorU32(
+            (plot_type == ImGuiPlotType_Lines) ? ImGuiCol_PlotLines : ImGuiCol_PlotHistogram);
+        const ImU32 col_hovered =
+            GetColorU32((plot_type == ImGuiPlotType_Lines) ? ImGuiCol_PlotLinesHovered
+                                                           : ImGuiCol_PlotHistogramHovered);
+
+        for (int n = 0; n < res_w; n++)
+        {
+            const float t1   = t0 + t_step;
+            const int v1_idx = (int)(t0 * item_count + 0.5f);
+            IM_ASSERT(v1_idx >= 0 && v1_idx < values_count);
+            const float v1   = values_getter(data, (v1_idx + values_offset + 1) % values_count);
+            const ImVec2 tp1 = ImVec2(t1, 1.0f - ImSaturate((v1 - scale_min) * inv_scale));
+
+            // NB: Draw calls are merged together by the DrawList system. Still, we should render
+            // our batch are lower level to save a bit of CPU.
+            ImVec2 pos0 = ImLerp(inner_bb.Min, inner_bb.Max, tp0);
+            ImVec2 pos1 = ImLerp(
+                inner_bb.Min, inner_bb.Max,
+                (plot_type == ImGuiPlotType_Lines) ? tp1 : ImVec2(tp1.x, histogram_zero_line_t));
+            if (plot_type == ImGuiPlotType_Lines)
+            {
+                window->DrawList->AddLine(pos0, pos1, v_hovered == v1_idx ? col_hovered : col_base);
+            }
+            else if (plot_type == ImGuiPlotType_Histogram)
+            {
+                if (pos1.x >= pos0.x + 2.0f)
+                    pos1.x -= 1.0f;
+                window->DrawList->AddRectFilled(pos0, pos1,
+                                                v_hovered == v1_idx ? col_hovered : col_base);
+            }
+
+            t0  = t1;
+            tp0 = tp1;
+        }
+    }
+
+    // Text overlay
+    if (overlay_text)
+        RenderTextClipped(ImVec2(frame_bb.Min.x, frame_bb.Min.y + style.FramePadding.y),
+                          frame_bb.Max, overlay_text, NULL, NULL, ImVec2(0.5f, 0.0f));
+
+    if (label_size.x > 0.0f)
+        RenderText(ImVec2(frame_bb.Max.x + style.ItemInnerSpacing.x, inner_bb.Min.y), label);
+}
+
+struct ImGuiPlotArrayGetterData
+{
+    const float *Values;
+    int Stride;
+
+    ImGuiPlotArrayGetterData(const float *values, int stride)
+    {
+        Values = values;
+        Stride = stride;
+    }
+};
+
+static float Plot_ArrayGetter(void *data, int idx)
+{
+    ImGuiPlotArrayGetterData *plot_data = (ImGuiPlotArrayGetterData *)data;
+    const float v = *(const float *)(const void *)((const unsigned char *)plot_data->Values +
+                                                   (size_t)idx * plot_data->Stride);
+    return v;
+}
+
+void ImGui::PlotLines(const char *label,
+                      const float *values,
+                      int values_count,
+                      int values_offset,
+                      const char *overlay_text,
+                      float scale_min,
+                      float scale_max,
+                      ImVec2 graph_size,
+                      int stride)
+{
+    ImGuiPlotArrayGetterData data(values, stride);
+    PlotEx(ImGuiPlotType_Lines, label, &Plot_ArrayGetter, (void *)&data, values_count,
+           values_offset, overlay_text, scale_min, scale_max, graph_size);
+}
+
+void ImGui::PlotLines(const char *label,
+                      float (*values_getter)(void *data, int idx),
+                      void *data,
+                      int values_count,
+                      int values_offset,
+                      const char *overlay_text,
+                      float scale_min,
+                      float scale_max,
+                      ImVec2 graph_size)
+{
+    PlotEx(ImGuiPlotType_Lines, label, values_getter, data, values_count, values_offset,
+           overlay_text, scale_min, scale_max, graph_size);
+}
+
+void ImGui::PlotHistogram(const char *label,
+                          const float *values,
+                          int values_count,
+                          int values_offset,
+                          const char *overlay_text,
+                          float scale_min,
+                          float scale_max,
+                          ImVec2 graph_size,
+                          int stride)
+{
+    ImGuiPlotArrayGetterData data(values, stride);
+    PlotEx(ImGuiPlotType_Histogram, label, &Plot_ArrayGetter, (void *)&data, values_count,
+           values_offset, overlay_text, scale_min, scale_max, graph_size);
+}
+
+void ImGui::PlotHistogram(const char *label,
+                          float (*values_getter)(void *data, int idx),
+                          void *data,
+                          int values_count,
+                          int values_offset,
+                          const char *overlay_text,
+                          float scale_min,
+                          float scale_max,
+                          ImVec2 graph_size)
+{
+    PlotEx(ImGuiPlotType_Histogram, label, values_getter, data, values_count, values_offset,
+           overlay_text, scale_min, scale_max, graph_size);
+}
+
+//-------------------------------------------------------------------------
+// [SECTION] Widgets: Value helpers
+// Those is not very useful, legacy API.
+//-------------------------------------------------------------------------
+// - Value()
+//-------------------------------------------------------------------------
+
+void ImGui::Value(const char *prefix, bool b)
+{
+    Text("%s: %s", prefix, (b ? "true" : "false"));
+}
+
+void ImGui::Value(const char *prefix, int v)
+{
+    Text("%s: %d", prefix, v);
+}
+
+void ImGui::Value(const char *prefix, unsigned int v)
+{
+    Text("%s: %d", prefix, v);
+}
+
+void ImGui::Value(const char *prefix, float v, const char *float_format)
+{
+    if (float_format)
+    {
+        char fmt[64];
+        ImFormatString(fmt, IM_ARRAYSIZE(fmt), "%%s: %s", float_format);
+        Text(fmt, prefix, v);
+    }
+    else
+    {
+        Text("%s: %.3f", prefix, v);
+    }
+}
+
+//-------------------------------------------------------------------------
+// [SECTION] MenuItem, BeginMenu, EndMenu, etc.
+//-------------------------------------------------------------------------
+// - ImGuiMenuColumns [Internal]
+// - BeginMainMenuBar()
+// - EndMainMenuBar()
+// - BeginMenuBar()
+// - EndMenuBar()
+// - BeginMenu()
+// - EndMenu()
+// - MenuItem()
+//-------------------------------------------------------------------------
+
+// Helpers for internal use
+ImGuiMenuColumns::ImGuiMenuColumns()
+{
+    Spacing = Width = NextWidth = 0.0f;
+    memset(Pos, 0, sizeof(Pos));
+    memset(NextWidths, 0, sizeof(NextWidths));
+}
+
+void ImGuiMenuColumns::Update(int count, float spacing, bool clear)
+{
+    IM_ASSERT(count == IM_ARRAYSIZE(Pos));
+    IM_UNUSED(count);
+    Width = NextWidth = 0.0f;
+    Spacing           = spacing;
+    if (clear)
+        memset(NextWidths, 0, sizeof(NextWidths));
+    for (int i = 0; i < IM_ARRAYSIZE(Pos); i++)
+    {
+        if (i > 0 && NextWidths[i] > 0.0f)
+            Width += Spacing;
+        Pos[i] = (float)(int)Width;
+        Width += NextWidths[i];
+        NextWidths[i] = 0.0f;
+    }
+}
+
+float ImGuiMenuColumns::DeclColumns(
+    float w0,
+    float w1,
+    float w2)  // not using va_arg because they promote float to double
+{
+    NextWidth     = 0.0f;
+    NextWidths[0] = ImMax(NextWidths[0], w0);
+    NextWidths[1] = ImMax(NextWidths[1], w1);
+    NextWidths[2] = ImMax(NextWidths[2], w2);
+    for (int i = 0; i < IM_ARRAYSIZE(Pos); i++)
+        NextWidth += NextWidths[i] + ((i > 0 && NextWidths[i] > 0.0f) ? Spacing : 0.0f);
+    return ImMax(Width, NextWidth);
+}
+
+float ImGuiMenuColumns::CalcExtraSpace(float avail_w)
+{
+    return ImMax(0.0f, avail_w - Width);
+}
+
+// For the main menu bar, which cannot be moved, we honor g.Style.DisplaySafeAreaPadding to ensure
+// text can be visible on a TV set.
+bool ImGui::BeginMainMenuBar()
+{
+    ImGuiContext &g = *GImGui;
+    g.NextWindowData.MenuBarOffsetMinVal =
+        ImVec2(g.Style.DisplaySafeAreaPadding.x,
+               ImMax(g.Style.DisplaySafeAreaPadding.y - g.Style.FramePadding.y, 0.0f));
+    SetNextWindowPos(ImVec2(0.0f, 0.0f));
+    SetNextWindowSize(ImVec2(g.IO.DisplaySize.x, g.NextWindowData.MenuBarOffsetMinVal.y +
+                                                     g.FontBaseSize + g.Style.FramePadding.y));
+    PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f);
+    PushStyleVar(ImGuiStyleVar_WindowMinSize, ImVec2(0, 0));
+    ImGuiWindowFlags window_flags = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize |
+                                    ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollbar |
+                                    ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_MenuBar;
+    bool is_open = Begin("##MainMenuBar", NULL, window_flags) && BeginMenuBar();
+    PopStyleVar(2);
+    g.NextWindowData.MenuBarOffsetMinVal = ImVec2(0.0f, 0.0f);
+    if (!is_open)
+    {
+        End();
+        return false;
+    }
+    return true;  //-V1020
+}
+
+void ImGui::EndMainMenuBar()
+{
+    EndMenuBar();
+
+    // When the user has left the menu layer (typically: closed menus through activation of an
+    // item), we restore focus to the previous window
+    // FIXME: With this strategy we won't be able to restore a NULL focus.
+    ImGuiContext &g = *GImGui;
+    if (g.CurrentWindow == g.NavWindow && g.NavLayer == 0 && !g.NavAnyRequest)
+        FocusTopMostWindowUnderOne(g.NavWindow, NULL);
+
+    End();
+}
+
+bool ImGui::BeginMenuBar()
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+    if (!(window->Flags & ImGuiWindowFlags_MenuBar))
+        return false;
+
+    IM_ASSERT(!window->DC.MenuBarAppending);
+    BeginGroup();  // Backup position on layer 0
+    PushID("##menubar");
+
+    // We don't clip with current window clipping rectangle as it is already set to the area below.
+    // However we clip with window full rect. We remove 1 worth of rounding to Max.x to that text in
+    // long menus and small windows don't tend to display over the lower-right rounded area, which
+    // looks particularly glitchy.
+    ImRect bar_rect = window->MenuBarRect();
+    ImRect clip_rect(ImFloor(bar_rect.Min.x + 0.5f),
+                     ImFloor(bar_rect.Min.y + window->WindowBorderSize + 0.5f),
+                     ImFloor(ImMax(bar_rect.Min.x, bar_rect.Max.x - window->WindowRounding) + 0.5f),
+                     ImFloor(bar_rect.Max.y + 0.5f));
+    clip_rect.ClipWith(window->OuterRectClipped);
+    PushClipRect(clip_rect.Min, clip_rect.Max, false);
+
+    window->DC.CursorPos           = ImVec2(bar_rect.Min.x + window->DC.MenuBarOffset.x,
+                                  bar_rect.Min.y + window->DC.MenuBarOffset.y);
+    window->DC.LayoutType          = ImGuiLayoutType_Horizontal;
+    window->DC.NavLayerCurrent     = ImGuiNavLayer_Menu;
+    window->DC.NavLayerCurrentMask = (1 << ImGuiNavLayer_Menu);
+    window->DC.MenuBarAppending    = true;
+    AlignTextToFramePadding();
+    return true;
+}
+
+void ImGui::EndMenuBar()
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return;
+    ImGuiContext &g = *GImGui;
+
+    // Nav: When a move request within one of our child menu failed, capture the request to navigate
+    // among our siblings.
+    if (NavMoveRequestButNoResultYet() &&
+        (g.NavMoveDir == ImGuiDir_Left || g.NavMoveDir == ImGuiDir_Right) &&
+        (g.NavWindow->Flags & ImGuiWindowFlags_ChildMenu))
+    {
+        ImGuiWindow *nav_earliest_child = g.NavWindow;
+        while (nav_earliest_child->ParentWindow &&
+               (nav_earliest_child->ParentWindow->Flags & ImGuiWindowFlags_ChildMenu))
+            nav_earliest_child = nav_earliest_child->ParentWindow;
+        if (nav_earliest_child->ParentWindow == window &&
+            nav_earliest_child->DC.ParentLayoutType == ImGuiLayoutType_Horizontal &&
+            g.NavMoveRequestForward == ImGuiNavForward_None)
+        {
+            // To do so we claim focus back, restore NavId and then process the movement request for
+            // yet another frame. This involve a one-frame delay which isn't very problematic in
+            // this situation. We could remove it by scoring in advance for multiple window
+            // (probably not worth the hassle/cost)
+            const ImGuiNavLayer layer = ImGuiNavLayer_Menu;
+            IM_ASSERT(window->DC.NavLayerActiveMaskNext & (1 << layer));  // Sanity check
+            FocusWindow(window);
+            SetNavIDWithRectRel(window->NavLastIds[layer], layer, window->NavRectRel[layer]);
+            g.NavLayer            = layer;
+            g.NavDisableHighlight = true;  // Hide highlight for the current frame so we don't see
+                                           // the intermediary selection.
+            g.NavMoveRequestForward = ImGuiNavForward_ForwardQueued;
+            NavMoveRequestCancel();
+        }
+    }
+
+    IM_ASSERT(window->Flags & ImGuiWindowFlags_MenuBar);
+    IM_ASSERT(window->DC.MenuBarAppending);
+    PopClipRect();
+    PopID();
+    window->DC.MenuBarOffset.x =
+        window->DC.CursorPos.x -
+        window->MenuBarRect().Min.x;  // Save horizontal position so next append can reuse it. This
+                                      // is kinda equivalent to a per-layer CursorPos.
+    window->DC.GroupStack.back().EmitItem = false;
+    EndGroup();  // Restore position on layer 0
+    window->DC.LayoutType          = ImGuiLayoutType_Vertical;
+    window->DC.NavLayerCurrent     = ImGuiNavLayer_Main;
+    window->DC.NavLayerCurrentMask = (1 << ImGuiNavLayer_Main);
+    window->DC.MenuBarAppending    = false;
+}
+
+bool ImGui::BeginMenu(const char *label, bool enabled)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    ImGuiContext &g         = *GImGui;
+    const ImGuiStyle &style = g.Style;
+    const ImGuiID id        = window->GetID(label);
+
+    ImVec2 label_size = CalcTextSize(label, NULL, true);
+
+    bool pressed;
+    bool menu_is_open = IsPopupOpen(id);
+    bool menuset_is_open =
+        !(window->Flags & ImGuiWindowFlags_Popup) &&
+        (g.OpenPopupStack.Size > g.BeginPopupStack.Size &&
+         g.OpenPopupStack[g.BeginPopupStack.Size].OpenParentId == window->IDStack.back());
+    ImGuiWindow *backed_nav_window = g.NavWindow;
+    if (menuset_is_open)
+        g.NavWindow = window;  // Odd hack to allow hovering across menus of a same menu-set
+                               // (otherwise we wouldn't be able to hover parent)
+
+    // The reference position stored in popup_pos will be used by Begin() to find a suitable
+    // position for the child menu, However the final position is going to be different! It is
+    // choosen by FindBestWindowPosForPopup(). e.g. Menus tend to overlap each other horizontally to
+    // amplify relative Z-ordering.
+    ImVec2 popup_pos, pos = window->DC.CursorPos;
+    if (window->DC.LayoutType == ImGuiLayoutType_Horizontal)
+    {
+        // Menu inside an horizontal menu bar
+        // Selectable extend their highlight by half ItemSpacing in each direction.
+        // For ChildMenu, the popup position will be overwritten by the call to
+        // FindBestWindowPosForPopup() in Begin()
+        popup_pos = ImVec2(pos.x - 1.0f - (float)(int)(style.ItemSpacing.x * 0.5f),
+                           pos.y - style.FramePadding.y + window->MenuBarHeight());
+        window->DC.CursorPos.x += (float)(int)(style.ItemSpacing.x * 0.5f);
+        PushStyleVar(ImGuiStyleVar_ItemSpacing,
+                     ImVec2(style.ItemSpacing.x * 2.0f, style.ItemSpacing.y));
+        float w = label_size.x;
+        pressed = Selectable(label, menu_is_open,
+                             ImGuiSelectableFlags_NoHoldingActiveID |
+                                 ImGuiSelectableFlags_PressedOnClick |
+                                 ImGuiSelectableFlags_DontClosePopups |
+                                 (!enabled ? ImGuiSelectableFlags_Disabled : 0),
+                             ImVec2(w, 0.0f));
+        PopStyleVar();
+        window->DC.CursorPos.x +=
+            (float)(int)(style.ItemSpacing.x *
+                         (-1.0f + 0.5f));  // -1 spacing to compensate the spacing added when
+                                           // Selectable() did a SameLine(). It would also work to
+                                           // call SameLine() ourselves after the PopStyleVar().
+    }
+    else
+    {
+        // Menu inside a menu
+        popup_pos = ImVec2(pos.x, pos.y - style.WindowPadding.y);
+        float w   = window->MenuColumns.DeclColumns(
+            label_size.x, 0.0f, (float)(int)(g.FontSize * 1.20f));  // Feedback to next frame
+        float extra_w = ImMax(0.0f, GetContentRegionAvail().x - w);
+        pressed       = Selectable(
+            label, menu_is_open,
+            ImGuiSelectableFlags_NoHoldingActiveID | ImGuiSelectableFlags_PressedOnClick |
+                ImGuiSelectableFlags_DontClosePopups | ImGuiSelectableFlags_DrawFillAvailWidth |
+                (!enabled ? ImGuiSelectableFlags_Disabled : 0),
+            ImVec2(w, 0.0f));
+        ImU32 text_col = GetColorU32(enabled ? ImGuiCol_Text : ImGuiCol_TextDisabled);
+        RenderArrow(window->DrawList,
+                    pos + ImVec2(window->MenuColumns.Pos[2] + extra_w + g.FontSize * 0.30f, 0.0f),
+                    text_col, ImGuiDir_Right);
+    }
+
+    const bool hovered = enabled && ItemHoverable(window->DC.LastItemRect, id);
+    if (menuset_is_open)
+        g.NavWindow = backed_nav_window;
+
+    bool want_open  = false;
+    bool want_close = false;
+    if (window->DC.LayoutType ==
+        ImGuiLayoutType_Vertical)  // (window->Flags &
+                                   // (ImGuiWindowFlags_Popup|ImGuiWindowFlags_ChildMenu))
+    {
+        // Close menu when not hovering it anymore unless we are moving roughly in the direction of
+        // the menu Implement http://bjk5.com/post/44698559168/breaking-down-amazons-mega-dropdown
+        // to avoid using timers, so menus feels more reactive.
+        bool moving_toward_other_child_menu = false;
+
+        ImGuiWindow *child_menu_window =
+            (g.BeginPopupStack.Size < g.OpenPopupStack.Size &&
+             g.OpenPopupStack[g.BeginPopupStack.Size].SourceWindow == window)
+                ? g.OpenPopupStack[g.BeginPopupStack.Size].Window
+                : NULL;
+        if (g.HoveredWindow == window && child_menu_window != NULL &&
+            !(window->Flags & ImGuiWindowFlags_MenuBar))
+        {
+            // FIXME-DPI: Values should be derived from a master "scale" factor.
+            ImRect next_window_rect = child_menu_window->Rect();
+            ImVec2 ta               = g.IO.MousePos - g.IO.MouseDelta;
+            ImVec2 tb = (window->Pos.x < child_menu_window->Pos.x) ? next_window_rect.GetTL()
+                                                                   : next_window_rect.GetTR();
+            ImVec2 tc = (window->Pos.x < child_menu_window->Pos.x) ? next_window_rect.GetBL()
+                                                                   : next_window_rect.GetBR();
+            float extra =
+                ImClamp(ImFabs(ta.x - tb.x) * 0.30f, 5.0f, 30.0f);  // add a bit of extra slack.
+            ta.x += (window->Pos.x < child_menu_window->Pos.x)
+                        ? -0.5f
+                        : +0.5f;  // to avoid numerical issues
+            tb.y = ta.y +
+                   ImMax((tb.y - extra) - ta.y,
+                         -100.0f);  // triangle is maximum 200 high to limit the slope and the bias
+                                    // toward large sub-menus // FIXME: Multiply by fb_scale?
+            tc.y                           = ta.y + ImMin((tc.y + extra) - ta.y, +100.0f);
+            moving_toward_other_child_menu = ImTriangleContainsPoint(ta, tb, tc, g.IO.MousePos);
+            // GetForegroundDrawList()->AddTriangleFilled(ta, tb, tc, moving_within_opened_triangle
+            // ? IM_COL32(0,128,0,128) : IM_COL32(128,0,0,128)); // [DEBUG]
+        }
+        if (menu_is_open && !hovered && g.HoveredWindow == window &&
+            g.HoveredIdPreviousFrame != 0 && g.HoveredIdPreviousFrame != id &&
+            !moving_toward_other_child_menu)
+            want_close = true;
+
+        if (!menu_is_open && hovered && pressed)  // Click to open
+            want_open = true;
+        else if (!menu_is_open && hovered && !moving_toward_other_child_menu)  // Hover to open
+            want_open = true;
+
+        if (g.NavActivateId == id)
+        {
+            want_close = menu_is_open;
+            want_open  = !menu_is_open;
+        }
+        if (g.NavId == id && g.NavMoveRequest &&
+            g.NavMoveDir == ImGuiDir_Right)  // Nav-Right to open
+        {
+            want_open = true;
+            NavMoveRequestCancel();
+        }
+    }
+    else
+    {
+        // Menu bar
+        if (menu_is_open && pressed && menuset_is_open)  // Click an open menu again to close it
+        {
+            want_close = true;
+            want_open = menu_is_open = false;
+        }
+        else if (pressed || (hovered && menuset_is_open &&
+                             !menu_is_open))  // First click to open, then hover to open others
+        {
+            want_open = true;
+        }
+        else if (g.NavId == id && g.NavMoveRequest &&
+                 g.NavMoveDir == ImGuiDir_Down)  // Nav-Down to open
+        {
+            want_open = true;
+            NavMoveRequestCancel();
+        }
+    }
+
+    if (!enabled)  // explicitly close if an open menu becomes disabled, facilitate users code a lot
+                   // in pattern such as 'if (BeginMenu("options", has_object)) { ..use object.. }'
+        want_close = true;
+    if (want_close && IsPopupOpen(id))
+        ClosePopupToLevel(g.BeginPopupStack.Size, true);
+
+    IMGUI_TEST_ENGINE_ITEM_INFO(id, label,
+                                window->DC.ItemFlags | ImGuiItemStatusFlags_Openable |
+                                    (menu_is_open ? ImGuiItemStatusFlags_Opened : 0));
+
+    if (!menu_is_open && want_open && g.OpenPopupStack.Size > g.BeginPopupStack.Size)
+    {
+        // Don't recycle same menu level in the same frame, first close the other menu and yield for
+        // a frame.
+        OpenPopup(label);
+        return false;
+    }
+
+    menu_is_open |= want_open;
+    if (want_open)
+        OpenPopup(label);
+
+    if (menu_is_open)
+    {
+        // Sub-menus are ChildWindow so that mouse can be hovering across them (otherwise top-most
+        // popup menu would steal focus and not allow hovering on parent menu)
+        SetNextWindowPos(popup_pos, ImGuiCond_Always);
+        ImGuiWindowFlags flags = ImGuiWindowFlags_ChildMenu | ImGuiWindowFlags_AlwaysAutoResize |
+                                 ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoTitleBar |
+                                 ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoNavFocus;
+        if (window->Flags & (ImGuiWindowFlags_Popup | ImGuiWindowFlags_ChildMenu))
+            flags |= ImGuiWindowFlags_ChildWindow;
+        menu_is_open = BeginPopupEx(id, flags);  // menu_is_open can be 'false' when the popup is
+                                                 // completely clipped (e.g. zero size display)
+    }
+
+    return menu_is_open;
+}
+
+void ImGui::EndMenu()
+{
+    // Nav: When a left move request _within our child menu_ failed, close ourselves (the _parent_
+    // menu). A menu doesn't close itself because EndMenuBar() wants the catch the last Left<>Right
+    // inputs. However, it means that with the current code, a BeginMenu() from outside another menu
+    // or a menu-bar won't be closable with the Left direction.
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+    if (g.NavWindow && g.NavWindow->ParentWindow == window && g.NavMoveDir == ImGuiDir_Left &&
+        NavMoveRequestButNoResultYet() && window->DC.LayoutType == ImGuiLayoutType_Vertical)
+    {
+        ClosePopupToLevel(g.BeginPopupStack.Size, true);
+        NavMoveRequestCancel();
+    }
+
+    EndPopup();
+}
+
+bool ImGui::MenuItem(const char *label, const char *shortcut, bool selected, bool enabled)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;
+
+    ImGuiContext &g   = *GImGui;
+    ImGuiStyle &style = g.Style;
+    ImVec2 pos        = window->DC.CursorPos;
+    ImVec2 label_size = CalcTextSize(label, NULL, true);
+
+    ImGuiSelectableFlags flags =
+        ImGuiSelectableFlags_PressedOnRelease | (enabled ? 0 : ImGuiSelectableFlags_Disabled);
+    bool pressed;
+    if (window->DC.LayoutType == ImGuiLayoutType_Horizontal)
+    {
+        // Mimic the exact layout spacing of BeginMenu() to allow MenuItem() inside a menu bar,
+        // which is a little misleading but may be useful Note that in this situation we render
+        // neither the shortcut neither the selected tick mark
+        float w = label_size.x;
+        window->DC.CursorPos.x += (float)(int)(style.ItemSpacing.x * 0.5f);
+        PushStyleVar(ImGuiStyleVar_ItemSpacing,
+                     ImVec2(style.ItemSpacing.x * 2.0f, style.ItemSpacing.y));
+        pressed = Selectable(label, false, flags, ImVec2(w, 0.0f));
+        PopStyleVar();
+        window->DC.CursorPos.x +=
+            (float)(int)(style.ItemSpacing.x *
+                         (-1.0f + 0.5f));  // -1 spacing to compensate the spacing added when
+                                           // Selectable() did a SameLine(). It would also work to
+                                           // call SameLine() ourselves after the PopStyleVar().
+    }
+    else
+    {
+        ImVec2 shortcut_size = shortcut ? CalcTextSize(shortcut, NULL) : ImVec2(0.0f, 0.0f);
+        float w              = window->MenuColumns.DeclColumns(
+            label_size.x, shortcut_size.x,
+            (float)(int)(g.FontSize * 1.20f));  // Feedback for next frame
+        float extra_w = ImMax(0.0f, GetContentRegionAvail().x - w);
+        pressed       = Selectable(label, false, flags | ImGuiSelectableFlags_DrawFillAvailWidth,
+                             ImVec2(w, 0.0f));
+        if (shortcut_size.x > 0.0f)
+        {
+            PushStyleColor(ImGuiCol_Text, g.Style.Colors[ImGuiCol_TextDisabled]);
+            RenderText(pos + ImVec2(window->MenuColumns.Pos[1] + extra_w, 0.0f), shortcut, NULL,
+                       false);
+            PopStyleColor();
+        }
+        if (selected)
+            RenderCheckMark(pos + ImVec2(window->MenuColumns.Pos[2] + extra_w + g.FontSize * 0.40f,
+                                         g.FontSize * 0.134f * 0.5f),
+                            GetColorU32(enabled ? ImGuiCol_Text : ImGuiCol_TextDisabled),
+                            g.FontSize * 0.866f);
+    }
+
+    IMGUI_TEST_ENGINE_ITEM_INFO(window->DC.LastItemId, label,
+                                window->DC.ItemFlags | ImGuiItemStatusFlags_Checkable |
+                                    (selected ? ImGuiItemStatusFlags_Checked : 0));
+    return pressed;
+}
+
+bool ImGui::MenuItem(const char *label, const char *shortcut, bool *p_selected, bool enabled)
+{
+    if (MenuItem(label, shortcut, p_selected ? *p_selected : false, enabled))
+    {
+        if (p_selected)
+            *p_selected = !*p_selected;
+        return true;
+    }
+    return false;
+}
+
+//-------------------------------------------------------------------------
+// [SECTION] Widgets: BeginTabBar, EndTabBar, etc.
+//-------------------------------------------------------------------------
+// [BETA API] API may evolve! This code has been extracted out of the Docking branch,
+// and some of the construct which are not used in Master may be left here to facilitate merging.
+//-------------------------------------------------------------------------
+// - BeginTabBar()
+// - BeginTabBarEx() [Internal]
+// - EndTabBar()
+// - TabBarLayout() [Internal]
+// - TabBarCalcTabID() [Internal]
+// - TabBarCalcMaxTabWidth() [Internal]
+// - TabBarFindTabById() [Internal]
+// - TabBarRemoveTab() [Internal]
+// - TabBarCloseTab() [Internal]
+// - TabBarScrollClamp()v
+// - TabBarScrollToTab() [Internal]
+// - TabBarQueueChangeTabOrder() [Internal]
+// - TabBarScrollingButtons() [Internal]
+// - TabBarTabListPopupButton() [Internal]
+//-------------------------------------------------------------------------
+
+namespace ImGui
+{
+static void TabBarLayout(ImGuiTabBar *tab_bar);
+static ImU32 TabBarCalcTabID(ImGuiTabBar *tab_bar, const char *label);
+static float TabBarCalcMaxTabWidth();
+static float TabBarScrollClamp(ImGuiTabBar *tab_bar, float scrolling);
+static void TabBarScrollToTab(ImGuiTabBar *tab_bar, ImGuiTabItem *tab);
+static ImGuiTabItem *TabBarScrollingButtons(ImGuiTabBar *tab_bar);
+static ImGuiTabItem *TabBarTabListPopupButton(ImGuiTabBar *tab_bar);
+}  // namespace ImGui
+
+ImGuiTabBar::ImGuiTabBar()
+{
+    ID            = 0;
+    SelectedTabId = NextSelectedTabId = VisibleTabId = 0;
+    CurrFrameVisible = PrevFrameVisible = -1;
+    ContentsHeight                      = 0.0f;
+    OffsetMax = OffsetNextTab = 0.0f;
+    ScrollingAnim = ScrollingTarget = ScrollingTargetDistToVisibility = ScrollingSpeed = 0.0f;
+    Flags               = ImGuiTabBarFlags_None;
+    ReorderRequestTabId = 0;
+    ReorderRequestDir   = 0;
+    WantLayout = VisibleTabWasSubmitted = false;
+    LastTabItemIdx                      = -1;
+}
+
+static int IMGUI_CDECL TabItemComparerByVisibleOffset(const void *lhs, const void *rhs)
+{
+    const ImGuiTabItem *a = (const ImGuiTabItem *)lhs;
+    const ImGuiTabItem *b = (const ImGuiTabItem *)rhs;
+    return (int)(a->Offset - b->Offset);
+}
+
+static ImGuiTabBar *GetTabBarFromTabBarRef(const ImGuiTabBarRef &ref)
+{
+    ImGuiContext &g = *GImGui;
+    return ref.Ptr ? ref.Ptr : g.TabBars.GetByIndex(ref.IndexInMainPool);
+}
+
+static ImGuiTabBarRef GetTabBarRefFromTabBar(ImGuiTabBar *tab_bar)
+{
+    ImGuiContext &g = *GImGui;
+    if (g.TabBars.Contains(tab_bar))
+        return ImGuiTabBarRef(g.TabBars.GetIndex(tab_bar));
+    return ImGuiTabBarRef(tab_bar);
+}
+
+bool ImGui::BeginTabBar(const char *str_id, ImGuiTabBarFlags flags)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+    if (window->SkipItems)
+        return false;
+
+    ImGuiID id           = window->GetID(str_id);
+    ImGuiTabBar *tab_bar = g.TabBars.GetOrAddByKey(id);
+    ImRect tab_bar_bb =
+        ImRect(window->DC.CursorPos.x, window->DC.CursorPos.y, window->WorkRect.Max.x,
+               window->DC.CursorPos.y + g.FontSize + g.Style.FramePadding.y * 2);
+    tab_bar->ID = id;
+    return BeginTabBarEx(tab_bar, tab_bar_bb, flags | ImGuiTabBarFlags_IsFocused);
+}
+
+bool ImGui::BeginTabBarEx(ImGuiTabBar *tab_bar, const ImRect &tab_bar_bb, ImGuiTabBarFlags flags)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+    if (window->SkipItems)
+        return false;
+
+    if ((flags & ImGuiTabBarFlags_DockNode) == 0)
+        PushOverrideID(tab_bar->ID);
+
+    // Add to stack
+    g.CurrentTabBarStack.push_back(GetTabBarRefFromTabBar(tab_bar));
+    g.CurrentTabBar = tab_bar;
+
+    if (tab_bar->CurrFrameVisible == g.FrameCount)
+    {
+        // IMGUI_DEBUG_LOG("BeginTabBarEx already called this frame\n", g.FrameCount);
+        IM_ASSERT(0);
+        return true;
+    }
+
+    // When toggling back from ordered to manually-reorderable, shuffle tabs to enforce the last
+    // visible order. Otherwise, the most recently inserted tabs would move at the end of visible
+    // list which can be a little too confusing or magic for the user.
+    if ((flags & ImGuiTabBarFlags_Reorderable) &&
+        !(tab_bar->Flags & ImGuiTabBarFlags_Reorderable) && tab_bar->Tabs.Size > 1 &&
+        tab_bar->PrevFrameVisible != -1)
+        ImQsort(tab_bar->Tabs.Data, tab_bar->Tabs.Size, sizeof(ImGuiTabItem),
+                TabItemComparerByVisibleOffset);
+
+    // Flags
+    if ((flags & ImGuiTabBarFlags_FittingPolicyMask_) == 0)
+        flags |= ImGuiTabBarFlags_FittingPolicyDefault_;
+
+    tab_bar->Flags            = flags;
+    tab_bar->BarRect          = tab_bar_bb;
+    tab_bar->WantLayout       = true;  // Layout will be done on the first call to ItemTab()
+    tab_bar->PrevFrameVisible = tab_bar->CurrFrameVisible;
+    tab_bar->CurrFrameVisible = g.FrameCount;
+    tab_bar->FramePadding     = g.Style.FramePadding;
+
+    // Layout
+    ItemSize(ImVec2(0.0f /*tab_bar->OffsetMax*/,
+                    tab_bar->BarRect.GetHeight()));  // Don't feed width back
+    window->DC.CursorPos.x = tab_bar->BarRect.Min.x;
+
+    // Draw separator
+    const ImU32 col =
+        GetColorU32((flags & ImGuiTabBarFlags_IsFocused) ? ImGuiCol_TabActive : ImGuiCol_Tab);
+    const float y = tab_bar->BarRect.Max.y - 1.0f;
+    {
+        const float separator_min_x =
+            tab_bar->BarRect.Min.x - ImFloor(window->WindowPadding.x * 0.5f);
+        const float separator_max_x =
+            tab_bar->BarRect.Max.x + ImFloor(window->WindowPadding.x * 0.5f);
+        window->DrawList->AddLine(ImVec2(separator_min_x, y), ImVec2(separator_max_x, y), col,
+                                  1.0f);
+    }
+    return true;
+}
+
+void ImGui::EndTabBar()
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+    if (window->SkipItems)
+        return;
+
+    ImGuiTabBar *tab_bar = g.CurrentTabBar;
+    if (tab_bar == NULL)
+    {
+        IM_ASSERT(tab_bar != NULL && "Mismatched BeginTabBar()/EndTabBar()!");
+        return;  // FIXME-ERRORHANDLING
+    }
+    if (tab_bar->WantLayout)
+        TabBarLayout(tab_bar);
+
+    // Restore the last visible height if no tab is visible, this reduce vertical flicker/movement
+    // when a tabs gets removed without calling SetTabItemClosed().
+    const bool tab_bar_appearing = (tab_bar->PrevFrameVisible + 1 < g.FrameCount);
+    if (tab_bar->VisibleTabWasSubmitted || tab_bar->VisibleTabId == 0 || tab_bar_appearing)
+        tab_bar->ContentsHeight = ImMax(window->DC.CursorPos.y - tab_bar->BarRect.Max.y, 0.0f);
+    else
+        window->DC.CursorPos.y = tab_bar->BarRect.Max.y + tab_bar->ContentsHeight;
+
+    if ((tab_bar->Flags & ImGuiTabBarFlags_DockNode) == 0)
+        PopID();
+
+    g.CurrentTabBarStack.pop_back();
+    g.CurrentTabBar =
+        g.CurrentTabBarStack.empty() ? NULL : GetTabBarFromTabBarRef(g.CurrentTabBarStack.back());
+}
+
+// This is called only once a frame before by the first call to ItemTab()
+// The reason we're not calling it in BeginTabBar() is to leave a chance to the user to call the
+// SetTabItemClosed() functions.
+static void ImGui::TabBarLayout(ImGuiTabBar *tab_bar)
+{
+    ImGuiContext &g     = *GImGui;
+    tab_bar->WantLayout = false;
+
+    // Garbage collect
+    int tab_dst_n = 0;
+    for (int tab_src_n = 0; tab_src_n < tab_bar->Tabs.Size; tab_src_n++)
+    {
+        ImGuiTabItem *tab = &tab_bar->Tabs[tab_src_n];
+        if (tab->LastFrameVisible < tab_bar->PrevFrameVisible)
+        {
+            if (tab->ID == tab_bar->SelectedTabId)
+                tab_bar->SelectedTabId = 0;
+            continue;
+        }
+        if (tab_dst_n != tab_src_n)
+            tab_bar->Tabs[tab_dst_n] = tab_bar->Tabs[tab_src_n];
+        tab_dst_n++;
+    }
+    if (tab_bar->Tabs.Size != tab_dst_n)
+        tab_bar->Tabs.resize(tab_dst_n);
+
+    // Setup next selected tab
+    ImGuiID scroll_track_selected_tab_id = 0;
+    if (tab_bar->NextSelectedTabId)
+    {
+        tab_bar->SelectedTabId       = tab_bar->NextSelectedTabId;
+        tab_bar->NextSelectedTabId   = 0;
+        scroll_track_selected_tab_id = tab_bar->SelectedTabId;
+    }
+
+    // Process order change request (we could probably process it when requested but it's just saner
+    // to do it in a single spot).
+    if (tab_bar->ReorderRequestTabId != 0)
+    {
+        if (ImGuiTabItem *tab1 = TabBarFindTabByID(tab_bar, tab_bar->ReorderRequestTabId))
+        {
+            // IM_ASSERT(tab_bar->Flags & ImGuiTabBarFlags_Reorderable); // <- this may happen when
+            // using debug tools
+            int tab2_order = tab_bar->GetTabOrder(tab1) + tab_bar->ReorderRequestDir;
+            if (tab2_order >= 0 && tab2_order < tab_bar->Tabs.Size)
+            {
+                ImGuiTabItem *tab2    = &tab_bar->Tabs[tab2_order];
+                ImGuiTabItem item_tmp = *tab1;
+                *tab1                 = *tab2;
+                *tab2                 = item_tmp;
+                if (tab2->ID == tab_bar->SelectedTabId)
+                    scroll_track_selected_tab_id = tab2->ID;
+                tab1 = tab2 = NULL;
+            }
+            if (tab_bar->Flags & ImGuiTabBarFlags_SaveSettings)
+                MarkIniSettingsDirty();
+        }
+        tab_bar->ReorderRequestTabId = 0;
+    }
+
+    // Tab List Popup (will alter tab_bar->BarRect and therefore the available width!)
+    const bool tab_list_popup_button = (tab_bar->Flags & ImGuiTabBarFlags_TabListPopupButton) != 0;
+    if (tab_list_popup_button)
+        if (ImGuiTabItem *tab_to_select =
+                TabBarTabListPopupButton(tab_bar))  // NB: Will alter BarRect.Max.x!
+            scroll_track_selected_tab_id = tab_bar->SelectedTabId = tab_to_select->ID;
+
+    // Compute ideal widths
+    g.ShrinkWidthBuffer.resize(tab_bar->Tabs.Size);
+    float width_total_contents               = 0.0f;
+    ImGuiTabItem *most_recently_selected_tab = NULL;
+    bool found_selected_tab_id               = false;
+    for (int tab_n = 0; tab_n < tab_bar->Tabs.Size; tab_n++)
+    {
+        ImGuiTabItem *tab = &tab_bar->Tabs[tab_n];
+        IM_ASSERT(tab->LastFrameVisible >= tab_bar->PrevFrameVisible);
+
+        if (most_recently_selected_tab == NULL ||
+            most_recently_selected_tab->LastFrameSelected < tab->LastFrameSelected)
+            most_recently_selected_tab = tab;
+        if (tab->ID == tab_bar->SelectedTabId)
+            found_selected_tab_id = true;
+
+        // Refresh tab width immediately, otherwise changes of style e.g. style.FramePadding.x would
+        // noticeably lag in the tab bar. Additionally, when using TabBarAddTab() to manipulate tab
+        // bar order we occasionally insert new tabs that don't have a width yet, and we cannot wait
+        // for the next BeginTabItem() call. We cannot compute this width within TabBarAddTab()
+        // because font size depends on the active window.
+        const char *tab_name        = tab_bar->GetTabName(tab);
+        const bool has_close_button = (tab->Flags & ImGuiTabItemFlags_NoCloseButton) ? false : true;
+        tab->WidthContents          = TabItemCalcSize(tab_name, has_close_button).x;
+
+        width_total_contents +=
+            (tab_n > 0 ? g.Style.ItemInnerSpacing.x : 0.0f) + tab->WidthContents;
+
+        // Store data so we can build an array sorted by width if we need to shrink tabs down
+        g.ShrinkWidthBuffer[tab_n].Index = tab_n;
+        g.ShrinkWidthBuffer[tab_n].Width = tab->WidthContents;
+    }
+
+    // Compute width
+    const float initial_offset_x = 0.0f;  // g.Style.ItemInnerSpacing.x;
+    const float width_avail      = ImMax(tab_bar->BarRect.GetWidth() - initial_offset_x, 0.0f);
+    float width_excess =
+        (width_avail < width_total_contents) ? (width_total_contents - width_avail) : 0.0f;
+    if (width_excess > 0.0f && (tab_bar->Flags & ImGuiTabBarFlags_FittingPolicyResizeDown))
+    {
+        // If we don't have enough room, resize down the largest tabs first
+        ShrinkWidths(g.ShrinkWidthBuffer.Data, g.ShrinkWidthBuffer.Size, width_excess);
+        for (int tab_n = 0; tab_n < tab_bar->Tabs.Size; tab_n++)
+            tab_bar->Tabs[g.ShrinkWidthBuffer[tab_n].Index].Width =
+                (float)(int)g.ShrinkWidthBuffer[tab_n].Width;
+    }
+    else
+    {
+        const float tab_max_width = TabBarCalcMaxTabWidth();
+        for (int tab_n = 0; tab_n < tab_bar->Tabs.Size; tab_n++)
+        {
+            ImGuiTabItem *tab = &tab_bar->Tabs[tab_n];
+            tab->Width        = ImMin(tab->WidthContents, tab_max_width);
+        }
+    }
+
+    // Layout all active tabs
+    float offset_x         = initial_offset_x;
+    tab_bar->OffsetNextTab = offset_x;  // This is used by non-reorderable tab bar where the
+                                        // submission order is always honored.
+    for (int tab_n = 0; tab_n < tab_bar->Tabs.Size; tab_n++)
+    {
+        ImGuiTabItem *tab = &tab_bar->Tabs[tab_n];
+        tab->Offset       = offset_x;
+        if (scroll_track_selected_tab_id == 0 && g.NavJustMovedToId == tab->ID)
+            scroll_track_selected_tab_id = tab->ID;
+        offset_x += tab->Width + g.Style.ItemInnerSpacing.x;
+    }
+    tab_bar->OffsetMax = ImMax(offset_x - g.Style.ItemInnerSpacing.x, 0.0f);
+
+    // Horizontal scrolling buttons
+    const bool scrolling_buttons =
+        (tab_bar->OffsetMax > tab_bar->BarRect.GetWidth() && tab_bar->Tabs.Size > 1) &&
+        !(tab_bar->Flags & ImGuiTabBarFlags_NoTabListScrollingButtons) &&
+        (tab_bar->Flags & ImGuiTabBarFlags_FittingPolicyScroll);
+    if (scrolling_buttons)
+        if (ImGuiTabItem *tab_to_select =
+                TabBarScrollingButtons(tab_bar))  // NB: Will alter BarRect.Max.x!
+            scroll_track_selected_tab_id = tab_bar->SelectedTabId = tab_to_select->ID;
+
+    // If we have lost the selected tab, select the next most recently active one
+    if (found_selected_tab_id == false)
+        tab_bar->SelectedTabId = 0;
+    if (tab_bar->SelectedTabId == 0 && tab_bar->NextSelectedTabId == 0 &&
+        most_recently_selected_tab != NULL)
+        scroll_track_selected_tab_id = tab_bar->SelectedTabId = most_recently_selected_tab->ID;
+
+    // Lock in visible tab
+    tab_bar->VisibleTabId           = tab_bar->SelectedTabId;
+    tab_bar->VisibleTabWasSubmitted = false;
+
+    // Update scrolling
+    if (scroll_track_selected_tab_id)
+        if (ImGuiTabItem *scroll_track_selected_tab =
+                TabBarFindTabByID(tab_bar, scroll_track_selected_tab_id))
+            TabBarScrollToTab(tab_bar, scroll_track_selected_tab);
+    tab_bar->ScrollingAnim   = TabBarScrollClamp(tab_bar, tab_bar->ScrollingAnim);
+    tab_bar->ScrollingTarget = TabBarScrollClamp(tab_bar, tab_bar->ScrollingTarget);
+    if (tab_bar->ScrollingAnim != tab_bar->ScrollingTarget)
+    {
+        // Scrolling speed adjust itself so we can always reach our target in 1/3 seconds.
+        // Teleport if we are aiming far off the visible line
+        tab_bar->ScrollingSpeed = ImMax(tab_bar->ScrollingSpeed, 70.0f * g.FontSize);
+        tab_bar->ScrollingSpeed =
+            ImMax(tab_bar->ScrollingSpeed,
+                  ImFabs(tab_bar->ScrollingTarget - tab_bar->ScrollingAnim) / 0.3f);
+        const bool teleport = (tab_bar->PrevFrameVisible + 1 < g.FrameCount) ||
+                              (tab_bar->ScrollingTargetDistToVisibility > 10.0f * g.FontSize);
+        tab_bar->ScrollingAnim =
+            teleport ? tab_bar->ScrollingTarget
+                     : ImLinearSweep(tab_bar->ScrollingAnim, tab_bar->ScrollingTarget,
+                                     g.IO.DeltaTime * tab_bar->ScrollingSpeed);
+    }
+    else
+    {
+        tab_bar->ScrollingSpeed = 0.0f;
+    }
+
+    // Clear name buffers
+    if ((tab_bar->Flags & ImGuiTabBarFlags_DockNode) == 0)
+        tab_bar->TabsNames.Buf.resize(0);
+}
+
+// Dockables uses Name/ID in the global namespace. Non-dockable items use the ID stack.
+static ImU32 ImGui::TabBarCalcTabID(ImGuiTabBar *tab_bar, const char *label)
+{
+    if (tab_bar->Flags & ImGuiTabBarFlags_DockNode)
+    {
+        ImGuiID id = ImHashStr(label);
+        KeepAliveID(id);
+        return id;
+    }
+    else
+    {
+        ImGuiWindow *window = GImGui->CurrentWindow;
+        return window->GetID(label);
+    }
+}
+
+static float ImGui::TabBarCalcMaxTabWidth()
+{
+    ImGuiContext &g = *GImGui;
+    return g.FontSize * 20.0f;
+}
+
+ImGuiTabItem *ImGui::TabBarFindTabByID(ImGuiTabBar *tab_bar, ImGuiID tab_id)
+{
+    if (tab_id != 0)
+        for (int n = 0; n < tab_bar->Tabs.Size; n++)
+            if (tab_bar->Tabs[n].ID == tab_id)
+                return &tab_bar->Tabs[n];
+    return NULL;
+}
+
+// The *TabId fields be already set by the docking system _before_ the actual TabItem was created,
+// so we clear them regardless.
+void ImGui::TabBarRemoveTab(ImGuiTabBar *tab_bar, ImGuiID tab_id)
+{
+    if (ImGuiTabItem *tab = TabBarFindTabByID(tab_bar, tab_id))
+        tab_bar->Tabs.erase(tab);
+    if (tab_bar->VisibleTabId == tab_id)
+    {
+        tab_bar->VisibleTabId = 0;
+    }
+    if (tab_bar->SelectedTabId == tab_id)
+    {
+        tab_bar->SelectedTabId = 0;
+    }
+    if (tab_bar->NextSelectedTabId == tab_id)
+    {
+        tab_bar->NextSelectedTabId = 0;
+    }
+}
+
+// Called on manual closure attempt
+void ImGui::TabBarCloseTab(ImGuiTabBar *tab_bar, ImGuiTabItem *tab)
+{
+    if ((tab_bar->VisibleTabId == tab->ID) && !(tab->Flags & ImGuiTabItemFlags_UnsavedDocument))
+    {
+        // This will remove a frame of lag for selecting another tab on closure.
+        // However we don't run it in the case where the 'Unsaved' flag is set, so user gets a
+        // chance to fully undo the closure
+        tab->LastFrameVisible  = -1;
+        tab_bar->SelectedTabId = tab_bar->NextSelectedTabId = 0;
+    }
+    else if ((tab_bar->VisibleTabId != tab->ID) && (tab->Flags & ImGuiTabItemFlags_UnsavedDocument))
+    {
+        // Actually select before expecting closure
+        tab_bar->NextSelectedTabId = tab->ID;
+    }
+}
+
+static float ImGui::TabBarScrollClamp(ImGuiTabBar *tab_bar, float scrolling)
+{
+    scrolling = ImMin(scrolling, tab_bar->OffsetMax - tab_bar->BarRect.GetWidth());
+    return ImMax(scrolling, 0.0f);
+}
+
+static void ImGui::TabBarScrollToTab(ImGuiTabBar *tab_bar, ImGuiTabItem *tab)
+{
+    ImGuiContext &g = *GImGui;
+    float margin =
+        g.FontSize * 1.0f;  // When to scroll to make Tab N+1 visible always make a bit of N visible
+                            // to suggest more scrolling area (since we don't have a scrollbar)
+    int order    = tab_bar->GetTabOrder(tab);
+    float tab_x1 = tab->Offset + (order > 0 ? -margin : 0.0f);
+    float tab_x2 = tab->Offset + tab->Width + (order + 1 < tab_bar->Tabs.Size ? margin : 1.0f);
+    tab_bar->ScrollingTargetDistToVisibility = 0.0f;
+    if (tab_bar->ScrollingTarget > tab_x1)
+    {
+        tab_bar->ScrollingTargetDistToVisibility = ImMax(tab_bar->ScrollingAnim - tab_x2, 0.0f);
+        tab_bar->ScrollingTarget                 = tab_x1;
+    }
+    else if (tab_bar->ScrollingTarget < tab_x2 - tab_bar->BarRect.GetWidth())
+    {
+        tab_bar->ScrollingTargetDistToVisibility =
+            ImMax((tab_x1 - tab_bar->BarRect.GetWidth()) - tab_bar->ScrollingAnim, 0.0f);
+        tab_bar->ScrollingTarget = tab_x2 - tab_bar->BarRect.GetWidth();
+    }
+}
+
+void ImGui::TabBarQueueChangeTabOrder(ImGuiTabBar *tab_bar, const ImGuiTabItem *tab, int dir)
+{
+    IM_ASSERT(dir == -1 || dir == +1);
+    IM_ASSERT(tab_bar->ReorderRequestTabId == 0);
+    tab_bar->ReorderRequestTabId = tab->ID;
+    tab_bar->ReorderRequestDir   = dir;
+}
+
+static ImGuiTabItem *ImGui::TabBarScrollingButtons(ImGuiTabBar *tab_bar)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+
+    const ImVec2 arrow_button_size(g.FontSize - 2.0f, g.FontSize + g.Style.FramePadding.y * 2.0f);
+    const float scrolling_buttons_width = arrow_button_size.x * 2.0f;
+
+    const ImVec2 backup_cursor_pos = window->DC.CursorPos;
+    // window->DrawList->AddRect(ImVec2(tab_bar->BarRect.Max.x - scrolling_buttons_width,
+    // tab_bar->BarRect.Min.y), ImVec2(tab_bar->BarRect.Max.x, tab_bar->BarRect.Max.y),
+    // IM_COL32(255,0,0,255));
+
+    const ImRect avail_bar_rect = tab_bar->BarRect;
+    bool want_clip_rect         = !avail_bar_rect.Contains(
+        ImRect(window->DC.CursorPos, window->DC.CursorPos + ImVec2(scrolling_buttons_width, 0.0f)));
+    if (want_clip_rect)
+        PushClipRect(tab_bar->BarRect.Min,
+                     tab_bar->BarRect.Max + ImVec2(g.Style.ItemInnerSpacing.x, 0.0f), true);
+
+    ImGuiTabItem *tab_to_select = NULL;
+
+    int select_dir   = 0;
+    ImVec4 arrow_col = g.Style.Colors[ImGuiCol_Text];
+    arrow_col.w *= 0.5f;
+
+    PushStyleColor(ImGuiCol_Text, arrow_col);
+    PushStyleColor(ImGuiCol_Button, ImVec4(0, 0, 0, 0));
+    const float backup_repeat_delay = g.IO.KeyRepeatDelay;
+    const float backup_repeat_rate  = g.IO.KeyRepeatRate;
+    g.IO.KeyRepeatDelay             = 0.250f;
+    g.IO.KeyRepeatRate              = 0.200f;
+    window->DC.CursorPos =
+        ImVec2(tab_bar->BarRect.Max.x - scrolling_buttons_width, tab_bar->BarRect.Min.y);
+    if (ArrowButtonEx("##<", ImGuiDir_Left, arrow_button_size,
+                      ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_Repeat))
+        select_dir = -1;
+    window->DC.CursorPos =
+        ImVec2(tab_bar->BarRect.Max.x - scrolling_buttons_width + arrow_button_size.x,
+               tab_bar->BarRect.Min.y);
+    if (ArrowButtonEx("##>", ImGuiDir_Right, arrow_button_size,
+                      ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_Repeat))
+        select_dir = +1;
+    PopStyleColor(2);
+    g.IO.KeyRepeatRate  = backup_repeat_rate;
+    g.IO.KeyRepeatDelay = backup_repeat_delay;
+
+    if (want_clip_rect)
+        PopClipRect();
+
+    if (select_dir != 0)
+        if (ImGuiTabItem *tab_item = TabBarFindTabByID(tab_bar, tab_bar->SelectedTabId))
+        {
+            int selected_order = tab_bar->GetTabOrder(tab_item);
+            int target_order   = selected_order + select_dir;
+            tab_to_select =
+                &tab_bar->Tabs[(target_order >= 0 && target_order < tab_bar->Tabs.Size)
+                                   ? target_order
+                                   : selected_order];  // If we are at the end of the list, still
+                                                       // scroll to make our tab visible
+        }
+    window->DC.CursorPos = backup_cursor_pos;
+    tab_bar->BarRect.Max.x -= scrolling_buttons_width + 1.0f;
+
+    return tab_to_select;
+}
+
+static ImGuiTabItem *ImGui::TabBarTabListPopupButton(ImGuiTabBar *tab_bar)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+
+    // We use g.Style.FramePadding.y to match the square ArrowButton size
+    const float tab_list_popup_button_width = g.FontSize + g.Style.FramePadding.y;
+    const ImVec2 backup_cursor_pos          = window->DC.CursorPos;
+    window->DC.CursorPos =
+        ImVec2(tab_bar->BarRect.Min.x - g.Style.FramePadding.y, tab_bar->BarRect.Min.y);
+    tab_bar->BarRect.Min.x += tab_list_popup_button_width;
+
+    ImVec4 arrow_col = g.Style.Colors[ImGuiCol_Text];
+    arrow_col.w *= 0.5f;
+    PushStyleColor(ImGuiCol_Text, arrow_col);
+    PushStyleColor(ImGuiCol_Button, ImVec4(0, 0, 0, 0));
+    bool open = BeginCombo("##v", NULL, ImGuiComboFlags_NoPreview);
+    PopStyleColor(2);
+
+    ImGuiTabItem *tab_to_select = NULL;
+    if (open)
+    {
+        for (int tab_n = 0; tab_n < tab_bar->Tabs.Size; tab_n++)
+        {
+            ImGuiTabItem *tab    = &tab_bar->Tabs[tab_n];
+            const char *tab_name = tab_bar->GetTabName(tab);
+            if (Selectable(tab_name, tab_bar->SelectedTabId == tab->ID))
+                tab_to_select = tab;
+        }
+        EndCombo();
+    }
+
+    window->DC.CursorPos = backup_cursor_pos;
+    return tab_to_select;
+}
+
+//-------------------------------------------------------------------------
+// [SECTION] Widgets: BeginTabItem, EndTabItem, etc.
+//-------------------------------------------------------------------------
+// [BETA API] API may evolve! This code has been extracted out of the Docking branch,
+// and some of the construct which are not used in Master may be left here to facilitate merging.
+//-------------------------------------------------------------------------
+// - BeginTabItem()
+// - EndTabItem()
+// - TabItemEx() [Internal]
+// - SetTabItemClosed()
+// - TabItemCalcSize() [Internal]
+// - TabItemBackground() [Internal]
+// - TabItemLabelAndCloseButton() [Internal]
+//-------------------------------------------------------------------------
+
+bool ImGui::BeginTabItem(const char *label, bool *p_open, ImGuiTabItemFlags flags)
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+    if (window->SkipItems)
+        return false;
+
+    ImGuiTabBar *tab_bar = g.CurrentTabBar;
+    if (tab_bar == NULL)
+    {
+        IM_ASSERT(tab_bar && "Needs to be called between BeginTabBar() and EndTabBar()!");
+        return false;  // FIXME-ERRORHANDLING
+    }
+    bool ret = TabItemEx(tab_bar, label, p_open, flags);
+    if (ret && !(flags & ImGuiTabItemFlags_NoPushId))
+    {
+        ImGuiTabItem *tab = &tab_bar->Tabs[tab_bar->LastTabItemIdx];
+        PushOverrideID(tab->ID);  // We already hashed 'label' so push into the ID stack directly
+                                  // instead of doing another hash through PushID(label)
+    }
+    return ret;
+}
+
+void ImGui::EndTabItem()
+{
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+    if (window->SkipItems)
+        return;
+
+    ImGuiTabBar *tab_bar = g.CurrentTabBar;
+    if (tab_bar == NULL)
+    {
+        IM_ASSERT(tab_bar != NULL && "Needs to be called between BeginTabBar() and EndTabBar()!");
+        return;
+    }
+    IM_ASSERT(tab_bar->LastTabItemIdx >= 0);
+    ImGuiTabItem *tab = &tab_bar->Tabs[tab_bar->LastTabItemIdx];
+    if (!(tab->Flags & ImGuiTabItemFlags_NoPushId))
+        window->IDStack.pop_back();
+}
+
+bool ImGui::TabItemEx(ImGuiTabBar *tab_bar,
+                      const char *label,
+                      bool *p_open,
+                      ImGuiTabItemFlags flags)
+{
+    // Layout whole tab bar if not already done
+    if (tab_bar->WantLayout)
+        TabBarLayout(tab_bar);
+
+    ImGuiContext &g     = *GImGui;
+    ImGuiWindow *window = g.CurrentWindow;
+    if (window->SkipItems)
+        return false;
+
+    const ImGuiStyle &style = g.Style;
+    const ImGuiID id        = TabBarCalcTabID(tab_bar, label);
+
+    // If the user called us with *p_open == false, we early out and don't render. We make a dummy
+    // call to ItemAdd() so that attempts to use a contextual popup menu with an implicit ID won't
+    // use an older ID.
+    if (p_open && !*p_open)
+    {
+        PushItemFlag(ImGuiItemFlags_NoNav | ImGuiItemFlags_NoNavDefaultFocus, true);
+        ItemAdd(ImRect(), id);
+        PopItemFlag();
+        return false;
+    }
+
+    // Calculate tab contents size
+    ImVec2 size = TabItemCalcSize(label, p_open != NULL);
+
+    // Acquire tab data
+    ImGuiTabItem *tab = TabBarFindTabByID(tab_bar, id);
+    bool tab_is_new   = false;
+    if (tab == NULL)
+    {
+        tab_bar->Tabs.push_back(ImGuiTabItem());
+        tab        = &tab_bar->Tabs.back();
+        tab->ID    = id;
+        tab->Width = size.x;
+        tab_is_new = true;
+    }
+    tab_bar->LastTabItemIdx = (short)tab_bar->Tabs.index_from_ptr(tab);
+    tab->WidthContents      = size.x;
+
+    if (p_open == NULL)
+        flags |= ImGuiTabItemFlags_NoCloseButton;
+
+    const bool tab_bar_appearing = (tab_bar->PrevFrameVisible + 1 < g.FrameCount);
+    const bool tab_bar_focused   = (tab_bar->Flags & ImGuiTabBarFlags_IsFocused) != 0;
+    const bool tab_appearing     = (tab->LastFrameVisible + 1 < g.FrameCount);
+    tab->LastFrameVisible        = g.FrameCount;
+    tab->Flags                   = flags;
+
+    // Append name with zero-terminator
+    tab->NameOffset = tab_bar->TabsNames.size();
+    tab_bar->TabsNames.append(label, label + strlen(label) + 1);
+
+    // If we are not reorderable, always reset offset based on submission order.
+    // (We already handled layout and sizing using the previous known order, but sizing is not
+    // affected by order!)
+    if (!tab_appearing && !(tab_bar->Flags & ImGuiTabBarFlags_Reorderable))
+    {
+        tab->Offset = tab_bar->OffsetNextTab;
+        tab_bar->OffsetNextTab += tab->Width + g.Style.ItemInnerSpacing.x;
+    }
+
+    // Update selected tab
+    if (tab_appearing && (tab_bar->Flags & ImGuiTabBarFlags_AutoSelectNewTabs) &&
+        tab_bar->NextSelectedTabId == 0)
+        if (!tab_bar_appearing || tab_bar->SelectedTabId == 0)
+            tab_bar->NextSelectedTabId = id;  // New tabs gets activated
+    if ((flags & ImGuiTabItemFlags_SetSelected) &&
+        (tab_bar->SelectedTabId != id))  // SetSelected can only be passed on explicit tab bar
+        tab_bar->NextSelectedTabId = id;
+
+    // Lock visibility
+    bool tab_contents_visible = (tab_bar->VisibleTabId == id);
+    if (tab_contents_visible)
+        tab_bar->VisibleTabWasSubmitted = true;
+
+    // On the very first frame of a tab bar we let first tab contents be visible to minimize
+    // appearing glitches
+    if (!tab_contents_visible && tab_bar->SelectedTabId == 0 && tab_bar_appearing)
+        if (tab_bar->Tabs.Size == 1 && !(tab_bar->Flags & ImGuiTabBarFlags_AutoSelectNewTabs))
+            tab_contents_visible = true;
+
+    if (tab_appearing && !(tab_bar_appearing && !tab_is_new))
+    {
+        PushItemFlag(ImGuiItemFlags_NoNav | ImGuiItemFlags_NoNavDefaultFocus, true);
+        ItemAdd(ImRect(), id);
+        PopItemFlag();
+        return tab_contents_visible;
+    }
+
+    if (tab_bar->SelectedTabId == id)
+        tab->LastFrameSelected = g.FrameCount;
+
+    // Backup current layout position
+    const ImVec2 backup_main_cursor_pos = window->DC.CursorPos;
+
+    // Layout
+    size.x = tab->Width;
+    window->DC.CursorPos =
+        tab_bar->BarRect.Min + ImVec2((float)(int)tab->Offset - tab_bar->ScrollingAnim, 0.0f);
+    ImVec2 pos = window->DC.CursorPos;
+    ImRect bb(pos, pos + size);
+
+    // We don't have CPU clipping primitives to clip the CloseButton (until it becomes a texture),
+    // so need to add an extra draw call (temporary in the case of vertical animation)
+    bool want_clip_rect =
+        (bb.Min.x < tab_bar->BarRect.Min.x) || (bb.Max.x >= tab_bar->BarRect.Max.x);
+    if (want_clip_rect)
+        PushClipRect(ImVec2(ImMax(bb.Min.x, tab_bar->BarRect.Min.x), bb.Min.y - 1),
+                     ImVec2(tab_bar->BarRect.Max.x, bb.Max.y), true);
+
+    ImVec2 backup_cursor_max_pos = window->DC.CursorMaxPos;
+    ItemSize(bb.GetSize(), style.FramePadding.y);
+    window->DC.CursorMaxPos = backup_cursor_max_pos;
+
+    if (!ItemAdd(bb, id))
+    {
+        if (want_clip_rect)
+            PopClipRect();
+        window->DC.CursorPos = backup_main_cursor_pos;
+        return tab_contents_visible;
+    }
+
+    // Click to Select a tab
+    ImGuiButtonFlags button_flags =
+        (ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_AllowItemOverlap);
+    if (g.DragDropActive)
+        button_flags |= ImGuiButtonFlags_PressedOnDragDropHold;
+    bool hovered, held;
+    bool pressed = ButtonBehavior(bb, id, &hovered, &held, button_flags);
+    if (pressed)
+        tab_bar->NextSelectedTabId = id;
+    hovered |= (g.HoveredId == id);
+
+    // Allow the close button to overlap unless we are dragging (in which case we don't want any
+    // overlapping tabs to be hovered)
+    if (!held)
+        SetItemAllowOverlap();
+
+    // Drag and drop: re-order tabs
+    if (held && !tab_appearing && IsMouseDragging(0))
+    {
+        if (!g.DragDropActive && (tab_bar->Flags & ImGuiTabBarFlags_Reorderable))
+        {
+            // While moving a tab it will jump on the other side of the mouse, so we also test for
+            // MouseDelta.x
+            if (g.IO.MouseDelta.x < 0.0f && g.IO.MousePos.x < bb.Min.x)
+            {
+                if (tab_bar->Flags & ImGuiTabBarFlags_Reorderable)
+                    TabBarQueueChangeTabOrder(tab_bar, tab, -1);
+            }
+            else if (g.IO.MouseDelta.x > 0.0f && g.IO.MousePos.x > bb.Max.x)
+            {
+                if (tab_bar->Flags & ImGuiTabBarFlags_Reorderable)
+                    TabBarQueueChangeTabOrder(tab_bar, tab, +1);
+            }
+        }
+    }
+
+#if 0
+    if (hovered && g.HoveredIdNotActiveTimer > 0.50f && bb.GetWidth() < tab->WidthContents)
+    {
+        // Enlarge tab display when hovering
+        bb.Max.x = bb.Min.x + (float)(int)ImLerp(bb.GetWidth(), tab->WidthContents, ImSaturate((g.HoveredIdNotActiveTimer - 0.40f) * 6.0f));
+        display_draw_list = GetForegroundDrawList(window);
+        TabItemBackground(display_draw_list, bb, flags, GetColorU32(ImGuiCol_TitleBgActive));
+    }
+#endif
+
+    // Render tab shape
+    ImDrawList *display_draw_list = window->DrawList;
+    const ImU32 tab_col =
+        GetColorU32((held || hovered)
+                        ? ImGuiCol_TabHovered
+                        : tab_contents_visible
+                              ? (tab_bar_focused ? ImGuiCol_TabActive : ImGuiCol_TabUnfocusedActive)
+                              : (tab_bar_focused ? ImGuiCol_Tab : ImGuiCol_TabUnfocused));
+    TabItemBackground(display_draw_list, bb, flags, tab_col);
+    RenderNavHighlight(bb, id);
+
+    // Select with right mouse button. This is so the common idiom for context menu automatically
+    // highlight the current widget.
+    const bool hovered_unblocked = IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup);
+    if (hovered_unblocked && (IsMouseClicked(1) || IsMouseReleased(1)))
+        tab_bar->NextSelectedTabId = id;
+
+    if (tab_bar->Flags & ImGuiTabBarFlags_NoCloseWithMiddleMouseButton)
+        flags |= ImGuiTabItemFlags_NoCloseWithMiddleMouseButton;
+
+    // Render tab label, process close button
+    const ImGuiID close_button_id = p_open ? window->GetID((void *)((intptr_t)id + 1)) : 0;
+    bool just_closed              = TabItemLabelAndCloseButton(
+        display_draw_list, bb, flags, tab_bar->FramePadding, label, id, close_button_id);
+    if (just_closed && p_open != NULL)
+    {
+        *p_open = false;
+        TabBarCloseTab(tab_bar, tab);
+    }
+
+    // Restore main window position so user can draw there
+    if (want_clip_rect)
+        PopClipRect();
+    window->DC.CursorPos = backup_main_cursor_pos;
+
+    // Tooltip (FIXME: Won't work over the close button because ItemOverlap systems messes up with
+    // HoveredIdTimer) We test IsItemHovered() to discard e.g. when another item is active or drag
+    // and drop over the tab bar (which g.HoveredId ignores)
+    if (g.HoveredId == id && !held && g.HoveredIdNotActiveTimer > 0.50f && IsItemHovered())
+        if (!(tab_bar->Flags & ImGuiTabBarFlags_NoTooltip))
+            SetTooltip("%.*s", (int)(FindRenderedTextEnd(label) - label), label);
+
+    return tab_contents_visible;
+}
+
+// [Public] This is call is 100% optional but it allows to remove some one-frame glitches when a tab
+// has been unexpectedly removed. To use it to need to call the function SetTabItemClosed() after
+// BeginTabBar() and before any call to BeginTabItem()
+void ImGui::SetTabItemClosed(const char *label)
+{
+    ImGuiContext &g = *GImGui;
+    bool is_within_manual_tab_bar =
+        g.CurrentTabBar && !(g.CurrentTabBar->Flags & ImGuiTabBarFlags_DockNode);
+    if (is_within_manual_tab_bar)
+    {
+        ImGuiTabBar *tab_bar = g.CurrentTabBar;
+        IM_ASSERT(tab_bar->WantLayout);  // Needs to be called AFTER BeginTabBar() and BEFORE the
+                                         // first call to BeginTabItem()
+        ImGuiID tab_id = TabBarCalcTabID(tab_bar, label);
+        TabBarRemoveTab(tab_bar, tab_id);
+    }
+}
+
+ImVec2 ImGui::TabItemCalcSize(const char *label, bool has_close_button)
+{
+    ImGuiContext &g   = *GImGui;
+    ImVec2 label_size = CalcTextSize(label, NULL, true);
+    ImVec2 size =
+        ImVec2(label_size.x + g.Style.FramePadding.x, label_size.y + g.Style.FramePadding.y * 2.0f);
+    if (has_close_button)
+        size.x += g.Style.FramePadding.x +
+                  (g.Style.ItemInnerSpacing.x +
+                   g.FontSize);  // We use Y intentionally to fit the close button circle.
+    else
+        size.x += g.Style.FramePadding.x + 1.0f;
+    return ImVec2(ImMin(size.x, TabBarCalcMaxTabWidth()), size.y);
+}
+
+void ImGui::TabItemBackground(ImDrawList *draw_list,
+                              const ImRect &bb,
+                              ImGuiTabItemFlags flags,
+                              ImU32 col)
+{
+    // While rendering tabs, we trim 1 pixel off the top of our bounding box so they can fit within
+    // a regular frame height while looking "detached" from it.
+    ImGuiContext &g   = *GImGui;
+    const float width = bb.GetWidth();
+    IM_UNUSED(flags);
+    IM_ASSERT(width > 0.0f);
+    const float rounding = ImMax(0.0f, ImMin(g.Style.TabRounding, width * 0.5f - 1.0f));
+    const float y1       = bb.Min.y + 1.0f;
+    const float y2       = bb.Max.y - 1.0f;
+    draw_list->PathLineTo(ImVec2(bb.Min.x, y2));
+    draw_list->PathArcToFast(ImVec2(bb.Min.x + rounding, y1 + rounding), rounding, 6, 9);
+    draw_list->PathArcToFast(ImVec2(bb.Max.x - rounding, y1 + rounding), rounding, 9, 12);
+    draw_list->PathLineTo(ImVec2(bb.Max.x, y2));
+    draw_list->PathFillConvex(col);
+    if (g.Style.TabBorderSize > 0.0f)
+    {
+        draw_list->PathLineTo(ImVec2(bb.Min.x + 0.5f, y2));
+        draw_list->PathArcToFast(ImVec2(bb.Min.x + rounding + 0.5f, y1 + rounding + 0.5f), rounding,
+                                 6, 9);
+        draw_list->PathArcToFast(ImVec2(bb.Max.x - rounding - 0.5f, y1 + rounding + 0.5f), rounding,
+                                 9, 12);
+        draw_list->PathLineTo(ImVec2(bb.Max.x - 0.5f, y2));
+        draw_list->PathStroke(GetColorU32(ImGuiCol_Border), false, g.Style.TabBorderSize);
+    }
+}
+
+// Render text label (with custom clipping) + Unsaved Document marker + Close Button logic
+// We tend to lock style.FramePadding for a given tab-bar, hence the 'frame_padding' parameter.
+bool ImGui::TabItemLabelAndCloseButton(ImDrawList *draw_list,
+                                       const ImRect &bb,
+                                       ImGuiTabItemFlags flags,
+                                       ImVec2 frame_padding,
+                                       const char *label,
+                                       ImGuiID tab_id,
+                                       ImGuiID close_button_id)
+{
+    ImGuiContext &g   = *GImGui;
+    ImVec2 label_size = CalcTextSize(label, NULL, true);
+    if (bb.GetWidth() <= 1.0f)
+        return false;
+
+    // Render text label (with clipping + alpha gradient) + unsaved marker
+    const char *TAB_UNSAVED_MARKER = "*";
+    ImRect text_pixel_clip_bb(bb.Min.x + frame_padding.x, bb.Min.y + frame_padding.y,
+                              bb.Max.x - frame_padding.x, bb.Max.y);
+    if (flags & ImGuiTabItemFlags_UnsavedDocument)
+    {
+        text_pixel_clip_bb.Max.x -= CalcTextSize(TAB_UNSAVED_MARKER, NULL, false).x;
+        ImVec2 unsaved_marker_pos(
+            ImMin(bb.Min.x + frame_padding.x + label_size.x + 2, text_pixel_clip_bb.Max.x),
+            bb.Min.y + frame_padding.y + (float)(int)(-g.FontSize * 0.25f));
+        RenderTextClippedEx(draw_list, unsaved_marker_pos, bb.Max - frame_padding,
+                            TAB_UNSAVED_MARKER, NULL, NULL);
+    }
+    ImRect text_ellipsis_clip_bb = text_pixel_clip_bb;
+
+    // Close Button
+    // We are relying on a subtle and confusing distinction between 'hovered' and 'g.HoveredId'
+    // which happens because we are using ImGuiButtonFlags_AllowOverlapMode + SetItemAllowOverlap()
+    //  'hovered' will be true when hovering the Tab but NOT when hovering the close button
+    //  'g.HoveredId==id' will be true when hovering the Tab including when hovering the close
+    //  button 'g.ActiveId==close_button_id' will be true when we are holding on the close button,
+    //  in which case both hovered booleans are false
+    bool close_button_pressed = false;
+    bool close_button_visible = false;
+    if (close_button_id != 0)
+        if (g.HoveredId == tab_id || g.HoveredId == close_button_id ||
+            g.ActiveId == close_button_id)
+            close_button_visible = true;
+    if (close_button_visible)
+    {
+        ImGuiItemHoveredDataBackup last_item_backup;
+        const float close_button_sz = g.FontSize;
+        PushStyleVar(ImGuiStyleVar_FramePadding, frame_padding);
+        if (CloseButton(close_button_id,
+                        ImVec2(bb.Max.x - frame_padding.x * 2.0f - close_button_sz, bb.Min.y)))
+            close_button_pressed = true;
+        PopStyleVar();
+        last_item_backup.Restore();
+
+        // Close with middle mouse button
+        if (!(flags & ImGuiTabItemFlags_NoCloseWithMiddleMouseButton) && IsMouseClicked(2))
+            close_button_pressed = true;
+
+        text_pixel_clip_bb.Max.x -= close_button_sz;
+    }
+
+    float ellipsis_max_x = close_button_visible ? text_pixel_clip_bb.Max.x : bb.Max.x - 1.0f;
+    RenderTextEllipsis(draw_list, text_ellipsis_clip_bb.Min, text_ellipsis_clip_bb.Max,
+                       text_pixel_clip_bb.Max.x, ellipsis_max_x, label, NULL, &label_size);
+
+    return close_button_pressed;
+}

--- a/third_party/imgui/imstb_rectpack.h
+++ b/third_party/imgui/imstb_rectpack.h
@@ -1,0 +1,680 @@
+// [DEAR IMGUI]
+// This is a slightly modified version of stb_rect_pack.h 0.99.
+// Those changes would need to be pushed into nothings/stb:
+// - Added STBRP__CDECL
+// Grep for [DEAR IMGUI] to find the changes.
+
+// stb_rect_pack.h - v0.99 - public domain - rectangle packing
+// Sean Barrett 2014
+//
+// Useful for e.g. packing rectangular textures into an atlas.
+// Does not do rotation.
+//
+// Not necessarily the awesomest packing method, but better than
+// the totally naive one in stb_truetype (which is primarily what
+// this is meant to replace).
+//
+// Has only had a few tests run, may have issues.
+//
+// More docs to come.
+//
+// No memory allocations; uses qsort() and assert() from stdlib.
+// Can override those by defining STBRP_SORT and STBRP_ASSERT.
+//
+// This library currently uses the Skyline Bottom-Left algorithm.
+//
+// Please note: better rectangle packers are welcome! Please
+// implement them to the same API, but with a different init
+// function.
+//
+// Credits
+//
+//  Library
+//    Sean Barrett
+//  Minor features
+//    Martins Mozeiko
+//    github:IntellectualKitty
+//
+//  Bugfixes / warning fixes
+//    Jeremy Jaussaud
+//
+// Version history:
+//
+//     0.99  (2019-02-07)  warning fixes
+//     0.11  (2017-03-03)  return packing success/fail result
+//     0.10  (2016-10-25)  remove cast-away-const to avoid warnings
+//     0.09  (2016-08-27)  fix compiler warnings
+//     0.08  (2015-09-13)  really fix bug with empty rects (w=0 or h=0)
+//     0.07  (2015-09-13)  fix bug with empty rects (w=0 or h=0)
+//     0.06  (2015-04-15)  added STBRP_SORT to allow replacing qsort
+//     0.05:  added STBRP_ASSERT to allow replacing assert
+//     0.04:  fixed minor bug in STBRP_LARGE_RECTS support
+//     0.01:  initial release
+//
+// LICENSE
+//
+//   See end of file for license information.
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//       INCLUDE SECTION
+//
+
+#ifndef STB_INCLUDE_STB_RECT_PACK_H
+#define STB_INCLUDE_STB_RECT_PACK_H
+
+#define STB_RECT_PACK_VERSION 1
+
+#ifdef STBRP_STATIC
+#define STBRP_DEF static
+#else
+#define STBRP_DEF extern
+#endif
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef struct stbrp_context stbrp_context;
+    typedef struct stbrp_node stbrp_node;
+    typedef struct stbrp_rect stbrp_rect;
+
+#ifdef STBRP_LARGE_RECTS
+    typedef int stbrp_coord;
+#else
+typedef unsigned short stbrp_coord;
+#endif
+
+    STBRP_DEF int stbrp_pack_rects(stbrp_context *context, stbrp_rect *rects, int num_rects);
+    // Assign packed locations to rectangles. The rectangles are of type
+    // 'stbrp_rect' defined below, stored in the array 'rects', and there
+    // are 'num_rects' many of them.
+    //
+    // Rectangles which are successfully packed have the 'was_packed' flag
+    // set to a non-zero value and 'x' and 'y' store the minimum location
+    // on each axis (i.e. bottom-left in cartesian coordinates, top-left
+    // if you imagine y increasing downwards). Rectangles which do not fit
+    // have the 'was_packed' flag set to 0.
+    //
+    // You should not try to access the 'rects' array from another thread
+    // while this function is running, as the function temporarily reorders
+    // the array while it executes.
+    //
+    // To pack into another rectangle, you need to call stbrp_init_target
+    // again. To continue packing into the same rectangle, you can call
+    // this function again. Calling this multiple times with multiple rect
+    // arrays will probably produce worse packing results than calling it
+    // a single time with the full rectangle array, but the option is
+    // available.
+    //
+    // The function returns 1 if all of the rectangles were successfully
+    // packed and 0 otherwise.
+
+    struct stbrp_rect
+    {
+        // reserved for your use:
+        int id;
+
+        // input:
+        stbrp_coord w, h;
+
+        // output:
+        stbrp_coord x, y;
+        int was_packed;  // non-zero if valid packing
+
+    };  // 16 bytes, nominally
+
+    STBRP_DEF void stbrp_init_target(stbrp_context *context,
+                                     int width,
+                                     int height,
+                                     stbrp_node *nodes,
+                                     int num_nodes);
+    // Initialize a rectangle packer to:
+    //    pack a rectangle that is 'width' by 'height' in dimensions
+    //    using temporary storage provided by the array 'nodes', which is 'num_nodes' long
+    //
+    // You must call this function every time you start packing into a new target.
+    //
+    // There is no "shutdown" function. The 'nodes' memory must stay valid for
+    // the following stbrp_pack_rects() call (or calls), but can be freed after
+    // the call (or calls) finish.
+    //
+    // Note: to guarantee best results, either:
+    //       1. make sure 'num_nodes' >= 'width'
+    //   or  2. call stbrp_allow_out_of_mem() defined below with 'allow_out_of_mem = 1'
+    //
+    // If you don't do either of the above things, widths will be quantized to multiples
+    // of small integers to guarantee the algorithm doesn't run out of temporary storage.
+    //
+    // If you do #2, then the non-quantized algorithm will be used, but the algorithm
+    // may run out of temporary storage and be unable to pack some rectangles.
+
+    STBRP_DEF void stbrp_setup_allow_out_of_mem(stbrp_context *context, int allow_out_of_mem);
+    // Optionally call this function after init but before doing any packing to
+    // change the handling of the out-of-temp-memory scenario, described above.
+    // If you call init again, this will be reset to the default (false).
+
+    STBRP_DEF void stbrp_setup_heuristic(stbrp_context *context, int heuristic);
+    // Optionally select which packing heuristic the library should use. Different
+    // heuristics will produce better/worse results for different data sets.
+    // If you call init again, this will be reset to the default.
+
+    enum
+    {
+        STBRP_HEURISTIC_Skyline_default       = 0,
+        STBRP_HEURISTIC_Skyline_BL_sortHeight = STBRP_HEURISTIC_Skyline_default,
+        STBRP_HEURISTIC_Skyline_BF_sortHeight
+    };
+
+    //////////////////////////////////////////////////////////////////////////////
+    //
+    // the details of the following structures don't matter to you, but they must
+    // be visible so you can handle the memory allocations for them
+
+    struct stbrp_node
+    {
+        stbrp_coord x, y;
+        stbrp_node *next;
+    };
+
+    struct stbrp_context
+    {
+        int width;
+        int height;
+        int align;
+        int init_mode;
+        int heuristic;
+        int num_nodes;
+        stbrp_node *active_head;
+        stbrp_node *free_head;
+        stbrp_node extra[2];  // we allocate two extra nodes so optimal user-node-count is 'width'
+                              // not 'width+2'
+    };
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//     IMPLEMENTATION SECTION
+//
+
+#ifdef STB_RECT_PACK_IMPLEMENTATION
+#ifndef STBRP_SORT
+#include <stdlib.h>
+#define STBRP_SORT qsort
+#endif
+
+#ifndef STBRP_ASSERT
+#include <assert.h>
+#define STBRP_ASSERT assert
+#endif
+
+// [DEAR IMGUI] Added STBRP__CDECL
+#ifdef _MSC_VER
+#define STBRP__NOTUSED(v) (void)(v)
+#define STBRP__CDECL __cdecl
+#else
+#define STBRP__NOTUSED(v) (void)sizeof(v)
+#define STBRP__CDECL
+#endif
+
+enum
+{
+    STBRP__INIT_skyline = 1
+};
+
+STBRP_DEF void stbrp_setup_heuristic(stbrp_context *context, int heuristic)
+{
+    switch (context->init_mode)
+    {
+        case STBRP__INIT_skyline:
+            STBRP_ASSERT(heuristic == STBRP_HEURISTIC_Skyline_BL_sortHeight ||
+                         heuristic == STBRP_HEURISTIC_Skyline_BF_sortHeight);
+            context->heuristic = heuristic;
+            break;
+        default:
+            STBRP_ASSERT(0);
+    }
+}
+
+STBRP_DEF void stbrp_setup_allow_out_of_mem(stbrp_context *context, int allow_out_of_mem)
+{
+    if (allow_out_of_mem)
+        // if it's ok to run out of memory, then don't bother aligning them;
+        // this gives better packing, but may fail due to OOM (even though
+        // the rectangles easily fit). @TODO a smarter approach would be to only
+        // quantize once we've hit OOM, then we could get rid of this parameter.
+        context->align = 1;
+    else
+    {
+        // if it's not ok to run out of memory, then quantize the widths
+        // so that num_nodes is always enough nodes.
+        //
+        // I.e. num_nodes * align >= width
+        //                  align >= width / num_nodes
+        //                  align = ceil(width/num_nodes)
+
+        context->align = (context->width + context->num_nodes - 1) / context->num_nodes;
+    }
+}
+
+STBRP_DEF void stbrp_init_target(stbrp_context *context,
+                                 int width,
+                                 int height,
+                                 stbrp_node *nodes,
+                                 int num_nodes)
+{
+    int i;
+#ifndef STBRP_LARGE_RECTS
+    STBRP_ASSERT(width <= 0xffff && height <= 0xffff);
+#endif
+
+    for (i = 0; i < num_nodes - 1; ++i)
+        nodes[i].next = &nodes[i + 1];
+    nodes[i].next        = NULL;
+    context->init_mode   = STBRP__INIT_skyline;
+    context->heuristic   = STBRP_HEURISTIC_Skyline_default;
+    context->free_head   = &nodes[0];
+    context->active_head = &context->extra[0];
+    context->width       = width;
+    context->height      = height;
+    context->num_nodes   = num_nodes;
+    stbrp_setup_allow_out_of_mem(context, 0);
+
+    // node 0 is the full width, node 1 is the sentinel (lets us not store width explicitly)
+    context->extra[0].x    = 0;
+    context->extra[0].y    = 0;
+    context->extra[0].next = &context->extra[1];
+    context->extra[1].x    = (stbrp_coord)width;
+#ifdef STBRP_LARGE_RECTS
+    context->extra[1].y = (1 << 30);
+#else
+    context->extra[1].y = 65535;
+#endif
+    context->extra[1].next = NULL;
+}
+
+// find minimum y position if it starts at x1
+static int stbrp__skyline_find_min_y(stbrp_context *c,
+                                     stbrp_node *first,
+                                     int x0,
+                                     int width,
+                                     int *pwaste)
+{
+    stbrp_node *node = first;
+    int x1           = x0 + width;
+    int min_y, visited_width, waste_area;
+
+    STBRP__NOTUSED(c);
+
+    STBRP_ASSERT(first->x <= x0);
+
+#if 0
+   // skip in case we're past the node
+   while (node->next->x <= x0)
+      ++node;
+#else
+    STBRP_ASSERT(node->next->x > x0);  // we ended up handling this in the caller for efficiency
+#endif
+
+    STBRP_ASSERT(node->x <= x0);
+
+    min_y         = 0;
+    waste_area    = 0;
+    visited_width = 0;
+    while (node->x < x1)
+    {
+        if (node->y > min_y)
+        {
+            // raise min_y higher.
+            // we've accounted for all waste up to min_y,
+            // but we'll now add more waste for everything we've visted
+            waste_area += visited_width * (node->y - min_y);
+            min_y = node->y;
+            // the first time through, visited_width might be reduced
+            if (node->x < x0)
+                visited_width += node->next->x - x0;
+            else
+                visited_width += node->next->x - node->x;
+        }
+        else
+        {
+            // add waste area
+            int under_width = node->next->x - node->x;
+            if (under_width + visited_width > width)
+                under_width = width - visited_width;
+            waste_area += under_width * (min_y - node->y);
+            visited_width += under_width;
+        }
+        node = node->next;
+    }
+
+    *pwaste = waste_area;
+    return min_y;
+}
+
+typedef struct
+{
+    int x, y;
+    stbrp_node **prev_link;
+} stbrp__findresult;
+
+static stbrp__findresult stbrp__skyline_find_best_pos(stbrp_context *c, int width, int height)
+{
+    int best_waste = (1 << 30), best_x, best_y = (1 << 30);
+    stbrp__findresult fr;
+    stbrp_node **prev, *node, *tail, **best = NULL;
+
+    // align to multiple of c->align
+    width = (width + c->align - 1);
+    width -= width % c->align;
+    STBRP_ASSERT(width % c->align == 0);
+
+    node = c->active_head;
+    prev = &c->active_head;
+    while (node->x + width <= c->width)
+    {
+        int y, waste;
+        y = stbrp__skyline_find_min_y(c, node, node->x, width, &waste);
+        if (c->heuristic == STBRP_HEURISTIC_Skyline_BL_sortHeight)
+        {  // actually just want to test BL
+            // bottom left
+            if (y < best_y)
+            {
+                best_y = y;
+                best   = prev;
+            }
+        }
+        else
+        {
+            // best-fit
+            if (y + height <= c->height)
+            {
+                // can only use it if it first vertically
+                if (y < best_y || (y == best_y && waste < best_waste))
+                {
+                    best_y     = y;
+                    best_waste = waste;
+                    best       = prev;
+                }
+            }
+        }
+        prev = &node->next;
+        node = node->next;
+    }
+
+    best_x = (best == NULL) ? 0 : (*best)->x;
+
+    // if doing best-fit (BF), we also have to try aligning right edge to each node position
+    //
+    // e.g, if fitting
+    //
+    //     ____________________
+    //    |____________________|
+    //
+    //            into
+    //
+    //   |                         |
+    //   |             ____________|
+    //   |____________|
+    //
+    // then right-aligned reduces waste, but bottom-left BL is always chooses left-aligned
+    //
+    // This makes BF take about 2x the time
+
+    if (c->heuristic == STBRP_HEURISTIC_Skyline_BF_sortHeight)
+    {
+        tail = c->active_head;
+        node = c->active_head;
+        prev = &c->active_head;
+        // find first node that's admissible
+        while (tail->x < width)
+            tail = tail->next;
+        while (tail)
+        {
+            int xpos = tail->x - width;
+            int y, waste;
+            STBRP_ASSERT(xpos >= 0);
+            // find the left position that matches this
+            while (node->next->x <= xpos)
+            {
+                prev = &node->next;
+                node = node->next;
+            }
+            STBRP_ASSERT(node->next->x > xpos && node->x <= xpos);
+            y = stbrp__skyline_find_min_y(c, node, xpos, width, &waste);
+            if (y + height < c->height)
+            {
+                if (y <= best_y)
+                {
+                    if (y < best_y || waste < best_waste || (waste == best_waste && xpos < best_x))
+                    {
+                        best_x = xpos;
+                        STBRP_ASSERT(y <= best_y);
+                        best_y     = y;
+                        best_waste = waste;
+                        best       = prev;
+                    }
+                }
+            }
+            tail = tail->next;
+        }
+    }
+
+    fr.prev_link = best;
+    fr.x         = best_x;
+    fr.y         = best_y;
+    return fr;
+}
+
+static stbrp__findresult stbrp__skyline_pack_rectangle(stbrp_context *context,
+                                                       int width,
+                                                       int height)
+{
+    // find best position according to heuristic
+    stbrp__findresult res = stbrp__skyline_find_best_pos(context, width, height);
+    stbrp_node *node, *cur;
+
+    // bail if:
+    //    1. it failed
+    //    2. the best node doesn't fit (we don't always check this)
+    //    3. we're out of memory
+    if (res.prev_link == NULL || res.y + height > context->height || context->free_head == NULL)
+    {
+        res.prev_link = NULL;
+        return res;
+    }
+
+    // on success, create new node
+    node    = context->free_head;
+    node->x = (stbrp_coord)res.x;
+    node->y = (stbrp_coord)(res.y + height);
+
+    context->free_head = node->next;
+
+    // insert the new node into the right starting point, and
+    // let 'cur' point to the remaining nodes needing to be
+    // stiched back in
+
+    cur = *res.prev_link;
+    if (cur->x < res.x)
+    {
+        // preserve the existing one, so start testing with the next one
+        stbrp_node *next = cur->next;
+        cur->next        = node;
+        cur              = next;
+    }
+    else
+    {
+        *res.prev_link = node;
+    }
+
+    // from here, traverse cur and free the nodes, until we get to one
+    // that shouldn't be freed
+    while (cur->next && cur->next->x <= res.x + width)
+    {
+        stbrp_node *next = cur->next;
+        // move the current node to the free list
+        cur->next          = context->free_head;
+        context->free_head = cur;
+        cur                = next;
+    }
+
+    // stitch the list back in
+    node->next = cur;
+
+    if (cur->x < res.x + width)
+        cur->x = (stbrp_coord)(res.x + width);
+
+#ifdef _DEBUG
+    cur = context->active_head;
+    while (cur->x < context->width)
+    {
+        STBRP_ASSERT(cur->x < cur->next->x);
+        cur = cur->next;
+    }
+    STBRP_ASSERT(cur->next == NULL);
+
+    {
+        int count = 0;
+        cur       = context->active_head;
+        while (cur)
+        {
+            cur = cur->next;
+            ++count;
+        }
+        cur = context->free_head;
+        while (cur)
+        {
+            cur = cur->next;
+            ++count;
+        }
+        STBRP_ASSERT(count == context->num_nodes + 2);
+    }
+#endif
+
+    return res;
+}
+
+// [DEAR IMGUI] Added STBRP__CDECL
+static int STBRP__CDECL rect_height_compare(const void *a, const void *b)
+{
+    const stbrp_rect *p = (const stbrp_rect *)a;
+    const stbrp_rect *q = (const stbrp_rect *)b;
+    if (p->h > q->h)
+        return -1;
+    if (p->h < q->h)
+        return 1;
+    return (p->w > q->w) ? -1 : (p->w < q->w);
+}
+
+// [DEAR IMGUI] Added STBRP__CDECL
+static int STBRP__CDECL rect_original_order(const void *a, const void *b)
+{
+    const stbrp_rect *p = (const stbrp_rect *)a;
+    const stbrp_rect *q = (const stbrp_rect *)b;
+    return (p->was_packed < q->was_packed) ? -1 : (p->was_packed > q->was_packed);
+}
+
+#ifdef STBRP_LARGE_RECTS
+#define STBRP__MAXVAL 0xffffffff
+#else
+#define STBRP__MAXVAL 0xffff
+#endif
+
+STBRP_DEF int stbrp_pack_rects(stbrp_context *context, stbrp_rect *rects, int num_rects)
+{
+    int i, all_rects_packed = 1;
+
+    // we use the 'was_packed' field internally to allow sorting/unsorting
+    for (i = 0; i < num_rects; ++i)
+    {
+        rects[i].was_packed = i;
+    }
+
+    // sort according to heuristic
+    STBRP_SORT(rects, num_rects, sizeof(rects[0]), rect_height_compare);
+
+    for (i = 0; i < num_rects; ++i)
+    {
+        if (rects[i].w == 0 || rects[i].h == 0)
+        {
+            rects[i].x = rects[i].y = 0;  // empty rect needs no space
+        }
+        else
+        {
+            stbrp__findresult fr = stbrp__skyline_pack_rectangle(context, rects[i].w, rects[i].h);
+            if (fr.prev_link)
+            {
+                rects[i].x = (stbrp_coord)fr.x;
+                rects[i].y = (stbrp_coord)fr.y;
+            }
+            else
+            {
+                rects[i].x = rects[i].y = STBRP__MAXVAL;
+            }
+        }
+    }
+
+    // unsort
+    STBRP_SORT(rects, num_rects, sizeof(rects[0]), rect_original_order);
+
+    // set was_packed flags and all_rects_packed status
+    for (i = 0; i < num_rects; ++i)
+    {
+        rects[i].was_packed = !(rects[i].x == STBRP__MAXVAL && rects[i].y == STBRP__MAXVAL);
+        if (!rects[i].was_packed)
+            all_rects_packed = 0;
+    }
+
+    // return the all_rects_packed status
+    return all_rects_packed;
+}
+#endif
+
+/*
+------------------------------------------------------------------------------
+This software is available under 2 licenses -- choose whichever you prefer.
+------------------------------------------------------------------------------
+ALTERNATIVE A - MIT License
+Copyright (c) 2017 Sean Barrett
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+------------------------------------------------------------------------------
+ALTERNATIVE B - Public Domain (www.unlicense.org)
+This is free and unencumbered software released into the public domain.
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this
+software, either in source code form or as a compiled binary, for any purpose,
+commercial or non-commercial, and by any means.
+In jurisdictions that recognize copyright laws, the author or authors of this
+software dedicate any and all copyright interest in the software to the public
+domain. We make this dedication for the benefit of the public at large and to
+the detriment of our heirs and successors. We intend this dedication to be an
+overt act of relinquishment in perpetuity of all present and future rights to
+this software under copyright law.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+------------------------------------------------------------------------------
+*/

--- a/third_party/imgui/imstb_textedit.h
+++ b/third_party/imgui/imstb_textedit.h
@@ -1,0 +1,1537 @@
+// [DEAR IMGUI]
+// This is a slightly modified version of stb_textedit.h 1.13.
+// Those changes would need to be pushed into nothings/stb:
+// - Fix in stb_textedit_discard_redo (see https://github.com/nothings/stb/issues/321)
+// Grep for [DEAR IMGUI] to find the changes.
+
+// stb_textedit.h - v1.13  - public domain - Sean Barrett
+// Development of this library was sponsored by RAD Game Tools
+//
+// This C header file implements the guts of a multi-line text-editing
+// widget; you implement display, word-wrapping, and low-level string
+// insertion/deletion, and stb_textedit will map user inputs into
+// insertions & deletions, plus updates to the cursor position,
+// selection state, and undo state.
+//
+// It is intended for use in games and other systems that need to build
+// their own custom widgets and which do not have heavy text-editing
+// requirements (this library is not recommended for use for editing large
+// texts, as its performance does not scale and it has limited undo).
+//
+// Non-trivial behaviors are modelled after Windows text controls.
+//
+//
+// LICENSE
+//
+// See end of file for license information.
+//
+//
+// DEPENDENCIES
+//
+// Uses the C runtime function 'memmove', which you can override
+// by defining STB_TEXTEDIT_memmove before the implementation.
+// Uses no other functions. Performs no runtime allocations.
+//
+//
+// VERSION HISTORY
+//
+//   1.13 (2019-02-07) fix bug in undo size management
+//   1.12 (2018-01-29) user can change STB_TEXTEDIT_KEYTYPE, fix redo to avoid crash
+//   1.11 (2017-03-03) fix HOME on last line, dragging off single-line textfield
+//   1.10 (2016-10-25) supress warnings about casting away const with -Wcast-qual
+//   1.9  (2016-08-27) customizable move-by-word
+//   1.8  (2016-04-02) better keyboard handling when mouse button is down
+//   1.7  (2015-09-13) change y range handling in case baseline is non-0
+//   1.6  (2015-04-15) allow STB_TEXTEDIT_memmove
+//   1.5  (2014-09-10) add support for secondary keys for OS X
+//   1.4  (2014-08-17) fix signed/unsigned warnings
+//   1.3  (2014-06-19) fix mouse clicking to round to nearest char boundary
+//   1.2  (2014-05-27) fix some RAD types that had crept into the new code
+//   1.1  (2013-12-15) move-by-word (requires STB_TEXTEDIT_IS_SPACE )
+//   1.0  (2012-07-26) improve documentation, initial public release
+//   0.3  (2012-02-24) bugfixes, single-line mode; insert mode
+//   0.2  (2011-11-28) fixes to undo/redo
+//   0.1  (2010-07-08) initial version
+//
+// ADDITIONAL CONTRIBUTORS
+//
+//   Ulf Winklemann: move-by-word in 1.1
+//   Fabian Giesen: secondary key inputs in 1.5
+//   Martins Mozeiko: STB_TEXTEDIT_memmove in 1.6
+//
+//   Bugfixes:
+//      Scott Graham
+//      Daniel Keller
+//      Omar Cornut
+//      Dan Thompson
+//
+// USAGE
+//
+// This file behaves differently depending on what symbols you define
+// before including it.
+//
+//
+// Header-file mode:
+//
+//   If you do not define STB_TEXTEDIT_IMPLEMENTATION before including this,
+//   it will operate in "header file" mode. In this mode, it declares a
+//   single public symbol, STB_TexteditState, which encapsulates the current
+//   state of a text widget (except for the string, which you will store
+//   separately).
+//
+//   To compile in this mode, you must define STB_TEXTEDIT_CHARTYPE to a
+//   primitive type that defines a single character (e.g. char, wchar_t, etc).
+//
+//   To save space or increase undo-ability, you can optionally define the
+//   following things that are used by the undo system:
+//
+//      STB_TEXTEDIT_POSITIONTYPE         small int type encoding a valid cursor position
+//      STB_TEXTEDIT_UNDOSTATECOUNT       the number of undo states to allow
+//      STB_TEXTEDIT_UNDOCHARCOUNT        the number of characters to store in the undo buffer
+//
+//   If you don't define these, they are set to permissive types and
+//   moderate sizes. The undo system does no memory allocations, so
+//   it grows STB_TexteditState by the worst-case storage which is (in bytes):
+//
+//        [4 + 3 * sizeof(STB_TEXTEDIT_POSITIONTYPE)] * STB_TEXTEDIT_UNDOSTATE_COUNT
+//      +          sizeof(STB_TEXTEDIT_CHARTYPE)      * STB_TEXTEDIT_UNDOCHAR_COUNT
+//
+//
+// Implementation mode:
+//
+//   If you define STB_TEXTEDIT_IMPLEMENTATION before including this, it
+//   will compile the implementation of the text edit widget, depending
+//   on a large number of symbols which must be defined before the include.
+//
+//   The implementation is defined only as static functions. You will then
+//   need to provide your own APIs in the same file which will access the
+//   static functions.
+//
+//   The basic concept is that you provide a "string" object which
+//   behaves like an array of characters. stb_textedit uses indices to
+//   refer to positions in the string, implicitly representing positions
+//   in the displayed textedit. This is true for both plain text and
+//   rich text; even with rich text stb_truetype interacts with your
+//   code as if there was an array of all the displayed characters.
+//
+// Symbols that must be the same in header-file and implementation mode:
+//
+//     STB_TEXTEDIT_CHARTYPE             the character type
+//     STB_TEXTEDIT_POSITIONTYPE         small type that is a valid cursor position
+//     STB_TEXTEDIT_UNDOSTATECOUNT       the number of undo states to allow
+//     STB_TEXTEDIT_UNDOCHARCOUNT        the number of characters to store in the undo buffer
+//
+// Symbols you must define for implementation mode:
+//
+//    STB_TEXTEDIT_STRING               the type of object representing a string being edited,
+//                                      typically this is a wrapper object with other data you need
+//
+//    STB_TEXTEDIT_STRINGLEN(obj)       the length of the string (ideally O(1))
+//    STB_TEXTEDIT_LAYOUTROW(&r,obj,n)  returns the results of laying out a line of characters
+//                                        starting from character #n (see discussion below)
+//    STB_TEXTEDIT_GETWIDTH(obj,n,i)    returns the pixel delta from the xpos of the i'th character
+//                                        to the xpos of the i+1'th char for a line of characters
+//                                        starting at character #n (i.e. accounts for kerning
+//                                        with previous char)
+//    STB_TEXTEDIT_KEYTOTEXT(k)         maps a keyboard input to an insertable character
+//                                        (return type is int, -1 means not valid to insert)
+//    STB_TEXTEDIT_GETCHAR(obj,i)       returns the i'th character of obj, 0-based
+//    STB_TEXTEDIT_NEWLINE              the character returned by _GETCHAR() we recognize
+//                                        as manually wordwrapping for end-of-line positioning
+//
+//    STB_TEXTEDIT_DELETECHARS(obj,i,n)      delete n characters starting at i
+//    STB_TEXTEDIT_INSERTCHARS(obj,i,c*,n)   insert n characters at i (pointed to by
+//    STB_TEXTEDIT_CHARTYPE*)
+//
+//    STB_TEXTEDIT_K_SHIFT       a power of two that is or'd in to a keyboard input to represent the
+//    shift key
+//
+//    STB_TEXTEDIT_K_LEFT        keyboard input to move cursor left
+//    STB_TEXTEDIT_K_RIGHT       keyboard input to move cursor right
+//    STB_TEXTEDIT_K_UP          keyboard input to move cursor up
+//    STB_TEXTEDIT_K_DOWN        keyboard input to move cursor down
+//    STB_TEXTEDIT_K_LINESTART   keyboard input to move cursor to start of line  // e.g. HOME
+//    STB_TEXTEDIT_K_LINEEND     keyboard input to move cursor to end of line    // e.g. END
+//    STB_TEXTEDIT_K_TEXTSTART   keyboard input to move cursor to start of text  // e.g. ctrl-HOME
+//    STB_TEXTEDIT_K_TEXTEND     keyboard input to move cursor to end of text    // e.g. ctrl-END
+//    STB_TEXTEDIT_K_DELETE      keyboard input to delete selection or character under cursor
+//    STB_TEXTEDIT_K_BACKSPACE   keyboard input to delete selection or character left of cursor
+//    STB_TEXTEDIT_K_UNDO        keyboard input to perform undo
+//    STB_TEXTEDIT_K_REDO        keyboard input to perform redo
+//
+// Optional:
+//    STB_TEXTEDIT_K_INSERT              keyboard input to toggle insert mode
+//    STB_TEXTEDIT_IS_SPACE(ch)          true if character is whitespace (e.g. 'isspace'),
+//                                          required for default WORDLEFT/WORDRIGHT handlers
+//    STB_TEXTEDIT_MOVEWORDLEFT(obj,i)   custom handler for WORDLEFT, returns index to move cursor
+//    to STB_TEXTEDIT_MOVEWORDRIGHT(obj,i)  custom handler for WORDRIGHT, returns index to move
+//    cursor to STB_TEXTEDIT_K_WORDLEFT            keyboard input to move cursor left one word //
+//    e.g. ctrl-LEFT STB_TEXTEDIT_K_WORDRIGHT           keyboard input to move cursor right one word
+//    // e.g. ctrl-RIGHT STB_TEXTEDIT_K_LINESTART2          secondary keyboard input to move cursor
+//    to start of line STB_TEXTEDIT_K_LINEEND2            secondary keyboard input to move cursor to
+//    end of line STB_TEXTEDIT_K_TEXTSTART2          secondary keyboard input to move cursor to
+//    start of text STB_TEXTEDIT_K_TEXTEND2            secondary keyboard input to move cursor to
+//    end of text
+//
+// Todo:
+//    STB_TEXTEDIT_K_PGUP        keyboard input to move cursor up a page
+//    STB_TEXTEDIT_K_PGDOWN      keyboard input to move cursor down a page
+//
+// Keyboard input must be encoded as a single integer value; e.g. a character code
+// and some bitflags that represent shift states. to simplify the interface, SHIFT must
+// be a bitflag, so we can test the shifted state of cursor movements to allow selection,
+// i.e. (STB_TEXTED_K_RIGHT|STB_TEXTEDIT_K_SHIFT) should be shifted right-arrow.
+//
+// You can encode other things, such as CONTROL or ALT, in additional bits, and
+// then test for their presence in e.g. STB_TEXTEDIT_K_WORDLEFT. For example,
+// my Windows implementations add an additional CONTROL bit, and an additional KEYDOWN
+// bit. Then all of the STB_TEXTEDIT_K_ values bitwise-or in the KEYDOWN bit,
+// and I pass both WM_KEYDOWN and WM_CHAR events to the "key" function in the
+// API below. The control keys will only match WM_KEYDOWN events because of the
+// keydown bit I add, and STB_TEXTEDIT_KEYTOTEXT only tests for the KEYDOWN
+// bit so it only decodes WM_CHAR events.
+//
+// STB_TEXTEDIT_LAYOUTROW returns information about the shape of one displayed
+// row of characters assuming they start on the i'th character--the width and
+// the height and the number of characters consumed. This allows this library
+// to traverse the entire layout incrementally. You need to compute word-wrapping
+// here.
+//
+// Each textfield keeps its own insert mode state, which is not how normal
+// applications work. To keep an app-wide insert mode, update/copy the
+// "insert_mode" field of STB_TexteditState before/after calling API functions.
+//
+// API
+//
+//    void stb_textedit_initialize_state(STB_TexteditState *state, int is_single_line)
+//
+//    void stb_textedit_click(STB_TEXTEDIT_STRING *str, STB_TexteditState *state, float x, float y)
+//    void stb_textedit_drag(STB_TEXTEDIT_STRING *str, STB_TexteditState *state, float x, float y)
+//    int  stb_textedit_cut(STB_TEXTEDIT_STRING *str, STB_TexteditState *state)
+//    int  stb_textedit_paste(STB_TEXTEDIT_STRING *str, STB_TexteditState *state,
+//    STB_TEXTEDIT_CHARTYPE *text, int len) void stb_textedit_key(STB_TEXTEDIT_STRING *str,
+//    STB_TexteditState *state, STB_TEXEDIT_KEYTYPE key)
+//
+//    Each of these functions potentially updates the string and updates the
+//    state.
+//
+//      initialize_state:
+//          set the textedit state to a known good default state when initially
+//          constructing the textedit.
+//
+//      click:
+//          call this with the mouse x,y on a mouse down; it will update the cursor
+//          and reset the selection start/end to the cursor point. the x,y must
+//          be relative to the text widget, with (0,0) being the top left.
+//
+//      drag:
+//          call this with the mouse x,y on a mouse drag/up; it will update the
+//          cursor and the selection end point
+//
+//      cut:
+//          call this to delete the current selection; returns true if there was
+//          one. you should FIRST copy the current selection to the system paste buffer.
+//          (To copy, just copy the current selection out of the string yourself.)
+//
+//      paste:
+//          call this to paste text at the current cursor point or over the current
+//          selection if there is one.
+//
+//      key:
+//          call this for keyboard inputs sent to the textfield. you can use it
+//          for "key down" events or for "translated" key events. if you need to
+//          do both (as in Win32), or distinguish Unicode characters from control
+//          inputs, set a high bit to distinguish the two; then you can define the
+//          various definitions like STB_TEXTEDIT_K_LEFT have the is-key-event bit
+//          set, and make STB_TEXTEDIT_KEYTOCHAR check that the is-key-event bit is
+//          clear. STB_TEXTEDIT_KEYTYPE defaults to int, but you can #define it to
+//          anything other type you wante before including.
+//
+//
+//   When rendering, you can read the cursor position and selection state from
+//   the STB_TexteditState.
+//
+//
+// Notes:
+//
+// This is designed to be usable in IMGUI, so it allows for the possibility of
+// running in an IMGUI that has NOT cached the multi-line layout. For this
+// reason, it provides an interface that is compatible with computing the
+// layout incrementally--we try to make sure we make as few passes through
+// as possible. (For example, to locate the mouse pointer in the text, we
+// could define functions that return the X and Y positions of characters
+// and binary search Y and then X, but if we're doing dynamic layout this
+// will run the layout algorithm many times, so instead we manually search
+// forward in one pass. Similar logic applies to e.g. up-arrow and
+// down-arrow movement.)
+//
+// If it's run in a widget that *has* cached the layout, then this is less
+// efficient, but it's not horrible on modern computers. But you wouldn't
+// want to edit million-line files with it.
+
+////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////
+////
+////   Header-file mode
+////
+////
+
+#ifndef INCLUDE_STB_TEXTEDIT_H
+#define INCLUDE_STB_TEXTEDIT_H
+
+////////////////////////////////////////////////////////////////////////
+//
+//     STB_TexteditState
+//
+// Definition of STB_TexteditState which you should store
+// per-textfield; it includes cursor position, selection state,
+// and undo state.
+//
+
+#ifndef STB_TEXTEDIT_UNDOSTATECOUNT
+#define STB_TEXTEDIT_UNDOSTATECOUNT 99
+#endif
+#ifndef STB_TEXTEDIT_UNDOCHARCOUNT
+#define STB_TEXTEDIT_UNDOCHARCOUNT 999
+#endif
+#ifndef STB_TEXTEDIT_CHARTYPE
+#define STB_TEXTEDIT_CHARTYPE int
+#endif
+#ifndef STB_TEXTEDIT_POSITIONTYPE
+#define STB_TEXTEDIT_POSITIONTYPE int
+#endif
+
+typedef struct
+{
+    // private data
+    STB_TEXTEDIT_POSITIONTYPE where;
+    STB_TEXTEDIT_POSITIONTYPE insert_length;
+    STB_TEXTEDIT_POSITIONTYPE delete_length;
+    int char_storage;
+} StbUndoRecord;
+
+typedef struct
+{
+    // private data
+    StbUndoRecord undo_rec[STB_TEXTEDIT_UNDOSTATECOUNT];
+    STB_TEXTEDIT_CHARTYPE undo_char[STB_TEXTEDIT_UNDOCHARCOUNT];
+    short undo_point, redo_point;
+    int undo_char_point, redo_char_point;
+} StbUndoState;
+
+typedef struct
+{
+    /////////////////////
+    //
+    // public data
+    //
+
+    int cursor;
+    // position of the text cursor within the string
+
+    int select_start;  // selection start point
+    int select_end;
+    // selection start and end point in characters; if equal, no selection.
+    // note that start may be less than or greater than end (e.g. when
+    // dragging the mouse, start is where the initial click was, and you
+    // can drag in either direction)
+
+    unsigned char insert_mode;
+    // each textfield keeps its own insert mode state. to keep an app-wide
+    // insert mode, copy this value in/out of the app state
+
+    /////////////////////
+    //
+    // private data
+    //
+    unsigned char cursor_at_end_of_line;  // not implemented yet
+    unsigned char initialized;
+    unsigned char has_preferred_x;
+    unsigned char single_line;
+    unsigned char padding1, padding2, padding3;
+    float preferred_x;  // this determines where the cursor up/down tries to seek to along x
+    StbUndoState undostate;
+} STB_TexteditState;
+
+////////////////////////////////////////////////////////////////////////
+//
+//     StbTexteditRow
+//
+// Result of layout query, used by stb_textedit to determine where
+// the text in each row is.
+
+// result of layout query
+typedef struct
+{
+    float x0, x1;            // starting x location, end x location (allows for align=right, etc)
+    float baseline_y_delta;  // position of baseline relative to previous row's baseline
+    float ymin, ymax;        // height of row above and below baseline
+    int num_chars;
+} StbTexteditRow;
+#endif  // INCLUDE_STB_TEXTEDIT_H
+
+////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////
+////
+////   Implementation mode
+////
+////
+
+// implementation isn't include-guarded, since it might have indirectly
+// included just the "header" portion
+#ifdef STB_TEXTEDIT_IMPLEMENTATION
+
+#ifndef STB_TEXTEDIT_memmove
+#include <string.h>
+#define STB_TEXTEDIT_memmove memmove
+#endif
+
+/////////////////////////////////////////////////////////////////////////////
+//
+//      Mouse input handling
+//
+
+// traverse the layout to locate the nearest character to a display position
+static int stb_text_locate_coord(STB_TEXTEDIT_STRING *str, float x, float y)
+{
+    StbTexteditRow r;
+    int n        = STB_TEXTEDIT_STRINGLEN(str);
+    float base_y = 0, prev_x;
+    int i        = 0, k;
+
+    r.x0 = r.x1 = 0;
+    r.ymin = r.ymax = 0;
+    r.num_chars     = 0;
+
+    // search rows to find one that straddles 'y'
+    while (i < n)
+    {
+        STB_TEXTEDIT_LAYOUTROW(&r, str, i);
+        if (r.num_chars <= 0)
+            return n;
+
+        if (i == 0 && y < base_y + r.ymin)
+            return 0;
+
+        if (y < base_y + r.ymax)
+            break;
+
+        i += r.num_chars;
+        base_y += r.baseline_y_delta;
+    }
+
+    // below all text, return 'after' last character
+    if (i >= n)
+        return n;
+
+    // check if it's before the beginning of the line
+    if (x < r.x0)
+        return i;
+
+    // check if it's before the end of the line
+    if (x < r.x1)
+    {
+        // search characters in row for one that straddles 'x'
+        prev_x = r.x0;
+        for (k = 0; k < r.num_chars; ++k)
+        {
+            float w = STB_TEXTEDIT_GETWIDTH(str, i, k);
+            if (x < prev_x + w)
+            {
+                if (x < prev_x + w / 2)
+                    return k + i;
+                else
+                    return k + i + 1;
+            }
+            prev_x += w;
+        }
+        // shouldn't happen, but if it does, fall through to end-of-line case
+    }
+
+    // if the last character is a newline, return that. otherwise return 'after' the last character
+    if (STB_TEXTEDIT_GETCHAR(str, i + r.num_chars - 1) == STB_TEXTEDIT_NEWLINE)
+        return i + r.num_chars - 1;
+    else
+        return i + r.num_chars;
+}
+
+// API click: on mouse down, move the cursor to the clicked location, and reset the selection
+static void stb_textedit_click(STB_TEXTEDIT_STRING *str, STB_TexteditState *state, float x, float y)
+{
+    // In single-line mode, just always make y = 0. This lets the drag keep working if the mouse
+    // goes off the top or bottom of the text
+    if (state->single_line)
+    {
+        StbTexteditRow r;
+        STB_TEXTEDIT_LAYOUTROW(&r, str, 0);
+        y = r.ymin;
+    }
+
+    state->cursor          = stb_text_locate_coord(str, x, y);
+    state->select_start    = state->cursor;
+    state->select_end      = state->cursor;
+    state->has_preferred_x = 0;
+}
+
+// API drag: on mouse drag, move the cursor and selection endpoint to the clicked location
+static void stb_textedit_drag(STB_TEXTEDIT_STRING *str, STB_TexteditState *state, float x, float y)
+{
+    int p = 0;
+
+    // In single-line mode, just always make y = 0. This lets the drag keep working if the mouse
+    // goes off the top or bottom of the text
+    if (state->single_line)
+    {
+        StbTexteditRow r;
+        STB_TEXTEDIT_LAYOUTROW(&r, str, 0);
+        y = r.ymin;
+    }
+
+    if (state->select_start == state->select_end)
+        state->select_start = state->cursor;
+
+    p             = stb_text_locate_coord(str, x, y);
+    state->cursor = state->select_end = p;
+}
+
+/////////////////////////////////////////////////////////////////////////////
+//
+//      Keyboard input handling
+//
+
+// forward declarations
+static void stb_text_undo(STB_TEXTEDIT_STRING *str, STB_TexteditState *state);
+static void stb_text_redo(STB_TEXTEDIT_STRING *str, STB_TexteditState *state);
+static void stb_text_makeundo_delete(STB_TEXTEDIT_STRING *str,
+                                     STB_TexteditState *state,
+                                     int where,
+                                     int length);
+static void stb_text_makeundo_insert(STB_TexteditState *state, int where, int length);
+static void stb_text_makeundo_replace(STB_TEXTEDIT_STRING *str,
+                                      STB_TexteditState *state,
+                                      int where,
+                                      int old_length,
+                                      int new_length);
+
+typedef struct
+{
+    float x, y;              // position of n'th character
+    float height;            // height of line
+    int first_char, length;  // first char of row, and length
+    int prev_first;          // first char of previous row
+} StbFindState;
+
+// find the x/y location of a character, and remember info about the previous row in
+// case we get a move-up event (for page up, we'll have to rescan)
+static void stb_textedit_find_charpos(StbFindState *find,
+                                      STB_TEXTEDIT_STRING *str,
+                                      int n,
+                                      int single_line)
+{
+    StbTexteditRow r;
+    int prev_start = 0;
+    int z          = STB_TEXTEDIT_STRINGLEN(str);
+    int i          = 0, first;
+
+    if (n == z)
+    {
+        // if it's at the end, then find the last line -- simpler than trying to
+        // explicitly handle this case in the regular code
+        if (single_line)
+        {
+            STB_TEXTEDIT_LAYOUTROW(&r, str, 0);
+            find->y          = 0;
+            find->first_char = 0;
+            find->length     = z;
+            find->height     = r.ymax - r.ymin;
+            find->x          = r.x1;
+        }
+        else
+        {
+            find->y      = 0;
+            find->x      = 0;
+            find->height = 1;
+            while (i < z)
+            {
+                STB_TEXTEDIT_LAYOUTROW(&r, str, i);
+                prev_start = i;
+                i += r.num_chars;
+            }
+            find->first_char = i;
+            find->length     = 0;
+            find->prev_first = prev_start;
+        }
+        return;
+    }
+
+    // search rows to find the one that straddles character n
+    find->y = 0;
+
+    for (;;)
+    {
+        STB_TEXTEDIT_LAYOUTROW(&r, str, i);
+        if (n < i + r.num_chars)
+            break;
+        prev_start = i;
+        i += r.num_chars;
+        find->y += r.baseline_y_delta;
+    }
+
+    find->first_char = first = i;
+    find->length             = r.num_chars;
+    find->height             = r.ymax - r.ymin;
+    find->prev_first         = prev_start;
+
+    // now scan to find xpos
+    find->x = r.x0;
+    for (i = 0; first + i < n; ++i)
+        find->x += STB_TEXTEDIT_GETWIDTH(str, first, i);
+}
+
+#define STB_TEXT_HAS_SELECTION(s) ((s)->select_start != (s)->select_end)
+
+// make the selection/cursor state valid if client altered the string
+static void stb_textedit_clamp(STB_TEXTEDIT_STRING *str, STB_TexteditState *state)
+{
+    int n = STB_TEXTEDIT_STRINGLEN(str);
+    if (STB_TEXT_HAS_SELECTION(state))
+    {
+        if (state->select_start > n)
+            state->select_start = n;
+        if (state->select_end > n)
+            state->select_end = n;
+        // if clamping forced them to be equal, move the cursor to match
+        if (state->select_start == state->select_end)
+            state->cursor = state->select_start;
+    }
+    if (state->cursor > n)
+        state->cursor = n;
+}
+
+// delete characters while updating undo
+static void stb_textedit_delete(STB_TEXTEDIT_STRING *str,
+                                STB_TexteditState *state,
+                                int where,
+                                int len)
+{
+    stb_text_makeundo_delete(str, state, where, len);
+    STB_TEXTEDIT_DELETECHARS(str, where, len);
+    state->has_preferred_x = 0;
+}
+
+// delete the section
+static void stb_textedit_delete_selection(STB_TEXTEDIT_STRING *str, STB_TexteditState *state)
+{
+    stb_textedit_clamp(str, state);
+    if (STB_TEXT_HAS_SELECTION(state))
+    {
+        if (state->select_start < state->select_end)
+        {
+            stb_textedit_delete(str, state, state->select_start,
+                                state->select_end - state->select_start);
+            state->select_end = state->cursor = state->select_start;
+        }
+        else
+        {
+            stb_textedit_delete(str, state, state->select_end,
+                                state->select_start - state->select_end);
+            state->select_start = state->cursor = state->select_end;
+        }
+        state->has_preferred_x = 0;
+    }
+}
+
+// canoncialize the selection so start <= end
+static void stb_textedit_sortselection(STB_TexteditState *state)
+{
+    if (state->select_end < state->select_start)
+    {
+        int temp            = state->select_end;
+        state->select_end   = state->select_start;
+        state->select_start = temp;
+    }
+}
+
+// move cursor to first character of selection
+static void stb_textedit_move_to_first(STB_TexteditState *state)
+{
+    if (STB_TEXT_HAS_SELECTION(state))
+    {
+        stb_textedit_sortselection(state);
+        state->cursor          = state->select_start;
+        state->select_end      = state->select_start;
+        state->has_preferred_x = 0;
+    }
+}
+
+// move cursor to last character of selection
+static void stb_textedit_move_to_last(STB_TEXTEDIT_STRING *str, STB_TexteditState *state)
+{
+    if (STB_TEXT_HAS_SELECTION(state))
+    {
+        stb_textedit_sortselection(state);
+        stb_textedit_clamp(str, state);
+        state->cursor          = state->select_end;
+        state->select_start    = state->select_end;
+        state->has_preferred_x = 0;
+    }
+}
+
+#ifdef STB_TEXTEDIT_IS_SPACE
+static int is_word_boundary(STB_TEXTEDIT_STRING *str, int idx)
+{
+    return idx > 0 ? (STB_TEXTEDIT_IS_SPACE(STB_TEXTEDIT_GETCHAR(str, idx - 1)) &&
+                      !STB_TEXTEDIT_IS_SPACE(STB_TEXTEDIT_GETCHAR(str, idx)))
+                   : 1;
+}
+
+#ifndef STB_TEXTEDIT_MOVEWORDLEFT
+static int stb_textedit_move_to_word_previous(STB_TEXTEDIT_STRING *str, int c)
+{
+    --c;  // always move at least one character
+    while (c >= 0 && !is_word_boundary(str, c))
+        --c;
+
+    if (c < 0)
+        c = 0;
+
+    return c;
+}
+#define STB_TEXTEDIT_MOVEWORDLEFT stb_textedit_move_to_word_previous
+#endif
+
+#ifndef STB_TEXTEDIT_MOVEWORDRIGHT
+static int stb_textedit_move_to_word_next(STB_TEXTEDIT_STRING *str, int c)
+{
+    const int len = STB_TEXTEDIT_STRINGLEN(str);
+    ++c;  // always move at least one character
+    while (c < len && !is_word_boundary(str, c))
+        ++c;
+
+    if (c > len)
+        c = len;
+
+    return c;
+}
+#define STB_TEXTEDIT_MOVEWORDRIGHT stb_textedit_move_to_word_next
+#endif
+
+#endif
+
+// update selection and cursor to match each other
+static void stb_textedit_prep_selection_at_cursor(STB_TexteditState *state)
+{
+    if (!STB_TEXT_HAS_SELECTION(state))
+        state->select_start = state->select_end = state->cursor;
+    else
+        state->cursor = state->select_end;
+}
+
+// API cut: delete selection
+static int stb_textedit_cut(STB_TEXTEDIT_STRING *str, STB_TexteditState *state)
+{
+    if (STB_TEXT_HAS_SELECTION(state))
+    {
+        stb_textedit_delete_selection(str, state);  // implicitly clamps
+        state->has_preferred_x = 0;
+        return 1;
+    }
+    return 0;
+}
+
+// API paste: replace existing selection with passed-in text
+static int stb_textedit_paste_internal(STB_TEXTEDIT_STRING *str,
+                                       STB_TexteditState *state,
+                                       STB_TEXTEDIT_CHARTYPE *text,
+                                       int len)
+{
+    // if there's a selection, the paste should delete it
+    stb_textedit_clamp(str, state);
+    stb_textedit_delete_selection(str, state);
+    // try to insert the characters
+    if (STB_TEXTEDIT_INSERTCHARS(str, state->cursor, text, len))
+    {
+        stb_text_makeundo_insert(state, state->cursor, len);
+        state->cursor += len;
+        state->has_preferred_x = 0;
+        return 1;
+    }
+    // remove the undo since we didn't actually insert the characters
+    if (state->undostate.undo_point)
+        --state->undostate.undo_point;
+    return 0;
+}
+
+#ifndef STB_TEXTEDIT_KEYTYPE
+#define STB_TEXTEDIT_KEYTYPE int
+#endif
+
+// API key: process a keyboard input
+static void stb_textedit_key(STB_TEXTEDIT_STRING *str,
+                             STB_TexteditState *state,
+                             STB_TEXTEDIT_KEYTYPE key)
+{
+retry:
+    switch (key)
+    {
+        default:
+        {
+            int c = STB_TEXTEDIT_KEYTOTEXT(key);
+            if (c > 0)
+            {
+                STB_TEXTEDIT_CHARTYPE ch = (STB_TEXTEDIT_CHARTYPE)c;
+
+                // can't add newline in single-line mode
+                if (c == '\n' && state->single_line)
+                    break;
+
+                if (state->insert_mode && !STB_TEXT_HAS_SELECTION(state) &&
+                    state->cursor < STB_TEXTEDIT_STRINGLEN(str))
+                {
+                    stb_text_makeundo_replace(str, state, state->cursor, 1, 1);
+                    STB_TEXTEDIT_DELETECHARS(str, state->cursor, 1);
+                    if (STB_TEXTEDIT_INSERTCHARS(str, state->cursor, &ch, 1))
+                    {
+                        ++state->cursor;
+                        state->has_preferred_x = 0;
+                    }
+                }
+                else
+                {
+                    stb_textedit_delete_selection(str, state);  // implicitly clamps
+                    if (STB_TEXTEDIT_INSERTCHARS(str, state->cursor, &ch, 1))
+                    {
+                        stb_text_makeundo_insert(state, state->cursor, 1);
+                        ++state->cursor;
+                        state->has_preferred_x = 0;
+                    }
+                }
+            }
+            break;
+        }
+
+#ifdef STB_TEXTEDIT_K_INSERT
+        case STB_TEXTEDIT_K_INSERT:
+            state->insert_mode = !state->insert_mode;
+            break;
+#endif
+
+        case STB_TEXTEDIT_K_UNDO:
+            stb_text_undo(str, state);
+            state->has_preferred_x = 0;
+            break;
+
+        case STB_TEXTEDIT_K_REDO:
+            stb_text_redo(str, state);
+            state->has_preferred_x = 0;
+            break;
+
+        case STB_TEXTEDIT_K_LEFT:
+            // if currently there's a selection, move cursor to start of selection
+            if (STB_TEXT_HAS_SELECTION(state))
+                stb_textedit_move_to_first(state);
+            else if (state->cursor > 0)
+                --state->cursor;
+            state->has_preferred_x = 0;
+            break;
+
+        case STB_TEXTEDIT_K_RIGHT:
+            // if currently there's a selection, move cursor to end of selection
+            if (STB_TEXT_HAS_SELECTION(state))
+                stb_textedit_move_to_last(str, state);
+            else
+                ++state->cursor;
+            stb_textedit_clamp(str, state);
+            state->has_preferred_x = 0;
+            break;
+
+        case STB_TEXTEDIT_K_LEFT | STB_TEXTEDIT_K_SHIFT:
+            stb_textedit_clamp(str, state);
+            stb_textedit_prep_selection_at_cursor(state);
+            // move selection left
+            if (state->select_end > 0)
+                --state->select_end;
+            state->cursor          = state->select_end;
+            state->has_preferred_x = 0;
+            break;
+
+#ifdef STB_TEXTEDIT_MOVEWORDLEFT
+        case STB_TEXTEDIT_K_WORDLEFT:
+            if (STB_TEXT_HAS_SELECTION(state))
+                stb_textedit_move_to_first(state);
+            else
+            {
+                state->cursor = STB_TEXTEDIT_MOVEWORDLEFT(str, state->cursor);
+                stb_textedit_clamp(str, state);
+            }
+            break;
+
+        case STB_TEXTEDIT_K_WORDLEFT | STB_TEXTEDIT_K_SHIFT:
+            if (!STB_TEXT_HAS_SELECTION(state))
+                stb_textedit_prep_selection_at_cursor(state);
+
+            state->cursor     = STB_TEXTEDIT_MOVEWORDLEFT(str, state->cursor);
+            state->select_end = state->cursor;
+
+            stb_textedit_clamp(str, state);
+            break;
+#endif
+
+#ifdef STB_TEXTEDIT_MOVEWORDRIGHT
+        case STB_TEXTEDIT_K_WORDRIGHT:
+            if (STB_TEXT_HAS_SELECTION(state))
+                stb_textedit_move_to_last(str, state);
+            else
+            {
+                state->cursor = STB_TEXTEDIT_MOVEWORDRIGHT(str, state->cursor);
+                stb_textedit_clamp(str, state);
+            }
+            break;
+
+        case STB_TEXTEDIT_K_WORDRIGHT | STB_TEXTEDIT_K_SHIFT:
+            if (!STB_TEXT_HAS_SELECTION(state))
+                stb_textedit_prep_selection_at_cursor(state);
+
+            state->cursor     = STB_TEXTEDIT_MOVEWORDRIGHT(str, state->cursor);
+            state->select_end = state->cursor;
+
+            stb_textedit_clamp(str, state);
+            break;
+#endif
+
+        case STB_TEXTEDIT_K_RIGHT | STB_TEXTEDIT_K_SHIFT:
+            stb_textedit_prep_selection_at_cursor(state);
+            // move selection right
+            ++state->select_end;
+            stb_textedit_clamp(str, state);
+            state->cursor          = state->select_end;
+            state->has_preferred_x = 0;
+            break;
+
+        case STB_TEXTEDIT_K_DOWN:
+        case STB_TEXTEDIT_K_DOWN | STB_TEXTEDIT_K_SHIFT:
+        {
+            StbFindState find;
+            StbTexteditRow row;
+            int i, sel = (key & STB_TEXTEDIT_K_SHIFT) != 0;
+
+            if (state->single_line)
+            {
+                // on windows, up&down in single-line behave like left&right
+                key = STB_TEXTEDIT_K_RIGHT | (key & STB_TEXTEDIT_K_SHIFT);
+                goto retry;
+            }
+
+            if (sel)
+                stb_textedit_prep_selection_at_cursor(state);
+            else if (STB_TEXT_HAS_SELECTION(state))
+                stb_textedit_move_to_last(str, state);
+
+            // compute current position of cursor point
+            stb_textedit_clamp(str, state);
+            stb_textedit_find_charpos(&find, str, state->cursor, state->single_line);
+
+            // now find character position down a row
+            if (find.length)
+            {
+                float goal_x = state->has_preferred_x ? state->preferred_x : find.x;
+                float x;
+                int start     = find.first_char + find.length;
+                state->cursor = start;
+                STB_TEXTEDIT_LAYOUTROW(&row, str, state->cursor);
+                x = row.x0;
+                for (i = 0; i < row.num_chars; ++i)
+                {
+                    float dx = STB_TEXTEDIT_GETWIDTH(str, start, i);
+#ifdef STB_TEXTEDIT_GETWIDTH_NEWLINE
+                    if (dx == STB_TEXTEDIT_GETWIDTH_NEWLINE)
+                        break;
+#endif
+                    x += dx;
+                    if (x > goal_x)
+                        break;
+                    ++state->cursor;
+                }
+                stb_textedit_clamp(str, state);
+
+                state->has_preferred_x = 1;
+                state->preferred_x     = goal_x;
+
+                if (sel)
+                    state->select_end = state->cursor;
+            }
+            break;
+        }
+
+        case STB_TEXTEDIT_K_UP:
+        case STB_TEXTEDIT_K_UP | STB_TEXTEDIT_K_SHIFT:
+        {
+            StbFindState find;
+            StbTexteditRow row;
+            int i, sel = (key & STB_TEXTEDIT_K_SHIFT) != 0;
+
+            if (state->single_line)
+            {
+                // on windows, up&down become left&right
+                key = STB_TEXTEDIT_K_LEFT | (key & STB_TEXTEDIT_K_SHIFT);
+                goto retry;
+            }
+
+            if (sel)
+                stb_textedit_prep_selection_at_cursor(state);
+            else if (STB_TEXT_HAS_SELECTION(state))
+                stb_textedit_move_to_first(state);
+
+            // compute current position of cursor point
+            stb_textedit_clamp(str, state);
+            stb_textedit_find_charpos(&find, str, state->cursor, state->single_line);
+
+            // can only go up if there's a previous row
+            if (find.prev_first != find.first_char)
+            {
+                // now find character position up a row
+                float goal_x = state->has_preferred_x ? state->preferred_x : find.x;
+                float x;
+                state->cursor = find.prev_first;
+                STB_TEXTEDIT_LAYOUTROW(&row, str, state->cursor);
+                x = row.x0;
+                for (i = 0; i < row.num_chars; ++i)
+                {
+                    float dx = STB_TEXTEDIT_GETWIDTH(str, find.prev_first, i);
+#ifdef STB_TEXTEDIT_GETWIDTH_NEWLINE
+                    if (dx == STB_TEXTEDIT_GETWIDTH_NEWLINE)
+                        break;
+#endif
+                    x += dx;
+                    if (x > goal_x)
+                        break;
+                    ++state->cursor;
+                }
+                stb_textedit_clamp(str, state);
+
+                state->has_preferred_x = 1;
+                state->preferred_x     = goal_x;
+
+                if (sel)
+                    state->select_end = state->cursor;
+            }
+            break;
+        }
+
+        case STB_TEXTEDIT_K_DELETE:
+        case STB_TEXTEDIT_K_DELETE | STB_TEXTEDIT_K_SHIFT:
+            if (STB_TEXT_HAS_SELECTION(state))
+                stb_textedit_delete_selection(str, state);
+            else
+            {
+                int n = STB_TEXTEDIT_STRINGLEN(str);
+                if (state->cursor < n)
+                    stb_textedit_delete(str, state, state->cursor, 1);
+            }
+            state->has_preferred_x = 0;
+            break;
+
+        case STB_TEXTEDIT_K_BACKSPACE:
+        case STB_TEXTEDIT_K_BACKSPACE | STB_TEXTEDIT_K_SHIFT:
+            if (STB_TEXT_HAS_SELECTION(state))
+                stb_textedit_delete_selection(str, state);
+            else
+            {
+                stb_textedit_clamp(str, state);
+                if (state->cursor > 0)
+                {
+                    stb_textedit_delete(str, state, state->cursor - 1, 1);
+                    --state->cursor;
+                }
+            }
+            state->has_preferred_x = 0;
+            break;
+
+#ifdef STB_TEXTEDIT_K_TEXTSTART2
+        case STB_TEXTEDIT_K_TEXTSTART2:
+#endif
+        case STB_TEXTEDIT_K_TEXTSTART:
+            state->cursor = state->select_start = state->select_end = 0;
+            state->has_preferred_x                                  = 0;
+            break;
+
+#ifdef STB_TEXTEDIT_K_TEXTEND2
+        case STB_TEXTEDIT_K_TEXTEND2:
+#endif
+        case STB_TEXTEDIT_K_TEXTEND:
+            state->cursor       = STB_TEXTEDIT_STRINGLEN(str);
+            state->select_start = state->select_end = 0;
+            state->has_preferred_x                  = 0;
+            break;
+
+#ifdef STB_TEXTEDIT_K_TEXTSTART2
+        case STB_TEXTEDIT_K_TEXTSTART2 | STB_TEXTEDIT_K_SHIFT:
+#endif
+        case STB_TEXTEDIT_K_TEXTSTART | STB_TEXTEDIT_K_SHIFT:
+            stb_textedit_prep_selection_at_cursor(state);
+            state->cursor = state->select_end = 0;
+            state->has_preferred_x            = 0;
+            break;
+
+#ifdef STB_TEXTEDIT_K_TEXTEND2
+        case STB_TEXTEDIT_K_TEXTEND2 | STB_TEXTEDIT_K_SHIFT:
+#endif
+        case STB_TEXTEDIT_K_TEXTEND | STB_TEXTEDIT_K_SHIFT:
+            stb_textedit_prep_selection_at_cursor(state);
+            state->cursor = state->select_end = STB_TEXTEDIT_STRINGLEN(str);
+            state->has_preferred_x            = 0;
+            break;
+
+#ifdef STB_TEXTEDIT_K_LINESTART2
+        case STB_TEXTEDIT_K_LINESTART2:
+#endif
+        case STB_TEXTEDIT_K_LINESTART:
+            stb_textedit_clamp(str, state);
+            stb_textedit_move_to_first(state);
+            if (state->single_line)
+                state->cursor = 0;
+            else
+                while (state->cursor > 0 &&
+                       STB_TEXTEDIT_GETCHAR(str, state->cursor - 1) != STB_TEXTEDIT_NEWLINE)
+                    --state->cursor;
+            state->has_preferred_x = 0;
+            break;
+
+#ifdef STB_TEXTEDIT_K_LINEEND2
+        case STB_TEXTEDIT_K_LINEEND2:
+#endif
+        case STB_TEXTEDIT_K_LINEEND:
+        {
+            int n = STB_TEXTEDIT_STRINGLEN(str);
+            stb_textedit_clamp(str, state);
+            stb_textedit_move_to_first(state);
+            if (state->single_line)
+                state->cursor = n;
+            else
+                while (state->cursor < n &&
+                       STB_TEXTEDIT_GETCHAR(str, state->cursor) != STB_TEXTEDIT_NEWLINE)
+                    ++state->cursor;
+            state->has_preferred_x = 0;
+            break;
+        }
+
+#ifdef STB_TEXTEDIT_K_LINESTART2
+        case STB_TEXTEDIT_K_LINESTART2 | STB_TEXTEDIT_K_SHIFT:
+#endif
+        case STB_TEXTEDIT_K_LINESTART | STB_TEXTEDIT_K_SHIFT:
+            stb_textedit_clamp(str, state);
+            stb_textedit_prep_selection_at_cursor(state);
+            if (state->single_line)
+                state->cursor = 0;
+            else
+                while (state->cursor > 0 &&
+                       STB_TEXTEDIT_GETCHAR(str, state->cursor - 1) != STB_TEXTEDIT_NEWLINE)
+                    --state->cursor;
+            state->select_end      = state->cursor;
+            state->has_preferred_x = 0;
+            break;
+
+#ifdef STB_TEXTEDIT_K_LINEEND2
+        case STB_TEXTEDIT_K_LINEEND2 | STB_TEXTEDIT_K_SHIFT:
+#endif
+        case STB_TEXTEDIT_K_LINEEND | STB_TEXTEDIT_K_SHIFT:
+        {
+            int n = STB_TEXTEDIT_STRINGLEN(str);
+            stb_textedit_clamp(str, state);
+            stb_textedit_prep_selection_at_cursor(state);
+            if (state->single_line)
+                state->cursor = n;
+            else
+                while (state->cursor < n &&
+                       STB_TEXTEDIT_GETCHAR(str, state->cursor) != STB_TEXTEDIT_NEWLINE)
+                    ++state->cursor;
+            state->select_end      = state->cursor;
+            state->has_preferred_x = 0;
+            break;
+        }
+
+            // @TODO:
+            //    STB_TEXTEDIT_K_PGUP      - move cursor up a page
+            //    STB_TEXTEDIT_K_PGDOWN    - move cursor down a page
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+//
+//      Undo processing
+//
+// @OPTIMIZE: the undo/redo buffer should be circular
+
+static void stb_textedit_flush_redo(StbUndoState *state)
+{
+    state->redo_point      = STB_TEXTEDIT_UNDOSTATECOUNT;
+    state->redo_char_point = STB_TEXTEDIT_UNDOCHARCOUNT;
+}
+
+// discard the oldest entry in the undo list
+static void stb_textedit_discard_undo(StbUndoState *state)
+{
+    if (state->undo_point > 0)
+    {
+        // if the 0th undo state has characters, clean those up
+        if (state->undo_rec[0].char_storage >= 0)
+        {
+            int n = state->undo_rec[0].insert_length, i;
+            // delete n characters from all other records
+            state->undo_char_point -= n;
+            STB_TEXTEDIT_memmove(state->undo_char, state->undo_char + n,
+                                 (size_t)(state->undo_char_point * sizeof(STB_TEXTEDIT_CHARTYPE)));
+            for (i = 0; i < state->undo_point; ++i)
+                if (state->undo_rec[i].char_storage >= 0)
+                    state->undo_rec[i].char_storage -=
+                        n;  // @OPTIMIZE: get rid of char_storage and infer it
+        }
+        --state->undo_point;
+        STB_TEXTEDIT_memmove(state->undo_rec, state->undo_rec + 1,
+                             (size_t)(state->undo_point * sizeof(state->undo_rec[0])));
+    }
+}
+
+// discard the oldest entry in the redo list--it's bad if this
+// ever happens, but because undo & redo have to store the actual
+// characters in different cases, the redo character buffer can
+// fill up even though the undo buffer didn't
+static void stb_textedit_discard_redo(StbUndoState *state)
+{
+    int k = STB_TEXTEDIT_UNDOSTATECOUNT - 1;
+
+    if (state->redo_point <= k)
+    {
+        // if the k'th undo state has characters, clean those up
+        if (state->undo_rec[k].char_storage >= 0)
+        {
+            int n = state->undo_rec[k].insert_length, i;
+            // move the remaining redo character data to the end of the buffer
+            state->redo_char_point += n;
+            STB_TEXTEDIT_memmove(state->undo_char + state->redo_char_point,
+                                 state->undo_char + state->redo_char_point - n,
+                                 (size_t)((STB_TEXTEDIT_UNDOCHARCOUNT - state->redo_char_point) *
+                                          sizeof(STB_TEXTEDIT_CHARTYPE)));
+            // adjust the position of all the other records to account for above memmove
+            for (i = state->redo_point; i < k; ++i)
+                if (state->undo_rec[i].char_storage >= 0)
+                    state->undo_rec[i].char_storage += n;
+        }
+        // now move all the redo records towards the end of the buffer; the first one is at
+        // 'redo_point' {DEAR IMGUI]
+        size_t move_size      = (size_t)((STB_TEXTEDIT_UNDOSTATECOUNT - state->redo_point - 1) *
+                                    sizeof(state->undo_rec[0]));
+        const char *buf_begin = (char *)state->undo_rec;
+        (void)buf_begin;
+        const char *buf_end = (char *)state->undo_rec + sizeof(state->undo_rec);
+        (void)buf_end;
+        IM_ASSERT(((char *)(state->undo_rec + state->redo_point)) >= buf_begin);
+        IM_ASSERT(((char *)(state->undo_rec + state->redo_point + 1) + move_size) <= buf_end);
+        STB_TEXTEDIT_memmove(state->undo_rec + state->redo_point + 1,
+                             state->undo_rec + state->redo_point, move_size);
+
+        // now move redo_point to point to the new one
+        ++state->redo_point;
+    }
+}
+
+static StbUndoRecord *stb_text_create_undo_record(StbUndoState *state, int numchars)
+{
+    // any time we create a new undo record, we discard redo
+    stb_textedit_flush_redo(state);
+
+    // if we have no free records, we have to make room, by sliding the
+    // existing records down
+    if (state->undo_point == STB_TEXTEDIT_UNDOSTATECOUNT)
+        stb_textedit_discard_undo(state);
+
+    // if the characters to store won't possibly fit in the buffer, we can't undo
+    if (numchars > STB_TEXTEDIT_UNDOCHARCOUNT)
+    {
+        state->undo_point      = 0;
+        state->undo_char_point = 0;
+        return NULL;
+    }
+
+    // if we don't have enough free characters in the buffer, we have to make room
+    while (state->undo_char_point + numchars > STB_TEXTEDIT_UNDOCHARCOUNT)
+        stb_textedit_discard_undo(state);
+
+    return &state->undo_rec[state->undo_point++];
+}
+
+static STB_TEXTEDIT_CHARTYPE *stb_text_createundo(StbUndoState *state,
+                                                  int pos,
+                                                  int insert_len,
+                                                  int delete_len)
+{
+    StbUndoRecord *r = stb_text_create_undo_record(state, insert_len);
+    if (r == NULL)
+        return NULL;
+
+    r->where         = pos;
+    r->insert_length = (STB_TEXTEDIT_POSITIONTYPE)insert_len;
+    r->delete_length = (STB_TEXTEDIT_POSITIONTYPE)delete_len;
+
+    if (insert_len == 0)
+    {
+        r->char_storage = -1;
+        return NULL;
+    }
+    else
+    {
+        r->char_storage = state->undo_char_point;
+        state->undo_char_point += insert_len;
+        return &state->undo_char[r->char_storage];
+    }
+}
+
+static void stb_text_undo(STB_TEXTEDIT_STRING *str, STB_TexteditState *state)
+{
+    StbUndoState *s = &state->undostate;
+    StbUndoRecord u, *r;
+    if (s->undo_point == 0)
+        return;
+
+    // we need to do two things: apply the undo record, and create a redo record
+    u               = s->undo_rec[s->undo_point - 1];
+    r               = &s->undo_rec[s->redo_point - 1];
+    r->char_storage = -1;
+
+    r->insert_length = u.delete_length;
+    r->delete_length = u.insert_length;
+    r->where         = u.where;
+
+    if (u.delete_length)
+    {
+        // if the undo record says to delete characters, then the redo record will
+        // need to re-insert the characters that get deleted, so we need to store
+        // them.
+
+        // there are three cases:
+        //    there's enough room to store the characters
+        //    characters stored for *redoing* don't leave room for redo
+        //    characters stored for *undoing* don't leave room for redo
+        // if the last is true, we have to bail
+
+        if (s->undo_char_point + u.delete_length >= STB_TEXTEDIT_UNDOCHARCOUNT)
+        {
+            // the undo records take up too much character space; there's no space to store the redo
+            // characters
+            r->insert_length = 0;
+        }
+        else
+        {
+            int i;
+
+            // there's definitely room to store the characters eventually
+            while (s->undo_char_point + u.delete_length > s->redo_char_point)
+            {
+                // should never happen:
+                if (s->redo_point == STB_TEXTEDIT_UNDOSTATECOUNT)
+                    return;
+                // there's currently not enough room, so discard a redo record
+                stb_textedit_discard_redo(s);
+            }
+            r = &s->undo_rec[s->redo_point - 1];
+
+            r->char_storage    = s->redo_char_point - u.delete_length;
+            s->redo_char_point = s->redo_char_point - u.delete_length;
+
+            // now save the characters
+            for (i = 0; i < u.delete_length; ++i)
+                s->undo_char[r->char_storage + i] = STB_TEXTEDIT_GETCHAR(str, u.where + i);
+        }
+
+        // now we can carry out the deletion
+        STB_TEXTEDIT_DELETECHARS(str, u.where, u.delete_length);
+    }
+
+    // check type of recorded action:
+    if (u.insert_length)
+    {
+        // easy case: was a deletion, so we need to insert n characters
+        STB_TEXTEDIT_INSERTCHARS(str, u.where, &s->undo_char[u.char_storage], u.insert_length);
+        s->undo_char_point -= u.insert_length;
+    }
+
+    state->cursor = u.where + u.insert_length;
+
+    s->undo_point--;
+    s->redo_point--;
+}
+
+static void stb_text_redo(STB_TEXTEDIT_STRING *str, STB_TexteditState *state)
+{
+    StbUndoState *s = &state->undostate;
+    StbUndoRecord *u, r;
+    if (s->redo_point == STB_TEXTEDIT_UNDOSTATECOUNT)
+        return;
+
+    // we need to do two things: apply the redo record, and create an undo record
+    u = &s->undo_rec[s->undo_point];
+    r = s->undo_rec[s->redo_point];
+
+    // we KNOW there must be room for the undo record, because the redo record
+    // was derived from an undo record
+
+    u->delete_length = r.insert_length;
+    u->insert_length = r.delete_length;
+    u->where         = r.where;
+    u->char_storage  = -1;
+
+    if (r.delete_length)
+    {
+        // the redo record requires us to delete characters, so the undo record
+        // needs to store the characters
+
+        if (s->undo_char_point + u->insert_length > s->redo_char_point)
+        {
+            u->insert_length = 0;
+            u->delete_length = 0;
+        }
+        else
+        {
+            int i;
+            u->char_storage    = s->undo_char_point;
+            s->undo_char_point = s->undo_char_point + u->insert_length;
+
+            // now save the characters
+            for (i = 0; i < u->insert_length; ++i)
+                s->undo_char[u->char_storage + i] = STB_TEXTEDIT_GETCHAR(str, u->where + i);
+        }
+
+        STB_TEXTEDIT_DELETECHARS(str, r.where, r.delete_length);
+    }
+
+    if (r.insert_length)
+    {
+        // easy case: need to insert n characters
+        STB_TEXTEDIT_INSERTCHARS(str, r.where, &s->undo_char[r.char_storage], r.insert_length);
+        s->redo_char_point += r.insert_length;
+    }
+
+    state->cursor = r.where + r.insert_length;
+
+    s->undo_point++;
+    s->redo_point++;
+}
+
+static void stb_text_makeundo_insert(STB_TexteditState *state, int where, int length)
+{
+    stb_text_createundo(&state->undostate, where, 0, length);
+}
+
+static void stb_text_makeundo_delete(STB_TEXTEDIT_STRING *str,
+                                     STB_TexteditState *state,
+                                     int where,
+                                     int length)
+{
+    int i;
+    STB_TEXTEDIT_CHARTYPE *p = stb_text_createundo(&state->undostate, where, length, 0);
+    if (p)
+    {
+        for (i = 0; i < length; ++i)
+            p[i] = STB_TEXTEDIT_GETCHAR(str, where + i);
+    }
+}
+
+static void stb_text_makeundo_replace(STB_TEXTEDIT_STRING *str,
+                                      STB_TexteditState *state,
+                                      int where,
+                                      int old_length,
+                                      int new_length)
+{
+    int i;
+    STB_TEXTEDIT_CHARTYPE *p =
+        stb_text_createundo(&state->undostate, where, old_length, new_length);
+    if (p)
+    {
+        for (i = 0; i < old_length; ++i)
+            p[i] = STB_TEXTEDIT_GETCHAR(str, where + i);
+    }
+}
+
+// reset the state to default
+static void stb_textedit_clear_state(STB_TexteditState *state, int is_single_line)
+{
+    state->undostate.undo_point      = 0;
+    state->undostate.undo_char_point = 0;
+    state->undostate.redo_point      = STB_TEXTEDIT_UNDOSTATECOUNT;
+    state->undostate.redo_char_point = STB_TEXTEDIT_UNDOCHARCOUNT;
+    state->select_end = state->select_start = 0;
+    state->cursor                           = 0;
+    state->has_preferred_x                  = 0;
+    state->preferred_x                      = 0;
+    state->cursor_at_end_of_line            = 0;
+    state->initialized                      = 1;
+    state->single_line                      = (unsigned char)is_single_line;
+    state->insert_mode                      = 0;
+}
+
+// API initialize
+static void stb_textedit_initialize_state(STB_TexteditState *state, int is_single_line)
+{
+    stb_textedit_clear_state(state, is_single_line);
+}
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
+
+static int stb_textedit_paste(STB_TEXTEDIT_STRING *str,
+                              STB_TexteditState *state,
+                              STB_TEXTEDIT_CHARTYPE const *ctext,
+                              int len)
+{
+    return stb_textedit_paste_internal(str, state, (STB_TEXTEDIT_CHARTYPE *)ctext, len);
+}
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+#endif  // STB_TEXTEDIT_IMPLEMENTATION
+
+/*
+------------------------------------------------------------------------------
+This software is available under 2 licenses -- choose whichever you prefer.
+------------------------------------------------------------------------------
+ALTERNATIVE A - MIT License
+Copyright (c) 2017 Sean Barrett
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+------------------------------------------------------------------------------
+ALTERNATIVE B - Public Domain (www.unlicense.org)
+This is free and unencumbered software released into the public domain.
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this
+software, either in source code form or as a compiled binary, for any purpose,
+commercial or non-commercial, and by any means.
+In jurisdictions that recognize copyright laws, the author or authors of this
+software dedicate any and all copyright interest in the software to the public
+domain. We make this dedication for the benefit of the public at large and to
+the detriment of our heirs and successors. We intend this dedication to be an
+overt act of relinquishment in perpetuity of all present and future rights to
+this software under copyright law.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+------------------------------------------------------------------------------
+*/

--- a/third_party/imgui/imstb_truetype.h
+++ b/third_party/imgui/imstb_truetype.h
@@ -1,0 +1,6165 @@
+// [DEAR IMGUI]
+// This is a slightly modified version of stb_truetype.h 1.20.
+// Mostly fixing for compiler and static analyzer warnings.
+// Grep for [DEAR IMGUI] to find the changes.
+
+// stb_truetype.h - v1.20 - public domain
+// authored from 2009-2016 by Sean Barrett / RAD Game Tools
+//
+//   This library processes TrueType files:
+//        parse files
+//        extract glyph metrics
+//        extract glyph shapes
+//        render glyphs to one-channel bitmaps with antialiasing (box filter)
+//        render glyphs to one-channel SDF bitmaps (signed-distance field/function)
+//
+//   Todo:
+//        non-MS cmaps
+//        crashproof on bad data
+//        hinting? (no longer patented)
+//        cleartype-style AA?
+//        optimize: use simple memory allocator for intermediates
+//        optimize: build edge-list directly from curves
+//        optimize: rasterize directly from curves?
+//
+// ADDITIONAL CONTRIBUTORS
+//
+//   Mikko Mononen: compound shape support, more cmap formats
+//   Tor Andersson: kerning, subpixel rendering
+//   Dougall Johnson: OpenType / Type 2 font handling
+//   Daniel Ribeiro Maciel: basic GPOS-based kerning
+//
+//   Misc other:
+//       Ryan Gordon
+//       Simon Glass
+//       github:IntellectualKitty
+//       Imanol Celaya
+//       Daniel Ribeiro Maciel
+//
+//   Bug/warning reports/fixes:
+//       "Zer" on mollyrocket       Fabian "ryg" Giesen
+//       Cass Everitt               Martins Mozeiko
+//       stoiko (Haemimont Games)   Cap Petschulat
+//       Brian Hook                 Omar Cornut
+//       Walter van Niftrik         github:aloucks
+//       David Gow                  Peter LaValle
+//       David Given                Sergey Popov
+//       Ivan-Assen Ivanov          Giumo X. Clanjor
+//       Anthony Pesch              Higor Euripedes
+//       Johan Duparc               Thomas Fields
+//       Hou Qiming                 Derek Vinyard
+//       Rob Loach                  Cort Stratton
+//       Kenney Phillis Jr.         github:oyvindjam
+//       Brian Costabile            github:vassvik
+//
+// VERSION HISTORY
+//
+//   1.20 (2019-02-07) PackFontRange skips missing codepoints; GetScaleFontVMetrics()
+//   1.19 (2018-02-11) GPOS kerning, STBTT_fmod
+//   1.18 (2018-01-29) add missing function
+//   1.17 (2017-07-23) make more arguments const; doc fix
+//   1.16 (2017-07-12) SDF support
+//   1.15 (2017-03-03) make more arguments const
+//   1.14 (2017-01-16) num-fonts-in-TTC function
+//   1.13 (2017-01-02) support OpenType fonts, certain Apple fonts
+//   1.12 (2016-10-25) suppress warnings about casting away const with -Wcast-qual
+//   1.11 (2016-04-02) fix unused-variable warning
+//   1.10 (2016-04-02) user-defined fabs(); rare memory leak; remove duplicate typedef
+//   1.09 (2016-01-16) warning fix; avoid crash on outofmem; use allocation userdata properly
+//   1.08 (2015-09-13) document stbtt_Rasterize(); fixes for vertical & horizontal edges
+//   1.07 (2015-08-01) allow PackFontRanges to accept arrays of sparse codepoints;
+//                     variant PackFontRanges to pack and render in separate phases;
+//                     fix stbtt_GetFontOFfsetForIndex (never worked for non-0 input?);
+//                     fixed an assert() bug in the new rasterizer
+//                     replace assert() with STBTT_assert() in new rasterizer
+//
+//   Full history can be found at the end of this file.
+//
+// LICENSE
+//
+//   See end of file for license information.
+//
+// USAGE
+//
+//   Include this file in whatever places need to refer to it. In ONE C/C++
+//   file, write:
+//      #define STB_TRUETYPE_IMPLEMENTATION
+//   before the #include of this file. This expands out the actual
+//   implementation into that C/C++ file.
+//
+//   To make the implementation private to the file that generates the implementation,
+//      #define STBTT_STATIC
+//
+//   Simple 3D API (don't ship this, but it's fine for tools and quick start)
+//           stbtt_BakeFontBitmap()               -- bake a font to a bitmap for use as texture
+//           stbtt_GetBakedQuad()                 -- compute quad to draw for a given char
+//
+//   Improved 3D API (more shippable):
+//           #include "stb_rect_pack.h"           -- optional, but you really want it
+//           stbtt_PackBegin()
+//           stbtt_PackSetOversampling()          -- for improved quality on small fonts
+//           stbtt_PackFontRanges()               -- pack and renders
+//           stbtt_PackEnd()
+//           stbtt_GetPackedQuad()
+//
+//   "Load" a font file from a memory buffer (you have to keep the buffer loaded)
+//           stbtt_InitFont()
+//           stbtt_GetFontOffsetForIndex()        -- indexing for TTC font collections
+//           stbtt_GetNumberOfFonts()             -- number of fonts for TTC font collections
+//
+//   Render a unicode codepoint to a bitmap
+//           stbtt_GetCodepointBitmap()           -- allocates and returns a bitmap
+//           stbtt_MakeCodepointBitmap()          -- renders into bitmap you provide
+//           stbtt_GetCodepointBitmapBox()        -- how big the bitmap must be
+//
+//   Character advance/positioning
+//           stbtt_GetCodepointHMetrics()
+//           stbtt_GetFontVMetrics()
+//           stbtt_GetFontVMetricsOS2()
+//           stbtt_GetCodepointKernAdvance()
+//
+//   Starting with version 1.06, the rasterizer was replaced with a new,
+//   faster and generally-more-precise rasterizer. The new rasterizer more
+//   accurately measures pixel coverage for anti-aliasing, except in the case
+//   where multiple shapes overlap, in which case it overestimates the AA pixel
+//   coverage. Thus, anti-aliasing of intersecting shapes may look wrong. If
+//   this turns out to be a problem, you can re-enable the old rasterizer with
+//        #define STBTT_RASTERIZER_VERSION 1
+//   which will incur about a 15% speed hit.
+//
+// ADDITIONAL DOCUMENTATION
+//
+//   Immediately after this block comment are a series of sample programs.
+//
+//   After the sample programs is the "header file" section. This section
+//   includes documentation for each API function.
+//
+//   Some important concepts to understand to use this library:
+//
+//      Codepoint
+//         Characters are defined by unicode codepoints, e.g. 65 is
+//         uppercase A, 231 is lowercase c with a cedilla, 0x7e30 is
+//         the hiragana for "ma".
+//
+//      Glyph
+//         A visual character shape (every codepoint is rendered as
+//         some glyph)
+//
+//      Glyph index
+//         A font-specific integer ID representing a glyph
+//
+//      Baseline
+//         Glyph shapes are defined relative to a baseline, which is the
+//         bottom of uppercase characters. Characters extend both above
+//         and below the baseline.
+//
+//      Current Point
+//         As you draw text to the screen, you keep track of a "current point"
+//         which is the origin of each character. The current point's vertical
+//         position is the baseline. Even "baked fonts" use this model.
+//
+//      Vertical Font Metrics
+//         The vertical qualities of the font, used to vertically position
+//         and space the characters. See docs for stbtt_GetFontVMetrics.
+//
+//      Font Size in Pixels or Points
+//         The preferred interface for specifying font sizes in stb_truetype
+//         is to specify how tall the font's vertical extent should be in pixels.
+//         If that sounds good enough, skip the next paragraph.
+//
+//         Most font APIs instead use "points", which are a common typographic
+//         measurement for describing font size, defined as 72 points per inch.
+//         stb_truetype provides a point API for compatibility. However, true
+//         "per inch" conventions don't make much sense on computer displays
+//         since different monitors have different number of pixels per
+//         inch. For example, Windows traditionally uses a convention that
+//         there are 96 pixels per inch, thus making 'inch' measurements have
+//         nothing to do with inches, and thus effectively defining a point to
+//         be 1.333 pixels. Additionally, the TrueType font data provides
+//         an explicit scale factor to scale a given font's glyphs to points,
+//         but the author has observed that this scale factor is often wrong
+//         for non-commercial fonts, thus making fonts scaled in points
+//         according to the TrueType spec incoherently sized in practice.
+//
+// DETAILED USAGE:
+//
+//  Scale:
+//    Select how high you want the font to be, in points or pixels.
+//    Call ScaleForPixelHeight or ScaleForMappingEmToPixels to compute
+//    a scale factor SF that will be used by all other functions.
+//
+//  Baseline:
+//    You need to select a y-coordinate that is the baseline of where
+//    your text will appear. Call GetFontBoundingBox to get the baseline-relative
+//    bounding box for all characters. SF*-y0 will be the distance in pixels
+//    that the worst-case character could extend above the baseline, so if
+//    you want the top edge of characters to appear at the top of the
+//    screen where y=0, then you would set the baseline to SF*-y0.
+//
+//  Current point:
+//    Set the current point where the first character will appear. The
+//    first character could extend left of the current point; this is font
+//    dependent. You can either choose a current point that is the leftmost
+//    point and hope, or add some padding, or check the bounding box or
+//    left-side-bearing of the first character to be displayed and set
+//    the current point based on that.
+//
+//  Displaying a character:
+//    Compute the bounding box of the character. It will contain signed values
+//    relative to <current_point, baseline>. I.e. if it returns x0,y0,x1,y1,
+//    then the character should be displayed in the rectangle from
+//    <current_point+SF*x0, baseline+SF*y0> to <current_point+SF*x1,baseline+SF*y1).
+//
+//  Advancing for the next character:
+//    Call GlyphHMetrics, and compute 'current_point += SF * advance'.
+//
+//
+// ADVANCED USAGE
+//
+//   Quality:
+//
+//    - Use the functions with Subpixel at the end to allow your characters
+//      to have subpixel positioning. Since the font is anti-aliased, not
+//      hinted, this is very import for quality. (This is not possible with
+//      baked fonts.)
+//
+//    - Kerning is now supported, and if you're supporting subpixel rendering
+//      then kerning is worth using to give your text a polished look.
+//
+//   Performance:
+//
+//    - Convert Unicode codepoints to glyph indexes and operate on the glyphs;
+//      if you don't do this, stb_truetype is forced to do the conversion on
+//      every call.
+//
+//    - There are a lot of memory allocations. We should modify it to take
+//      a temp buffer and allocate from the temp buffer (without freeing),
+//      should help performance a lot.
+//
+// NOTES
+//
+//   The system uses the raw data found in the .ttf file without changing it
+//   and without building auxiliary data structures. This is a bit inefficient
+//   on little-endian systems (the data is big-endian), but assuming you're
+//   caching the bitmaps or glyph shapes this shouldn't be a big deal.
+//
+//   It appears to be very hard to programmatically determine what font a
+//   given file is in a general way. I provide an API for this, but I don't
+//   recommend it.
+//
+//
+// SOURCE STATISTICS (based on v0.6c, 2050 LOC)
+//
+//   Documentation & header file        520 LOC  \___ 660 LOC documentation
+//   Sample code                        140 LOC  /
+//   Truetype parsing                   620 LOC  ---- 620 LOC TrueType
+//   Software rasterization             240 LOC  \.
+//   Curve tessellation                 120 LOC   \__ 550 LOC Bitmap creation
+//   Bitmap management                  100 LOC   /
+//   Baked bitmap interface              70 LOC  /
+//   Font name matching & access        150 LOC  ---- 150
+//   C runtime library abstraction       60 LOC  ----  60
+//
+//
+// PERFORMANCE MEASUREMENTS FOR 1.06:
+//
+//                      32-bit     64-bit
+//   Previous release:  8.83 s     7.68 s
+//   Pool allocations:  7.72 s     6.34 s
+//   Inline sort     :  6.54 s     5.65 s
+//   New rasterizer  :  5.63 s     5.00 s
+
+//////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+////
+////  SAMPLE PROGRAMS
+////
+//
+//  Incomplete text-in-3d-api example, which draws quads properly aligned to be lossless
+//
+#if 0
+#define STB_TRUETYPE_IMPLEMENTATION  // force following include to generate implementation
+#include "stb_truetype.h"
+
+unsigned char ttf_buffer[1<<20];
+unsigned char temp_bitmap[512*512];
+
+stbtt_bakedchar cdata[96]; // ASCII 32..126 is 95 glyphs
+GLuint ftex;
+
+void my_stbtt_initfont(void)
+{
+   fread(ttf_buffer, 1, 1<<20, fopen("c:/windows/fonts/times.ttf", "rb"));
+   stbtt_BakeFontBitmap(ttf_buffer,0, 32.0, temp_bitmap,512,512, 32,96, cdata); // no guarantee this fits!
+   // can free ttf_buffer at this point
+   glGenTextures(1, &ftex);
+   glBindTexture(GL_TEXTURE_2D, ftex);
+   glTexImage2D(GL_TEXTURE_2D, 0, GL_ALPHA, 512,512, 0, GL_ALPHA, GL_UNSIGNED_BYTE, temp_bitmap);
+   // can free temp_bitmap at this point
+   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+}
+
+void my_stbtt_print(float x, float y, char *text)
+{
+   // assume orthographic projection with units = screen pixels, origin at top left
+   glEnable(GL_TEXTURE_2D);
+   glBindTexture(GL_TEXTURE_2D, ftex);
+   glBegin(GL_QUADS);
+   while (*text) {
+      if (*text >= 32 && *text < 128) {
+         stbtt_aligned_quad q;
+         stbtt_GetBakedQuad(cdata, 512,512, *text-32, &x,&y,&q,1);//1=opengl & d3d10+,0=d3d9
+         glTexCoord2f(q.s0,q.t1); glVertex2f(q.x0,q.y0);
+         glTexCoord2f(q.s1,q.t1); glVertex2f(q.x1,q.y0);
+         glTexCoord2f(q.s1,q.t0); glVertex2f(q.x1,q.y1);
+         glTexCoord2f(q.s0,q.t0); glVertex2f(q.x0,q.y1);
+      }
+      ++text;
+   }
+   glEnd();
+}
+#endif
+//
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+// Complete program (this compiles): get a single bitmap, print as ASCII art
+//
+#if 0
+#include <stdio.h>
+#define STB_TRUETYPE_IMPLEMENTATION  // force following include to generate implementation
+#include "stb_truetype.h"
+
+char ttf_buffer[1<<25];
+
+int main(int argc, char **argv)
+{
+   stbtt_fontinfo font;
+   unsigned char *bitmap;
+   int w,h,i,j,c = (argc > 1 ? atoi(argv[1]) : 'a'), s = (argc > 2 ? atoi(argv[2]) : 20);
+
+   fread(ttf_buffer, 1, 1<<25, fopen(argc > 3 ? argv[3] : "c:/windows/fonts/arialbd.ttf", "rb"));
+
+   stbtt_InitFont(&font, ttf_buffer, stbtt_GetFontOffsetForIndex(ttf_buffer,0));
+   bitmap = stbtt_GetCodepointBitmap(&font, 0,stbtt_ScaleForPixelHeight(&font, s), c, &w, &h, 0,0);
+
+   for (j=0; j < h; ++j) {
+      for (i=0; i < w; ++i)
+         putchar(" .:ioVM@"[bitmap[j*w+i]>>5]);
+      putchar('\n');
+   }
+   return 0;
+}
+#endif
+//
+// Output:
+//
+//     .ii.
+//    @@@@@@.
+//   V@Mio@@o
+//   :i.  V@V
+//     :oM@@M
+//   :@@@MM@M
+//   @@o  o@M
+//  :@@.  M@M
+//   @@@o@@@@
+//   :M@@V:@@.
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+// Complete program: print "Hello World!" banner, with bugs
+//
+#if 0
+char buffer[24<<20];
+unsigned char screen[20][79];
+
+int main(int arg, char **argv)
+{
+   stbtt_fontinfo font;
+   int i,j,ascent,baseline,ch=0;
+   float scale, xpos=2; // leave a little padding in case the character extends left
+   char *text = "Heljo World!"; // intentionally misspelled to show 'lj' brokenness
+
+   fread(buffer, 1, 1000000, fopen("c:/windows/fonts/arialbd.ttf", "rb"));
+   stbtt_InitFont(&font, buffer, 0);
+
+   scale = stbtt_ScaleForPixelHeight(&font, 15);
+   stbtt_GetFontVMetrics(&font, &ascent,0,0);
+   baseline = (int) (ascent*scale);
+
+   while (text[ch]) {
+      int advance,lsb,x0,y0,x1,y1;
+      float x_shift = xpos - (float) floor(xpos);
+      stbtt_GetCodepointHMetrics(&font, text[ch], &advance, &lsb);
+      stbtt_GetCodepointBitmapBoxSubpixel(&font, text[ch], scale,scale,x_shift,0, &x0,&y0,&x1,&y1);
+      stbtt_MakeCodepointBitmapSubpixel(&font, &screen[baseline + y0][(int) xpos + x0], x1-x0,y1-y0, 79, scale,scale,x_shift,0, text[ch]);
+      // note that this stomps the old data, so where character boxes overlap (e.g. 'lj') it's wrong
+      // because this API is really for baking character bitmaps into textures. if you want to render
+      // a sequence of characters, you really need to render each bitmap to a temp buffer, then
+      // "alpha blend" that into the working buffer
+      xpos += (advance * scale);
+      if (text[ch+1])
+         xpos += scale*stbtt_GetCodepointKernAdvance(&font, text[ch],text[ch+1]);
+      ++ch;
+   }
+
+   for (j=0; j < 20; ++j) {
+      for (i=0; i < 78; ++i)
+         putchar(" .:ioVM@"[screen[j][i]>>5]);
+      putchar('\n');
+   }
+
+   return 0;
+}
+#endif
+
+//////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+////
+////   INTEGRATION WITH YOUR CODEBASE
+////
+////   The following sections allow you to supply alternate definitions
+////   of C library functions used by stb_truetype, e.g. if you don't
+////   link with the C runtime library.
+
+#ifdef STB_TRUETYPE_IMPLEMENTATION
+// #define your own (u)stbtt_int8/16/32 before including to override this
+#ifndef stbtt_uint8
+typedef unsigned char stbtt_uint8;
+typedef signed char stbtt_int8;
+typedef unsigned short stbtt_uint16;
+typedef signed short stbtt_int16;
+typedef unsigned int stbtt_uint32;
+typedef signed int stbtt_int32;
+#endif
+
+typedef char stbtt__check_size32[sizeof(stbtt_int32) == 4 ? 1 : -1];
+typedef char stbtt__check_size16[sizeof(stbtt_int16) == 2 ? 1 : -1];
+
+// e.g. #define your own STBTT_ifloor/STBTT_iceil() to avoid math.h
+#ifndef STBTT_ifloor
+#include <math.h>
+#define STBTT_ifloor(x) ((int)floor(x))
+#define STBTT_iceil(x) ((int)ceil(x))
+#endif
+
+#ifndef STBTT_sqrt
+#include <math.h>
+#define STBTT_sqrt(x) sqrt(x)
+#define STBTT_pow(x, y) pow(x, y)
+#endif
+
+#ifndef STBTT_fmod
+#include <math.h>
+#define STBTT_fmod(x, y) fmod(x, y)
+#endif
+
+#ifndef STBTT_cos
+#include <math.h>
+#define STBTT_cos(x) cos(x)
+#define STBTT_acos(x) acos(x)
+#endif
+
+#ifndef STBTT_fabs
+#include <math.h>
+#define STBTT_fabs(x) fabs(x)
+#endif
+
+// #define your own functions "STBTT_malloc" / "STBTT_free" to avoid malloc.h
+#ifndef STBTT_malloc
+#include <stdlib.h>
+#define STBTT_malloc(x, u) ((void)(u), malloc(x))
+#define STBTT_free(x, u) ((void)(u), free(x))
+#endif
+
+#ifndef STBTT_assert
+#include <assert.h>
+#define STBTT_assert(x) assert(x)
+#endif
+
+#ifndef STBTT_strlen
+#include <string.h>
+#define STBTT_strlen(x) strlen(x)
+#endif
+
+#ifndef STBTT_memcpy
+#include <string.h>
+#define STBTT_memcpy memcpy
+#define STBTT_memset memset
+#endif
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
+////
+////   INTERFACE
+////
+////
+
+#ifndef __STB_INCLUDE_STB_TRUETYPE_H__
+#define __STB_INCLUDE_STB_TRUETYPE_H__
+
+#ifdef STBTT_STATIC
+#define STBTT_DEF static
+#else
+#define STBTT_DEF extern
+#endif
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    // private structure
+    typedef struct
+    {
+        unsigned char *data;
+        int cursor;
+        int size;
+    } stbtt__buf;
+
+    //////////////////////////////////////////////////////////////////////////////
+    //
+    // TEXTURE BAKING API
+    //
+    // If you use this API, you only have to call two functions ever.
+    //
+
+    typedef struct
+    {
+        unsigned short x0, y0, x1, y1;  // coordinates of bbox in bitmap
+        float xoff, yoff, xadvance;
+    } stbtt_bakedchar;
+
+    STBTT_DEF int stbtt_BakeFontBitmap(
+        const unsigned char *data,
+        int offset,          // font location (use offset=0 for plain .ttf)
+        float pixel_height,  // height of font in pixels
+        unsigned char *pixels,
+        int pw,
+        int ph,  // bitmap to be filled in
+        int first_char,
+        int num_chars,               // characters to bake
+        stbtt_bakedchar *chardata);  // you allocate this, it's num_chars long
+    // if return is positive, the first unused row of the bitmap
+    // if return is negative, returns the negative of the number of characters that fit
+    // if return is 0, no characters fit and no rows were used
+    // This uses a very crappy packing.
+
+    typedef struct
+    {
+        float x0, y0, s0, t0;  // top-left
+        float x1, y1, s1, t1;  // bottom-right
+    } stbtt_aligned_quad;
+
+    STBTT_DEF void stbtt_GetBakedQuad(
+        const stbtt_bakedchar *chardata,
+        int pw,
+        int ph,          // same data as above
+        int char_index,  // character to display
+        float *xpos,
+        float *ypos,            // pointers to current position in screen pixel space
+        stbtt_aligned_quad *q,  // output: quad to draw
+        int opengl_fillrule);   // true if opengl fill rule; false if DX9 or earlier
+    // Call GetBakedQuad with char_index = 'character - first_char', and it
+    // creates the quad you need to draw and advances the current position.
+    //
+    // The coordinate system used assumes y increases downwards.
+    //
+    // Characters will extend both above and below the current position;
+    // see discussion of "BASELINE" above.
+    //
+    // It's inefficient; you might want to c&p it and optimize it.
+
+    STBTT_DEF void stbtt_GetScaledFontVMetrics(const unsigned char *fontdata,
+                                               int index,
+                                               float size,
+                                               float *ascent,
+                                               float *descent,
+                                               float *lineGap);
+    // Query the font vertical metrics without having to create a font first.
+
+    //////////////////////////////////////////////////////////////////////////////
+    //
+    // NEW TEXTURE BAKING API
+    //
+    // This provides options for packing multiple fonts into one atlas, not
+    // perfectly but better than nothing.
+
+    typedef struct
+    {
+        unsigned short x0, y0, x1, y1;  // coordinates of bbox in bitmap
+        float xoff, yoff, xadvance;
+        float xoff2, yoff2;
+    } stbtt_packedchar;
+
+    typedef struct stbtt_pack_context stbtt_pack_context;
+    typedef struct stbtt_fontinfo stbtt_fontinfo;
+#ifndef STB_RECT_PACK_VERSION
+    typedef struct stbrp_rect stbrp_rect;
+#endif
+
+    STBTT_DEF int stbtt_PackBegin(stbtt_pack_context *spc,
+                                  unsigned char *pixels,
+                                  int width,
+                                  int height,
+                                  int stride_in_bytes,
+                                  int padding,
+                                  void *alloc_context);
+    // Initializes a packing context stored in the passed-in stbtt_pack_context.
+    // Future calls using this context will pack characters into the bitmap passed
+    // in here: a 1-channel bitmap that is width * height. stride_in_bytes is
+    // the distance from one row to the next (or 0 to mean they are packed tightly
+    // together). "padding" is the amount of padding to leave between each
+    // character (normally you want '1' for bitmaps you'll use as textures with
+    // bilinear filtering).
+    //
+    // Returns 0 on failure, 1 on success.
+
+    STBTT_DEF void stbtt_PackEnd(stbtt_pack_context *spc);
+    // Cleans up the packing context and frees all memory.
+
+#define STBTT_POINT_SIZE(x) (-(x))
+
+    STBTT_DEF int stbtt_PackFontRange(stbtt_pack_context *spc,
+                                      const unsigned char *fontdata,
+                                      int font_index,
+                                      float font_size,
+                                      int first_unicode_char_in_range,
+                                      int num_chars_in_range,
+                                      stbtt_packedchar *chardata_for_range);
+    // Creates character bitmaps from the font_index'th font found in fontdata (use
+    // font_index=0 if you don't know what that is). It creates num_chars_in_range
+    // bitmaps for characters with unicode values starting at first_unicode_char_in_range
+    // and increasing. Data for how to render them is stored in chardata_for_range;
+    // pass these to stbtt_GetPackedQuad to get back renderable quads.
+    //
+    // font_size is the full height of the character from ascender to descender,
+    // as computed by stbtt_ScaleForPixelHeight. To use a point size as computed
+    // by stbtt_ScaleForMappingEmToPixels, wrap the point size in STBTT_POINT_SIZE()
+    // and pass that result as 'font_size':
+    //       ...,                  20 , ... // font max minus min y is 20 pixels tall
+    //       ..., STBTT_POINT_SIZE(20), ... // 'M' is 20 pixels tall
+
+    typedef struct
+    {
+        float font_size;
+        int first_unicode_codepoint_in_range;  // if non-zero, then the chars are continuous, and
+                                               // this is the first codepoint
+        int *array_of_unicode_codepoints;      // if non-zero, then this is an array of unicode
+                                               // codepoints
+        int num_chars;
+        stbtt_packedchar *chardata_for_range;      // output
+        unsigned char h_oversample, v_oversample;  // don't set these, they're used internally
+    } stbtt_pack_range;
+
+    STBTT_DEF int stbtt_PackFontRanges(stbtt_pack_context *spc,
+                                       const unsigned char *fontdata,
+                                       int font_index,
+                                       stbtt_pack_range *ranges,
+                                       int num_ranges);
+    // Creates character bitmaps from multiple ranges of characters stored in
+    // ranges. This will usually create a better-packed bitmap than multiple
+    // calls to stbtt_PackFontRange. Note that you can call this multiple
+    // times within a single PackBegin/PackEnd.
+
+    STBTT_DEF void stbtt_PackSetOversampling(stbtt_pack_context *spc,
+                                             unsigned int h_oversample,
+                                             unsigned int v_oversample);
+    // Oversampling a font increases the quality by allowing higher-quality subpixel
+    // positioning, and is especially valuable at smaller text sizes.
+    //
+    // This function sets the amount of oversampling for all following calls to
+    // stbtt_PackFontRange(s) or stbtt_PackFontRangesGatherRects for a given
+    // pack context. The default (no oversampling) is achieved by h_oversample=1
+    // and v_oversample=1. The total number of pixels required is
+    // h_oversample*v_oversample larger than the default; for example, 2x2
+    // oversampling requires 4x the storage of 1x1. For best results, render
+    // oversampled textures with bilinear filtering. Look at the readme in
+    // stb/tests/oversample for information about oversampled fonts
+    //
+    // To use with PackFontRangesGather etc., you must set it before calls
+    // call to PackFontRangesGatherRects.
+
+    STBTT_DEF void stbtt_PackSetSkipMissingCodepoints(stbtt_pack_context *spc, int skip);
+    // If skip != 0, this tells stb_truetype to skip any codepoints for which
+    // there is no corresponding glyph. If skip=0, which is the default, then
+    // codepoints without a glyph recived the font's "missing character" glyph,
+    // typically an empty box by convention.
+
+    STBTT_DEF void stbtt_GetPackedQuad(
+        const stbtt_packedchar *chardata,
+        int pw,
+        int ph,          // same data as above
+        int char_index,  // character to display
+        float *xpos,
+        float *ypos,            // pointers to current position in screen pixel space
+        stbtt_aligned_quad *q,  // output: quad to draw
+        int align_to_integer);
+
+    STBTT_DEF int stbtt_PackFontRangesGatherRects(stbtt_pack_context *spc,
+                                                  const stbtt_fontinfo *info,
+                                                  stbtt_pack_range *ranges,
+                                                  int num_ranges,
+                                                  stbrp_rect *rects);
+    STBTT_DEF void stbtt_PackFontRangesPackRects(stbtt_pack_context *spc,
+                                                 stbrp_rect *rects,
+                                                 int num_rects);
+    STBTT_DEF int stbtt_PackFontRangesRenderIntoRects(stbtt_pack_context *spc,
+                                                      const stbtt_fontinfo *info,
+                                                      stbtt_pack_range *ranges,
+                                                      int num_ranges,
+                                                      stbrp_rect *rects);
+    // Calling these functions in sequence is roughly equivalent to calling
+    // stbtt_PackFontRanges(). If you more control over the packing of multiple
+    // fonts, or if you want to pack custom data into a font texture, take a look
+    // at the source to of stbtt_PackFontRanges() and create a custom version
+    // using these functions, e.g. call GatherRects multiple times,
+    // building up a single array of rects, then call PackRects once,
+    // then call RenderIntoRects repeatedly. This may result in a
+    // better packing than calling PackFontRanges multiple times
+    // (or it may not).
+
+    // this is an opaque structure that you shouldn't mess with which holds
+    // all the context needed from PackBegin to PackEnd.
+    struct stbtt_pack_context
+    {
+        void *user_allocator_context;
+        void *pack_info;
+        int width;
+        int height;
+        int stride_in_bytes;
+        int padding;
+        int skip_missing;
+        unsigned int h_oversample, v_oversample;
+        unsigned char *pixels;
+        void *nodes;
+    };
+
+    //////////////////////////////////////////////////////////////////////////////
+    //
+    // FONT LOADING
+    //
+    //
+
+    STBTT_DEF int stbtt_GetNumberOfFonts(const unsigned char *data);
+    // This function will determine the number of fonts in a font file.  TrueType
+    // collection (.ttc) files may contain multiple fonts, while TrueType font
+    // (.ttf) files only contain one font. The number of fonts can be used for
+    // indexing with the previous function where the index is between zero and one
+    // less than the total fonts. If an error occurs, -1 is returned.
+
+    STBTT_DEF int stbtt_GetFontOffsetForIndex(const unsigned char *data, int index);
+    // Each .ttf/.ttc file may have more than one font. Each font has a sequential
+    // index number starting from 0. Call this function to get the font offset for
+    // a given index; it returns -1 if the index is out of range. A regular .ttf
+    // file will only define one font and it always be at offset 0, so it will
+    // return '0' for index 0, and -1 for all other indices.
+
+    // The following structure is defined publicly so you can declare one on
+    // the stack or as a global or etc, but you should treat it as opaque.
+    struct stbtt_fontinfo
+    {
+        void *userdata;
+        unsigned char *data;  // pointer to .ttf file
+        int fontstart;        // offset of start of font
+
+        int numGlyphs;  // number of glyphs, needed for range checking
+
+        int loca, head, glyf, hhea, hmtx, kern,
+            gpos;              // table locations as offset from start of .ttf
+        int index_map;         // a cmap mapping for our chosen character encoding
+        int indexToLocFormat;  // format needed to map from glyph index to glyph
+
+        stbtt__buf cff;          // cff font data
+        stbtt__buf charstrings;  // the charstring index
+        stbtt__buf gsubrs;       // global charstring subroutines index
+        stbtt__buf subrs;        // private charstring subroutines index
+        stbtt__buf fontdicts;    // array of font dicts
+        stbtt__buf fdselect;     // map from glyph to fontdict
+    };
+
+    STBTT_DEF int stbtt_InitFont(stbtt_fontinfo *info, const unsigned char *data, int offset);
+    // Given an offset into the file that defines a font, this function builds
+    // the necessary cached info for the rest of the system. You must allocate
+    // the stbtt_fontinfo yourself, and stbtt_InitFont will fill it out. You don't
+    // need to do anything special to free it, because the contents are pure
+    // value data with no additional data structures. Returns 0 on failure.
+
+    //////////////////////////////////////////////////////////////////////////////
+    //
+    // CHARACTER TO GLYPH-INDEX CONVERSIOn
+
+    STBTT_DEF int stbtt_FindGlyphIndex(const stbtt_fontinfo *info, int unicode_codepoint);
+    // If you're going to perform multiple operations on the same character
+    // and you want a speed-up, call this function with the character you're
+    // going to process, then use glyph-based functions instead of the
+    // codepoint-based functions.
+    // Returns 0 if the character codepoint is not defined in the font.
+
+    //////////////////////////////////////////////////////////////////////////////
+    //
+    // CHARACTER PROPERTIES
+    //
+
+    STBTT_DEF float stbtt_ScaleForPixelHeight(const stbtt_fontinfo *info, float pixels);
+    // computes a scale factor to produce a font whose "height" is 'pixels' tall.
+    // Height is measured as the distance from the highest ascender to the lowest
+    // descender; in other words, it's equivalent to calling stbtt_GetFontVMetrics
+    // and computing:
+    //       scale = pixels / (ascent - descent)
+    // so if you prefer to measure height by the ascent only, use a similar calculation.
+
+    STBTT_DEF float stbtt_ScaleForMappingEmToPixels(const stbtt_fontinfo *info, float pixels);
+    // computes a scale factor to produce a font whose EM size is mapped to
+    // 'pixels' tall. This is probably what traditional APIs compute, but
+    // I'm not positive.
+
+    STBTT_DEF void stbtt_GetFontVMetrics(const stbtt_fontinfo *info,
+                                         int *ascent,
+                                         int *descent,
+                                         int *lineGap);
+    // ascent is the coordinate above the baseline the font extends; descent
+    // is the coordinate below the baseline the font extends (i.e. it is typically negative)
+    // lineGap is the spacing between one row's descent and the next row's ascent...
+    // so you should advance the vertical position by "*ascent - *descent + *lineGap"
+    //   these are expressed in unscaled coordinates, so you must multiply by
+    //   the scale factor for a given size
+
+    STBTT_DEF int stbtt_GetFontVMetricsOS2(const stbtt_fontinfo *info,
+                                           int *typoAscent,
+                                           int *typoDescent,
+                                           int *typoLineGap);
+    // analogous to GetFontVMetrics, but returns the "typographic" values from the OS/2
+    // table (specific to MS/Windows TTF files).
+    //
+    // Returns 1 on success (table present), 0 on failure.
+
+    STBTT_DEF void stbtt_GetFontBoundingBox(const stbtt_fontinfo *info,
+                                            int *x0,
+                                            int *y0,
+                                            int *x1,
+                                            int *y1);
+    // the bounding box around all possible characters
+
+    STBTT_DEF void stbtt_GetCodepointHMetrics(const stbtt_fontinfo *info,
+                                              int codepoint,
+                                              int *advanceWidth,
+                                              int *leftSideBearing);
+    // leftSideBearing is the offset from the current horizontal position to the left edge of the
+    // character advanceWidth is the offset from the current horizontal position to the next
+    // horizontal position
+    //   these are expressed in unscaled coordinates
+
+    STBTT_DEF int stbtt_GetCodepointKernAdvance(const stbtt_fontinfo *info, int ch1, int ch2);
+    // an additional amount to add to the 'advance' value between ch1 and ch2
+
+    STBTT_DEF int stbtt_GetCodepointBox(const stbtt_fontinfo *info,
+                                        int codepoint,
+                                        int *x0,
+                                        int *y0,
+                                        int *x1,
+                                        int *y1);
+    // Gets the bounding box of the visible part of the glyph, in unscaled coordinates
+
+    STBTT_DEF void stbtt_GetGlyphHMetrics(const stbtt_fontinfo *info,
+                                          int glyph_index,
+                                          int *advanceWidth,
+                                          int *leftSideBearing);
+    STBTT_DEF int stbtt_GetGlyphKernAdvance(const stbtt_fontinfo *info, int glyph1, int glyph2);
+    STBTT_DEF int stbtt_GetGlyphBox(const stbtt_fontinfo *info,
+                                    int glyph_index,
+                                    int *x0,
+                                    int *y0,
+                                    int *x1,
+                                    int *y1);
+    // as above, but takes one or more glyph indices for greater efficiency
+
+    //////////////////////////////////////////////////////////////////////////////
+    //
+    // GLYPH SHAPES (you probably don't need these, but they have to go before
+    // the bitmaps for C declaration-order reasons)
+    //
+
+#ifndef STBTT_vmove  // you can predefine these to use different values (but why?)
+    enum
+    {
+        STBTT_vmove = 1,
+        STBTT_vline,
+        STBTT_vcurve,
+        STBTT_vcubic
+    };
+#endif
+
+#ifndef stbtt_vertex  // you can predefine this to use different values
+                      // (we share this with other code at RAD)
+#define stbtt_vertex_type \
+    short  // can't use stbtt_int16 because that's not visible in the header file
+    typedef struct
+    {
+        stbtt_vertex_type x, y, cx, cy, cx1, cy1;
+        unsigned char type, padding;
+    } stbtt_vertex;
+#endif
+
+    STBTT_DEF int stbtt_IsGlyphEmpty(const stbtt_fontinfo *info, int glyph_index);
+    // returns non-zero if nothing is drawn for this glyph
+
+    STBTT_DEF int stbtt_GetCodepointShape(const stbtt_fontinfo *info,
+                                          int unicode_codepoint,
+                                          stbtt_vertex **vertices);
+    STBTT_DEF int stbtt_GetGlyphShape(const stbtt_fontinfo *info,
+                                      int glyph_index,
+                                      stbtt_vertex **vertices);
+    // returns # of vertices and fills *vertices with the pointer to them
+    //   these are expressed in "unscaled" coordinates
+    //
+    // The shape is a series of contours. Each one starts with
+    // a STBTT_moveto, then consists of a series of mixed
+    // STBTT_lineto and STBTT_curveto segments. A lineto
+    // draws a line from previous endpoint to its x,y; a curveto
+    // draws a quadratic bezier from previous endpoint to
+    // its x,y, using cx,cy as the bezier control point.
+
+    STBTT_DEF void stbtt_FreeShape(const stbtt_fontinfo *info, stbtt_vertex *vertices);
+    // frees the data allocated above
+
+    //////////////////////////////////////////////////////////////////////////////
+    //
+    // BITMAP RENDERING
+    //
+
+    STBTT_DEF void stbtt_FreeBitmap(unsigned char *bitmap, void *userdata);
+    // frees the bitmap allocated below
+
+    STBTT_DEF unsigned char *stbtt_GetCodepointBitmap(const stbtt_fontinfo *info,
+                                                      float scale_x,
+                                                      float scale_y,
+                                                      int codepoint,
+                                                      int *width,
+                                                      int *height,
+                                                      int *xoff,
+                                                      int *yoff);
+    // allocates a large-enough single-channel 8bpp bitmap and renders the
+    // specified character/glyph at the specified scale into it, with
+    // antialiasing. 0 is no coverage (transparent), 255 is fully covered (opaque).
+    // *width & *height are filled out with the width & height of the bitmap,
+    // which is stored left-to-right, top-to-bottom.
+    //
+    // xoff/yoff are the offset it pixel space from the glyph origin to the top-left of the bitmap
+
+    STBTT_DEF unsigned char *stbtt_GetCodepointBitmapSubpixel(const stbtt_fontinfo *info,
+                                                              float scale_x,
+                                                              float scale_y,
+                                                              float shift_x,
+                                                              float shift_y,
+                                                              int codepoint,
+                                                              int *width,
+                                                              int *height,
+                                                              int *xoff,
+                                                              int *yoff);
+    // the same as stbtt_GetCodepoitnBitmap, but you can specify a subpixel
+    // shift for the character
+
+    STBTT_DEF void stbtt_MakeCodepointBitmap(const stbtt_fontinfo *info,
+                                             unsigned char *output,
+                                             int out_w,
+                                             int out_h,
+                                             int out_stride,
+                                             float scale_x,
+                                             float scale_y,
+                                             int codepoint);
+    // the same as stbtt_GetCodepointBitmap, but you pass in storage for the bitmap
+    // in the form of 'output', with row spacing of 'out_stride' bytes. the bitmap
+    // is clipped to out_w/out_h bytes. Call stbtt_GetCodepointBitmapBox to get the
+    // width and height and positioning info for it first.
+
+    STBTT_DEF void stbtt_MakeCodepointBitmapSubpixel(const stbtt_fontinfo *info,
+                                                     unsigned char *output,
+                                                     int out_w,
+                                                     int out_h,
+                                                     int out_stride,
+                                                     float scale_x,
+                                                     float scale_y,
+                                                     float shift_x,
+                                                     float shift_y,
+                                                     int codepoint);
+    // same as stbtt_MakeCodepointBitmap, but you can specify a subpixel
+    // shift for the character
+
+    STBTT_DEF void stbtt_MakeCodepointBitmapSubpixelPrefilter(const stbtt_fontinfo *info,
+                                                              unsigned char *output,
+                                                              int out_w,
+                                                              int out_h,
+                                                              int out_stride,
+                                                              float scale_x,
+                                                              float scale_y,
+                                                              float shift_x,
+                                                              float shift_y,
+                                                              int oversample_x,
+                                                              int oversample_y,
+                                                              float *sub_x,
+                                                              float *sub_y,
+                                                              int codepoint);
+    // same as stbtt_MakeCodepointBitmapSubpixel, but prefiltering
+    // is performed (see stbtt_PackSetOversampling)
+
+    STBTT_DEF void stbtt_GetCodepointBitmapBox(const stbtt_fontinfo *font,
+                                               int codepoint,
+                                               float scale_x,
+                                               float scale_y,
+                                               int *ix0,
+                                               int *iy0,
+                                               int *ix1,
+                                               int *iy1);
+    // get the bbox of the bitmap centered around the glyph origin; so the
+    // bitmap width is ix1-ix0, height is iy1-iy0, and location to place
+    // the bitmap top left is (leftSideBearing*scale,iy0).
+    // (Note that the bitmap uses y-increases-down, but the shape uses
+    // y-increases-up, so CodepointBitmapBox and CodepointBox are inverted.)
+
+    STBTT_DEF void stbtt_GetCodepointBitmapBoxSubpixel(const stbtt_fontinfo *font,
+                                                       int codepoint,
+                                                       float scale_x,
+                                                       float scale_y,
+                                                       float shift_x,
+                                                       float shift_y,
+                                                       int *ix0,
+                                                       int *iy0,
+                                                       int *ix1,
+                                                       int *iy1);
+    // same as stbtt_GetCodepointBitmapBox, but you can specify a subpixel
+    // shift for the character
+
+    // the following functions are equivalent to the above functions, but operate
+    // on glyph indices instead of Unicode codepoints (for efficiency)
+    STBTT_DEF unsigned char *stbtt_GetGlyphBitmap(const stbtt_fontinfo *info,
+                                                  float scale_x,
+                                                  float scale_y,
+                                                  int glyph,
+                                                  int *width,
+                                                  int *height,
+                                                  int *xoff,
+                                                  int *yoff);
+    STBTT_DEF unsigned char *stbtt_GetGlyphBitmapSubpixel(const stbtt_fontinfo *info,
+                                                          float scale_x,
+                                                          float scale_y,
+                                                          float shift_x,
+                                                          float shift_y,
+                                                          int glyph,
+                                                          int *width,
+                                                          int *height,
+                                                          int *xoff,
+                                                          int *yoff);
+    STBTT_DEF void stbtt_MakeGlyphBitmap(const stbtt_fontinfo *info,
+                                         unsigned char *output,
+                                         int out_w,
+                                         int out_h,
+                                         int out_stride,
+                                         float scale_x,
+                                         float scale_y,
+                                         int glyph);
+    STBTT_DEF void stbtt_MakeGlyphBitmapSubpixel(const stbtt_fontinfo *info,
+                                                 unsigned char *output,
+                                                 int out_w,
+                                                 int out_h,
+                                                 int out_stride,
+                                                 float scale_x,
+                                                 float scale_y,
+                                                 float shift_x,
+                                                 float shift_y,
+                                                 int glyph);
+    STBTT_DEF void stbtt_MakeGlyphBitmapSubpixelPrefilter(const stbtt_fontinfo *info,
+                                                          unsigned char *output,
+                                                          int out_w,
+                                                          int out_h,
+                                                          int out_stride,
+                                                          float scale_x,
+                                                          float scale_y,
+                                                          float shift_x,
+                                                          float shift_y,
+                                                          int oversample_x,
+                                                          int oversample_y,
+                                                          float *sub_x,
+                                                          float *sub_y,
+                                                          int glyph);
+    STBTT_DEF void stbtt_GetGlyphBitmapBox(const stbtt_fontinfo *font,
+                                           int glyph,
+                                           float scale_x,
+                                           float scale_y,
+                                           int *ix0,
+                                           int *iy0,
+                                           int *ix1,
+                                           int *iy1);
+    STBTT_DEF void stbtt_GetGlyphBitmapBoxSubpixel(const stbtt_fontinfo *font,
+                                                   int glyph,
+                                                   float scale_x,
+                                                   float scale_y,
+                                                   float shift_x,
+                                                   float shift_y,
+                                                   int *ix0,
+                                                   int *iy0,
+                                                   int *ix1,
+                                                   int *iy1);
+
+    // @TODO: don't expose this structure
+    typedef struct
+    {
+        int w, h, stride;
+        unsigned char *pixels;
+    } stbtt__bitmap;
+
+    // rasterize a shape with quadratic beziers into a bitmap
+    STBTT_DEF void stbtt_Rasterize(stbtt__bitmap *result,     // 1-channel bitmap to draw into
+                                   float flatness_in_pixels,  // allowable error of curve in pixels
+                                   stbtt_vertex *vertices,    // array of vertices defining shape
+                                   int num_verts,             // number of vertices in above array
+                                   float scale_x,
+                                   float scale_y,  // scale applied to input vertices
+                                   float shift_x,
+                                   float shift_y,  // translation applied to input vertices
+                                   int x_off,
+                                   int y_off,        // another translation applied to input
+                                   int invert,       // if non-zero, vertically flip shape
+                                   void *userdata);  // context for to STBTT_MALLOC
+
+    //////////////////////////////////////////////////////////////////////////////
+    //
+    // Signed Distance Function (or Field) rendering
+
+    STBTT_DEF void stbtt_FreeSDF(unsigned char *bitmap, void *userdata);
+    // frees the SDF bitmap allocated below
+
+    STBTT_DEF unsigned char *stbtt_GetGlyphSDF(const stbtt_fontinfo *info,
+                                               float scale,
+                                               int glyph,
+                                               int padding,
+                                               unsigned char onedge_value,
+                                               float pixel_dist_scale,
+                                               int *width,
+                                               int *height,
+                                               int *xoff,
+                                               int *yoff);
+    STBTT_DEF unsigned char *stbtt_GetCodepointSDF(const stbtt_fontinfo *info,
+                                                   float scale,
+                                                   int codepoint,
+                                                   int padding,
+                                                   unsigned char onedge_value,
+                                                   float pixel_dist_scale,
+                                                   int *width,
+                                                   int *height,
+                                                   int *xoff,
+                                                   int *yoff);
+    // These functions compute a discretized SDF field for a single character, suitable for storing
+    // in a single-channel texture, sampling with bilinear filtering, and testing against
+    // larger than some threshold to produce scalable fonts.
+    //        info              --  the font
+    //        scale             --  controls the size of the resulting SDF bitmap, same as it would
+    //        be creating a regular bitmap glyph/codepoint   --  the character to generate the SDF
+    //        for padding           --  extra "pixels" around the character which are filled with
+    //        the distance to the character (not 0),
+    //                                 which allows effects like bit outlines
+    //        onedge_value      --  value 0-255 to test the SDF against to reconstruct the character
+    //        (i.e. the isocontour of the character) pixel_dist_scale  --  what value the SDF should
+    //        increase by when moving one SDF "pixel" away from the edge (on the 0..255 scale)
+    //                                 if positive, > onedge_value is inside; if negative, <
+    //                                 onedge_value is inside
+    //        width,height      --  output height & width of the SDF bitmap (including padding)
+    //        xoff,yoff         --  output origin of the character
+    //        return value      --  a 2D array of bytes 0..255, width*height in size
+    //
+    // pixel_dist_scale & onedge_value are a scale & bias that allows you to make
+    // optimal use of the limited 0..255 for your application, trading off precision
+    // and special effects. SDF values outside the range 0..255 are clamped to 0..255.
+    //
+    // Example:
+    //      scale = stbtt_ScaleForPixelHeight(22)
+    //      padding = 5
+    //      onedge_value = 180
+    //      pixel_dist_scale = 180/5.0 = 36.0
+    //
+    //      This will create an SDF bitmap in which the character is about 22 pixels
+    //      high but the whole bitmap is about 22+5+5=32 pixels high. To produce a filled
+    //      shape, sample the SDF at each pixel and fill the pixel if the SDF value
+    //      is greater than or equal to 180/255. (You'll actually want to antialias,
+    //      which is beyond the scope of this example.) Additionally, you can compute
+    //      offset outlines (e.g. to stroke the character border inside & outside,
+    //      or only outside). For example, to fill outside the character up to 3 SDF
+    //      pixels, you would compare against (180-36.0*3)/255 = 72/255. The above
+    //      choice of variables maps a range from 5 pixels outside the shape to
+    //      2 pixels inside the shape to 0..255; this is intended primarily for apply
+    //      outside effects only (the interior range is needed to allow proper
+    //      antialiasing of the font at *smaller* sizes)
+    //
+    // The function computes the SDF analytically at each SDF pixel, not by e.g.
+    // building a higher-res bitmap and approximating it. In theory the quality
+    // should be as high as possible for an SDF of this size & representation, but
+    // unclear if this is true in practice (perhaps building a higher-res bitmap
+    // and computing from that can allow drop-out prevention).
+    //
+    // The algorithm has not been optimized at all, so expect it to be slow
+    // if computing lots of characters or very large sizes.
+
+    //////////////////////////////////////////////////////////////////////////////
+    //
+    // Finding the right font...
+    //
+    // You should really just solve this offline, keep your own tables
+    // of what font is what, and don't try to get it out of the .ttf file.
+    // That's because getting it out of the .ttf file is really hard, because
+    // the names in the file can appear in many possible encodings, in many
+    // possible languages, and e.g. if you need a case-insensitive comparison,
+    // the details of that depend on the encoding & language in a complex way
+    // (actually underspecified in truetype, but also gigantic).
+    //
+    // But you can use the provided functions in two possible ways:
+    //     stbtt_FindMatchingFont() will use *case-sensitive* comparisons on
+    //             unicode-encoded names to try to find the font you want;
+    //             you can run this before calling stbtt_InitFont()
+    //
+    //     stbtt_GetFontNameString() lets you get any of the various strings
+    //             from the file yourself and do your own comparisons on them.
+    //             You have to have called stbtt_InitFont() first.
+
+    STBTT_DEF int stbtt_FindMatchingFont(const unsigned char *fontdata,
+                                         const char *name,
+                                         int flags);
+// returns the offset (not index) of the font that matches, or -1 if none
+//   if you use STBTT_MACSTYLE_DONTCARE, use a font name like "Arial Bold".
+//   if you use any other flag, use a font name like "Arial"; this checks
+//     the 'macStyle' header field; i don't know if fonts set this consistently
+#define STBTT_MACSTYLE_DONTCARE 0
+#define STBTT_MACSTYLE_BOLD 1
+#define STBTT_MACSTYLE_ITALIC 2
+#define STBTT_MACSTYLE_UNDERSCORE 4
+#define STBTT_MACSTYLE_NONE 8  // <= not same as 0, this makes us check the bitfield is 0
+
+    STBTT_DEF int stbtt_CompareUTF8toUTF16_bigendian(const char *s1,
+                                                     int len1,
+                                                     const char *s2,
+                                                     int len2);
+    // returns 1/0 whether the first string interpreted as utf8 is identical to
+    // the second string interpreted as big-endian utf16... useful for strings from next func
+
+    STBTT_DEF const char *stbtt_GetFontNameString(const stbtt_fontinfo *font,
+                                                  int *length,
+                                                  int platformID,
+                                                  int encodingID,
+                                                  int languageID,
+                                                  int nameID);
+    // returns the string (which may be big-endian double byte, e.g. for unicode)
+    // and puts the length in bytes in *length.
+    //
+    // some of the values for the IDs are below; for more see the truetype spec:
+    //     http://developer.apple.com/textfonts/TTRefMan/RM06/Chap6name.html
+    //     http://www.microsoft.com/typography/otspec/name.htm
+
+    enum
+    {  // platformID
+        STBTT_PLATFORM_ID_UNICODE   = 0,
+        STBTT_PLATFORM_ID_MAC       = 1,
+        STBTT_PLATFORM_ID_ISO       = 2,
+        STBTT_PLATFORM_ID_MICROSOFT = 3
+    };
+
+    enum
+    {  // encodingID for STBTT_PLATFORM_ID_UNICODE
+        STBTT_UNICODE_EID_UNICODE_1_0      = 0,
+        STBTT_UNICODE_EID_UNICODE_1_1      = 1,
+        STBTT_UNICODE_EID_ISO_10646        = 2,
+        STBTT_UNICODE_EID_UNICODE_2_0_BMP  = 3,
+        STBTT_UNICODE_EID_UNICODE_2_0_FULL = 4
+    };
+
+    enum
+    {  // encodingID for STBTT_PLATFORM_ID_MICROSOFT
+        STBTT_MS_EID_SYMBOL       = 0,
+        STBTT_MS_EID_UNICODE_BMP  = 1,
+        STBTT_MS_EID_SHIFTJIS     = 2,
+        STBTT_MS_EID_UNICODE_FULL = 10
+    };
+
+    enum
+    {  // encodingID for STBTT_PLATFORM_ID_MAC; same as Script Manager codes
+        STBTT_MAC_EID_ROMAN        = 0,
+        STBTT_MAC_EID_ARABIC       = 4,
+        STBTT_MAC_EID_JAPANESE     = 1,
+        STBTT_MAC_EID_HEBREW       = 5,
+        STBTT_MAC_EID_CHINESE_TRAD = 2,
+        STBTT_MAC_EID_GREEK        = 6,
+        STBTT_MAC_EID_KOREAN       = 3,
+        STBTT_MAC_EID_RUSSIAN      = 7
+    };
+
+    enum
+    {  // languageID for STBTT_PLATFORM_ID_MICROSOFT; same as LCID...
+       // problematic because there are e.g. 16 english LCIDs and 16 arabic LCIDs
+        STBTT_MS_LANG_ENGLISH  = 0x0409,
+        STBTT_MS_LANG_ITALIAN  = 0x0410,
+        STBTT_MS_LANG_CHINESE  = 0x0804,
+        STBTT_MS_LANG_JAPANESE = 0x0411,
+        STBTT_MS_LANG_DUTCH    = 0x0413,
+        STBTT_MS_LANG_KOREAN   = 0x0412,
+        STBTT_MS_LANG_FRENCH   = 0x040c,
+        STBTT_MS_LANG_RUSSIAN  = 0x0419,
+        STBTT_MS_LANG_GERMAN   = 0x0407,
+        STBTT_MS_LANG_SPANISH  = 0x0409,
+        STBTT_MS_LANG_HEBREW   = 0x040d,
+        STBTT_MS_LANG_SWEDISH  = 0x041D
+    };
+
+    enum
+    {  // languageID for STBTT_PLATFORM_ID_MAC
+        STBTT_MAC_LANG_ENGLISH            = 0,
+        STBTT_MAC_LANG_JAPANESE           = 11,
+        STBTT_MAC_LANG_ARABIC             = 12,
+        STBTT_MAC_LANG_KOREAN             = 23,
+        STBTT_MAC_LANG_DUTCH              = 4,
+        STBTT_MAC_LANG_RUSSIAN            = 32,
+        STBTT_MAC_LANG_FRENCH             = 1,
+        STBTT_MAC_LANG_SPANISH            = 6,
+        STBTT_MAC_LANG_GERMAN             = 2,
+        STBTT_MAC_LANG_SWEDISH            = 5,
+        STBTT_MAC_LANG_HEBREW             = 10,
+        STBTT_MAC_LANG_CHINESE_SIMPLIFIED = 33,
+        STBTT_MAC_LANG_ITALIAN            = 3,
+        STBTT_MAC_LANG_CHINESE_TRAD       = 19
+    };
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // __STB_INCLUDE_STB_TRUETYPE_H__
+
+///////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
+////
+////   IMPLEMENTATION
+////
+////
+
+#ifdef STB_TRUETYPE_IMPLEMENTATION
+
+#ifndef STBTT_MAX_OVERSAMPLE
+#define STBTT_MAX_OVERSAMPLE 8
+#endif
+
+#if STBTT_MAX_OVERSAMPLE > 255
+#error "STBTT_MAX_OVERSAMPLE cannot be > 255"
+#endif
+
+typedef int
+    stbtt__test_oversample_pow2[(STBTT_MAX_OVERSAMPLE & (STBTT_MAX_OVERSAMPLE - 1)) == 0 ? 1 : -1];
+
+#ifndef STBTT_RASTERIZER_VERSION
+#define STBTT_RASTERIZER_VERSION 2
+#endif
+
+#ifdef _MSC_VER
+#define STBTT__NOTUSED(v) (void)(v)
+#else
+#define STBTT__NOTUSED(v) (void)sizeof(v)
+#endif
+
+//////////////////////////////////////////////////////////////////////////
+//
+// stbtt__buf helpers to parse data from file
+//
+
+static stbtt_uint8 stbtt__buf_get8(stbtt__buf *b)
+{
+    if (b->cursor >= b->size)
+        return 0;
+    return b->data[b->cursor++];
+}
+
+static stbtt_uint8 stbtt__buf_peek8(stbtt__buf *b)
+{
+    if (b->cursor >= b->size)
+        return 0;
+    return b->data[b->cursor];
+}
+
+static void stbtt__buf_seek(stbtt__buf *b, int o)
+{
+    STBTT_assert(!(o > b->size || o < 0));
+    b->cursor = (o > b->size || o < 0) ? b->size : o;
+}
+
+static void stbtt__buf_skip(stbtt__buf *b, int o)
+{
+    stbtt__buf_seek(b, b->cursor + o);
+}
+
+static stbtt_uint32 stbtt__buf_get(stbtt__buf *b, int n)
+{
+    stbtt_uint32 v = 0;
+    int i;
+    STBTT_assert(n >= 1 && n <= 4);
+    for (i = 0; i < n; i++)
+        v = (v << 8) | stbtt__buf_get8(b);
+    return v;
+}
+
+static stbtt__buf stbtt__new_buf(const void *p, size_t size)
+{
+    stbtt__buf r;
+    STBTT_assert(size < 0x40000000);
+    r.data   = (stbtt_uint8 *)p;
+    r.size   = (int)size;
+    r.cursor = 0;
+    return r;
+}
+
+#define stbtt__buf_get16(b) stbtt__buf_get((b), 2)
+#define stbtt__buf_get32(b) stbtt__buf_get((b), 4)
+
+static stbtt__buf stbtt__buf_range(const stbtt__buf *b, int o, int s)
+{
+    stbtt__buf r = stbtt__new_buf(NULL, 0);
+    if (o < 0 || s < 0 || o > b->size || s > b->size - o)
+        return r;
+    r.data = b->data + o;
+    r.size = s;
+    return r;
+}
+
+static stbtt__buf stbtt__cff_get_index(stbtt__buf *b)
+{
+    int count, start, offsize;
+    start = b->cursor;
+    count = stbtt__buf_get16(b);
+    if (count)
+    {
+        offsize = stbtt__buf_get8(b);
+        STBTT_assert(offsize >= 1 && offsize <= 4);
+        stbtt__buf_skip(b, offsize * count);
+        stbtt__buf_skip(b, stbtt__buf_get(b, offsize) - 1);
+    }
+    return stbtt__buf_range(b, start, b->cursor - start);
+}
+
+static stbtt_uint32 stbtt__cff_int(stbtt__buf *b)
+{
+    int b0 = stbtt__buf_get8(b);
+    if (b0 >= 32 && b0 <= 246)
+        return b0 - 139;
+    else if (b0 >= 247 && b0 <= 250)
+        return (b0 - 247) * 256 + stbtt__buf_get8(b) + 108;
+    else if (b0 >= 251 && b0 <= 254)
+        return -(b0 - 251) * 256 - stbtt__buf_get8(b) - 108;
+    else if (b0 == 28)
+        return stbtt__buf_get16(b);
+    else if (b0 == 29)
+        return stbtt__buf_get32(b);
+    STBTT_assert(0);
+    return 0;
+}
+
+static void stbtt__cff_skip_operand(stbtt__buf *b)
+{
+    int v, b0 = stbtt__buf_peek8(b);
+    STBTT_assert(b0 >= 28);
+    if (b0 == 30)
+    {
+        stbtt__buf_skip(b, 1);
+        while (b->cursor < b->size)
+        {
+            v = stbtt__buf_get8(b);
+            if ((v & 0xF) == 0xF || (v >> 4) == 0xF)
+                break;
+        }
+    }
+    else
+    {
+        stbtt__cff_int(b);
+    }
+}
+
+static stbtt__buf stbtt__dict_get(stbtt__buf *b, int key)
+{
+    stbtt__buf_seek(b, 0);
+    while (b->cursor < b->size)
+    {
+        int start = b->cursor, end, op;
+        while (stbtt__buf_peek8(b) >= 28)
+            stbtt__cff_skip_operand(b);
+        end = b->cursor;
+        op  = stbtt__buf_get8(b);
+        if (op == 12)
+            op = stbtt__buf_get8(b) | 0x100;
+        if (op == key)
+            return stbtt__buf_range(b, start, end - start);
+    }
+    return stbtt__buf_range(b, 0, 0);
+}
+
+static void stbtt__dict_get_ints(stbtt__buf *b, int key, int outcount, stbtt_uint32 *out)
+{
+    int i;
+    stbtt__buf operands = stbtt__dict_get(b, key);
+    for (i = 0; i < outcount && operands.cursor < operands.size; i++)
+        out[i] = stbtt__cff_int(&operands);
+}
+
+static int stbtt__cff_index_count(stbtt__buf *b)
+{
+    stbtt__buf_seek(b, 0);
+    return stbtt__buf_get16(b);
+}
+
+static stbtt__buf stbtt__cff_index_get(stbtt__buf b, int i)
+{
+    int count, offsize, start, end;
+    stbtt__buf_seek(&b, 0);
+    count   = stbtt__buf_get16(&b);
+    offsize = stbtt__buf_get8(&b);
+    STBTT_assert(i >= 0 && i < count);
+    STBTT_assert(offsize >= 1 && offsize <= 4);
+    stbtt__buf_skip(&b, i * offsize);
+    start = stbtt__buf_get(&b, offsize);
+    end   = stbtt__buf_get(&b, offsize);
+    return stbtt__buf_range(&b, 2 + (count + 1) * offsize + start, end - start);
+}
+
+//////////////////////////////////////////////////////////////////////////
+//
+// accessors to parse data from file
+//
+
+// on platforms that don't allow misaligned reads, if we want to allow
+// truetype fonts that aren't padded to alignment, define ALLOW_UNALIGNED_TRUETYPE
+
+#define ttBYTE(p) (*(stbtt_uint8 *)(p))
+#define ttCHAR(p) (*(stbtt_int8 *)(p))
+#define ttFixed(p) ttLONG(p)
+
+static stbtt_uint16 ttUSHORT(stbtt_uint8 *p)
+{
+    return p[0] * 256 + p[1];
+}
+static stbtt_int16 ttSHORT(stbtt_uint8 *p)
+{
+    return p[0] * 256 + p[1];
+}
+static stbtt_uint32 ttULONG(stbtt_uint8 *p)
+{
+    return (p[0] << 24) + (p[1] << 16) + (p[2] << 8) + p[3];
+}
+static stbtt_int32 ttLONG(stbtt_uint8 *p)
+{
+    return (p[0] << 24) + (p[1] << 16) + (p[2] << 8) + p[3];
+}
+
+#define stbtt_tag4(p, c0, c1, c2, c3) \
+    ((p)[0] == (c0) && (p)[1] == (c1) && (p)[2] == (c2) && (p)[3] == (c3))
+#define stbtt_tag(p, str) stbtt_tag4(p, str[0], str[1], str[2], str[3])
+
+static int stbtt__isfont(stbtt_uint8 *font)
+{
+    // check the version number
+    if (stbtt_tag4(font, '1', 0, 0, 0))
+        return 1;  // TrueType 1
+    if (stbtt_tag(font, "typ1"))
+        return 1;  // TrueType with type 1 font -- we don't support this!
+    if (stbtt_tag(font, "OTTO"))
+        return 1;  // OpenType with CFF
+    if (stbtt_tag4(font, 0, 1, 0, 0))
+        return 1;  // OpenType 1.0
+    if (stbtt_tag(font, "true"))
+        return 1;  // Apple specification for TrueType fonts
+    return 0;
+}
+
+// @OPTIMIZE: binary search
+static stbtt_uint32 stbtt__find_table(stbtt_uint8 *data, stbtt_uint32 fontstart, const char *tag)
+{
+    stbtt_int32 num_tables = ttUSHORT(data + fontstart + 4);
+    stbtt_uint32 tabledir  = fontstart + 12;
+    stbtt_int32 i;
+    for (i = 0; i < num_tables; ++i)
+    {
+        stbtt_uint32 loc = tabledir + 16 * i;
+        if (stbtt_tag(data + loc + 0, tag))
+            return ttULONG(data + loc + 8);
+    }
+    return 0;
+}
+
+static int stbtt_GetFontOffsetForIndex_internal(unsigned char *font_collection, int index)
+{
+    // if it's just a font, there's only one valid index
+    if (stbtt__isfont(font_collection))
+        return index == 0 ? 0 : -1;
+
+    // check if it's a TTC
+    if (stbtt_tag(font_collection, "ttcf"))
+    {
+        // version 1?
+        if (ttULONG(font_collection + 4) == 0x00010000 ||
+            ttULONG(font_collection + 4) == 0x00020000)
+        {
+            stbtt_int32 n = ttLONG(font_collection + 8);
+            if (index >= n)
+                return -1;
+            return ttULONG(font_collection + 12 + index * 4);
+        }
+    }
+    return -1;
+}
+
+static int stbtt_GetNumberOfFonts_internal(unsigned char *font_collection)
+{
+    // if it's just a font, there's only one valid font
+    if (stbtt__isfont(font_collection))
+        return 1;
+
+    // check if it's a TTC
+    if (stbtt_tag(font_collection, "ttcf"))
+    {
+        // version 1?
+        if (ttULONG(font_collection + 4) == 0x00010000 ||
+            ttULONG(font_collection + 4) == 0x00020000)
+        {
+            return ttLONG(font_collection + 8);
+        }
+    }
+    return 0;
+}
+
+static stbtt__buf stbtt__get_subrs(stbtt__buf cff, stbtt__buf fontdict)
+{
+    stbtt_uint32 subrsoff = 0, private_loc[2] = {0, 0};
+    stbtt__buf pdict;
+    stbtt__dict_get_ints(&fontdict, 18, 2, private_loc);
+    if (!private_loc[1] || !private_loc[0])
+        return stbtt__new_buf(NULL, 0);
+    pdict = stbtt__buf_range(&cff, private_loc[1], private_loc[0]);
+    stbtt__dict_get_ints(&pdict, 19, 1, &subrsoff);
+    if (!subrsoff)
+        return stbtt__new_buf(NULL, 0);
+    stbtt__buf_seek(&cff, private_loc[1] + subrsoff);
+    return stbtt__cff_get_index(&cff);
+}
+
+static int stbtt_InitFont_internal(stbtt_fontinfo *info, unsigned char *data, int fontstart)
+{
+    stbtt_uint32 cmap, t;
+    stbtt_int32 i, numTables;
+
+    info->data      = data;
+    info->fontstart = fontstart;
+    info->cff       = stbtt__new_buf(NULL, 0);
+
+    cmap       = stbtt__find_table(data, fontstart, "cmap");  // required
+    info->loca = stbtt__find_table(data, fontstart, "loca");  // required
+    info->head = stbtt__find_table(data, fontstart, "head");  // required
+    info->glyf = stbtt__find_table(data, fontstart, "glyf");  // required
+    info->hhea = stbtt__find_table(data, fontstart, "hhea");  // required
+    info->hmtx = stbtt__find_table(data, fontstart, "hmtx");  // required
+    info->kern = stbtt__find_table(data, fontstart, "kern");  // not required
+    info->gpos = stbtt__find_table(data, fontstart, "GPOS");  // not required
+
+    if (!cmap || !info->head || !info->hhea || !info->hmtx)
+        return 0;
+    if (info->glyf)
+    {
+        // required for truetype
+        if (!info->loca)
+            return 0;
+    }
+    else
+    {
+        // initialization for CFF / Type2 fonts (OTF)
+        stbtt__buf b, topdict, topdictidx;
+        stbtt_uint32 cstype = 2, charstrings = 0, fdarrayoff = 0, fdselectoff = 0;
+        stbtt_uint32 cff;
+
+        cff = stbtt__find_table(data, fontstart, "CFF ");
+        if (!cff)
+            return 0;
+
+        info->fontdicts = stbtt__new_buf(NULL, 0);
+        info->fdselect  = stbtt__new_buf(NULL, 0);
+
+        // @TODO this should use size from table (not 512MB)
+        info->cff = stbtt__new_buf(data + cff, 512 * 1024 * 1024);
+        b         = info->cff;
+
+        // read the header
+        stbtt__buf_skip(&b, 2);
+        stbtt__buf_seek(&b, stbtt__buf_get8(&b));  // hdrsize
+
+        // @TODO the name INDEX could list multiple fonts,
+        // but we just use the first one.
+        stbtt__cff_get_index(&b);  // name INDEX
+        topdictidx = stbtt__cff_get_index(&b);
+        topdict    = stbtt__cff_index_get(topdictidx, 0);
+        stbtt__cff_get_index(&b);  // string INDEX
+        info->gsubrs = stbtt__cff_get_index(&b);
+
+        stbtt__dict_get_ints(&topdict, 17, 1, &charstrings);
+        stbtt__dict_get_ints(&topdict, 0x100 | 6, 1, &cstype);
+        stbtt__dict_get_ints(&topdict, 0x100 | 36, 1, &fdarrayoff);
+        stbtt__dict_get_ints(&topdict, 0x100 | 37, 1, &fdselectoff);
+        info->subrs = stbtt__get_subrs(b, topdict);
+
+        // we only support Type 2 charstrings
+        if (cstype != 2)
+            return 0;
+        if (charstrings == 0)
+            return 0;
+
+        if (fdarrayoff)
+        {
+            // looks like a CID font
+            if (!fdselectoff)
+                return 0;
+            stbtt__buf_seek(&b, fdarrayoff);
+            info->fontdicts = stbtt__cff_get_index(&b);
+            info->fdselect  = stbtt__buf_range(&b, fdselectoff, b.size - fdselectoff);
+        }
+
+        stbtt__buf_seek(&b, charstrings);
+        info->charstrings = stbtt__cff_get_index(&b);
+    }
+
+    t = stbtt__find_table(data, fontstart, "maxp");
+    if (t)
+        info->numGlyphs = ttUSHORT(data + t + 4);
+    else
+        info->numGlyphs = 0xffff;
+
+    // find a cmap encoding table we understand *now* to avoid searching
+    // later. (todo: could make this installable)
+    // the same regardless of glyph.
+    numTables       = ttUSHORT(data + cmap + 2);
+    info->index_map = 0;
+    for (i = 0; i < numTables; ++i)
+    {
+        stbtt_uint32 encoding_record = cmap + 4 + 8 * i;
+        // find an encoding we understand:
+        switch (ttUSHORT(data + encoding_record))
+        {
+            case STBTT_PLATFORM_ID_MICROSOFT:
+                switch (ttUSHORT(data + encoding_record + 2))
+                {
+                    case STBTT_MS_EID_UNICODE_BMP:
+                    case STBTT_MS_EID_UNICODE_FULL:
+                        // MS/Unicode
+                        info->index_map = cmap + ttULONG(data + encoding_record + 4);
+                        break;
+                }
+                break;
+            case STBTT_PLATFORM_ID_UNICODE:
+                // Mac/iOS has these
+                // all the encodingIDs are unicode, so we don't bother to check it
+                info->index_map = cmap + ttULONG(data + encoding_record + 4);
+                break;
+        }
+    }
+    if (info->index_map == 0)
+        return 0;
+
+    info->indexToLocFormat = ttUSHORT(data + info->head + 50);
+    return 1;
+}
+
+STBTT_DEF int stbtt_FindGlyphIndex(const stbtt_fontinfo *info, int unicode_codepoint)
+{
+    stbtt_uint8 *data      = info->data;
+    stbtt_uint32 index_map = info->index_map;
+
+    stbtt_uint16 format = ttUSHORT(data + index_map + 0);
+    if (format == 0)
+    {  // apple byte encoding
+        stbtt_int32 bytes = ttUSHORT(data + index_map + 2);
+        if (unicode_codepoint < bytes - 6)
+            return ttBYTE(data + index_map + 6 + unicode_codepoint);
+        return 0;
+    }
+    else if (format == 6)
+    {
+        stbtt_uint32 first = ttUSHORT(data + index_map + 6);
+        stbtt_uint32 count = ttUSHORT(data + index_map + 8);
+        if ((stbtt_uint32)unicode_codepoint >= first &&
+            (stbtt_uint32)unicode_codepoint < first + count)
+            return ttUSHORT(data + index_map + 10 + (unicode_codepoint - first) * 2);
+        return 0;
+    }
+    else if (format == 2)
+    {
+        STBTT_assert(0);  // @TODO: high-byte mapping for japanese/chinese/korean
+        return 0;
+    }
+    else if (format == 4)
+    {  // standard mapping for windows fonts: binary search collection of ranges
+        stbtt_uint16 segcount      = ttUSHORT(data + index_map + 6) >> 1;
+        stbtt_uint16 searchRange   = ttUSHORT(data + index_map + 8) >> 1;
+        stbtt_uint16 entrySelector = ttUSHORT(data + index_map + 10);
+        stbtt_uint16 rangeShift    = ttUSHORT(data + index_map + 12) >> 1;
+
+        // do a binary search of the segments
+        stbtt_uint32 endCount = index_map + 14;
+        stbtt_uint32 search   = endCount;
+
+        if (unicode_codepoint > 0xffff)
+            return 0;
+
+        // they lie from endCount .. endCount + segCount
+        // but searchRange is the nearest power of two, so...
+        if (unicode_codepoint >= ttUSHORT(data + search + rangeShift * 2))
+            search += rangeShift * 2;
+
+        // now decrement to bias correctly to find smallest
+        search -= 2;
+        while (entrySelector)
+        {
+            stbtt_uint16 end;
+            searchRange >>= 1;
+            end = ttUSHORT(data + search + searchRange * 2);
+            if (unicode_codepoint > end)
+                search += searchRange * 2;
+            --entrySelector;
+        }
+        search += 2;
+
+        {
+            stbtt_uint16 offset, start;
+            stbtt_uint16 item = (stbtt_uint16)((search - endCount) >> 1);
+
+            STBTT_assert(unicode_codepoint <= ttUSHORT(data + endCount + 2 * item));
+            start = ttUSHORT(data + index_map + 14 + segcount * 2 + 2 + 2 * item);
+            if (unicode_codepoint < start)
+                return 0;
+
+            offset = ttUSHORT(data + index_map + 14 + segcount * 6 + 2 + 2 * item);
+            if (offset == 0)
+                return (stbtt_uint16)(unicode_codepoint +
+                                      ttSHORT(data + index_map + 14 + segcount * 4 + 2 + 2 * item));
+
+            return ttUSHORT(data + offset + (unicode_codepoint - start) * 2 + index_map + 14 +
+                            segcount * 6 + 2 + 2 * item);
+        }
+    }
+    else if (format == 12 || format == 13)
+    {
+        stbtt_uint32 ngroups = ttULONG(data + index_map + 12);
+        stbtt_int32 low, high;
+        low  = 0;
+        high = (stbtt_int32)ngroups;
+        // Binary search the right group.
+        while (low < high)
+        {
+            stbtt_int32 mid = low + ((high - low) >> 1);  // rounds down, so low <= mid < high
+            stbtt_uint32 start_char = ttULONG(data + index_map + 16 + mid * 12);
+            stbtt_uint32 end_char   = ttULONG(data + index_map + 16 + mid * 12 + 4);
+            if ((stbtt_uint32)unicode_codepoint < start_char)
+                high = mid;
+            else if ((stbtt_uint32)unicode_codepoint > end_char)
+                low = mid + 1;
+            else
+            {
+                stbtt_uint32 start_glyph = ttULONG(data + index_map + 16 + mid * 12 + 8);
+                if (format == 12)
+                    return start_glyph + unicode_codepoint - start_char;
+                else  // format == 13
+                    return start_glyph;
+            }
+        }
+        return 0;  // not found
+    }
+    // @TODO
+    STBTT_assert(0);
+    return 0;
+}
+
+STBTT_DEF int stbtt_GetCodepointShape(const stbtt_fontinfo *info,
+                                      int unicode_codepoint,
+                                      stbtt_vertex **vertices)
+{
+    return stbtt_GetGlyphShape(info, stbtt_FindGlyphIndex(info, unicode_codepoint), vertices);
+}
+
+static void stbtt_setvertex(stbtt_vertex *v,
+                            stbtt_uint8 type,
+                            stbtt_int32 x,
+                            stbtt_int32 y,
+                            stbtt_int32 cx,
+                            stbtt_int32 cy)
+{
+    v->type = type;
+    v->x    = (stbtt_int16)x;
+    v->y    = (stbtt_int16)y;
+    v->cx   = (stbtt_int16)cx;
+    v->cy   = (stbtt_int16)cy;
+}
+
+static int stbtt__GetGlyfOffset(const stbtt_fontinfo *info, int glyph_index)
+{
+    int g1, g2;
+
+    STBTT_assert(!info->cff.size);
+
+    if (glyph_index >= info->numGlyphs)
+        return -1;  // glyph index out of range
+    if (info->indexToLocFormat >= 2)
+        return -1;  // unknown index->glyph map format
+
+    if (info->indexToLocFormat == 0)
+    {
+        g1 = info->glyf + ttUSHORT(info->data + info->loca + glyph_index * 2) * 2;
+        g2 = info->glyf + ttUSHORT(info->data + info->loca + glyph_index * 2 + 2) * 2;
+    }
+    else
+    {
+        g1 = info->glyf + ttULONG(info->data + info->loca + glyph_index * 4);
+        g2 = info->glyf + ttULONG(info->data + info->loca + glyph_index * 4 + 4);
+    }
+
+    return g1 == g2 ? -1 : g1;  // if length is 0, return -1
+}
+
+static int stbtt__GetGlyphInfoT2(const stbtt_fontinfo *info,
+                                 int glyph_index,
+                                 int *x0,
+                                 int *y0,
+                                 int *x1,
+                                 int *y1);
+
+STBTT_DEF int stbtt_GetGlyphBox(const stbtt_fontinfo *info,
+                                int glyph_index,
+                                int *x0,
+                                int *y0,
+                                int *x1,
+                                int *y1)
+{
+    if (info->cff.size)
+    {
+        stbtt__GetGlyphInfoT2(info, glyph_index, x0, y0, x1, y1);
+    }
+    else
+    {
+        int g = stbtt__GetGlyfOffset(info, glyph_index);
+        if (g < 0)
+            return 0;
+
+        if (x0)
+            *x0 = ttSHORT(info->data + g + 2);
+        if (y0)
+            *y0 = ttSHORT(info->data + g + 4);
+        if (x1)
+            *x1 = ttSHORT(info->data + g + 6);
+        if (y1)
+            *y1 = ttSHORT(info->data + g + 8);
+    }
+    return 1;
+}
+
+STBTT_DEF int stbtt_GetCodepointBox(const stbtt_fontinfo *info,
+                                    int codepoint,
+                                    int *x0,
+                                    int *y0,
+                                    int *x1,
+                                    int *y1)
+{
+    return stbtt_GetGlyphBox(info, stbtt_FindGlyphIndex(info, codepoint), x0, y0, x1, y1);
+}
+
+STBTT_DEF int stbtt_IsGlyphEmpty(const stbtt_fontinfo *info, int glyph_index)
+{
+    stbtt_int16 numberOfContours;
+    int g;
+    if (info->cff.size)
+        return stbtt__GetGlyphInfoT2(info, glyph_index, NULL, NULL, NULL, NULL) == 0;
+    g = stbtt__GetGlyfOffset(info, glyph_index);
+    if (g < 0)
+        return 1;
+    numberOfContours = ttSHORT(info->data + g);
+    return numberOfContours == 0;
+}
+
+static int stbtt__close_shape(stbtt_vertex *vertices,
+                              int num_vertices,
+                              int was_off,
+                              int start_off,
+                              stbtt_int32 sx,
+                              stbtt_int32 sy,
+                              stbtt_int32 scx,
+                              stbtt_int32 scy,
+                              stbtt_int32 cx,
+                              stbtt_int32 cy)
+{
+    if (start_off)
+    {
+        if (was_off)
+            stbtt_setvertex(&vertices[num_vertices++], STBTT_vcurve, (cx + scx) >> 1,
+                            (cy + scy) >> 1, cx, cy);
+        stbtt_setvertex(&vertices[num_vertices++], STBTT_vcurve, sx, sy, scx, scy);
+    }
+    else
+    {
+        if (was_off)
+            stbtt_setvertex(&vertices[num_vertices++], STBTT_vcurve, sx, sy, cx, cy);
+        else
+            stbtt_setvertex(&vertices[num_vertices++], STBTT_vline, sx, sy, 0, 0);
+    }
+    return num_vertices;
+}
+
+static int stbtt__GetGlyphShapeTT(const stbtt_fontinfo *info,
+                                  int glyph_index,
+                                  stbtt_vertex **pvertices)
+{
+    stbtt_int16 numberOfContours;
+    stbtt_uint8 *endPtsOfContours;
+    stbtt_uint8 *data      = info->data;
+    stbtt_vertex *vertices = 0;
+    int num_vertices       = 0;
+    int g                  = stbtt__GetGlyfOffset(info, glyph_index);
+
+    *pvertices = NULL;
+
+    if (g < 0)
+        return 0;
+
+    numberOfContours = ttSHORT(data + g);
+
+    if (numberOfContours > 0)
+    {
+        stbtt_uint8 flags = 0, flagcount;
+        stbtt_int32 ins, i, j = 0, m, n, next_move, was_off = 0, off, start_off = 0;
+        stbtt_int32 x, y, cx, cy, sx, sy, scx, scy;
+        stbtt_uint8 *points;
+        endPtsOfContours = (data + g + 10);
+        ins              = ttUSHORT(data + g + 10 + numberOfContours * 2);
+        points           = data + g + 10 + numberOfContours * 2 + 2 + ins;
+
+        n = 1 + ttUSHORT(endPtsOfContours + numberOfContours * 2 - 2);
+
+        m        = n + 2 * numberOfContours;  // a loose bound on how many vertices we might need
+        vertices = (stbtt_vertex *)STBTT_malloc(m * sizeof(vertices[0]), info->userdata);
+        if (vertices == 0)
+            return 0;
+
+        next_move = 0;
+        flagcount = 0;
+
+        // in first pass, we load uninterpreted data into the allocated array
+        // above, shifted to the end of the array so we won't overwrite it when
+        // we create our final data starting from the front
+
+        off = m - n;  // starting offset for uninterpreted data, regardless of how m ends up being
+                      // calculated
+
+        // first load flags
+
+        for (i = 0; i < n; ++i)
+        {
+            if (flagcount == 0)
+            {
+                flags = *points++;
+                if (flags & 8)
+                    flagcount = *points++;
+            }
+            else
+                --flagcount;
+            vertices[off + i].type = flags;
+        }
+
+        // now load x coordinates
+        x = 0;
+        for (i = 0; i < n; ++i)
+        {
+            flags = vertices[off + i].type;
+            if (flags & 2)
+            {
+                stbtt_int16 dx = *points++;
+                x += (flags & 16) ? dx : -dx;  // ???
+            }
+            else
+            {
+                if (!(flags & 16))
+                {
+                    x = x + (stbtt_int16)(points[0] * 256 + points[1]);
+                    points += 2;
+                }
+            }
+            vertices[off + i].x = (stbtt_int16)x;
+        }
+
+        // now load y coordinates
+        y = 0;
+        for (i = 0; i < n; ++i)
+        {
+            flags = vertices[off + i].type;
+            if (flags & 4)
+            {
+                stbtt_int16 dy = *points++;
+                y += (flags & 32) ? dy : -dy;  // ???
+            }
+            else
+            {
+                if (!(flags & 32))
+                {
+                    y = y + (stbtt_int16)(points[0] * 256 + points[1]);
+                    points += 2;
+                }
+            }
+            vertices[off + i].y = (stbtt_int16)y;
+        }
+
+        // now convert them to our format
+        num_vertices = 0;
+        sx = sy = cx = cy = scx = scy = 0;
+        for (i = 0; i < n; ++i)
+        {
+            flags = vertices[off + i].type;
+            x     = (stbtt_int16)vertices[off + i].x;
+            y     = (stbtt_int16)vertices[off + i].y;
+
+            if (next_move == i)
+            {
+                if (i != 0)
+                    num_vertices = stbtt__close_shape(vertices, num_vertices, was_off, start_off,
+                                                      sx, sy, scx, scy, cx, cy);
+
+                // now start the new one
+                start_off = !(flags & 1);
+                if (start_off)
+                {
+                    // if we start off with an off-curve point, then when we need to find a point on
+                    // the curve where we can start, and we need to save some state for when we
+                    // wraparound.
+                    scx = x;
+                    scy = y;
+                    if (!(vertices[off + i + 1].type & 1))
+                    {
+                        // next point is also a curve point, so interpolate an on-point curve
+                        sx = (x + (stbtt_int32)vertices[off + i + 1].x) >> 1;
+                        sy = (y + (stbtt_int32)vertices[off + i + 1].y) >> 1;
+                    }
+                    else
+                    {
+                        // otherwise just use the next point as our start point
+                        sx = (stbtt_int32)vertices[off + i + 1].x;
+                        sy = (stbtt_int32)vertices[off + i + 1].y;
+                        ++i;  // we're using point i+1 as the starting point, so skip it
+                    }
+                }
+                else
+                {
+                    sx = x;
+                    sy = y;
+                }
+                stbtt_setvertex(&vertices[num_vertices++], STBTT_vmove, sx, sy, 0, 0);
+                was_off   = 0;
+                next_move = 1 + ttUSHORT(endPtsOfContours + j * 2);
+                ++j;
+            }
+            else
+            {
+                if (!(flags & 1))
+                {                 // if it's a curve
+                    if (was_off)  // two off-curve control points in a row means interpolate an
+                                  // on-curve midpoint
+                        stbtt_setvertex(&vertices[num_vertices++], STBTT_vcurve, (cx + x) >> 1,
+                                        (cy + y) >> 1, cx, cy);
+                    cx      = x;
+                    cy      = y;
+                    was_off = 1;
+                }
+                else
+                {
+                    if (was_off)
+                        stbtt_setvertex(&vertices[num_vertices++], STBTT_vcurve, x, y, cx, cy);
+                    else
+                        stbtt_setvertex(&vertices[num_vertices++], STBTT_vline, x, y, 0, 0);
+                    was_off = 0;
+                }
+            }
+        }
+        num_vertices = stbtt__close_shape(vertices, num_vertices, was_off, start_off, sx, sy, scx,
+                                          scy, cx, cy);
+    }
+    else if (numberOfContours == -1)
+    {
+        // Compound shapes.
+        int more          = 1;
+        stbtt_uint8 *comp = data + g + 10;
+        num_vertices      = 0;
+        vertices          = 0;
+        while (more)
+        {
+            stbtt_uint16 flags, gidx;
+            int comp_num_verts       = 0, i;
+            stbtt_vertex *comp_verts = 0, *tmp = 0;
+            float mtx[6] = {1, 0, 0, 1, 0, 0}, m, n;
+
+            flags = ttSHORT(comp);
+            comp += 2;
+            gidx = ttSHORT(comp);
+            comp += 2;
+
+            if (flags & 2)
+            {  // XY values
+                if (flags & 1)
+                {  // shorts
+                    mtx[4] = ttSHORT(comp);
+                    comp += 2;
+                    mtx[5] = ttSHORT(comp);
+                    comp += 2;
+                }
+                else
+                {
+                    mtx[4] = ttCHAR(comp);
+                    comp += 1;
+                    mtx[5] = ttCHAR(comp);
+                    comp += 1;
+                }
+            }
+            else
+            {
+                // @TODO handle matching point
+                STBTT_assert(0);
+            }
+            if (flags & (1 << 3))
+            {  // WE_HAVE_A_SCALE
+                mtx[0] = mtx[3] = ttSHORT(comp) / 16384.0f;
+                comp += 2;
+                mtx[1] = mtx[2] = 0;
+            }
+            else if (flags & (1 << 6))
+            {  // WE_HAVE_AN_X_AND_YSCALE
+                mtx[0] = ttSHORT(comp) / 16384.0f;
+                comp += 2;
+                mtx[1] = mtx[2] = 0;
+                mtx[3]          = ttSHORT(comp) / 16384.0f;
+                comp += 2;
+            }
+            else if (flags & (1 << 7))
+            {  // WE_HAVE_A_TWO_BY_TWO
+                mtx[0] = ttSHORT(comp) / 16384.0f;
+                comp += 2;
+                mtx[1] = ttSHORT(comp) / 16384.0f;
+                comp += 2;
+                mtx[2] = ttSHORT(comp) / 16384.0f;
+                comp += 2;
+                mtx[3] = ttSHORT(comp) / 16384.0f;
+                comp += 2;
+            }
+
+            // Find transformation scales.
+            m = (float)STBTT_sqrt(mtx[0] * mtx[0] + mtx[1] * mtx[1]);
+            n = (float)STBTT_sqrt(mtx[2] * mtx[2] + mtx[3] * mtx[3]);
+
+            // Get indexed glyph.
+            comp_num_verts = stbtt_GetGlyphShape(info, gidx, &comp_verts);
+            if (comp_num_verts > 0)
+            {
+                // Transform vertices.
+                for (i = 0; i < comp_num_verts; ++i)
+                {
+                    stbtt_vertex *v = &comp_verts[i];
+                    stbtt_vertex_type x, y;
+                    x     = v->x;
+                    y     = v->y;
+                    v->x  = (stbtt_vertex_type)(m * (mtx[0] * x + mtx[2] * y + mtx[4]));
+                    v->y  = (stbtt_vertex_type)(n * (mtx[1] * x + mtx[3] * y + mtx[5]));
+                    x     = v->cx;
+                    y     = v->cy;
+                    v->cx = (stbtt_vertex_type)(m * (mtx[0] * x + mtx[2] * y + mtx[4]));
+                    v->cy = (stbtt_vertex_type)(n * (mtx[1] * x + mtx[3] * y + mtx[5]));
+                }
+                // Append vertices.
+                tmp = (stbtt_vertex *)STBTT_malloc(
+                    (num_vertices + comp_num_verts) * sizeof(stbtt_vertex), info->userdata);
+                if (!tmp)
+                {
+                    if (vertices)
+                        STBTT_free(vertices, info->userdata);
+                    if (comp_verts)
+                        STBTT_free(comp_verts, info->userdata);
+                    return 0;
+                }
+                if (num_vertices > 0)
+                    STBTT_memcpy(tmp, vertices, num_vertices * sizeof(stbtt_vertex));  //-V595
+                STBTT_memcpy(tmp + num_vertices, comp_verts, comp_num_verts * sizeof(stbtt_vertex));
+                if (vertices)
+                    STBTT_free(vertices, info->userdata);
+                vertices = tmp;
+                STBTT_free(comp_verts, info->userdata);
+                num_vertices += comp_num_verts;
+            }
+            // More components ?
+            more = flags & (1 << 5);
+        }
+    }
+    else if (numberOfContours < 0)
+    {
+        // @TODO other compound variations?
+        STBTT_assert(0);
+    }
+    else
+    {
+        // numberOfCounters == 0, do nothing
+    }
+
+    *pvertices = vertices;
+    return num_vertices;
+}
+
+typedef struct
+{
+    int bounds;
+    int started;
+    float first_x, first_y;
+    float x, y;
+    stbtt_int32 min_x, max_x, min_y, max_y;
+
+    stbtt_vertex *pvertices;
+    int num_vertices;
+} stbtt__csctx;
+
+#define STBTT__CSCTX_INIT(bounds)                  \
+    {                                              \
+        bounds, 0, 0, 0, 0, 0, 0, 0, 0, 0, NULL, 0 \
+    }
+
+static void stbtt__track_vertex(stbtt__csctx *c, stbtt_int32 x, stbtt_int32 y)
+{
+    if (x > c->max_x || !c->started)
+        c->max_x = x;
+    if (y > c->max_y || !c->started)
+        c->max_y = y;
+    if (x < c->min_x || !c->started)
+        c->min_x = x;
+    if (y < c->min_y || !c->started)
+        c->min_y = y;
+    c->started = 1;
+}
+
+static void stbtt__csctx_v(stbtt__csctx *c,
+                           stbtt_uint8 type,
+                           stbtt_int32 x,
+                           stbtt_int32 y,
+                           stbtt_int32 cx,
+                           stbtt_int32 cy,
+                           stbtt_int32 cx1,
+                           stbtt_int32 cy1)
+{
+    if (c->bounds)
+    {
+        stbtt__track_vertex(c, x, y);
+        if (type == STBTT_vcubic)
+        {
+            stbtt__track_vertex(c, cx, cy);
+            stbtt__track_vertex(c, cx1, cy1);
+        }
+    }
+    else
+    {
+        stbtt_setvertex(&c->pvertices[c->num_vertices], type, x, y, cx, cy);
+        c->pvertices[c->num_vertices].cx1 = (stbtt_int16)cx1;
+        c->pvertices[c->num_vertices].cy1 = (stbtt_int16)cy1;
+    }
+    c->num_vertices++;
+}
+
+static void stbtt__csctx_close_shape(stbtt__csctx *ctx)
+{
+    if (ctx->first_x != ctx->x || ctx->first_y != ctx->y)
+        stbtt__csctx_v(ctx, STBTT_vline, (int)ctx->first_x, (int)ctx->first_y, 0, 0, 0, 0);
+}
+
+static void stbtt__csctx_rmove_to(stbtt__csctx *ctx, float dx, float dy)
+{
+    stbtt__csctx_close_shape(ctx);
+    ctx->first_x = ctx->x = ctx->x + dx;
+    ctx->first_y = ctx->y = ctx->y + dy;
+    stbtt__csctx_v(ctx, STBTT_vmove, (int)ctx->x, (int)ctx->y, 0, 0, 0, 0);
+}
+
+static void stbtt__csctx_rline_to(stbtt__csctx *ctx, float dx, float dy)
+{
+    ctx->x += dx;
+    ctx->y += dy;
+    stbtt__csctx_v(ctx, STBTT_vline, (int)ctx->x, (int)ctx->y, 0, 0, 0, 0);
+}
+
+static void stbtt__csctx_rccurve_to(stbtt__csctx *ctx,
+                                    float dx1,
+                                    float dy1,
+                                    float dx2,
+                                    float dy2,
+                                    float dx3,
+                                    float dy3)
+{
+    float cx1 = ctx->x + dx1;
+    float cy1 = ctx->y + dy1;
+    float cx2 = cx1 + dx2;
+    float cy2 = cy1 + dy2;
+    ctx->x    = cx2 + dx3;
+    ctx->y    = cy2 + dy3;
+    stbtt__csctx_v(ctx, STBTT_vcubic, (int)ctx->x, (int)ctx->y, (int)cx1, (int)cy1, (int)cx2,
+                   (int)cy2);
+}
+
+static stbtt__buf stbtt__get_subr(stbtt__buf idx, int n)
+{
+    int count = stbtt__cff_index_count(&idx);
+    int bias  = 107;
+    if (count >= 33900)
+        bias = 32768;
+    else if (count >= 1240)
+        bias = 1131;
+    n += bias;
+    if (n < 0 || n >= count)
+        return stbtt__new_buf(NULL, 0);
+    return stbtt__cff_index_get(idx, n);
+}
+
+static stbtt__buf stbtt__cid_get_glyph_subrs(const stbtt_fontinfo *info, int glyph_index)
+{
+    stbtt__buf fdselect = info->fdselect;
+    int nranges, start, end, v, fmt, fdselector = -1, i;
+
+    stbtt__buf_seek(&fdselect, 0);
+    fmt = stbtt__buf_get8(&fdselect);
+    if (fmt == 0)
+    {
+        // untested
+        stbtt__buf_skip(&fdselect, glyph_index);
+        fdselector = stbtt__buf_get8(&fdselect);
+    }
+    else if (fmt == 3)
+    {
+        nranges = stbtt__buf_get16(&fdselect);
+        start   = stbtt__buf_get16(&fdselect);
+        for (i = 0; i < nranges; i++)
+        {
+            v   = stbtt__buf_get8(&fdselect);
+            end = stbtt__buf_get16(&fdselect);
+            if (glyph_index >= start && glyph_index < end)
+            {
+                fdselector = v;
+                break;
+            }
+            start = end;
+        }
+    }
+    if (fdselector == -1)
+        stbtt__new_buf(NULL, 0);
+    return stbtt__get_subrs(info->cff, stbtt__cff_index_get(info->fontdicts, fdselector));
+}
+
+static int stbtt__run_charstring(const stbtt_fontinfo *info, int glyph_index, stbtt__csctx *c)
+{
+    int in_header = 1, maskbits = 0, subr_stack_height = 0, sp = 0, v, i, b0;
+    int has_subrs = 0, clear_stack;
+    float s[48];
+    stbtt__buf subr_stack[10], subrs = info->subrs, b;
+    float f;
+
+#define STBTT__CSERR(s) (0)
+
+    // this currently ignores the initial width value, which isn't needed if we have hmtx
+    b = stbtt__cff_index_get(info->charstrings, glyph_index);
+    while (b.cursor < b.size)
+    {
+        i           = 0;
+        clear_stack = 1;
+        b0          = stbtt__buf_get8(&b);
+        switch (b0)
+        {
+            // @TODO implement hinting
+            case 0x13:  // hintmask
+            case 0x14:  // cntrmask
+                if (in_header)
+                    maskbits += (sp / 2);  // implicit "vstem"
+                in_header = 0;
+                stbtt__buf_skip(&b, (maskbits + 7) / 8);
+                break;
+
+            case 0x01:  // hstem
+            case 0x03:  // vstem
+            case 0x12:  // hstemhm
+            case 0x17:  // vstemhm
+                maskbits += (sp / 2);
+                break;
+
+            case 0x15:  // rmoveto
+                in_header = 0;
+                if (sp < 2)
+                    return STBTT__CSERR("rmoveto stack");
+                stbtt__csctx_rmove_to(c, s[sp - 2], s[sp - 1]);
+                break;
+            case 0x04:  // vmoveto
+                in_header = 0;
+                if (sp < 1)
+                    return STBTT__CSERR("vmoveto stack");
+                stbtt__csctx_rmove_to(c, 0, s[sp - 1]);
+                break;
+            case 0x16:  // hmoveto
+                in_header = 0;
+                if (sp < 1)
+                    return STBTT__CSERR("hmoveto stack");
+                stbtt__csctx_rmove_to(c, s[sp - 1], 0);
+                break;
+
+            case 0x05:  // rlineto
+                if (sp < 2)
+                    return STBTT__CSERR("rlineto stack");
+                for (; i + 1 < sp; i += 2)
+                    stbtt__csctx_rline_to(c, s[i], s[i + 1]);
+                break;
+
+                // hlineto/vlineto and vhcurveto/hvcurveto alternate horizontal and vertical
+                // starting from a different place.
+
+            case 0x07:  // vlineto
+                if (sp < 1)
+                    return STBTT__CSERR("vlineto stack");
+                goto vlineto;
+            case 0x06:  // hlineto
+                if (sp < 1)
+                    return STBTT__CSERR("hlineto stack");
+                for (;;)
+                {
+                    if (i >= sp)
+                        break;
+                    stbtt__csctx_rline_to(c, s[i], 0);
+                    i++;
+                vlineto:
+                    if (i >= sp)
+                        break;
+                    stbtt__csctx_rline_to(c, 0, s[i]);
+                    i++;
+                }
+                break;
+
+            case 0x1F:  // hvcurveto
+                if (sp < 4)
+                    return STBTT__CSERR("hvcurveto stack");
+                goto hvcurveto;
+            case 0x1E:  // vhcurveto
+                if (sp < 4)
+                    return STBTT__CSERR("vhcurveto stack");
+                for (;;)
+                {
+                    if (i + 3 >= sp)
+                        break;
+                    stbtt__csctx_rccurve_to(c, 0, s[i], s[i + 1], s[i + 2], s[i + 3],
+                                            (sp - i == 5) ? s[i + 4] : 0.0f);
+                    i += 4;
+                hvcurveto:
+                    if (i + 3 >= sp)
+                        break;
+                    stbtt__csctx_rccurve_to(c, s[i], 0, s[i + 1], s[i + 2],
+                                            (sp - i == 5) ? s[i + 4] : 0.0f, s[i + 3]);
+                    i += 4;
+                }
+                break;
+
+            case 0x08:  // rrcurveto
+                if (sp < 6)
+                    return STBTT__CSERR("rcurveline stack");
+                for (; i + 5 < sp; i += 6)
+                    stbtt__csctx_rccurve_to(c, s[i], s[i + 1], s[i + 2], s[i + 3], s[i + 4],
+                                            s[i + 5]);
+                break;
+
+            case 0x18:  // rcurveline
+                if (sp < 8)
+                    return STBTT__CSERR("rcurveline stack");
+                for (; i + 5 < sp - 2; i += 6)
+                    stbtt__csctx_rccurve_to(c, s[i], s[i + 1], s[i + 2], s[i + 3], s[i + 4],
+                                            s[i + 5]);
+                if (i + 1 >= sp)
+                    return STBTT__CSERR("rcurveline stack");
+                stbtt__csctx_rline_to(c, s[i], s[i + 1]);
+                break;
+
+            case 0x19:  // rlinecurve
+                if (sp < 8)
+                    return STBTT__CSERR("rlinecurve stack");
+                for (; i + 1 < sp - 6; i += 2)
+                    stbtt__csctx_rline_to(c, s[i], s[i + 1]);
+                if (i + 5 >= sp)
+                    return STBTT__CSERR("rlinecurve stack");
+                stbtt__csctx_rccurve_to(c, s[i], s[i + 1], s[i + 2], s[i + 3], s[i + 4], s[i + 5]);
+                break;
+
+            case 0x1A:  // vvcurveto
+            case 0x1B:  // hhcurveto
+                if (sp < 4)
+                    return STBTT__CSERR("(vv|hh)curveto stack");
+                f = 0.0;
+                if (sp & 1)
+                {
+                    f = s[i];
+                    i++;
+                }
+                for (; i + 3 < sp; i += 4)
+                {
+                    if (b0 == 0x1B)
+                        stbtt__csctx_rccurve_to(c, s[i], f, s[i + 1], s[i + 2], s[i + 3], 0.0);
+                    else
+                        stbtt__csctx_rccurve_to(c, f, s[i], s[i + 1], s[i + 2], 0.0, s[i + 3]);
+                    f = 0.0;
+                }
+                break;
+
+            case 0x0A:  // callsubr
+                if (!has_subrs)
+                {
+                    if (info->fdselect.size)
+                        subrs = stbtt__cid_get_glyph_subrs(info, glyph_index);
+                    has_subrs = 1;
+                }
+                // fallthrough
+            case 0x1D:  // callgsubr
+                if (sp < 1)
+                    return STBTT__CSERR("call(g|)subr stack");
+                v = (int)s[--sp];
+                if (subr_stack_height >= 10)
+                    return STBTT__CSERR("recursion limit");
+                subr_stack[subr_stack_height++] = b;
+                b = stbtt__get_subr(b0 == 0x0A ? subrs : info->gsubrs, v);
+                if (b.size == 0)
+                    return STBTT__CSERR("subr not found");
+                b.cursor    = 0;
+                clear_stack = 0;
+                break;
+
+            case 0x0B:  // return
+                if (subr_stack_height <= 0)
+                    return STBTT__CSERR("return outside subr");
+                b           = subr_stack[--subr_stack_height];
+                clear_stack = 0;
+                break;
+
+            case 0x0E:  // endchar
+                stbtt__csctx_close_shape(c);
+                return 1;
+
+            case 0x0C:
+            {  // two-byte escape
+                float dx1, dx2, dx3, dx4, dx5, dx6, dy1, dy2, dy3, dy4, dy5, dy6;
+                float dx, dy;
+                int b1 = stbtt__buf_get8(&b);
+                switch (b1)
+                {
+                    // @TODO These "flex" implementations ignore the flex-depth and resolution,
+                    // and always draw beziers.
+                    case 0x22:  // hflex
+                        if (sp < 7)
+                            return STBTT__CSERR("hflex stack");
+                        dx1 = s[0];
+                        dx2 = s[1];
+                        dy2 = s[2];
+                        dx3 = s[3];
+                        dx4 = s[4];
+                        dx5 = s[5];
+                        dx6 = s[6];
+                        stbtt__csctx_rccurve_to(c, dx1, 0, dx2, dy2, dx3, 0);
+                        stbtt__csctx_rccurve_to(c, dx4, 0, dx5, -dy2, dx6, 0);
+                        break;
+
+                    case 0x23:  // flex
+                        if (sp < 13)
+                            return STBTT__CSERR("flex stack");
+                        dx1 = s[0];
+                        dy1 = s[1];
+                        dx2 = s[2];
+                        dy2 = s[3];
+                        dx3 = s[4];
+                        dy3 = s[5];
+                        dx4 = s[6];
+                        dy4 = s[7];
+                        dx5 = s[8];
+                        dy5 = s[9];
+                        dx6 = s[10];
+                        dy6 = s[11];
+                        // fd is s[12]
+                        stbtt__csctx_rccurve_to(c, dx1, dy1, dx2, dy2, dx3, dy3);
+                        stbtt__csctx_rccurve_to(c, dx4, dy4, dx5, dy5, dx6, dy6);
+                        break;
+
+                    case 0x24:  // hflex1
+                        if (sp < 9)
+                            return STBTT__CSERR("hflex1 stack");
+                        dx1 = s[0];
+                        dy1 = s[1];
+                        dx2 = s[2];
+                        dy2 = s[3];
+                        dx3 = s[4];
+                        dx4 = s[5];
+                        dx5 = s[6];
+                        dy5 = s[7];
+                        dx6 = s[8];
+                        stbtt__csctx_rccurve_to(c, dx1, dy1, dx2, dy2, dx3, 0);
+                        stbtt__csctx_rccurve_to(c, dx4, 0, dx5, dy5, dx6, -(dy1 + dy2 + dy5));
+                        break;
+
+                    case 0x25:  // flex1
+                        if (sp < 11)
+                            return STBTT__CSERR("flex1 stack");
+                        dx1 = s[0];
+                        dy1 = s[1];
+                        dx2 = s[2];
+                        dy2 = s[3];
+                        dx3 = s[4];
+                        dy3 = s[5];
+                        dx4 = s[6];
+                        dy4 = s[7];
+                        dx5 = s[8];
+                        dy5 = s[9];
+                        dx6 = dy6 = s[10];
+                        dx        = dx1 + dx2 + dx3 + dx4 + dx5;
+                        dy        = dy1 + dy2 + dy3 + dy4 + dy5;
+                        if (STBTT_fabs(dx) > STBTT_fabs(dy))
+                            dy6 = -dy;
+                        else
+                            dx6 = -dx;
+                        stbtt__csctx_rccurve_to(c, dx1, dy1, dx2, dy2, dx3, dy3);
+                        stbtt__csctx_rccurve_to(c, dx4, dy4, dx5, dy5, dx6, dy6);
+                        break;
+
+                    default:
+                        return STBTT__CSERR("unimplemented");
+                }
+            }
+            break;
+
+            default:
+                if (b0 != 255 && b0 != 28 && (b0 < 32 || b0 > 254))  //-V560
+                    return STBTT__CSERR("reserved operator");
+
+                // push immediate
+                if (b0 == 255)
+                {
+                    f = (float)(stbtt_int32)stbtt__buf_get32(&b) / 0x10000;
+                }
+                else
+                {
+                    stbtt__buf_skip(&b, -1);
+                    f = (float)(stbtt_int16)stbtt__cff_int(&b);
+                }
+                if (sp >= 48)
+                    return STBTT__CSERR("push stack overflow");
+                s[sp++]     = f;
+                clear_stack = 0;
+                break;
+        }
+        if (clear_stack)
+            sp = 0;
+    }
+    return STBTT__CSERR("no endchar");
+
+#undef STBTT__CSERR
+}
+
+static int stbtt__GetGlyphShapeT2(const stbtt_fontinfo *info,
+                                  int glyph_index,
+                                  stbtt_vertex **pvertices)
+{
+    // runs the charstring twice, once to count and once to output (to avoid realloc)
+    stbtt__csctx count_ctx  = STBTT__CSCTX_INIT(1);
+    stbtt__csctx output_ctx = STBTT__CSCTX_INIT(0);
+    if (stbtt__run_charstring(info, glyph_index, &count_ctx))
+    {
+        *pvertices = (stbtt_vertex *)STBTT_malloc(count_ctx.num_vertices * sizeof(stbtt_vertex),
+                                                  info->userdata);
+        output_ctx.pvertices = *pvertices;
+        if (stbtt__run_charstring(info, glyph_index, &output_ctx))
+        {
+            STBTT_assert(output_ctx.num_vertices == count_ctx.num_vertices);
+            return output_ctx.num_vertices;
+        }
+    }
+    *pvertices = NULL;
+    return 0;
+}
+
+static int stbtt__GetGlyphInfoT2(const stbtt_fontinfo *info,
+                                 int glyph_index,
+                                 int *x0,
+                                 int *y0,
+                                 int *x1,
+                                 int *y1)
+{
+    stbtt__csctx c = STBTT__CSCTX_INIT(1);
+    int r          = stbtt__run_charstring(info, glyph_index, &c);
+    if (x0)
+        *x0 = r ? c.min_x : 0;
+    if (y0)
+        *y0 = r ? c.min_y : 0;
+    if (x1)
+        *x1 = r ? c.max_x : 0;
+    if (y1)
+        *y1 = r ? c.max_y : 0;
+    return r ? c.num_vertices : 0;
+}
+
+STBTT_DEF int stbtt_GetGlyphShape(const stbtt_fontinfo *info,
+                                  int glyph_index,
+                                  stbtt_vertex **pvertices)
+{
+    if (!info->cff.size)
+        return stbtt__GetGlyphShapeTT(info, glyph_index, pvertices);
+    else
+        return stbtt__GetGlyphShapeT2(info, glyph_index, pvertices);
+}
+
+STBTT_DEF void stbtt_GetGlyphHMetrics(const stbtt_fontinfo *info,
+                                      int glyph_index,
+                                      int *advanceWidth,
+                                      int *leftSideBearing)
+{
+    stbtt_uint16 numOfLongHorMetrics = ttUSHORT(info->data + info->hhea + 34);
+    if (glyph_index < numOfLongHorMetrics)
+    {
+        if (advanceWidth)
+            *advanceWidth = ttSHORT(info->data + info->hmtx + 4 * glyph_index);
+        if (leftSideBearing)
+            *leftSideBearing = ttSHORT(info->data + info->hmtx + 4 * glyph_index + 2);
+    }
+    else
+    {
+        if (advanceWidth)
+            *advanceWidth = ttSHORT(info->data + info->hmtx + 4 * (numOfLongHorMetrics - 1));
+        if (leftSideBearing)
+            *leftSideBearing = ttSHORT(info->data + info->hmtx + 4 * numOfLongHorMetrics +
+                                       2 * (glyph_index - numOfLongHorMetrics));
+    }
+}
+
+static int stbtt__GetGlyphKernInfoAdvance(const stbtt_fontinfo *info, int glyph1, int glyph2)
+{
+    stbtt_uint8 *data = info->data + info->kern;
+    stbtt_uint32 needle, straw;
+    int l, r, m;
+
+    // we only look at the first table. it must be 'horizontal' and format 0.
+    if (!info->kern)
+        return 0;
+    if (ttUSHORT(data + 2) < 1)  // number of tables, need at least 1
+        return 0;
+    if (ttUSHORT(data + 8) != 1)  // horizontal flag must be set in format
+        return 0;
+
+    l      = 0;
+    r      = ttUSHORT(data + 10) - 1;
+    needle = glyph1 << 16 | glyph2;
+    while (l <= r)
+    {
+        m     = (l + r) >> 1;
+        straw = ttULONG(data + 18 + (m * 6));  // note: unaligned read
+        if (needle < straw)
+            r = m - 1;
+        else if (needle > straw)
+            l = m + 1;
+        else
+            return ttSHORT(data + 22 + (m * 6));
+    }
+    return 0;
+}
+
+static stbtt_int32 stbtt__GetCoverageIndex(stbtt_uint8 *coverageTable, int glyph)
+{
+    stbtt_uint16 coverageFormat = ttUSHORT(coverageTable);
+    switch (coverageFormat)
+    {
+        case 1:
+        {
+            stbtt_uint16 glyphCount = ttUSHORT(coverageTable + 2);
+
+            // Binary search.
+            stbtt_int32 l = 0, r = glyphCount - 1, m;
+            int straw, needle    = glyph;
+            while (l <= r)
+            {
+                stbtt_uint8 *glyphArray = coverageTable + 4;
+                stbtt_uint16 glyphID;
+                m       = (l + r) >> 1;
+                glyphID = ttUSHORT(glyphArray + 2 * m);
+                straw   = glyphID;
+                if (needle < straw)
+                    r = m - 1;
+                else if (needle > straw)
+                    l = m + 1;
+                else
+                {
+                    return m;
+                }
+            }
+        }
+        break;
+
+        case 2:
+        {
+            stbtt_uint16 rangeCount = ttUSHORT(coverageTable + 2);
+            stbtt_uint8 *rangeArray = coverageTable + 4;
+
+            // Binary search.
+            stbtt_int32 l = 0, r = rangeCount - 1, m;
+            int strawStart, strawEnd, needle = glyph;
+            while (l <= r)
+            {
+                stbtt_uint8 *rangeRecord;
+                m           = (l + r) >> 1;
+                rangeRecord = rangeArray + 6 * m;
+                strawStart  = ttUSHORT(rangeRecord);
+                strawEnd    = ttUSHORT(rangeRecord + 2);
+                if (needle < strawStart)
+                    r = m - 1;
+                else if (needle > strawEnd)
+                    l = m + 1;
+                else
+                {
+                    stbtt_uint16 startCoverageIndex = ttUSHORT(rangeRecord + 4);
+                    return startCoverageIndex + glyph - strawStart;
+                }
+            }
+        }
+        break;
+
+        default:
+        {
+            // There are no other cases.
+            STBTT_assert(0);
+        }
+        break;
+    }
+
+    return -1;
+}
+
+static stbtt_int32 stbtt__GetGlyphClass(stbtt_uint8 *classDefTable, int glyph)
+{
+    stbtt_uint16 classDefFormat = ttUSHORT(classDefTable);
+    switch (classDefFormat)
+    {
+        case 1:
+        {
+            stbtt_uint16 startGlyphID        = ttUSHORT(classDefTable + 2);
+            stbtt_uint16 glyphCount          = ttUSHORT(classDefTable + 4);
+            stbtt_uint8 *classDef1ValueArray = classDefTable + 6;
+
+            if (glyph >= startGlyphID && glyph < startGlyphID + glyphCount)
+                return (stbtt_int32)ttUSHORT(classDef1ValueArray + 2 * (glyph - startGlyphID));
+
+            // [DEAR IMGUI] Commented to fix static analyzer warning
+            // classDefTable = classDef1ValueArray + 2 * glyphCount;
+        }
+        break;
+
+        case 2:
+        {
+            stbtt_uint16 classRangeCount   = ttUSHORT(classDefTable + 2);
+            stbtt_uint8 *classRangeRecords = classDefTable + 4;
+
+            // Binary search.
+            stbtt_int32 l = 0, r = classRangeCount - 1, m;
+            int strawStart, strawEnd, needle = glyph;
+            while (l <= r)
+            {
+                stbtt_uint8 *classRangeRecord;
+                m                = (l + r) >> 1;
+                classRangeRecord = classRangeRecords + 6 * m;
+                strawStart       = ttUSHORT(classRangeRecord);
+                strawEnd         = ttUSHORT(classRangeRecord + 2);
+                if (needle < strawStart)
+                    r = m - 1;
+                else if (needle > strawEnd)
+                    l = m + 1;
+                else
+                    return (stbtt_int32)ttUSHORT(classRangeRecord + 4);
+            }
+
+            // [DEAR IMGUI] Commented to fix static analyzer warning
+            // classDefTable = classRangeRecords + 6 * classRangeCount;
+        }
+        break;
+
+        default:
+        {
+            // There are no other cases.
+            STBTT_assert(0);
+        }
+        break;
+    }
+
+    return -1;
+}
+
+// Define to STBTT_assert(x) if you want to break on unimplemented formats.
+#define STBTT_GPOS_TODO_assert(x)
+
+static stbtt_int32 stbtt__GetGlyphGPOSInfoAdvance(const stbtt_fontinfo *info,
+                                                  int glyph1,
+                                                  int glyph2)
+{
+    stbtt_uint16 lookupListOffset;
+    stbtt_uint8 *lookupList;
+    stbtt_uint16 lookupCount;
+    stbtt_uint8 *data;
+    stbtt_int32 i;
+
+    if (!info->gpos)
+        return 0;
+
+    data = info->data + info->gpos;
+
+    if (ttUSHORT(data + 0) != 1)
+        return 0;  // Major version 1
+    if (ttUSHORT(data + 2) != 0)
+        return 0;  // Minor version 0
+
+    lookupListOffset = ttUSHORT(data + 8);
+    lookupList       = data + lookupListOffset;
+    lookupCount      = ttUSHORT(lookupList);
+
+    for (i = 0; i < lookupCount; ++i)
+    {
+        stbtt_uint16 lookupOffset = ttUSHORT(lookupList + 2 + 2 * i);
+        stbtt_uint8 *lookupTable  = lookupList + lookupOffset;
+
+        stbtt_uint16 lookupType      = ttUSHORT(lookupTable);
+        stbtt_uint16 subTableCount   = ttUSHORT(lookupTable + 4);
+        stbtt_uint8 *subTableOffsets = lookupTable + 6;
+        switch (lookupType)
+        {
+            case 2:
+            {  // Pair Adjustment Positioning Subtable
+                stbtt_int32 sti;
+                for (sti = 0; sti < subTableCount; sti++)
+                {
+                    stbtt_uint16 subtableOffset = ttUSHORT(subTableOffsets + 2 * sti);
+                    stbtt_uint8 *table          = lookupTable + subtableOffset;
+                    stbtt_uint16 posFormat      = ttUSHORT(table);
+                    stbtt_uint16 coverageOffset = ttUSHORT(table + 2);
+                    stbtt_int32 coverageIndex =
+                        stbtt__GetCoverageIndex(table + coverageOffset, glyph1);
+                    if (coverageIndex == -1)
+                        continue;
+
+                    switch (posFormat)
+                    {
+                        case 1:
+                        {
+                            stbtt_int32 l, r, m;
+                            int straw, needle;
+                            stbtt_uint16 valueFormat1              = ttUSHORT(table + 4);
+                            stbtt_uint16 valueFormat2              = ttUSHORT(table + 6);
+                            stbtt_int32 valueRecordPairSizeInBytes = 2;
+                            stbtt_uint16 pairSetCount              = ttUSHORT(table + 8);
+                            stbtt_uint16 pairPosOffset  = ttUSHORT(table + 10 + 2 * coverageIndex);
+                            stbtt_uint8 *pairValueTable = table + pairPosOffset;
+                            stbtt_uint16 pairValueCount = ttUSHORT(pairValueTable);
+                            stbtt_uint8 *pairValueArray = pairValueTable + 2;
+                            // TODO: Support more formats.
+                            STBTT_GPOS_TODO_assert(valueFormat1 == 4);
+                            if (valueFormat1 != 4)
+                                return 0;
+                            STBTT_GPOS_TODO_assert(valueFormat2 == 0);
+                            if (valueFormat2 != 0)
+                                return 0;
+
+                            STBTT_assert(coverageIndex < pairSetCount);
+                            STBTT__NOTUSED(pairSetCount);
+
+                            needle = glyph2;
+                            r      = pairValueCount - 1;
+                            l      = 0;
+
+                            // Binary search.
+                            while (l <= r)
+                            {
+                                stbtt_uint16 secondGlyph;
+                                stbtt_uint8 *pairValue;
+                                m           = (l + r) >> 1;
+                                pairValue   = pairValueArray + (2 + valueRecordPairSizeInBytes) * m;
+                                secondGlyph = ttUSHORT(pairValue);
+                                straw       = secondGlyph;
+                                if (needle < straw)
+                                    r = m - 1;
+                                else if (needle > straw)
+                                    l = m + 1;
+                                else
+                                {
+                                    stbtt_int16 xAdvance = ttSHORT(pairValue + 2);
+                                    return xAdvance;
+                                }
+                            }
+                        }
+                        break;
+
+                        case 2:
+                        {
+                            stbtt_uint16 valueFormat1 = ttUSHORT(table + 4);
+                            stbtt_uint16 valueFormat2 = ttUSHORT(table + 6);
+
+                            stbtt_uint16 classDef1Offset = ttUSHORT(table + 8);
+                            stbtt_uint16 classDef2Offset = ttUSHORT(table + 10);
+                            int glyph1class = stbtt__GetGlyphClass(table + classDef1Offset, glyph1);
+                            int glyph2class = stbtt__GetGlyphClass(table + classDef2Offset, glyph2);
+
+                            stbtt_uint16 class1Count = ttUSHORT(table + 12);
+                            stbtt_uint16 class2Count = ttUSHORT(table + 14);
+                            STBTT_assert(glyph1class < class1Count);
+                            STBTT_assert(glyph2class < class2Count);
+
+                            // TODO: Support more formats.
+                            STBTT_GPOS_TODO_assert(valueFormat1 == 4);
+                            if (valueFormat1 != 4)
+                                return 0;
+                            STBTT_GPOS_TODO_assert(valueFormat2 == 0);
+                            if (valueFormat2 != 0)
+                                return 0;
+
+                            if (glyph1class >= 0 && glyph1class < class1Count && glyph2class >= 0 &&
+                                glyph2class < class2Count)
+                            {
+                                stbtt_uint8 *class1Records = table + 16;
+                                stbtt_uint8 *class2Records =
+                                    class1Records + 2 * (glyph1class * class2Count);
+                                stbtt_int16 xAdvance = ttSHORT(class2Records + 2 * glyph2class);
+                                return xAdvance;
+                            }
+                        }
+                        break;
+
+                        default:
+                        {
+                            // There are no other cases.
+                            STBTT_assert(0);
+                            break;
+                        };
+                    }
+                }
+                break;
+            };
+
+            default:
+                // TODO: Implement other stuff.
+                break;
+        }
+    }
+
+    return 0;
+}
+
+STBTT_DEF int stbtt_GetGlyphKernAdvance(const stbtt_fontinfo *info, int g1, int g2)
+{
+    int xAdvance = 0;
+
+    if (info->gpos)
+        xAdvance += stbtt__GetGlyphGPOSInfoAdvance(info, g1, g2);
+
+    if (info->kern)
+        xAdvance += stbtt__GetGlyphKernInfoAdvance(info, g1, g2);
+
+    return xAdvance;
+}
+
+STBTT_DEF int stbtt_GetCodepointKernAdvance(const stbtt_fontinfo *info, int ch1, int ch2)
+{
+    if (!info->kern &&
+        !info->gpos)  // if no kerning table, don't waste time looking up both codepoint->glyphs
+        return 0;
+    return stbtt_GetGlyphKernAdvance(info, stbtt_FindGlyphIndex(info, ch1),
+                                     stbtt_FindGlyphIndex(info, ch2));
+}
+
+STBTT_DEF void stbtt_GetCodepointHMetrics(const stbtt_fontinfo *info,
+                                          int codepoint,
+                                          int *advanceWidth,
+                                          int *leftSideBearing)
+{
+    stbtt_GetGlyphHMetrics(info, stbtt_FindGlyphIndex(info, codepoint), advanceWidth,
+                           leftSideBearing);
+}
+
+STBTT_DEF void stbtt_GetFontVMetrics(const stbtt_fontinfo *info,
+                                     int *ascent,
+                                     int *descent,
+                                     int *lineGap)
+{
+    if (ascent)
+        *ascent = ttSHORT(info->data + info->hhea + 4);
+    if (descent)
+        *descent = ttSHORT(info->data + info->hhea + 6);
+    if (lineGap)
+        *lineGap = ttSHORT(info->data + info->hhea + 8);
+}
+
+STBTT_DEF int stbtt_GetFontVMetricsOS2(const stbtt_fontinfo *info,
+                                       int *typoAscent,
+                                       int *typoDescent,
+                                       int *typoLineGap)
+{
+    int tab = stbtt__find_table(info->data, info->fontstart, "OS/2");
+    if (!tab)
+        return 0;
+    if (typoAscent)
+        *typoAscent = ttSHORT(info->data + tab + 68);
+    if (typoDescent)
+        *typoDescent = ttSHORT(info->data + tab + 70);
+    if (typoLineGap)
+        *typoLineGap = ttSHORT(info->data + tab + 72);
+    return 1;
+}
+
+STBTT_DEF void stbtt_GetFontBoundingBox(const stbtt_fontinfo *info,
+                                        int *x0,
+                                        int *y0,
+                                        int *x1,
+                                        int *y1)
+{
+    *x0 = ttSHORT(info->data + info->head + 36);
+    *y0 = ttSHORT(info->data + info->head + 38);
+    *x1 = ttSHORT(info->data + info->head + 40);
+    *y1 = ttSHORT(info->data + info->head + 42);
+}
+
+STBTT_DEF float stbtt_ScaleForPixelHeight(const stbtt_fontinfo *info, float height)
+{
+    int fheight = ttSHORT(info->data + info->hhea + 4) - ttSHORT(info->data + info->hhea + 6);
+    return (float)height / fheight;
+}
+
+STBTT_DEF float stbtt_ScaleForMappingEmToPixels(const stbtt_fontinfo *info, float pixels)
+{
+    int unitsPerEm = ttUSHORT(info->data + info->head + 18);
+    return pixels / unitsPerEm;
+}
+
+STBTT_DEF void stbtt_FreeShape(const stbtt_fontinfo *info, stbtt_vertex *v)
+{
+    STBTT_free(v, info->userdata);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// antialiasing software rasterizer
+//
+
+STBTT_DEF void stbtt_GetGlyphBitmapBoxSubpixel(const stbtt_fontinfo *font,
+                                               int glyph,
+                                               float scale_x,
+                                               float scale_y,
+                                               float shift_x,
+                                               float shift_y,
+                                               int *ix0,
+                                               int *iy0,
+                                               int *ix1,
+                                               int *iy1)
+{
+    int x0 = 0, y0 = 0, x1, y1;  // =0 suppresses compiler warning
+    if (!stbtt_GetGlyphBox(font, glyph, &x0, &y0, &x1, &y1))
+    {
+        // e.g. space character
+        if (ix0)
+            *ix0 = 0;
+        if (iy0)
+            *iy0 = 0;
+        if (ix1)
+            *ix1 = 0;
+        if (iy1)
+            *iy1 = 0;
+    }
+    else
+    {
+        // move to integral bboxes (treating pixels as little squares, what pixels get touched)?
+        if (ix0)
+            *ix0 = STBTT_ifloor(x0 * scale_x + shift_x);
+        if (iy0)
+            *iy0 = STBTT_ifloor(-y1 * scale_y + shift_y);
+        if (ix1)
+            *ix1 = STBTT_iceil(x1 * scale_x + shift_x);
+        if (iy1)
+            *iy1 = STBTT_iceil(-y0 * scale_y + shift_y);
+    }
+}
+
+STBTT_DEF void stbtt_GetGlyphBitmapBox(const stbtt_fontinfo *font,
+                                       int glyph,
+                                       float scale_x,
+                                       float scale_y,
+                                       int *ix0,
+                                       int *iy0,
+                                       int *ix1,
+                                       int *iy1)
+{
+    stbtt_GetGlyphBitmapBoxSubpixel(font, glyph, scale_x, scale_y, 0.0f, 0.0f, ix0, iy0, ix1, iy1);
+}
+
+STBTT_DEF void stbtt_GetCodepointBitmapBoxSubpixel(const stbtt_fontinfo *font,
+                                                   int codepoint,
+                                                   float scale_x,
+                                                   float scale_y,
+                                                   float shift_x,
+                                                   float shift_y,
+                                                   int *ix0,
+                                                   int *iy0,
+                                                   int *ix1,
+                                                   int *iy1)
+{
+    stbtt_GetGlyphBitmapBoxSubpixel(font, stbtt_FindGlyphIndex(font, codepoint), scale_x, scale_y,
+                                    shift_x, shift_y, ix0, iy0, ix1, iy1);
+}
+
+STBTT_DEF void stbtt_GetCodepointBitmapBox(const stbtt_fontinfo *font,
+                                           int codepoint,
+                                           float scale_x,
+                                           float scale_y,
+                                           int *ix0,
+                                           int *iy0,
+                                           int *ix1,
+                                           int *iy1)
+{
+    stbtt_GetCodepointBitmapBoxSubpixel(font, codepoint, scale_x, scale_y, 0.0f, 0.0f, ix0, iy0,
+                                        ix1, iy1);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//  Rasterizer
+
+typedef struct stbtt__hheap_chunk
+{
+    struct stbtt__hheap_chunk *next;
+} stbtt__hheap_chunk;
+
+typedef struct stbtt__hheap
+{
+    struct stbtt__hheap_chunk *head;
+    void *first_free;
+    int num_remaining_in_head_chunk;
+} stbtt__hheap;
+
+static void *stbtt__hheap_alloc(stbtt__hheap *hh, size_t size, void *userdata)
+{
+    if (hh->first_free)
+    {
+        void *p        = hh->first_free;
+        hh->first_free = *(void **)p;
+        return p;
+    }
+    else
+    {
+        if (hh->num_remaining_in_head_chunk == 0)
+        {
+            int count             = (size < 32 ? 2000 : size < 128 ? 800 : 100);
+            stbtt__hheap_chunk *c = (stbtt__hheap_chunk *)STBTT_malloc(
+                sizeof(stbtt__hheap_chunk) + size * count, userdata);
+            if (c == NULL)
+                return NULL;
+            c->next                         = hh->head;
+            hh->head                        = c;
+            hh->num_remaining_in_head_chunk = count;
+        }
+        --hh->num_remaining_in_head_chunk;
+        return (char *)(hh->head) + sizeof(stbtt__hheap_chunk) +
+               size * hh->num_remaining_in_head_chunk;
+    }
+}
+
+static void stbtt__hheap_free(stbtt__hheap *hh, void *p)
+{
+    *(void **)p    = hh->first_free;
+    hh->first_free = p;
+}
+
+static void stbtt__hheap_cleanup(stbtt__hheap *hh, void *userdata)
+{
+    stbtt__hheap_chunk *c = hh->head;
+    while (c)
+    {
+        stbtt__hheap_chunk *n = c->next;
+        STBTT_free(c, userdata);
+        c = n;
+    }
+}
+
+typedef struct stbtt__edge
+{
+    float x0, y0, x1, y1;
+    int invert;
+} stbtt__edge;
+
+typedef struct stbtt__active_edge
+{
+    struct stbtt__active_edge *next;
+#if STBTT_RASTERIZER_VERSION == 1
+    int x, dx;
+    float ey;
+    int direction;
+#elif STBTT_RASTERIZER_VERSION == 2
+    float fx, fdx, fdy;
+    float direction;
+    float sy;
+    float ey;
+#else
+#error "Unrecognized value of STBTT_RASTERIZER_VERSION"
+#endif
+} stbtt__active_edge;
+
+#if STBTT_RASTERIZER_VERSION == 1
+#define STBTT_FIXSHIFT 10
+#define STBTT_FIX (1 << STBTT_FIXSHIFT)
+#define STBTT_FIXMASK (STBTT_FIX - 1)
+
+static stbtt__active_edge *stbtt__new_active(stbtt__hheap *hh,
+                                             stbtt__edge *e,
+                                             int off_x,
+                                             float start_point,
+                                             void *userdata)
+{
+    stbtt__active_edge *z = (stbtt__active_edge *)stbtt__hheap_alloc(hh, sizeof(*z), userdata);
+    float dxdy            = (e->x1 - e->x0) / (e->y1 - e->y0);
+    STBTT_assert(z != NULL);
+    if (!z)
+        return z;
+
+    // round dx down to avoid overshooting
+    if (dxdy < 0)
+        z->dx = -STBTT_ifloor(STBTT_FIX * -dxdy);
+    else
+        z->dx = STBTT_ifloor(STBTT_FIX * dxdy);
+
+    z->x =
+        STBTT_ifloor(STBTT_FIX * e->x0 +
+                     z->dx * (start_point -
+                              e->y0));  // use z->dx so when we offset later it's by the same amount
+    z->x -= off_x * STBTT_FIX;
+
+    z->ey        = e->y1;
+    z->next      = 0;
+    z->direction = e->invert ? 1 : -1;
+    return z;
+}
+#elif STBTT_RASTERIZER_VERSION == 2
+static stbtt__active_edge *stbtt__new_active(stbtt__hheap *hh,
+                                             stbtt__edge *e,
+                                             int off_x,
+                                             float start_point,
+                                             void *userdata)
+{
+    stbtt__active_edge *z = (stbtt__active_edge *)stbtt__hheap_alloc(hh, sizeof(*z), userdata);
+    float dxdy = (e->x1 - e->x0) / (e->y1 - e->y0);
+    STBTT_assert(z != NULL);
+    // STBTT_assert(e->y0 <= start_point);
+    if (!z)
+        return z;
+    z->fdx = dxdy;
+    z->fdy = dxdy != 0.0f ? (1.0f / dxdy) : 0.0f;
+    z->fx = e->x0 + dxdy * (start_point - e->y0);
+    z->fx -= off_x;
+    z->direction = e->invert ? 1.0f : -1.0f;
+    z->sy = e->y0;
+    z->ey = e->y1;
+    z->next = 0;
+    return z;
+}
+#else
+#error "Unrecognized value of STBTT_RASTERIZER_VERSION"
+#endif
+
+#if STBTT_RASTERIZER_VERSION == 1
+// note: this routine clips fills that extend off the edges... ideally this
+// wouldn't happen, but it could happen if the truetype glyph bounding boxes
+// are wrong, or if the user supplies a too-small bitmap
+static void stbtt__fill_active_edges(unsigned char *scanline,
+                                     int len,
+                                     stbtt__active_edge *e,
+                                     int max_weight)
+{
+    // non-zero winding fill
+    int x0 = 0, w = 0;
+
+    while (e)
+    {
+        if (w == 0)
+        {
+            // if we're currently at zero, we need to record the edge start point
+            x0 = e->x;
+            w += e->direction;
+        }
+        else
+        {
+            int x1 = e->x;
+            w += e->direction;
+            // if we went to zero, we need to draw
+            if (w == 0)
+            {
+                int i = x0 >> STBTT_FIXSHIFT;
+                int j = x1 >> STBTT_FIXSHIFT;
+
+                if (i < len && j >= 0)
+                {
+                    if (i == j)
+                    {
+                        // x0,x1 are the same pixel, so compute combined coverage
+                        scanline[i] =
+                            scanline[i] + (stbtt_uint8)((x1 - x0) * max_weight >> STBTT_FIXSHIFT);
+                    }
+                    else
+                    {
+                        if (i >= 0)  // add antialiasing for x0
+                            scanline[i] =
+                                scanline[i] +
+                                (stbtt_uint8)(((STBTT_FIX - (x0 & STBTT_FIXMASK)) * max_weight) >>
+                                              STBTT_FIXSHIFT);
+                        else
+                            i = -1;  // clip
+
+                        if (j < len)  // add antialiasing for x1
+                            scanline[j] =
+                                scanline[j] + (stbtt_uint8)(((x1 & STBTT_FIXMASK) * max_weight) >>
+                                                            STBTT_FIXSHIFT);
+                        else
+                            j = len;  // clip
+
+                        for (++i; i < j; ++i)  // fill pixels between x0 and x1
+                            scanline[i] = scanline[i] + (stbtt_uint8)max_weight;
+                    }
+                }
+            }
+        }
+
+        e = e->next;
+    }
+}
+
+static void stbtt__rasterize_sorted_edges(stbtt__bitmap *result,
+                                          stbtt__edge *e,
+                                          int n,
+                                          int vsubsample,
+                                          int off_x,
+                                          int off_y,
+                                          void *userdata)
+{
+    stbtt__hheap hh            = {0, 0, 0};
+    stbtt__active_edge *active = NULL;
+    int y, j = 0;
+    int max_weight = (255 / vsubsample);  // weight per vertical scanline
+    int s;                                // vertical subsample index
+    unsigned char scanline_data[512], *scanline;
+
+    if (result->w > 512)
+        scanline = (unsigned char *)STBTT_malloc(result->w, userdata);
+    else
+        scanline = scanline_data;
+
+    y       = off_y * vsubsample;
+    e[n].y0 = (off_y + result->h) * (float)vsubsample + 1;
+
+    while (j < result->h)
+    {
+        STBTT_memset(scanline, 0, result->w);
+        for (s = 0; s < vsubsample; ++s)
+        {
+            // find center of pixel for this scanline
+            float scan_y              = y + 0.5f;
+            stbtt__active_edge **step = &active;
+
+            // update all active edges;
+            // remove all active edges that terminate before the center of this scanline
+            while (*step)
+            {
+                stbtt__active_edge *z = *step;
+                if (z->ey <= scan_y)
+                {
+                    *step = z->next;  // delete from list
+                    STBTT_assert(z->direction);
+                    z->direction = 0;
+                    stbtt__hheap_free(&hh, z);
+                }
+                else
+                {
+                    z->x += z->dx;            // advance to position for current scanline
+                    step = &((*step)->next);  // advance through list
+                }
+            }
+
+            // resort the list if needed
+            for (;;)
+            {
+                int changed = 0;
+                step        = &active;
+                while (*step && (*step)->next)
+                {
+                    if ((*step)->x > (*step)->next->x)
+                    {
+                        stbtt__active_edge *t = *step;
+                        stbtt__active_edge *q = t->next;
+
+                        t->next = q->next;
+                        q->next = t;
+                        *step   = q;
+                        changed = 1;
+                    }
+                    step = &(*step)->next;
+                }
+                if (!changed)
+                    break;
+            }
+
+            // insert all edges that start before the center of this scanline -- omit ones that also
+            // end on this scanline
+            while (e->y0 <= scan_y)
+            {
+                if (e->y1 > scan_y)
+                {
+                    stbtt__active_edge *z = stbtt__new_active(&hh, e, off_x, scan_y, userdata);
+                    if (z != NULL)
+                    {
+                        // find insertion point
+                        if (active == NULL)
+                            active = z;
+                        else if (z->x < active->x)
+                        {
+                            // insert at front
+                            z->next = active;
+                            active  = z;
+                        }
+                        else
+                        {
+                            // find thing to insert AFTER
+                            stbtt__active_edge *p = active;
+                            while (p->next && p->next->x < z->x)
+                                p = p->next;
+                            // at this point, p->next->x is NOT < z->x
+                            z->next = p->next;
+                            p->next = z;
+                        }
+                    }
+                }
+                ++e;
+            }
+
+            // now process all active edges in XOR fashion
+            if (active)
+                stbtt__fill_active_edges(scanline, result->w, active, max_weight);
+
+            ++y;
+        }
+        STBTT_memcpy(result->pixels + j * result->stride, scanline, result->w);
+        ++j;
+    }
+
+    stbtt__hheap_cleanup(&hh, userdata);
+
+    if (scanline != scanline_data)
+        STBTT_free(scanline, userdata);
+}
+
+#elif STBTT_RASTERIZER_VERSION == 2
+
+// the edge passed in here does not cross the vertical line at x or the vertical line at x+1
+// (i.e. it has already been clipped to those)
+static void stbtt__handle_clipped_edge(float *scanline,
+                                       int x,
+                                       stbtt__active_edge *e,
+                                       float x0,
+                                       float y0,
+                                       float x1,
+                                       float y1)
+{
+    if (y0 == y1)
+        return;
+    STBTT_assert(y0 < y1);
+    STBTT_assert(e->sy <= e->ey);
+    if (y0 > e->ey)
+        return;
+    if (y1 < e->sy)
+        return;
+    if (y0 < e->sy)
+    {
+        x0 += (x1 - x0) * (e->sy - y0) / (y1 - y0);
+        y0 = e->sy;
+    }
+    if (y1 > e->ey)
+    {
+        x1 += (x1 - x0) * (e->ey - y1) / (y1 - y0);
+        y1 = e->ey;
+    }
+
+    if (x0 == x)
+        STBTT_assert(x1 <= x + 1);
+    else if (x0 == x + 1)
+        STBTT_assert(x1 >= x);
+    else if (x0 <= x)
+        STBTT_assert(x1 <= x);
+    else if (x0 >= x + 1)
+        STBTT_assert(x1 >= x + 1);
+    else
+        STBTT_assert(x1 >= x && x1 <= x + 1);
+
+    if (x0 <= x && x1 <= x)
+        scanline[x] += e->direction * (y1 - y0);
+    else if (x0 >= x + 1 && x1 >= x + 1)
+        ;
+    else
+    {
+        STBTT_assert(x0 >= x && x0 <= x + 1 && x1 >= x && x1 <= x + 1);
+        scanline[x] += e->direction * (y1 - y0) *
+                       (1 - ((x0 - x) + (x1 - x)) / 2);  // coverage = 1 - average x position
+    }
+}
+
+static void stbtt__fill_active_edges_new(float *scanline,
+                                         float *scanline_fill,
+                                         int len,
+                                         stbtt__active_edge *e,
+                                         float y_top)
+{
+    float y_bottom = y_top + 1;
+
+    while (e)
+    {
+        // brute force every pixel
+
+        // compute intersection points with top & bottom
+        STBTT_assert(e->ey >= y_top);
+
+        if (e->fdx == 0)
+        {
+            float x0 = e->fx;
+            if (x0 < len)
+            {
+                if (x0 >= 0)
+                {
+                    stbtt__handle_clipped_edge(scanline, (int)x0, e, x0, y_top, x0, y_bottom);
+                    stbtt__handle_clipped_edge(scanline_fill - 1, (int)x0 + 1, e, x0, y_top, x0,
+                                               y_bottom);
+                }
+                else
+                {
+                    stbtt__handle_clipped_edge(scanline_fill - 1, 0, e, x0, y_top, x0, y_bottom);
+                }
+            }
+        }
+        else
+        {
+            float x0 = e->fx;
+            float dx = e->fdx;
+            float xb = x0 + dx;
+            float x_top, x_bottom;
+            float sy0, sy1;
+            float dy = e->fdy;
+            STBTT_assert(e->sy <= y_bottom && e->ey >= y_top);
+
+            // compute endpoints of line segment clipped to this scanline (if the
+            // line segment starts on this scanline. x0 is the intersection of the
+            // line with y_top, but that may be off the line segment.
+            if (e->sy > y_top)
+            {
+                x_top = x0 + dx * (e->sy - y_top);
+                sy0 = e->sy;
+            }
+            else
+            {
+                x_top = x0;
+                sy0 = y_top;
+            }
+            if (e->ey < y_bottom)
+            {
+                x_bottom = x0 + dx * (e->ey - y_top);
+                sy1 = e->ey;
+            }
+            else
+            {
+                x_bottom = xb;
+                sy1 = y_bottom;
+            }
+
+            if (x_top >= 0 && x_bottom >= 0 && x_top < len && x_bottom < len)
+            {
+                // from here on, we don't have to range check x values
+
+                if ((int)x_top == (int)x_bottom)
+                {
+                    float height;
+                    // simple case, only spans one pixel
+                    int x = (int)x_top;
+                    height = sy1 - sy0;
+                    STBTT_assert(x >= 0 && x < len);
+                    scanline[x] += e->direction * (1 - ((x_top - x) + (x_bottom - x)) / 2) * height;
+                    scanline_fill[x] +=
+                        e->direction * height;  // everything right of this pixel is filled
+                }
+                else
+                {
+                    int x, x1, x2;
+                    float y_crossing, step, sign, area;
+                    // covers 2+ pixels
+                    if (x_top > x_bottom)
+                    {
+                        // flip scanline vertically; signed area is the same
+                        float t;
+                        sy0 = y_bottom - (sy0 - y_top);
+                        sy1 = y_bottom - (sy1 - y_top);
+                        t = sy0, sy0 = sy1, sy1 = t;
+                        t = x_bottom, x_bottom = x_top, x_top = t;
+                        dx = -dx;
+                        dy = -dy;
+                        t = x0, x0 = xb, xb = t;
+                        // [DEAR IMGUI] Fix static analyzer warning
+                        (void)dx;  // [ImGui: fix static analyzer warning]
+                    }
+
+                    x1 = (int)x_top;
+                    x2 = (int)x_bottom;
+                    // compute intersection with y axis at x1+1
+                    y_crossing = (x1 + 1 - x0) * dy + y_top;
+
+                    sign = e->direction;
+                    // area of the rectangle covered from y0..y_crossing
+                    area = sign * (y_crossing - sy0);
+                    // area of the triangle (x_top,y0), (x+1,y0), (x+1,y_crossing)
+                    scanline[x1] += area * (1 - ((x_top - x1) + (x1 + 1 - x1)) / 2);
+
+                    step = sign * dy;
+                    for (x = x1 + 1; x < x2; ++x)
+                    {
+                        scanline[x] += area + step / 2;
+                        area += step;
+                    }
+                    y_crossing += dy * (x2 - (x1 + 1));
+
+                    STBTT_assert(STBTT_fabs(area) <= 1.01f);
+
+                    scanline[x2] +=
+                        area + sign * (1 - ((x2 - x2) + (x_bottom - x2)) / 2) * (sy1 - y_crossing);
+
+                    scanline_fill[x2] += sign * (sy1 - sy0);
+                }
+            }
+            else
+            {
+                // if edge goes outside of box we're drawing, we require
+                // clipping logic. since this does not match the intended use
+                // of this library, we use a different, very slow brute
+                // force implementation
+                int x;
+                for (x = 0; x < len; ++x)
+                {
+                    // cases:
+                    //
+                    // there can be up to two intersections with the pixel. any intersection
+                    // with left or right edges can be handled by splitting into two (or three)
+                    // regions. intersections with top & bottom do not necessitate case-wise logic.
+                    //
+                    // the old way of doing this found the intersections with the left & right
+                    // edges, then used some simple logic to produce up to three segments in sorted
+                    // order from top-to-bottom. however, this had a problem: if an x edge was
+                    // epsilon across the x border, then the corresponding y position might not be
+                    // distinct from the other y segment, and it might ignored as an empty segment.
+                    // to avoid that, we need to explicitly produce segments based on x positions.
+
+                    // rename variables to clearly-defined pairs
+                    float y0 = y_top;
+                    float x1 = (float)(x);
+                    float x2 = (float)(x + 1);
+                    float x3 = xb;
+                    float y3 = y_bottom;
+
+                    // x = e->x + e->dx * (y-y_top)
+                    // (y-y_top) = (x - e->x) / e->dx
+                    // y = (x - e->x) / e->dx + y_top
+                    float y1 = (x - x0) / dx + y_top;
+                    float y2 = (x + 1 - x0) / dx + y_top;
+
+                    if (x0 < x1 && x3 > x2)
+                    {  // three segments descending down-right
+                        stbtt__handle_clipped_edge(scanline, x, e, x0, y0, x1, y1);
+                        stbtt__handle_clipped_edge(scanline, x, e, x1, y1, x2, y2);
+                        stbtt__handle_clipped_edge(scanline, x, e, x2, y2, x3, y3);
+                    }
+                    else if (x3 < x1 && x0 > x2)
+                    {  // three segments descending down-left
+                        stbtt__handle_clipped_edge(scanline, x, e, x0, y0, x2, y2);
+                        stbtt__handle_clipped_edge(scanline, x, e, x2, y2, x1, y1);
+                        stbtt__handle_clipped_edge(scanline, x, e, x1, y1, x3, y3);
+                    }
+                    else if (x0 < x1 && x3 > x1)
+                    {  // two segments across x, down-right
+                        stbtt__handle_clipped_edge(scanline, x, e, x0, y0, x1, y1);
+                        stbtt__handle_clipped_edge(scanline, x, e, x1, y1, x3, y3);
+                    }
+                    else if (x3 < x1 && x0 > x1)
+                    {  // two segments across x, down-left
+                        stbtt__handle_clipped_edge(scanline, x, e, x0, y0, x1, y1);
+                        stbtt__handle_clipped_edge(scanline, x, e, x1, y1, x3, y3);
+                    }
+                    else if (x0 < x2 && x3 > x2)
+                    {  // two segments across x+1, down-right
+                        stbtt__handle_clipped_edge(scanline, x, e, x0, y0, x2, y2);
+                        stbtt__handle_clipped_edge(scanline, x, e, x2, y2, x3, y3);
+                    }
+                    else if (x3 < x2 && x0 > x2)
+                    {  // two segments across x+1, down-left
+                        stbtt__handle_clipped_edge(scanline, x, e, x0, y0, x2, y2);
+                        stbtt__handle_clipped_edge(scanline, x, e, x2, y2, x3, y3);
+                    }
+                    else
+                    {  // one segment
+                        stbtt__handle_clipped_edge(scanline, x, e, x0, y0, x3, y3);
+                    }
+                }
+            }
+        }
+        e = e->next;
+    }
+}
+
+// directly AA rasterize edges w/o supersampling
+static void stbtt__rasterize_sorted_edges(stbtt__bitmap *result,
+                                          stbtt__edge *e,
+                                          int n,
+                                          int vsubsample,
+                                          int off_x,
+                                          int off_y,
+                                          void *userdata)
+{
+    stbtt__hheap hh = {0, 0, 0};
+    stbtt__active_edge *active = NULL;
+    int y, j = 0, i;
+    float scanline_data[129], *scanline, *scanline2;
+
+    STBTT__NOTUSED(vsubsample);
+
+    if (result->w > 64)
+        scanline = (float *)STBTT_malloc((result->w * 2 + 1) * sizeof(float), userdata);
+    else
+        scanline = scanline_data;
+
+    scanline2 = scanline + result->w;
+
+    y = off_y;
+    e[n].y0 = (float)(off_y + result->h) + 1;
+
+    while (j < result->h)
+    {
+        // find center of pixel for this scanline
+        float scan_y_top = y + 0.0f;
+        float scan_y_bottom = y + 1.0f;
+        stbtt__active_edge **step = &active;
+
+        STBTT_memset(scanline, 0, result->w * sizeof(scanline[0]));
+        STBTT_memset(scanline2, 0, (result->w + 1) * sizeof(scanline[0]));
+
+        // update all active edges;
+        // remove all active edges that terminate before the top of this scanline
+        while (*step)
+        {
+            stbtt__active_edge *z = *step;
+            if (z->ey <= scan_y_top)
+            {
+                *step = z->next;  // delete from list
+                STBTT_assert(z->direction);
+                z->direction = 0;
+                stbtt__hheap_free(&hh, z);
+            }
+            else
+            {
+                step = &((*step)->next);  // advance through list
+            }
+        }
+
+        // insert all edges that start before the bottom of this scanline
+        while (e->y0 <= scan_y_bottom)
+        {
+            if (e->y0 != e->y1)
+            {
+                stbtt__active_edge *z = stbtt__new_active(&hh, e, off_x, scan_y_top, userdata);
+                if (z != NULL)
+                {
+                    if (j == 0 && off_y != 0)
+                    {
+                        if (z->ey < scan_y_top)
+                        {
+                            // this can happen due to subpixel positioning and some kind of fp
+                            // rounding error i think
+                            z->ey = scan_y_top;
+                        }
+                    }
+                    STBTT_assert(z->ey >= scan_y_top);  // if we get really unlucky a tiny bit of an
+                                                        // edge can be out of bounds
+                    // insert at front
+                    z->next = active;
+                    active = z;
+                }
+            }
+            ++e;
+        }
+
+        // now process all active edges
+        if (active)
+            stbtt__fill_active_edges_new(scanline, scanline2 + 1, result->w, active, scan_y_top);
+
+        {
+            float sum = 0;
+            for (i = 0; i < result->w; ++i)
+            {
+                float k;
+                int m;
+                sum += scanline2[i];
+                k = scanline[i] + sum;
+                k = (float)STBTT_fabs(k) * 255 + 0.5f;
+                m = (int)k;
+                if (m > 255)
+                    m = 255;
+                result->pixels[j * result->stride + i] = (unsigned char)m;
+            }
+        }
+        // advance all the edges
+        step = &active;
+        while (*step)
+        {
+            stbtt__active_edge *z = *step;
+            z->fx += z->fdx;          // advance to position for current scanline
+            step = &((*step)->next);  // advance through list
+        }
+
+        ++y;
+        ++j;
+    }
+
+    stbtt__hheap_cleanup(&hh, userdata);
+
+    if (scanline != scanline_data)
+        STBTT_free(scanline, userdata);
+}
+#else
+#error "Unrecognized value of STBTT_RASTERIZER_VERSION"
+#endif
+
+#define STBTT__COMPARE(a, b) ((a)->y0 < (b)->y0)
+
+static void stbtt__sort_edges_ins_sort(stbtt__edge *p, int n)
+{
+    int i, j;
+    for (i = 1; i < n; ++i)
+    {
+        stbtt__edge t = p[i], *a = &t;
+        j = i;
+        while (j > 0)
+        {
+            stbtt__edge *b = &p[j - 1];
+            int c          = STBTT__COMPARE(a, b);
+            if (!c)
+                break;
+            p[j] = p[j - 1];
+            --j;
+        }
+        if (i != j)
+            p[j] = t;
+    }
+}
+
+static void stbtt__sort_edges_quicksort(stbtt__edge *p, int n)
+{
+    /* threshold for transitioning to insertion sort */
+    while (n > 12)
+    {
+        stbtt__edge t;
+        int c01, c12, c, m, i, j;
+
+        /* compute median of three */
+        m   = n >> 1;
+        c01 = STBTT__COMPARE(&p[0], &p[m]);
+        c12 = STBTT__COMPARE(&p[m], &p[n - 1]);
+        /* if 0 >= mid >= end, or 0 < mid < end, then use mid */
+        if (c01 != c12)
+        {
+            /* otherwise, we'll need to swap something else to middle */
+            int z;
+            c = STBTT__COMPARE(&p[0], &p[n - 1]);
+            /* 0>mid && mid<n:  0>n => n; 0<n => 0 */
+            /* 0<mid && mid>n:  0>n => 0; 0<n => n */
+            z    = (c == c12) ? 0 : n - 1;
+            t    = p[z];
+            p[z] = p[m];
+            p[m] = t;
+        }
+        /* now p[m] is the median-of-three */
+        /* swap it to the beginning so it won't move around */
+        t    = p[0];
+        p[0] = p[m];
+        p[m] = t;
+
+        /* partition loop */
+        i = 1;
+        j = n - 1;
+        for (;;)
+        {
+            /* handling of equality is crucial here */
+            /* for sentinels & efficiency with duplicates */
+            for (;; ++i)
+            {
+                if (!STBTT__COMPARE(&p[i], &p[0]))
+                    break;
+            }
+            for (;; --j)
+            {
+                if (!STBTT__COMPARE(&p[0], &p[j]))
+                    break;
+            }
+            /* make sure we haven't crossed */
+            if (i >= j)
+                break;
+            t    = p[i];
+            p[i] = p[j];
+            p[j] = t;
+
+            ++i;
+            --j;
+        }
+        /* recurse on smaller side, iterate on larger */
+        if (j < (n - i))
+        {
+            stbtt__sort_edges_quicksort(p, j);
+            p = p + i;
+            n = n - i;
+        }
+        else
+        {
+            stbtt__sort_edges_quicksort(p + i, n - i);
+            n = j;
+        }
+    }
+}
+
+static void stbtt__sort_edges(stbtt__edge *p, int n)
+{
+    stbtt__sort_edges_quicksort(p, n);
+    stbtt__sort_edges_ins_sort(p, n);
+}
+
+typedef struct
+{
+    float x, y;
+} stbtt__point;
+
+static void stbtt__rasterize(stbtt__bitmap *result,
+                             stbtt__point *pts,
+                             int *wcount,
+                             int windings,
+                             float scale_x,
+                             float scale_y,
+                             float shift_x,
+                             float shift_y,
+                             int off_x,
+                             int off_y,
+                             int invert,
+                             void *userdata)
+{
+    float y_scale_inv = invert ? -scale_y : scale_y;
+    stbtt__edge *e;
+    int n, i, j, k, m;
+#if STBTT_RASTERIZER_VERSION == 1
+    int vsubsample = result->h < 8 ? 15 : 5;
+#elif STBTT_RASTERIZER_VERSION == 2
+    int vsubsample = 1;
+#else
+#error "Unrecognized value of STBTT_RASTERIZER_VERSION"
+#endif
+    // vsubsample should divide 255 evenly; otherwise we won't reach full opacity
+
+    // now we have to blow out the windings into explicit edge lists
+    n = 0;
+    for (i = 0; i < windings; ++i)
+        n += wcount[i];
+
+    e = (stbtt__edge *)STBTT_malloc(sizeof(*e) * (n + 1),
+                                    userdata);  // add an extra one as a sentinel
+    if (e == 0)
+        return;
+    n = 0;
+
+    m = 0;
+    for (i = 0; i < windings; ++i)
+    {
+        stbtt__point *p = pts + m;
+        m += wcount[i];
+        j = wcount[i] - 1;
+        for (k = 0; k < wcount[i]; j = k++)
+        {
+            int a = k, b = j;
+            // skip the edge if horizontal
+            if (p[j].y == p[k].y)
+                continue;
+            // add edge from j to k to the list
+            e[n].invert = 0;
+            if (invert ? p[j].y > p[k].y : p[j].y < p[k].y)
+            {
+                e[n].invert = 1;
+                a = j, b = k;
+            }
+            e[n].x0 = p[a].x * scale_x + shift_x;
+            e[n].y0 = (p[a].y * y_scale_inv + shift_y) * vsubsample;
+            e[n].x1 = p[b].x * scale_x + shift_x;
+            e[n].y1 = (p[b].y * y_scale_inv + shift_y) * vsubsample;
+            ++n;
+        }
+    }
+
+    // now sort the edges by their highest point (should snap to integer, and then by x)
+    // STBTT_sort(e, n, sizeof(e[0]), stbtt__edge_compare);
+    stbtt__sort_edges(e, n);
+
+    // now, traverse the scanlines and find the intersections on each scanline, use xor winding rule
+    stbtt__rasterize_sorted_edges(result, e, n, vsubsample, off_x, off_y, userdata);
+
+    STBTT_free(e, userdata);
+}
+
+static void stbtt__add_point(stbtt__point *points, int n, float x, float y)
+{
+    if (!points)
+        return;  // during first pass, it's unallocated
+    points[n].x = x;
+    points[n].y = y;
+}
+
+// tessellate until threshold p is happy... @TODO warped to compensate for non-linear stretching
+static int stbtt__tesselate_curve(stbtt__point *points,
+                                  int *num_points,
+                                  float x0,
+                                  float y0,
+                                  float x1,
+                                  float y1,
+                                  float x2,
+                                  float y2,
+                                  float objspace_flatness_squared,
+                                  int n)
+{
+    // midpoint
+    float mx = (x0 + 2 * x1 + x2) / 4;
+    float my = (y0 + 2 * y1 + y2) / 4;
+    // versus directly drawn line
+    float dx = (x0 + x2) / 2 - mx;
+    float dy = (y0 + y2) / 2 - my;
+    if (n > 16)  // 65536 segments on one curve better be enough!
+        return 1;
+    if (dx * dx + dy * dy > objspace_flatness_squared)
+    {  // half-pixel error allowed... need to be smaller if AA
+        stbtt__tesselate_curve(points, num_points, x0, y0, (x0 + x1) / 2.0f, (y0 + y1) / 2.0f, mx,
+                               my, objspace_flatness_squared, n + 1);
+        stbtt__tesselate_curve(points, num_points, mx, my, (x1 + x2) / 2.0f, (y1 + y2) / 2.0f, x2,
+                               y2, objspace_flatness_squared, n + 1);
+    }
+    else
+    {
+        stbtt__add_point(points, *num_points, x2, y2);
+        *num_points = *num_points + 1;
+    }
+    return 1;
+}
+
+static void stbtt__tesselate_cubic(stbtt__point *points,
+                                   int *num_points,
+                                   float x0,
+                                   float y0,
+                                   float x1,
+                                   float y1,
+                                   float x2,
+                                   float y2,
+                                   float x3,
+                                   float y3,
+                                   float objspace_flatness_squared,
+                                   int n)
+{
+    // @TODO this "flatness" calculation is just made-up nonsense that seems to work well enough
+    float dx0      = x1 - x0;
+    float dy0      = y1 - y0;
+    float dx1      = x2 - x1;
+    float dy1      = y2 - y1;
+    float dx2      = x3 - x2;
+    float dy2      = y3 - y2;
+    float dx       = x3 - x0;
+    float dy       = y3 - y0;
+    float longlen  = (float)(STBTT_sqrt(dx0 * dx0 + dy0 * dy0) + STBTT_sqrt(dx1 * dx1 + dy1 * dy1) +
+                            STBTT_sqrt(dx2 * dx2 + dy2 * dy2));
+    float shortlen = (float)STBTT_sqrt(dx * dx + dy * dy);
+    float flatness_squared = longlen * longlen - shortlen * shortlen;
+
+    if (n > 16)  // 65536 segments on one curve better be enough!
+        return;
+
+    if (flatness_squared > objspace_flatness_squared)
+    {
+        float x01 = (x0 + x1) / 2;
+        float y01 = (y0 + y1) / 2;
+        float x12 = (x1 + x2) / 2;
+        float y12 = (y1 + y2) / 2;
+        float x23 = (x2 + x3) / 2;
+        float y23 = (y2 + y3) / 2;
+
+        float xa = (x01 + x12) / 2;
+        float ya = (y01 + y12) / 2;
+        float xb = (x12 + x23) / 2;
+        float yb = (y12 + y23) / 2;
+
+        float mx = (xa + xb) / 2;
+        float my = (ya + yb) / 2;
+
+        stbtt__tesselate_cubic(points, num_points, x0, y0, x01, y01, xa, ya, mx, my,
+                               objspace_flatness_squared, n + 1);
+        stbtt__tesselate_cubic(points, num_points, mx, my, xb, yb, x23, y23, x3, y3,
+                               objspace_flatness_squared, n + 1);
+    }
+    else
+    {
+        stbtt__add_point(points, *num_points, x3, y3);
+        *num_points = *num_points + 1;
+    }
+}
+
+// returns number of contours
+static stbtt__point *stbtt_FlattenCurves(stbtt_vertex *vertices,
+                                         int num_verts,
+                                         float objspace_flatness,
+                                         int **contour_lengths,
+                                         int *num_contours,
+                                         void *userdata)
+{
+    stbtt__point *points = 0;
+    int num_points       = 0;
+
+    float objspace_flatness_squared = objspace_flatness * objspace_flatness;
+    int i, n = 0, start = 0, pass;
+
+    // count how many "moves" there are to get the contour count
+    for (i = 0; i < num_verts; ++i)
+        if (vertices[i].type == STBTT_vmove)
+            ++n;
+
+    *num_contours = n;
+    if (n == 0)
+        return 0;
+
+    *contour_lengths = (int *)STBTT_malloc(sizeof(**contour_lengths) * n, userdata);
+
+    if (*contour_lengths == 0)
+    {
+        *num_contours = 0;
+        return 0;
+    }
+
+    // make two passes through the points so we don't need to realloc
+    for (pass = 0; pass < 2; ++pass)
+    {
+        float x = 0, y = 0;
+        if (pass == 1)
+        {
+            points = (stbtt__point *)STBTT_malloc(num_points * sizeof(points[0]), userdata);
+            if (points == NULL)
+                goto error;
+        }
+        num_points = 0;
+        n          = -1;
+        for (i = 0; i < num_verts; ++i)
+        {
+            switch (vertices[i].type)
+            {
+                case STBTT_vmove:
+                    // start the next contour
+                    if (n >= 0)
+                        (*contour_lengths)[n] = num_points - start;
+                    ++n;
+                    start = num_points;
+
+                    x = vertices[i].x, y = vertices[i].y;
+                    stbtt__add_point(points, num_points++, x, y);
+                    break;
+                case STBTT_vline:
+                    x = vertices[i].x, y = vertices[i].y;
+                    stbtt__add_point(points, num_points++, x, y);
+                    break;
+                case STBTT_vcurve:
+                    stbtt__tesselate_curve(points, &num_points, x, y, vertices[i].cx,
+                                           vertices[i].cy, vertices[i].x, vertices[i].y,
+                                           objspace_flatness_squared, 0);
+                    x = vertices[i].x, y = vertices[i].y;
+                    break;
+                case STBTT_vcubic:
+                    stbtt__tesselate_cubic(points, &num_points, x, y, vertices[i].cx,
+                                           vertices[i].cy, vertices[i].cx1, vertices[i].cy1,
+                                           vertices[i].x, vertices[i].y, objspace_flatness_squared,
+                                           0);
+                    x = vertices[i].x, y = vertices[i].y;
+                    break;
+            }
+        }
+        (*contour_lengths)[n] = num_points - start;
+    }
+
+    return points;
+error:
+    STBTT_free(points, userdata);
+    STBTT_free(*contour_lengths, userdata);
+    *contour_lengths = 0;
+    *num_contours    = 0;
+    return NULL;
+}
+
+STBTT_DEF void stbtt_Rasterize(stbtt__bitmap *result,
+                               float flatness_in_pixels,
+                               stbtt_vertex *vertices,
+                               int num_verts,
+                               float scale_x,
+                               float scale_y,
+                               float shift_x,
+                               float shift_y,
+                               int x_off,
+                               int y_off,
+                               int invert,
+                               void *userdata)
+{
+    float scale            = scale_x > scale_y ? scale_y : scale_x;
+    int winding_count      = 0;
+    int *winding_lengths   = NULL;
+    stbtt__point *windings = stbtt_FlattenCurves(vertices, num_verts, flatness_in_pixels / scale,
+                                                 &winding_lengths, &winding_count, userdata);
+    if (windings)
+    {
+        stbtt__rasterize(result, windings, winding_lengths, winding_count, scale_x, scale_y,
+                         shift_x, shift_y, x_off, y_off, invert, userdata);
+        STBTT_free(winding_lengths, userdata);
+        STBTT_free(windings, userdata);
+    }
+}
+
+STBTT_DEF void stbtt_FreeBitmap(unsigned char *bitmap, void *userdata)
+{
+    STBTT_free(bitmap, userdata);
+}
+
+STBTT_DEF unsigned char *stbtt_GetGlyphBitmapSubpixel(const stbtt_fontinfo *info,
+                                                      float scale_x,
+                                                      float scale_y,
+                                                      float shift_x,
+                                                      float shift_y,
+                                                      int glyph,
+                                                      int *width,
+                                                      int *height,
+                                                      int *xoff,
+                                                      int *yoff)
+{
+    int ix0, iy0, ix1, iy1;
+    stbtt__bitmap gbm;
+    stbtt_vertex *vertices;
+    int num_verts = stbtt_GetGlyphShape(info, glyph, &vertices);
+
+    if (scale_x == 0)
+        scale_x = scale_y;
+    if (scale_y == 0)
+    {
+        if (scale_x == 0)
+        {
+            STBTT_free(vertices, info->userdata);
+            return NULL;
+        }
+        scale_y = scale_x;
+    }
+
+    stbtt_GetGlyphBitmapBoxSubpixel(info, glyph, scale_x, scale_y, shift_x, shift_y, &ix0, &iy0,
+                                    &ix1, &iy1);
+
+    // now we get the size
+    gbm.w      = (ix1 - ix0);
+    gbm.h      = (iy1 - iy0);
+    gbm.pixels = NULL;  // in case we error
+
+    if (width)
+        *width = gbm.w;
+    if (height)
+        *height = gbm.h;
+    if (xoff)
+        *xoff = ix0;
+    if (yoff)
+        *yoff = iy0;
+
+    if (gbm.w && gbm.h)
+    {
+        gbm.pixels = (unsigned char *)STBTT_malloc(gbm.w * gbm.h, info->userdata);
+        if (gbm.pixels)
+        {
+            gbm.stride = gbm.w;
+
+            stbtt_Rasterize(&gbm, 0.35f, vertices, num_verts, scale_x, scale_y, shift_x, shift_y,
+                            ix0, iy0, 1, info->userdata);
+        }
+    }
+    STBTT_free(vertices, info->userdata);
+    return gbm.pixels;
+}
+
+STBTT_DEF unsigned char *stbtt_GetGlyphBitmap(const stbtt_fontinfo *info,
+                                              float scale_x,
+                                              float scale_y,
+                                              int glyph,
+                                              int *width,
+                                              int *height,
+                                              int *xoff,
+                                              int *yoff)
+{
+    return stbtt_GetGlyphBitmapSubpixel(info, scale_x, scale_y, 0.0f, 0.0f, glyph, width, height,
+                                        xoff, yoff);
+}
+
+STBTT_DEF void stbtt_MakeGlyphBitmapSubpixel(const stbtt_fontinfo *info,
+                                             unsigned char *output,
+                                             int out_w,
+                                             int out_h,
+                                             int out_stride,
+                                             float scale_x,
+                                             float scale_y,
+                                             float shift_x,
+                                             float shift_y,
+                                             int glyph)
+{
+    int ix0, iy0;
+    stbtt_vertex *vertices;
+    int num_verts = stbtt_GetGlyphShape(info, glyph, &vertices);
+    stbtt__bitmap gbm;
+
+    stbtt_GetGlyphBitmapBoxSubpixel(info, glyph, scale_x, scale_y, shift_x, shift_y, &ix0, &iy0, 0,
+                                    0);
+    gbm.pixels = output;
+    gbm.w      = out_w;
+    gbm.h      = out_h;
+    gbm.stride = out_stride;
+
+    if (gbm.w && gbm.h)
+        stbtt_Rasterize(&gbm, 0.35f, vertices, num_verts, scale_x, scale_y, shift_x, shift_y, ix0,
+                        iy0, 1, info->userdata);
+
+    STBTT_free(vertices, info->userdata);
+}
+
+STBTT_DEF void stbtt_MakeGlyphBitmap(const stbtt_fontinfo *info,
+                                     unsigned char *output,
+                                     int out_w,
+                                     int out_h,
+                                     int out_stride,
+                                     float scale_x,
+                                     float scale_y,
+                                     int glyph)
+{
+    stbtt_MakeGlyphBitmapSubpixel(info, output, out_w, out_h, out_stride, scale_x, scale_y, 0.0f,
+                                  0.0f, glyph);
+}
+
+STBTT_DEF unsigned char *stbtt_GetCodepointBitmapSubpixel(const stbtt_fontinfo *info,
+                                                          float scale_x,
+                                                          float scale_y,
+                                                          float shift_x,
+                                                          float shift_y,
+                                                          int codepoint,
+                                                          int *width,
+                                                          int *height,
+                                                          int *xoff,
+                                                          int *yoff)
+{
+    return stbtt_GetGlyphBitmapSubpixel(info, scale_x, scale_y, shift_x, shift_y,
+                                        stbtt_FindGlyphIndex(info, codepoint), width, height, xoff,
+                                        yoff);
+}
+
+STBTT_DEF void stbtt_MakeCodepointBitmapSubpixelPrefilter(const stbtt_fontinfo *info,
+                                                          unsigned char *output,
+                                                          int out_w,
+                                                          int out_h,
+                                                          int out_stride,
+                                                          float scale_x,
+                                                          float scale_y,
+                                                          float shift_x,
+                                                          float shift_y,
+                                                          int oversample_x,
+                                                          int oversample_y,
+                                                          float *sub_x,
+                                                          float *sub_y,
+                                                          int codepoint)
+{
+    stbtt_MakeGlyphBitmapSubpixelPrefilter(info, output, out_w, out_h, out_stride, scale_x, scale_y,
+                                           shift_x, shift_y, oversample_x, oversample_y, sub_x,
+                                           sub_y, stbtt_FindGlyphIndex(info, codepoint));
+}
+
+STBTT_DEF void stbtt_MakeCodepointBitmapSubpixel(const stbtt_fontinfo *info,
+                                                 unsigned char *output,
+                                                 int out_w,
+                                                 int out_h,
+                                                 int out_stride,
+                                                 float scale_x,
+                                                 float scale_y,
+                                                 float shift_x,
+                                                 float shift_y,
+                                                 int codepoint)
+{
+    stbtt_MakeGlyphBitmapSubpixel(info, output, out_w, out_h, out_stride, scale_x, scale_y, shift_x,
+                                  shift_y, stbtt_FindGlyphIndex(info, codepoint));
+}
+
+STBTT_DEF unsigned char *stbtt_GetCodepointBitmap(const stbtt_fontinfo *info,
+                                                  float scale_x,
+                                                  float scale_y,
+                                                  int codepoint,
+                                                  int *width,
+                                                  int *height,
+                                                  int *xoff,
+                                                  int *yoff)
+{
+    return stbtt_GetCodepointBitmapSubpixel(info, scale_x, scale_y, 0.0f, 0.0f, codepoint, width,
+                                            height, xoff, yoff);
+}
+
+STBTT_DEF void stbtt_MakeCodepointBitmap(const stbtt_fontinfo *info,
+                                         unsigned char *output,
+                                         int out_w,
+                                         int out_h,
+                                         int out_stride,
+                                         float scale_x,
+                                         float scale_y,
+                                         int codepoint)
+{
+    stbtt_MakeCodepointBitmapSubpixel(info, output, out_w, out_h, out_stride, scale_x, scale_y,
+                                      0.0f, 0.0f, codepoint);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// bitmap baking
+//
+// This is SUPER-CRAPPY packing to keep source code small
+
+static int stbtt_BakeFontBitmap_internal(unsigned char *data,
+                                         int offset,  // font location (use offset=0 for plain .ttf)
+                                         float pixel_height,  // height of font in pixels
+                                         unsigned char *pixels,
+                                         int pw,
+                                         int ph,  // bitmap to be filled in
+                                         int first_char,
+                                         int num_chars,  // characters to bake
+                                         stbtt_bakedchar *chardata)
+{
+    float scale;
+    int x, y, bottom_y, i;
+    stbtt_fontinfo f;
+    f.userdata = NULL;
+    if (!stbtt_InitFont(&f, data, offset))
+        return -1;
+    STBTT_memset(pixels, 0, pw * ph);  // background of 0 around pixels
+    x = y    = 1;
+    bottom_y = 1;
+
+    scale = stbtt_ScaleForPixelHeight(&f, pixel_height);
+
+    for (i = 0; i < num_chars; ++i)
+    {
+        int advance, lsb, x0, y0, x1, y1, gw, gh;
+        int g = stbtt_FindGlyphIndex(&f, first_char + i);
+        stbtt_GetGlyphHMetrics(&f, g, &advance, &lsb);
+        stbtt_GetGlyphBitmapBox(&f, g, scale, scale, &x0, &y0, &x1, &y1);
+        gw = x1 - x0;
+        gh = y1 - y0;
+        if (x + gw + 1 >= pw)
+            y = bottom_y, x = 1;  // advance to next row
+        if (y + gh + 1 >= ph)  // check if it fits vertically AFTER potentially moving to next row
+            return -i;
+        STBTT_assert(x + gw < pw);
+        STBTT_assert(y + gh < ph);
+        stbtt_MakeGlyphBitmap(&f, pixels + x + y * pw, gw, gh, pw, scale, scale, g);
+        chardata[i].x0       = (stbtt_int16)x;
+        chardata[i].y0       = (stbtt_int16)y;
+        chardata[i].x1       = (stbtt_int16)(x + gw);
+        chardata[i].y1       = (stbtt_int16)(y + gh);
+        chardata[i].xadvance = scale * advance;
+        chardata[i].xoff     = (float)x0;
+        chardata[i].yoff     = (float)y0;
+        x                    = x + gw + 1;
+        if (y + gh + 1 > bottom_y)
+            bottom_y = y + gh + 1;
+    }
+    return bottom_y;
+}
+
+STBTT_DEF void stbtt_GetBakedQuad(const stbtt_bakedchar *chardata,
+                                  int pw,
+                                  int ph,
+                                  int char_index,
+                                  float *xpos,
+                                  float *ypos,
+                                  stbtt_aligned_quad *q,
+                                  int opengl_fillrule)
+{
+    float d3d_bias = opengl_fillrule ? 0 : -0.5f;
+    float ipw = 1.0f / pw, iph = 1.0f / ph;
+    const stbtt_bakedchar *b = chardata + char_index;
+    int round_x              = STBTT_ifloor((*xpos + b->xoff) + 0.5f);
+    int round_y              = STBTT_ifloor((*ypos + b->yoff) + 0.5f);
+
+    q->x0 = round_x + d3d_bias;
+    q->y0 = round_y + d3d_bias;
+    q->x1 = round_x + b->x1 - b->x0 + d3d_bias;
+    q->y1 = round_y + b->y1 - b->y0 + d3d_bias;
+
+    q->s0 = b->x0 * ipw;
+    q->t0 = b->y0 * iph;
+    q->s1 = b->x1 * ipw;
+    q->t1 = b->y1 * iph;
+
+    *xpos += b->xadvance;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// rectangle packing replacement routines if you don't have stb_rect_pack.h
+//
+
+#ifndef STB_RECT_PACK_VERSION
+
+typedef int stbrp_coord;
+
+////////////////////////////////////////////////////////////////////////////////////
+//                                                                                //
+//                                                                                //
+// COMPILER WARNING ?!?!?                                                         //
+//                                                                                //
+//                                                                                //
+// if you get a compile warning due to these symbols being defined more than      //
+// once, move #include "stb_rect_pack.h" before #include "stb_truetype.h"         //
+//                                                                                //
+////////////////////////////////////////////////////////////////////////////////////
+
+typedef struct
+{
+    int width, height;
+    int x, y, bottom_y;
+} stbrp_context;
+
+typedef struct
+{
+    unsigned char x;
+} stbrp_node;
+
+struct stbrp_rect
+{
+    stbrp_coord x, y;
+    int id, w, h, was_packed;
+};
+
+static void stbrp_init_target(stbrp_context *con, int pw, int ph, stbrp_node *nodes, int num_nodes)
+{
+    con->width    = pw;
+    con->height   = ph;
+    con->x        = 0;
+    con->y        = 0;
+    con->bottom_y = 0;
+    STBTT__NOTUSED(nodes);
+    STBTT__NOTUSED(num_nodes);
+}
+
+static void stbrp_pack_rects(stbrp_context *con, stbrp_rect *rects, int num_rects)
+{
+    int i;
+    for (i = 0; i < num_rects; ++i)
+    {
+        if (con->x + rects[i].w > con->width)
+        {
+            con->x = 0;
+            con->y = con->bottom_y;
+        }
+        if (con->y + rects[i].h > con->height)
+            break;
+        rects[i].x          = con->x;
+        rects[i].y          = con->y;
+        rects[i].was_packed = 1;
+        con->x += rects[i].w;
+        if (con->y + rects[i].h > con->bottom_y)
+            con->bottom_y = con->y + rects[i].h;
+    }
+    for (; i < num_rects; ++i)
+        rects[i].was_packed = 0;
+}
+#endif
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// bitmap baking
+//
+// This is SUPER-AWESOME (tm Ryan Gordon) packing using stb_rect_pack.h. If
+// stb_rect_pack.h isn't available, it uses the BakeFontBitmap strategy.
+
+STBTT_DEF int stbtt_PackBegin(stbtt_pack_context *spc,
+                              unsigned char *pixels,
+                              int pw,
+                              int ph,
+                              int stride_in_bytes,
+                              int padding,
+                              void *alloc_context)
+{
+    stbrp_context *context = (stbrp_context *)STBTT_malloc(sizeof(*context), alloc_context);
+    int num_nodes          = pw - padding;
+    stbrp_node *nodes      = (stbrp_node *)STBTT_malloc(sizeof(*nodes) * num_nodes, alloc_context);
+
+    if (context == NULL || nodes == NULL)
+    {
+        if (context != NULL)
+            STBTT_free(context, alloc_context);
+        if (nodes != NULL)
+            STBTT_free(nodes, alloc_context);
+        return 0;
+    }
+
+    spc->user_allocator_context = alloc_context;
+    spc->width                  = pw;
+    spc->height                 = ph;
+    spc->pixels                 = pixels;
+    spc->pack_info              = context;
+    spc->nodes                  = nodes;
+    spc->padding                = padding;
+    spc->stride_in_bytes        = stride_in_bytes != 0 ? stride_in_bytes : pw;
+    spc->h_oversample           = 1;
+    spc->v_oversample           = 1;
+    spc->skip_missing           = 0;
+
+    stbrp_init_target(context, pw - padding, ph - padding, nodes, num_nodes);
+
+    if (pixels)
+        STBTT_memset(pixels, 0, pw * ph);  // background of 0 around pixels
+
+    return 1;
+}
+
+STBTT_DEF void stbtt_PackEnd(stbtt_pack_context *spc)
+{
+    STBTT_free(spc->nodes, spc->user_allocator_context);
+    STBTT_free(spc->pack_info, spc->user_allocator_context);
+}
+
+STBTT_DEF void stbtt_PackSetOversampling(stbtt_pack_context *spc,
+                                         unsigned int h_oversample,
+                                         unsigned int v_oversample)
+{
+    STBTT_assert(h_oversample <= STBTT_MAX_OVERSAMPLE);
+    STBTT_assert(v_oversample <= STBTT_MAX_OVERSAMPLE);
+    if (h_oversample <= STBTT_MAX_OVERSAMPLE)
+        spc->h_oversample = h_oversample;
+    if (v_oversample <= STBTT_MAX_OVERSAMPLE)
+        spc->v_oversample = v_oversample;
+}
+
+STBTT_DEF void stbtt_PackSetSkipMissingCodepoints(stbtt_pack_context *spc, int skip)
+{
+    spc->skip_missing = skip;
+}
+
+#define STBTT__OVER_MASK (STBTT_MAX_OVERSAMPLE - 1)
+
+static void stbtt__h_prefilter(unsigned char *pixels,
+                               int w,
+                               int h,
+                               int stride_in_bytes,
+                               unsigned int kernel_width)
+{
+    unsigned char buffer[STBTT_MAX_OVERSAMPLE];
+    int safe_w = w - kernel_width;
+    int j;
+    STBTT_memset(buffer, 0, STBTT_MAX_OVERSAMPLE);  // suppress bogus warning from VS2013 -analyze
+    for (j = 0; j < h; ++j)
+    {
+        int i;
+        unsigned int total;
+        STBTT_memset(buffer, 0, kernel_width);
+
+        total = 0;
+
+        // make kernel_width a constant in common cases so compiler can optimize out the divide
+        switch (kernel_width)
+        {
+            case 2:
+                for (i = 0; i <= safe_w; ++i)
+                {
+                    total += pixels[i] - buffer[i & STBTT__OVER_MASK];
+                    buffer[(i + kernel_width) & STBTT__OVER_MASK] = pixels[i];
+                    pixels[i]                                     = (unsigned char)(total / 2);
+                }
+                break;
+            case 3:
+                for (i = 0; i <= safe_w; ++i)
+                {
+                    total += pixels[i] - buffer[i & STBTT__OVER_MASK];
+                    buffer[(i + kernel_width) & STBTT__OVER_MASK] = pixels[i];
+                    pixels[i]                                     = (unsigned char)(total / 3);
+                }
+                break;
+            case 4:
+                for (i = 0; i <= safe_w; ++i)
+                {
+                    total += pixels[i] - buffer[i & STBTT__OVER_MASK];
+                    buffer[(i + kernel_width) & STBTT__OVER_MASK] = pixels[i];
+                    pixels[i]                                     = (unsigned char)(total / 4);
+                }
+                break;
+            case 5:
+                for (i = 0; i <= safe_w; ++i)
+                {
+                    total += pixels[i] - buffer[i & STBTT__OVER_MASK];
+                    buffer[(i + kernel_width) & STBTT__OVER_MASK] = pixels[i];
+                    pixels[i]                                     = (unsigned char)(total / 5);
+                }
+                break;
+            default:
+                for (i = 0; i <= safe_w; ++i)
+                {
+                    total += pixels[i] - buffer[i & STBTT__OVER_MASK];
+                    buffer[(i + kernel_width) & STBTT__OVER_MASK] = pixels[i];
+                    pixels[i] = (unsigned char)(total / kernel_width);
+                }
+                break;
+        }
+
+        for (; i < w; ++i)
+        {
+            STBTT_assert(pixels[i] == 0);
+            total -= buffer[i & STBTT__OVER_MASK];
+            pixels[i] = (unsigned char)(total / kernel_width);
+        }
+
+        pixels += stride_in_bytes;
+    }
+}
+
+static void stbtt__v_prefilter(unsigned char *pixels,
+                               int w,
+                               int h,
+                               int stride_in_bytes,
+                               unsigned int kernel_width)
+{
+    unsigned char buffer[STBTT_MAX_OVERSAMPLE];
+    int safe_h = h - kernel_width;
+    int j;
+    STBTT_memset(buffer, 0, STBTT_MAX_OVERSAMPLE);  // suppress bogus warning from VS2013 -analyze
+    for (j = 0; j < w; ++j)
+    {
+        int i;
+        unsigned int total;
+        STBTT_memset(buffer, 0, kernel_width);
+
+        total = 0;
+
+        // make kernel_width a constant in common cases so compiler can optimize out the divide
+        switch (kernel_width)
+        {
+            case 2:
+                for (i = 0; i <= safe_h; ++i)
+                {
+                    total += pixels[i * stride_in_bytes] - buffer[i & STBTT__OVER_MASK];
+                    buffer[(i + kernel_width) & STBTT__OVER_MASK] = pixels[i * stride_in_bytes];
+                    pixels[i * stride_in_bytes]                   = (unsigned char)(total / 2);
+                }
+                break;
+            case 3:
+                for (i = 0; i <= safe_h; ++i)
+                {
+                    total += pixels[i * stride_in_bytes] - buffer[i & STBTT__OVER_MASK];
+                    buffer[(i + kernel_width) & STBTT__OVER_MASK] = pixels[i * stride_in_bytes];
+                    pixels[i * stride_in_bytes]                   = (unsigned char)(total / 3);
+                }
+                break;
+            case 4:
+                for (i = 0; i <= safe_h; ++i)
+                {
+                    total += pixels[i * stride_in_bytes] - buffer[i & STBTT__OVER_MASK];
+                    buffer[(i + kernel_width) & STBTT__OVER_MASK] = pixels[i * stride_in_bytes];
+                    pixels[i * stride_in_bytes]                   = (unsigned char)(total / 4);
+                }
+                break;
+            case 5:
+                for (i = 0; i <= safe_h; ++i)
+                {
+                    total += pixels[i * stride_in_bytes] - buffer[i & STBTT__OVER_MASK];
+                    buffer[(i + kernel_width) & STBTT__OVER_MASK] = pixels[i * stride_in_bytes];
+                    pixels[i * stride_in_bytes]                   = (unsigned char)(total / 5);
+                }
+                break;
+            default:
+                for (i = 0; i <= safe_h; ++i)
+                {
+                    total += pixels[i * stride_in_bytes] - buffer[i & STBTT__OVER_MASK];
+                    buffer[(i + kernel_width) & STBTT__OVER_MASK] = pixels[i * stride_in_bytes];
+                    pixels[i * stride_in_bytes] = (unsigned char)(total / kernel_width);
+                }
+                break;
+        }
+
+        for (; i < h; ++i)
+        {
+            STBTT_assert(pixels[i * stride_in_bytes] == 0);
+            total -= buffer[i & STBTT__OVER_MASK];
+            pixels[i * stride_in_bytes] = (unsigned char)(total / kernel_width);
+        }
+
+        pixels += 1;
+    }
+}
+
+static float stbtt__oversample_shift(int oversample)
+{
+    if (!oversample)
+        return 0.0f;
+
+    // The prefilter is a box filter of width "oversample",
+    // which shifts phase by (oversample - 1)/2 pixels in
+    // oversampled space. We want to shift in the opposite
+    // direction to counter this.
+    return (float)-(oversample - 1) / (2.0f * (float)oversample);
+}
+
+// rects array must be big enough to accommodate all characters in the given ranges
+STBTT_DEF int stbtt_PackFontRangesGatherRects(stbtt_pack_context *spc,
+                                              const stbtt_fontinfo *info,
+                                              stbtt_pack_range *ranges,
+                                              int num_ranges,
+                                              stbrp_rect *rects)
+{
+    int i, j, k;
+
+    k = 0;
+    for (i = 0; i < num_ranges; ++i)
+    {
+        float fh    = ranges[i].font_size;
+        float scale = fh > 0 ? stbtt_ScaleForPixelHeight(info, fh)
+                             : stbtt_ScaleForMappingEmToPixels(info, -fh);
+        ranges[i].h_oversample = (unsigned char)spc->h_oversample;
+        ranges[i].v_oversample = (unsigned char)spc->v_oversample;
+        for (j = 0; j < ranges[i].num_chars; ++j)
+        {
+            int x0, y0, x1, y1;
+            int codepoint = ranges[i].array_of_unicode_codepoints == NULL
+                                ? ranges[i].first_unicode_codepoint_in_range + j
+                                : ranges[i].array_of_unicode_codepoints[j];
+            int glyph = stbtt_FindGlyphIndex(info, codepoint);
+            if (glyph == 0 && spc->skip_missing)
+            {
+                rects[k].w = rects[k].h = 0;
+            }
+            else
+            {
+                stbtt_GetGlyphBitmapBoxSubpixel(info, glyph, scale * spc->h_oversample,
+                                                scale * spc->v_oversample, 0, 0, &x0, &y0, &x1,
+                                                &y1);
+                rects[k].w = (stbrp_coord)(x1 - x0 + spc->padding + spc->h_oversample - 1);
+                rects[k].h = (stbrp_coord)(y1 - y0 + spc->padding + spc->v_oversample - 1);
+            }
+            ++k;
+        }
+    }
+
+    return k;
+}
+
+STBTT_DEF void stbtt_MakeGlyphBitmapSubpixelPrefilter(const stbtt_fontinfo *info,
+                                                      unsigned char *output,
+                                                      int out_w,
+                                                      int out_h,
+                                                      int out_stride,
+                                                      float scale_x,
+                                                      float scale_y,
+                                                      float shift_x,
+                                                      float shift_y,
+                                                      int prefilter_x,
+                                                      int prefilter_y,
+                                                      float *sub_x,
+                                                      float *sub_y,
+                                                      int glyph)
+{
+    stbtt_MakeGlyphBitmapSubpixel(info, output, out_w - (prefilter_x - 1),
+                                  out_h - (prefilter_y - 1), out_stride, scale_x, scale_y, shift_x,
+                                  shift_y, glyph);
+
+    if (prefilter_x > 1)
+        stbtt__h_prefilter(output, out_w, out_h, out_stride, prefilter_x);
+
+    if (prefilter_y > 1)
+        stbtt__v_prefilter(output, out_w, out_h, out_stride, prefilter_y);
+
+    *sub_x = stbtt__oversample_shift(prefilter_x);
+    *sub_y = stbtt__oversample_shift(prefilter_y);
+}
+
+// rects array must be big enough to accommodate all characters in the given ranges
+STBTT_DEF int stbtt_PackFontRangesRenderIntoRects(stbtt_pack_context *spc,
+                                                  const stbtt_fontinfo *info,
+                                                  stbtt_pack_range *ranges,
+                                                  int num_ranges,
+                                                  stbrp_rect *rects)
+{
+    int i, j, k, return_value = 1;
+
+    // save current values
+    int old_h_over = spc->h_oversample;
+    int old_v_over = spc->v_oversample;
+
+    k = 0;
+    for (i = 0; i < num_ranges; ++i)
+    {
+        float fh    = ranges[i].font_size;
+        float scale = fh > 0 ? stbtt_ScaleForPixelHeight(info, fh)
+                             : stbtt_ScaleForMappingEmToPixels(info, -fh);
+        float recip_h, recip_v, sub_x, sub_y;
+        spc->h_oversample = ranges[i].h_oversample;
+        spc->v_oversample = ranges[i].v_oversample;
+        recip_h           = 1.0f / spc->h_oversample;
+        recip_v           = 1.0f / spc->v_oversample;
+        sub_x             = stbtt__oversample_shift(spc->h_oversample);
+        sub_y             = stbtt__oversample_shift(spc->v_oversample);
+        for (j = 0; j < ranges[i].num_chars; ++j)
+        {
+            stbrp_rect *r = &rects[k];
+            if (r->was_packed && r->w != 0 && r->h != 0)
+            {
+                stbtt_packedchar *bc = &ranges[i].chardata_for_range[j];
+                int advance, lsb, x0, y0, x1, y1;
+                int codepoint = ranges[i].array_of_unicode_codepoints == NULL
+                                    ? ranges[i].first_unicode_codepoint_in_range + j
+                                    : ranges[i].array_of_unicode_codepoints[j];
+                int glyph       = stbtt_FindGlyphIndex(info, codepoint);
+                stbrp_coord pad = (stbrp_coord)spc->padding;
+
+                // pad on left and top
+                r->x += pad;
+                r->y += pad;
+                r->w -= pad;
+                r->h -= pad;
+                stbtt_GetGlyphHMetrics(info, glyph, &advance, &lsb);
+                stbtt_GetGlyphBitmapBox(info, glyph, scale * spc->h_oversample,
+                                        scale * spc->v_oversample, &x0, &y0, &x1, &y1);
+                stbtt_MakeGlyphBitmapSubpixel(
+                    info, spc->pixels + r->x + r->y * spc->stride_in_bytes,
+                    r->w - spc->h_oversample + 1, r->h - spc->v_oversample + 1,
+                    spc->stride_in_bytes, scale * spc->h_oversample, scale * spc->v_oversample, 0,
+                    0, glyph);
+
+                if (spc->h_oversample > 1)
+                    stbtt__h_prefilter(spc->pixels + r->x + r->y * spc->stride_in_bytes, r->w, r->h,
+                                       spc->stride_in_bytes, spc->h_oversample);
+
+                if (spc->v_oversample > 1)
+                    stbtt__v_prefilter(spc->pixels + r->x + r->y * spc->stride_in_bytes, r->w, r->h,
+                                       spc->stride_in_bytes, spc->v_oversample);
+
+                bc->x0       = (stbtt_int16)r->x;
+                bc->y0       = (stbtt_int16)r->y;
+                bc->x1       = (stbtt_int16)(r->x + r->w);
+                bc->y1       = (stbtt_int16)(r->y + r->h);
+                bc->xadvance = scale * advance;
+                bc->xoff     = (float)x0 * recip_h + sub_x;
+                bc->yoff     = (float)y0 * recip_v + sub_y;
+                bc->xoff2    = (x0 + r->w) * recip_h + sub_x;
+                bc->yoff2    = (y0 + r->h) * recip_v + sub_y;
+            }
+            else
+            {
+                return_value = 0;  // if any fail, report failure
+            }
+
+            ++k;
+        }
+    }
+
+    // restore original values
+    spc->h_oversample = old_h_over;
+    spc->v_oversample = old_v_over;
+
+    return return_value;
+}
+
+STBTT_DEF void stbtt_PackFontRangesPackRects(stbtt_pack_context *spc,
+                                             stbrp_rect *rects,
+                                             int num_rects)
+{
+    stbrp_pack_rects((stbrp_context *)spc->pack_info, rects, num_rects);
+}
+
+STBTT_DEF int stbtt_PackFontRanges(stbtt_pack_context *spc,
+                                   const unsigned char *fontdata,
+                                   int font_index,
+                                   stbtt_pack_range *ranges,
+                                   int num_ranges)
+{
+    stbtt_fontinfo info;
+    int i, j, n, return_value = 1;
+    // stbrp_context *context = (stbrp_context *) spc->pack_info;
+    stbrp_rect *rects;
+
+    // flag all characters as NOT packed
+    for (i = 0; i < num_ranges; ++i)
+        for (j = 0; j < ranges[i].num_chars; ++j)
+            ranges[i].chardata_for_range[j].x0     = ranges[i].chardata_for_range[j].y0 =
+                ranges[i].chardata_for_range[j].x1 = ranges[i].chardata_for_range[j].y1 = 0;
+
+    n = 0;
+    for (i = 0; i < num_ranges; ++i)
+        n += ranges[i].num_chars;
+
+    rects = (stbrp_rect *)STBTT_malloc(sizeof(*rects) * n, spc->user_allocator_context);
+    if (rects == NULL)
+        return 0;
+
+    info.userdata = spc->user_allocator_context;
+    stbtt_InitFont(&info, fontdata, stbtt_GetFontOffsetForIndex(fontdata, font_index));
+
+    n = stbtt_PackFontRangesGatherRects(spc, &info, ranges, num_ranges, rects);
+
+    stbtt_PackFontRangesPackRects(spc, rects, n);
+
+    return_value = stbtt_PackFontRangesRenderIntoRects(spc, &info, ranges, num_ranges, rects);
+
+    STBTT_free(rects, spc->user_allocator_context);
+    return return_value;
+}
+
+STBTT_DEF int stbtt_PackFontRange(stbtt_pack_context *spc,
+                                  const unsigned char *fontdata,
+                                  int font_index,
+                                  float font_size,
+                                  int first_unicode_codepoint_in_range,
+                                  int num_chars_in_range,
+                                  stbtt_packedchar *chardata_for_range)
+{
+    stbtt_pack_range range;
+    range.first_unicode_codepoint_in_range = first_unicode_codepoint_in_range;
+    range.array_of_unicode_codepoints      = NULL;
+    range.num_chars                        = num_chars_in_range;
+    range.chardata_for_range               = chardata_for_range;
+    range.font_size                        = font_size;
+    return stbtt_PackFontRanges(spc, fontdata, font_index, &range, 1);
+}
+
+STBTT_DEF void stbtt_GetScaledFontVMetrics(const unsigned char *fontdata,
+                                           int index,
+                                           float size,
+                                           float *ascent,
+                                           float *descent,
+                                           float *lineGap)
+{
+    int i_ascent, i_descent, i_lineGap;
+    float scale;
+    stbtt_fontinfo info;
+    stbtt_InitFont(&info, fontdata, stbtt_GetFontOffsetForIndex(fontdata, index));
+    scale = size > 0 ? stbtt_ScaleForPixelHeight(&info, size)
+                     : stbtt_ScaleForMappingEmToPixels(&info, -size);
+    stbtt_GetFontVMetrics(&info, &i_ascent, &i_descent, &i_lineGap);
+    *ascent  = (float)i_ascent * scale;
+    *descent = (float)i_descent * scale;
+    *lineGap = (float)i_lineGap * scale;
+}
+
+STBTT_DEF void stbtt_GetPackedQuad(const stbtt_packedchar *chardata,
+                                   int pw,
+                                   int ph,
+                                   int char_index,
+                                   float *xpos,
+                                   float *ypos,
+                                   stbtt_aligned_quad *q,
+                                   int align_to_integer)
+{
+    float ipw = 1.0f / pw, iph = 1.0f / ph;
+    const stbtt_packedchar *b = chardata + char_index;
+
+    if (align_to_integer)
+    {
+        float x = (float)STBTT_ifloor((*xpos + b->xoff) + 0.5f);
+        float y = (float)STBTT_ifloor((*ypos + b->yoff) + 0.5f);
+        q->x0   = x;
+        q->y0   = y;
+        q->x1   = x + b->xoff2 - b->xoff;
+        q->y1   = y + b->yoff2 - b->yoff;
+    }
+    else
+    {
+        q->x0 = *xpos + b->xoff;
+        q->y0 = *ypos + b->yoff;
+        q->x1 = *xpos + b->xoff2;
+        q->y1 = *ypos + b->yoff2;
+    }
+
+    q->s0 = b->x0 * ipw;
+    q->t0 = b->y0 * iph;
+    q->s1 = b->x1 * ipw;
+    q->t1 = b->y1 * iph;
+
+    *xpos += b->xadvance;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// sdf computation
+//
+
+#define STBTT_min(a, b) ((a) < (b) ? (a) : (b))
+#define STBTT_max(a, b) ((a) < (b) ? (b) : (a))
+
+static int stbtt__ray_intersect_bezier(float orig[2],
+                                       float ray[2],
+                                       float q0[2],
+                                       float q1[2],
+                                       float q2[2],
+                                       float hits[2][2])
+{
+    float q0perp = q0[1] * ray[0] - q0[0] * ray[1];
+    float q1perp = q1[1] * ray[0] - q1[0] * ray[1];
+    float q2perp = q2[1] * ray[0] - q2[0] * ray[1];
+    float roperp = orig[1] * ray[0] - orig[0] * ray[1];
+
+    float a = q0perp - 2 * q1perp + q2perp;
+    float b = q1perp - q0perp;
+    float c = q0perp - roperp;
+
+    float s0 = 0., s1 = 0.;
+    int num_s = 0;
+
+    if (a != 0.0)
+    {
+        float discr = b * b - a * c;
+        if (discr > 0.0)
+        {
+            float rcpna = -1 / a;
+            float d     = (float)STBTT_sqrt(discr);
+            s0          = (b + d) * rcpna;
+            s1          = (b - d) * rcpna;
+            if (s0 >= 0.0 && s0 <= 1.0)
+                num_s = 1;
+            if (d > 0.0 && s1 >= 0.0 && s1 <= 1.0)
+            {
+                if (num_s == 0)
+                    s0 = s1;
+                ++num_s;
+            }
+        }
+    }
+    else
+    {
+        // 2*b*s + c = 0
+        // s = -c / (2*b)
+        s0 = c / (-2 * b);
+        if (s0 >= 0.0 && s0 <= 1.0)
+            num_s = 1;
+    }
+
+    if (num_s == 0)
+        return 0;
+    else
+    {
+        float rcp_len2 = 1 / (ray[0] * ray[0] + ray[1] * ray[1]);
+        float rayn_x = ray[0] * rcp_len2, rayn_y = ray[1] * rcp_len2;
+
+        float q0d = q0[0] * rayn_x + q0[1] * rayn_y;
+        float q1d = q1[0] * rayn_x + q1[1] * rayn_y;
+        float q2d = q2[0] * rayn_x + q2[1] * rayn_y;
+        float rod = orig[0] * rayn_x + orig[1] * rayn_y;
+
+        float q10d = q1d - q0d;
+        float q20d = q2d - q0d;
+        float q0rd = q0d - rod;
+
+        hits[0][0] = q0rd + s0 * (2.0f - 2.0f * s0) * q10d + s0 * s0 * q20d;
+        hits[0][1] = a * s0 + b;
+
+        if (num_s > 1)
+        {
+            hits[1][0] = q0rd + s1 * (2.0f - 2.0f * s1) * q10d + s1 * s1 * q20d;
+            hits[1][1] = a * s1 + b;
+            return 2;
+        }
+        else
+        {
+            return 1;
+        }
+    }
+}
+
+static int equal(float *a, float *b)
+{
+    return (a[0] == b[0] && a[1] == b[1]);
+}
+
+static int stbtt__compute_crossings_x(float x, float y, int nverts, stbtt_vertex *verts)
+{
+    int i;
+    float orig[2], ray[2] = {1, 0};
+    float y_frac;
+    int winding = 0;
+
+    orig[0] = x;
+    // orig[1] = y; // [DEAR IMGUI] commmented double assignment
+
+    // make sure y never passes through a vertex of the shape
+    y_frac = (float)STBTT_fmod(y, 1.0f);
+    if (y_frac < 0.01f)
+        y += 0.01f;
+    else if (y_frac > 0.99f)
+        y -= 0.01f;
+    orig[1] = y;
+
+    // test a ray from (-infinity,y) to (x,y)
+    for (i = 0; i < nverts; ++i)
+    {
+        if (verts[i].type == STBTT_vline)
+        {
+            int x0 = (int)verts[i - 1].x, y0 = (int)verts[i - 1].y;
+            int x1 = (int)verts[i].x, y1 = (int)verts[i].y;
+            if (y > STBTT_min(y0, y1) && y < STBTT_max(y0, y1) && x > STBTT_min(x0, x1))
+            {
+                float x_inter = (y - y0) / (y1 - y0) * (x1 - x0) + x0;
+                if (x_inter < x)
+                    winding += (y0 < y1) ? 1 : -1;
+            }
+        }
+        if (verts[i].type == STBTT_vcurve)
+        {
+            int x0 = (int)verts[i - 1].x, y0 = (int)verts[i - 1].y;
+            int x1 = (int)verts[i].cx, y1 = (int)verts[i].cy;
+            int x2 = (int)verts[i].x, y2 = (int)verts[i].y;
+            int ax = STBTT_min(x0, STBTT_min(x1, x2)), ay = STBTT_min(y0, STBTT_min(y1, y2));
+            int by = STBTT_max(y0, STBTT_max(y1, y2));
+            if (y > ay && y < by && x > ax)
+            {
+                float q0[2], q1[2], q2[2];
+                float hits[2][2];
+                q0[0] = (float)x0;
+                q0[1] = (float)y0;
+                q1[0] = (float)x1;
+                q1[1] = (float)y1;
+                q2[0] = (float)x2;
+                q2[1] = (float)y2;
+                if (equal(q0, q1) || equal(q1, q2))
+                {
+                    x0 = (int)verts[i - 1].x;
+                    y0 = (int)verts[i - 1].y;
+                    x1 = (int)verts[i].x;
+                    y1 = (int)verts[i].y;
+                    if (y > STBTT_min(y0, y1) && y < STBTT_max(y0, y1) && x > STBTT_min(x0, x1))
+                    {
+                        float x_inter = (y - y0) / (y1 - y0) * (x1 - x0) + x0;
+                        if (x_inter < x)
+                            winding += (y0 < y1) ? 1 : -1;
+                    }
+                }
+                else
+                {
+                    int num_hits = stbtt__ray_intersect_bezier(orig, ray, q0, q1, q2, hits);
+                    if (num_hits >= 1)
+                        if (hits[0][0] < 0)
+                            winding += (hits[0][1] < 0 ? -1 : 1);
+                    if (num_hits >= 2)
+                        if (hits[1][0] < 0)
+                            winding += (hits[1][1] < 0 ? -1 : 1);
+                }
+            }
+        }
+    }
+    return winding;
+}
+
+static float stbtt__cuberoot(float x)
+{
+    if (x < 0)
+        return -(float)STBTT_pow(-x, 1.0f / 3.0f);
+    else
+        return (float)STBTT_pow(x, 1.0f / 3.0f);
+}
+
+// x^3 + c*x^2 + b*x + a = 0
+static int stbtt__solve_cubic(float a, float b, float c, float *r)
+{
+    float s  = -a / 3;
+    float p  = b - a * a / 3;
+    float q  = a * (2 * a * a - 9 * b) / 27 + c;
+    float p3 = p * p * p;
+    float d  = q * q + 4 * p3 / 27;
+    if (d >= 0)
+    {
+        float z = (float)STBTT_sqrt(d);
+        float u = (-q + z) / 2;
+        float v = (-q - z) / 2;
+        u       = stbtt__cuberoot(u);
+        v       = stbtt__cuberoot(v);
+        r[0]    = s + u + v;
+        return 1;
+    }
+    else
+    {
+        float u = (float)STBTT_sqrt(-p / 3);
+        float v = (float)STBTT_acos(-STBTT_sqrt(-27 / p3) * q / 2) /
+                  3;  // p3 must be negative, since d is negative
+        float m = (float)STBTT_cos(v);
+        float n = (float)STBTT_cos(v - 3.141592 / 2) * 1.732050808f;
+        r[0]    = s + u * 2 * m;
+        r[1]    = s - u * (m + n);
+        r[2]    = s - u * (m - n);
+
+        // STBTT_assert( STBTT_fabs(((r[0]+a)*r[0]+b)*r[0]+c) < 0.05f);  // these asserts may not be
+        // safe at all scales, though they're in bezier t parameter units so maybe? STBTT_assert(
+        // STBTT_fabs(((r[1]+a)*r[1]+b)*r[1]+c) < 0.05f); STBTT_assert(
+        // STBTT_fabs(((r[2]+a)*r[2]+b)*r[2]+c) < 0.05f);
+        return 3;
+    }
+}
+
+STBTT_DEF unsigned char *stbtt_GetGlyphSDF(const stbtt_fontinfo *info,
+                                           float scale,
+                                           int glyph,
+                                           int padding,
+                                           unsigned char onedge_value,
+                                           float pixel_dist_scale,
+                                           int *width,
+                                           int *height,
+                                           int *xoff,
+                                           int *yoff)
+{
+    float scale_x = scale, scale_y = scale;
+    int ix0, iy0, ix1, iy1;
+    int w, h;
+    unsigned char *data;
+
+    // if one scale is 0, use same scale for both
+    if (scale_x == 0)
+        scale_x = scale_y;
+    if (scale_y == 0)
+    {
+        if (scale_x == 0)
+            return NULL;  // if both scales are 0, return NULL
+        scale_y = scale_x;
+    }
+
+    stbtt_GetGlyphBitmapBoxSubpixel(info, glyph, scale, scale, 0.0f, 0.0f, &ix0, &iy0, &ix1, &iy1);
+
+    // if empty, return NULL
+    if (ix0 == ix1 || iy0 == iy1)
+        return NULL;
+
+    ix0 -= padding;
+    iy0 -= padding;
+    ix1 += padding;
+    iy1 += padding;
+
+    w = (ix1 - ix0);
+    h = (iy1 - iy0);
+
+    if (width)
+        *width = w;
+    if (height)
+        *height = h;
+    if (xoff)
+        *xoff = ix0;
+    if (yoff)
+        *yoff = iy0;
+
+    // invert for y-downwards bitmaps
+    scale_y = -scale_y;
+
+    {
+        int x, y, i, j;
+        float *precompute;
+        stbtt_vertex *verts;
+        int num_verts = stbtt_GetGlyphShape(info, glyph, &verts);
+        data          = (unsigned char *)STBTT_malloc(w * h, info->userdata);
+        precompute    = (float *)STBTT_malloc(num_verts * sizeof(float), info->userdata);
+
+        for (i = 0, j = num_verts - 1; i < num_verts; j = i++)
+        {
+            if (verts[i].type == STBTT_vline)
+            {
+                float x0 = verts[i].x * scale_x, y0 = verts[i].y * scale_y;
+                float x1 = verts[j].x * scale_x, y1 = verts[j].y * scale_y;
+                float dist    = (float)STBTT_sqrt((x1 - x0) * (x1 - x0) + (y1 - y0) * (y1 - y0));
+                precompute[i] = (dist == 0) ? 0.0f : 1.0f / dist;
+            }
+            else if (verts[i].type == STBTT_vcurve)
+            {
+                float x2 = verts[j].x * scale_x, y2 = verts[j].y * scale_y;
+                float x1 = verts[i].cx * scale_x, y1 = verts[i].cy * scale_y;
+                float x0 = verts[i].x * scale_x, y0 = verts[i].y * scale_y;
+                float bx = x0 - 2 * x1 + x2, by = y0 - 2 * y1 + y2;
+                float len2 = bx * bx + by * by;
+                if (len2 != 0.0f)
+                    precompute[i] = 1.0f / (bx * bx + by * by);
+                else
+                    precompute[i] = 0.0f;
+            }
+            else
+                precompute[i] = 0.0f;
+        }
+
+        for (y = iy0; y < iy1; ++y)
+        {
+            for (x = ix0; x < ix1; ++x)
+            {
+                float val;
+                float min_dist = 999999.0f;
+                float sx       = (float)x + 0.5f;
+                float sy       = (float)y + 0.5f;
+                float x_gspace = (sx / scale_x);
+                float y_gspace = (sy / scale_y);
+
+                int winding = stbtt__compute_crossings_x(
+                    x_gspace, y_gspace, num_verts,
+                    verts);  // @OPTIMIZE: this could just be a rasterization, but needs to be line
+                             // vs. non-tesselated curves so a new path
+
+                for (i = 0; i < num_verts; ++i)
+                {
+                    float x0 = verts[i].x * scale_x, y0 = verts[i].y * scale_y;
+
+                    // check against every point here rather than inside line/curve primitives --
+                    // @TODO: wrong if multiple 'moves' in a row produce a garbage point, and given
+                    // culling, probably more efficient to do within line/curve
+                    float dist2 = (x0 - sx) * (x0 - sx) + (y0 - sy) * (y0 - sy);
+                    if (dist2 < min_dist * min_dist)
+                        min_dist = (float)STBTT_sqrt(dist2);
+
+                    if (verts[i].type == STBTT_vline)
+                    {
+                        float x1 = verts[i - 1].x * scale_x, y1 = verts[i - 1].y * scale_y;
+
+                        // coarse culling against bbox
+                        // if (sx > STBTT_min(x0,x1)-min_dist && sx < STBTT_max(x0,x1)+min_dist &&
+                        //    sy > STBTT_min(y0,y1)-min_dist && sy < STBTT_max(y0,y1)+min_dist)
+                        float dist =
+                            (float)STBTT_fabs((x1 - x0) * (y0 - sy) - (y1 - y0) * (x0 - sx)) *
+                            precompute[i];
+                        STBTT_assert(i != 0);
+                        if (dist < min_dist)
+                        {
+                            // check position along line
+                            // x' = x0 + t*(x1-x0), y' = y0 + t*(y1-y0)
+                            // minimize (x'-sx)*(x'-sx)+(y'-sy)*(y'-sy)
+                            float dx = x1 - x0, dy = y1 - y0;
+                            float px = x0 - sx, py = y0 - sy;
+                            // minimize (px+t*dx)^2 + (py+t*dy)^2 = px*px + 2*px*dx*t + t^2*dx*dx +
+                            // py*py + 2*py*dy*t + t^2*dy*dy derivative: 2*px*dx + 2*py*dy +
+                            // (2*dx*dx+2*dy*dy)*t, set to 0 and solve
+                            float t = -(px * dx + py * dy) / (dx * dx + dy * dy);
+                            if (t >= 0.0f && t <= 1.0f)
+                                min_dist = dist;
+                        }
+                    }
+                    else if (verts[i].type == STBTT_vcurve)
+                    {
+                        float x2 = verts[i - 1].x * scale_x, y2 = verts[i - 1].y * scale_y;
+                        float x1 = verts[i].cx * scale_x, y1 = verts[i].cy * scale_y;
+                        float box_x0 = STBTT_min(STBTT_min(x0, x1), x2);
+                        float box_y0 = STBTT_min(STBTT_min(y0, y1), y2);
+                        float box_x1 = STBTT_max(STBTT_max(x0, x1), x2);
+                        float box_y1 = STBTT_max(STBTT_max(y0, y1), y2);
+                        // coarse culling against bbox to avoid computing cubic unnecessarily
+                        if (sx > box_x0 - min_dist && sx < box_x1 + min_dist &&
+                            sy > box_y0 - min_dist && sy < box_y1 + min_dist)
+                        {
+                            int num  = 0;
+                            float ax = x1 - x0, ay = y1 - y0;
+                            float bx = x0 - 2 * x1 + x2, by = y0 - 2 * y1 + y2;
+                            float mx = x0 - sx, my = y0 - sy;
+                            float res[3], px, py, t, it;
+                            float a_inv = precompute[i];
+                            if (a_inv == 0.0)
+                            {  // if a_inv is 0, it's 2nd degree so use quadratic formula
+                                float a = 3 * (ax * bx + ay * by);
+                                float b = 2 * (ax * ax + ay * ay) + (mx * bx + my * by);
+                                float c = mx * ax + my * ay;
+                                if (a == 0.0)
+                                {  // if a is 0, it's linear
+                                    if (b != 0.0)
+                                    {
+                                        res[num++] = -c / b;
+                                    }
+                                }
+                                else
+                                {
+                                    float discriminant = b * b - 4 * a * c;
+                                    if (discriminant < 0)
+                                        num = 0;
+                                    else
+                                    {
+                                        float root = (float)STBTT_sqrt(discriminant);
+                                        res[0]     = (-b - root) / (2 * a);
+                                        res[1]     = (-b + root) / (2 * a);
+                                        num = 2;  // don't bother distinguishing 1-solution case, as
+                                                  // code below will still work
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                float b = 3 * (ax * bx + ay * by) *
+                                          a_inv;  // could precompute this as it doesn't depend on
+                                                  // sample point
+                                float c = (2 * (ax * ax + ay * ay) + (mx * bx + my * by)) * a_inv;
+                                float d = (mx * ax + my * ay) * a_inv;
+                                num     = stbtt__solve_cubic(b, c, d, res);
+                            }
+                            if (num >= 1 && res[0] >= 0.0f && res[0] <= 1.0f)
+                            {
+                                t = res[0], it = 1.0f - t;
+                                px    = it * it * x0 + 2 * t * it * x1 + t * t * x2;
+                                py    = it * it * y0 + 2 * t * it * y1 + t * t * y2;
+                                dist2 = (px - sx) * (px - sx) + (py - sy) * (py - sy);
+                                if (dist2 < min_dist * min_dist)
+                                    min_dist = (float)STBTT_sqrt(dist2);
+                            }
+                            if (num >= 2 && res[1] >= 0.0f && res[1] <= 1.0f)
+                            {
+                                t = res[1], it = 1.0f - t;
+                                px    = it * it * x0 + 2 * t * it * x1 + t * t * x2;
+                                py    = it * it * y0 + 2 * t * it * y1 + t * t * y2;
+                                dist2 = (px - sx) * (px - sx) + (py - sy) * (py - sy);
+                                if (dist2 < min_dist * min_dist)
+                                    min_dist = (float)STBTT_sqrt(dist2);
+                            }
+                            if (num >= 3 && res[2] >= 0.0f && res[2] <= 1.0f)
+                            {
+                                t = res[2], it = 1.0f - t;
+                                px    = it * it * x0 + 2 * t * it * x1 + t * t * x2;
+                                py    = it * it * y0 + 2 * t * it * y1 + t * t * y2;
+                                dist2 = (px - sx) * (px - sx) + (py - sy) * (py - sy);
+                                if (dist2 < min_dist * min_dist)
+                                    min_dist = (float)STBTT_sqrt(dist2);
+                            }
+                        }
+                    }
+                }
+                if (winding == 0)
+                    min_dist = -min_dist;  // if outside the shape, value is negative
+                val = onedge_value + pixel_dist_scale * min_dist;
+                if (val < 0)
+                    val = 0;
+                else if (val > 255)
+                    val = 255;
+                data[(y - iy0) * w + (x - ix0)] = (unsigned char)val;
+            }
+        }
+        STBTT_free(precompute, info->userdata);
+        STBTT_free(verts, info->userdata);
+    }
+    return data;
+}
+
+STBTT_DEF unsigned char *stbtt_GetCodepointSDF(const stbtt_fontinfo *info,
+                                               float scale,
+                                               int codepoint,
+                                               int padding,
+                                               unsigned char onedge_value,
+                                               float pixel_dist_scale,
+                                               int *width,
+                                               int *height,
+                                               int *xoff,
+                                               int *yoff)
+{
+    return stbtt_GetGlyphSDF(info, scale, stbtt_FindGlyphIndex(info, codepoint), padding,
+                             onedge_value, pixel_dist_scale, width, height, xoff, yoff);
+}
+
+STBTT_DEF void stbtt_FreeSDF(unsigned char *bitmap, void *userdata)
+{
+    STBTT_free(bitmap, userdata);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// font name matching -- recommended not to use this
+//
+
+// check if a utf8 string contains a prefix which is the utf16 string; if so return length of
+// matching utf8 string
+static stbtt_int32 stbtt__CompareUTF8toUTF16_bigendian_prefix(stbtt_uint8 *s1,
+                                                              stbtt_int32 len1,
+                                                              stbtt_uint8 *s2,
+                                                              stbtt_int32 len2)
+{
+    stbtt_int32 i = 0;
+
+    // convert utf16 to utf8 and compare the results while converting
+    while (len2)
+    {
+        stbtt_uint16 ch = s2[0] * 256 + s2[1];
+        if (ch < 0x80)
+        {
+            if (i >= len1)
+                return -1;
+            if (s1[i++] != ch)
+                return -1;
+        }
+        else if (ch < 0x800)
+        {
+            if (i + 1 >= len1)
+                return -1;
+            if (s1[i++] != 0xc0 + (ch >> 6))
+                return -1;
+            if (s1[i++] != 0x80 + (ch & 0x3f))
+                return -1;
+        }
+        else if (ch >= 0xd800 && ch < 0xdc00)
+        {
+            stbtt_uint32 c;
+            stbtt_uint16 ch2 = s2[2] * 256 + s2[3];
+            if (i + 3 >= len1)
+                return -1;
+            c = ((ch - 0xd800) << 10) + (ch2 - 0xdc00) + 0x10000;
+            if (s1[i++] != 0xf0 + (c >> 18))
+                return -1;
+            if (s1[i++] != 0x80 + ((c >> 12) & 0x3f))
+                return -1;
+            if (s1[i++] != 0x80 + ((c >> 6) & 0x3f))
+                return -1;
+            if (s1[i++] != 0x80 + ((c)&0x3f))
+                return -1;
+            s2 += 2;  // plus another 2 below
+            len2 -= 2;
+        }
+        else if (ch >= 0xdc00 && ch < 0xe000)
+        {
+            return -1;
+        }
+        else
+        {
+            if (i + 2 >= len1)
+                return -1;
+            if (s1[i++] != 0xe0 + (ch >> 12))
+                return -1;
+            if (s1[i++] != 0x80 + ((ch >> 6) & 0x3f))
+                return -1;
+            if (s1[i++] != 0x80 + ((ch)&0x3f))
+                return -1;
+        }
+        s2 += 2;
+        len2 -= 2;
+    }
+    return i;
+}
+
+static int stbtt_CompareUTF8toUTF16_bigendian_internal(char *s1, int len1, char *s2, int len2)
+{
+    return len1 == stbtt__CompareUTF8toUTF16_bigendian_prefix((stbtt_uint8 *)s1, len1,
+                                                              (stbtt_uint8 *)s2, len2);
+}
+
+// returns results in whatever encoding you request... but note that 2-byte encodings
+// will be BIG-ENDIAN... use stbtt_CompareUTF8toUTF16_bigendian() to compare
+STBTT_DEF const char *stbtt_GetFontNameString(const stbtt_fontinfo *font,
+                                              int *length,
+                                              int platformID,
+                                              int encodingID,
+                                              int languageID,
+                                              int nameID)
+{
+    stbtt_int32 i, count, stringOffset;
+    stbtt_uint8 *fc     = font->data;
+    stbtt_uint32 offset = font->fontstart;
+    stbtt_uint32 nm     = stbtt__find_table(fc, offset, "name");
+    if (!nm)
+        return NULL;
+
+    count        = ttUSHORT(fc + nm + 2);
+    stringOffset = nm + ttUSHORT(fc + nm + 4);
+    for (i = 0; i < count; ++i)
+    {
+        stbtt_uint32 loc = nm + 6 + 12 * i;
+        if (platformID == ttUSHORT(fc + loc + 0) && encodingID == ttUSHORT(fc + loc + 2) &&
+            languageID == ttUSHORT(fc + loc + 4) && nameID == ttUSHORT(fc + loc + 6))
+        {
+            *length = ttUSHORT(fc + loc + 8);
+            return (const char *)(fc + stringOffset + ttUSHORT(fc + loc + 10));
+        }
+    }
+    return NULL;
+}
+
+static int stbtt__matchpair(stbtt_uint8 *fc,
+                            stbtt_uint32 nm,
+                            stbtt_uint8 *name,
+                            stbtt_int32 nlen,
+                            stbtt_int32 target_id,
+                            stbtt_int32 next_id)
+{
+    stbtt_int32 i;
+    stbtt_int32 count        = ttUSHORT(fc + nm + 2);
+    stbtt_int32 stringOffset = nm + ttUSHORT(fc + nm + 4);
+
+    for (i = 0; i < count; ++i)
+    {
+        stbtt_uint32 loc = nm + 6 + 12 * i;
+        stbtt_int32 id   = ttUSHORT(fc + loc + 6);
+        if (id == target_id)
+        {
+            // find the encoding
+            stbtt_int32 platform = ttUSHORT(fc + loc + 0), encoding = ttUSHORT(fc + loc + 2),
+                        language = ttUSHORT(fc + loc + 4);
+
+            // is this a Unicode encoding?
+            if (platform == 0 || (platform == 3 && encoding == 1) ||
+                (platform == 3 && encoding == 10))
+            {
+                stbtt_int32 slen = ttUSHORT(fc + loc + 8);
+                stbtt_int32 off  = ttUSHORT(fc + loc + 10);
+
+                // check if there's a prefix match
+                stbtt_int32 matchlen = stbtt__CompareUTF8toUTF16_bigendian_prefix(
+                    name, nlen, fc + stringOffset + off, slen);
+                if (matchlen >= 0)
+                {
+                    // check for target_id+1 immediately following, with same encoding & language
+                    if (i + 1 < count && ttUSHORT(fc + loc + 12 + 6) == next_id &&
+                        ttUSHORT(fc + loc + 12) == platform &&
+                        ttUSHORT(fc + loc + 12 + 2) == encoding &&
+                        ttUSHORT(fc + loc + 12 + 4) == language)
+                    {
+                        slen = ttUSHORT(fc + loc + 12 + 8);
+                        off  = ttUSHORT(fc + loc + 12 + 10);
+                        if (slen == 0)
+                        {
+                            if (matchlen == nlen)
+                                return 1;
+                        }
+                        else if (matchlen < nlen && name[matchlen] == ' ')
+                        {
+                            ++matchlen;
+                            if (stbtt_CompareUTF8toUTF16_bigendian_internal(
+                                    (char *)(name + matchlen), nlen - matchlen,
+                                    (char *)(fc + stringOffset + off), slen))
+                                return 1;
+                        }
+                    }
+                    else
+                    {
+                        // if nothing immediately following
+                        if (matchlen == nlen)
+                            return 1;
+                    }
+                }
+            }
+
+            // @TODO handle other encodings
+        }
+    }
+    return 0;
+}
+
+static int stbtt__matches(stbtt_uint8 *fc,
+                          stbtt_uint32 offset,
+                          stbtt_uint8 *name,
+                          stbtt_int32 flags)
+{
+    stbtt_int32 nlen = (stbtt_int32)STBTT_strlen((char *)name);
+    stbtt_uint32 nm, hd;
+    if (!stbtt__isfont(fc + offset))
+        return 0;
+
+    // check italics/bold/underline flags in macStyle...
+    if (flags)
+    {
+        hd = stbtt__find_table(fc, offset, "head");
+        if ((ttUSHORT(fc + hd + 44) & 7) != (flags & 7))
+            return 0;
+    }
+
+    nm = stbtt__find_table(fc, offset, "name");
+    if (!nm)
+        return 0;
+
+    if (flags)
+    {
+        // if we checked the macStyle flags, then just check the family and ignore the subfamily
+        if (stbtt__matchpair(fc, nm, name, nlen, 16, -1))
+            return 1;
+        if (stbtt__matchpair(fc, nm, name, nlen, 1, -1))
+            return 1;
+        if (stbtt__matchpair(fc, nm, name, nlen, 3, -1))
+            return 1;
+    }
+    else
+    {
+        if (stbtt__matchpair(fc, nm, name, nlen, 16, 17))
+            return 1;
+        if (stbtt__matchpair(fc, nm, name, nlen, 1, 2))
+            return 1;
+        if (stbtt__matchpair(fc, nm, name, nlen, 3, -1))
+            return 1;
+    }
+
+    return 0;
+}
+
+static int stbtt_FindMatchingFont_internal(unsigned char *font_collection,
+                                           char *name_utf8,
+                                           stbtt_int32 flags)
+{
+    stbtt_int32 i;
+    for (i = 0;; ++i)
+    {
+        stbtt_int32 off = stbtt_GetFontOffsetForIndex(font_collection, i);
+        if (off < 0)
+            return off;
+        if (stbtt__matches((stbtt_uint8 *)font_collection, off, (stbtt_uint8 *)name_utf8, flags))
+            return off;
+    }
+}
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
+
+STBTT_DEF int stbtt_BakeFontBitmap(const unsigned char *data,
+                                   int offset,
+                                   float pixel_height,
+                                   unsigned char *pixels,
+                                   int pw,
+                                   int ph,
+                                   int first_char,
+                                   int num_chars,
+                                   stbtt_bakedchar *chardata)
+{
+    return stbtt_BakeFontBitmap_internal((unsigned char *)data, offset, pixel_height, pixels, pw,
+                                         ph, first_char, num_chars, chardata);
+}
+
+STBTT_DEF int stbtt_GetFontOffsetForIndex(const unsigned char *data, int index)
+{
+    return stbtt_GetFontOffsetForIndex_internal((unsigned char *)data, index);
+}
+
+STBTT_DEF int stbtt_GetNumberOfFonts(const unsigned char *data)
+{
+    return stbtt_GetNumberOfFonts_internal((unsigned char *)data);
+}
+
+STBTT_DEF int stbtt_InitFont(stbtt_fontinfo *info, const unsigned char *data, int offset)
+{
+    return stbtt_InitFont_internal(info, (unsigned char *)data, offset);
+}
+
+STBTT_DEF int stbtt_FindMatchingFont(const unsigned char *fontdata, const char *name, int flags)
+{
+    return stbtt_FindMatchingFont_internal((unsigned char *)fontdata, (char *)name, flags);
+}
+
+STBTT_DEF int stbtt_CompareUTF8toUTF16_bigendian(const char *s1, int len1, const char *s2, int len2)
+{
+    return stbtt_CompareUTF8toUTF16_bigendian_internal((char *)s1, len1, (char *)s2, len2);
+}
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+#endif  // STB_TRUETYPE_IMPLEMENTATION
+
+// FULL VERSION HISTORY
+//
+//   1.19 (2018-02-11) OpenType GPOS kerning (horizontal only), STBTT_fmod
+//   1.18 (2018-01-29) add missing function
+//   1.17 (2017-07-23) make more arguments const; doc fix
+//   1.16 (2017-07-12) SDF support
+//   1.15 (2017-03-03) make more arguments const
+//   1.14 (2017-01-16) num-fonts-in-TTC function
+//   1.13 (2017-01-02) support OpenType fonts, certain Apple fonts
+//   1.12 (2016-10-25) suppress warnings about casting away const with -Wcast-qual
+//   1.11 (2016-04-02) fix unused-variable warning
+//   1.10 (2016-04-02) allow user-defined fabs() replacement
+//                     fix memory leak if fontsize=0.0
+//                     fix warning from duplicate typedef
+//   1.09 (2016-01-16) warning fix; avoid crash on outofmem; use alloc userdata for PackFontRanges
+//   1.08 (2015-09-13) document stbtt_Rasterize(); fixes for vertical & horizontal edges
+//   1.07 (2015-08-01) allow PackFontRanges to accept arrays of sparse codepoints;
+//                     allow PackFontRanges to pack and render in separate phases;
+//                     fix stbtt_GetFontOFfsetForIndex (never worked for non-0 input?);
+//                     fixed an assert() bug in the new rasterizer
+//                     replace assert() with STBTT_assert() in new rasterizer
+//   1.06 (2015-07-14) performance improvements (~35% faster on x86 and x64 on test machine)
+//                     also more precise AA rasterizer, except if shapes overlap
+//                     remove need for STBTT_sort
+//   1.05 (2015-04-15) fix misplaced definitions for STBTT_STATIC
+//   1.04 (2015-04-15) typo in example
+//   1.03 (2015-04-12) STBTT_STATIC, fix memory leak in new packing, various fixes
+//   1.02 (2014-12-10) fix various warnings & compile issues w/ stb_rect_pack, C++
+//   1.01 (2014-12-08) fix subpixel position when oversampling to exactly match
+//                        non-oversampled; STBTT_POINT_SIZE for packed case only
+//   1.00 (2014-12-06) add new PackBegin etc. API, w/ support for oversampling
+//   0.99 (2014-09-18) fix multiple bugs with subpixel rendering (ryg)
+//   0.9  (2014-08-07) support certain mac/iOS fonts without an MS platformID
+//   0.8b (2014-07-07) fix a warning
+//   0.8  (2014-05-25) fix a few more warnings
+//   0.7  (2013-09-25) bugfix: subpixel glyph bug fixed in 0.5 had come back
+//   0.6c (2012-07-24) improve documentation
+//   0.6b (2012-07-20) fix a few more warnings
+//   0.6  (2012-07-17) fix warnings; added stbtt_ScaleForMappingEmToPixels,
+//                        stbtt_GetFontBoundingBox, stbtt_IsGlyphEmpty
+//   0.5  (2011-12-09) bugfixes:
+//                        subpixel glyph renderer computed wrong bounding box
+//                        first vertex of shape can be off-curve (FreeSans)
+//   0.4b (2011-12-03) fixed an error in the font baking example
+//   0.4  (2011-12-01) kerning, subpixel rendering (tor)
+//                    bugfixes for:
+//                        codepoint-to-glyph conversion using table fmt=12
+//                        codepoint-to-glyph conversion using table fmt=4
+//                        stbtt_GetBakedQuad with non-square texture (Zer)
+//                    updated Hello World! sample to use kerning and subpixel
+//                    fixed some warnings
+//   0.3  (2009-06-24) cmap fmt=12, compound shapes (MM)
+//                    userdata, malloc-from-userdata, non-zero fill (stb)
+//   0.2  (2009-03-11) Fix unsigned/signed char warnings
+//   0.1  (2009-03-09) First public release
+//
+
+/*
+------------------------------------------------------------------------------
+This software is available under 2 licenses -- choose whichever you prefer.
+------------------------------------------------------------------------------
+ALTERNATIVE A - MIT License
+Copyright (c) 2017 Sean Barrett
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+------------------------------------------------------------------------------
+ALTERNATIVE B - Public Domain (www.unlicense.org)
+This is free and unencumbered software released into the public domain.
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this
+software, either in source code form or as a compiled binary, for any purpose,
+commercial or non-commercial, and by any means.
+In jurisdictions that recognize copyright laws, the author or authors of this
+software dedicate any and all copyright interest in the software to the public
+domain. We make this dedication for the benefit of the public at large and to
+the detriment of our heirs and successors. We intend this dedication to be an
+overt act of relinquishment in perpetuity of all present and future rights to
+this software under copyright law.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+------------------------------------------------------------------------------
+*/


### PR DESCRIPTION
1. Add alpha blending toggle to Aquarium. By default, alpha
blending is disabled. To enable alpha blending, you can
pass "--enable-alpha-blending=[0, 1]" by cmd args.
2. Replace alpha value of shaders by regex to specify the alpha
value.
3. Because imgui enabled alpha blending to show text, which renders
text by an gray bitmap, the logic of imgui is revised to show
text when alpha blending is disabled. In addition,imgui is compiled
as source files of the project instead of third party.