### PR TITLE
Fix mismatching binutils configuration

### DIFF
--- a/build_overrides/build.gni
+++ b/build_overrides/build.gni
@@ -8,6 +8,6 @@ build_with_chromium = false
 
 use_system_xcode = true
 
-linux_use_bundled_binutils_override = true
+linux_use_bundled_binutils_override = false
 
 ignore_elf32_limitations = false


### PR DESCRIPTION
The hermetic binutils are missing in the DEPS file, but building can still finish quietly because system ones would be used as the fallback. To avoid confusion, tentatively unset linux_use_bundled_binutils_override in GN configuration.
