### PR TITLE
Print average fps

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,8 +305,8 @@ aquarium.exe --num-fish 10000 --backend dawn_d3d12 --buffer-mapping-async
 # "--enable-full-screen-mode" : Render aquarium in full screen mode instead of window mode.
 aquarium.exe --num-fish 10000 --backend dawn_d3d12 --enable-full-screen-mode
 
-# "--record-fps-frequency [count]" : Run aquarium 10 min and print fps log when exit.
-aquarium.exe --num-fish 10000 --backend dawn_d3d12 --record-fps-frequency [count]
+# "--print-log" : print log including average fps when exit the application.
+aquarium.exe --num-fish 10000 --backend dawn_d3d12 --print-log
 
 # "--test-time [second]" : Render the application for some second and then exit, and the application will run 5 min by default.
 aquarium.exe --num-fish 10000 --backend dawn_d3d12 --test-time 30

--- a/src/aquarium-optimized/Aquarium.cpp
+++ b/src/aquarium-optimized/Aquarium.cpp
@@ -290,21 +290,9 @@ bool Aquarium::init(int argc, char **argv)
 
             toggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEFULLSCREENMODE));
         }
-        else if (cmd == "--record-fps-frequency")
+        else if (cmd == "--print-log")
         {
-            toggleBitset.set(static_cast<size_t>(TOGGLE::RECORDFPSFREQUENCY));
-            if (argv[i + 1] == nullptr)
-            {
-                std::cout << "Please specify record fps frequency." << std::endl;
-                return false;
-            }
-
-            logCount = strtol(argv[i++ + 1], &pNext, 10);
-            if (logCount == 0)
-            {
-                std::cout << "Please input a number after --record-fps-frequency." << std::endl;
-                return false;
-            }
+            toggleBitset.set(static_cast<size_t>(TOGGLE::PRINTLOG));
         }
         else if (cmd == "--buffer-mapping-async")
         {
@@ -444,9 +432,9 @@ void Aquarium::display()
 
     mContext->Terminate();
 
-    if (toggleBitset.test(static_cast<size_t>(TOGGLE::RECORDFPSFREQUENCY)))
+    if (toggleBitset.test(static_cast<size_t>(TOGGLE::PRINTLOG)))
     {
-        printRecordFps();
+        printAvgFps();
     }
 }
 
@@ -711,24 +699,15 @@ double Aquarium::getElapsedTime()
     return elapsedTime;
 }
 
-void Aquarium::printRecordFps()
+void Aquarium::printAvgFps()
 {
-    std::vector<float> fps = mFpsTimer.getRecordFps();
-    if (fps.size() == 0)
-    {
-        std::cout << "No fps data, maybe record frequency count is too large or rendering time is "
-                     "too short."
-                  << std::endl;
-        return;
-    }
+    int avg = mFpsTimer.variance();
 
-    std::cout << "Print FPS Data:" << std::endl;
-    for (auto f : fps)
+    std::cout << "Avg FPS: " << avg << std::endl;
+    if (avg == 0)
     {
-        std::cout << f << ";";
+        std::cout << "Invalid value. The fps is unstable." << std::endl;
     }
-
-    std::cout << std::endl << "End." << std::endl;
 }
 
 void Aquarium::updateGlobalUniforms()

--- a/src/aquarium-optimized/Aquarium.h
+++ b/src/aquarium-optimized/Aquarium.h
@@ -131,8 +131,8 @@ enum TOGGLE : short
     UPATEANDDRAWFOREACHMODEL,
     // Support Full Screen mode
     ENABLEFULLSCREENMODE,
-    // Log fps frequency
-    RECORDFPSFREQUENCY,
+    // Print logs such as avg fps
+    PRINTLOG,
     // Use async buffer mapping to upload data
     BUFFERMAPPINGASYNC,
     // Turn off vsync, donot limit fps to 60
@@ -478,7 +478,7 @@ class Aquarium
     void updateWorldProjections(const std::vector<float> &w);
     BACKENDTYPE getBackendType(const std::string &backendPath);
     double getElapsedTime();
-    void printRecordFps();
+    void printAvgFps();
     void resetFpsTime();
     void updateWorldMatrix(Model *model);
 

--- a/src/common/FPSTimer.cpp
+++ b/src/common/FPSTimer.cpp
@@ -18,7 +18,6 @@ FPSTimer::FPSTimer()
 	  mTimeTableCursor(0),
       mHistoryFPS(NUM_HISTORY_DATA, 1.0f),
       mHistoryFrameTime(NUM_HISTORY_DATA, 100.0f),
-      mRecordFpsFrequencyCursor(0),
       mAverageFPS(0.0)
 {}
 
@@ -42,18 +41,28 @@ void FPSTimer::update(double elapsedTime, double renderingTime, int logCount)
     }
     mHistoryFPS[NUM_HISTORY_DATA - 1]       = mAverageFPS;
     mHistoryFrameTime[NUM_HISTORY_DATA - 1] = 1000.0 / mAverageFPS;
-
-    // Ignore first 5s.
-    if (renderingTime < 5)
-	{
-       return;
-	}
-
-    if (mRecordFpsFrequencyCursor % logCount == 0)
-    {
-        mRecordFps.push_back(mAverageFPS);
-        mRecordFpsFrequencyCursor = 0;
-    }
-    mRecordFpsFrequencyCursor++;
 }
 
+int FPSTimer::variance() const
+{
+    float avg = 0.f;
+    for (int i = 0; i < NUM_HISTORY_DATA; i++)
+    {
+        avg += mHistoryFPS[i];
+    }
+    avg /= NUM_HISTORY_DATA;
+
+    float var = 0.f;
+    for (int i = 0; i < NUM_HISTORY_DATA; i++)
+    {
+        var += pow(mHistoryFPS[i] - avg, 2);
+    }
+    var /= NUM_HISTORY_DATA;
+
+    if (var < FPS_VALID_THRESHOLD)
+    {
+        return ceil(avg);
+    }
+
+    return 0;
+}

--- a/src/common/FPSTimer.h
+++ b/src/common/FPSTimer.h
@@ -13,6 +13,7 @@
 
 constexpr int NUM_HISTORY_DATA = 100;
 constexpr int NUM_FRAMES_TO_AVERAGE = 128;
+constexpr int FPS_VALID_THRESHOLD   = 5;
 
 class FPSTimer
 {
@@ -23,7 +24,7 @@ public:
   double getAverageFPS() const { return mAverageFPS; }
   const float *getHistoryFps() const { return mHistoryFPS.data(); }
   const float *getHistoryFrameTime() const { return mHistoryFrameTime.data(); }
-  std::vector<float> &getRecordFps() { return mRecordFps; }
+  int variance() const;
 
 private:
   double mTotalTime;
@@ -32,8 +33,7 @@ private:
 
   std::vector<float> mHistoryFPS;
   std::vector<float> mHistoryFrameTime;
-  std::vector<float> mRecordFps;
-  int mRecordFpsFrequencyCursor;
+
   double mAverageFPS;
 };
 

--- a/src/include/CmdArgsHelper.h
+++ b/src/include/CmdArgsHelper.h
@@ -20,7 +20,7 @@ const char *cmdArgsStrAquarium = R"(Options and arguments:
 --enable-full-screen-mode       : Render aquarium in full screen mode instead of window mode.
 --integrated-gpu        : Choose integrated gpu to render the application. This is only supported on Dawn and D3D12 backend.
 --num-fish [count]      : specifies how many fishes will be rendered.
---record-fps-frequency [count]  : Record fps every count frame and print fps log when exit.
+--print-log             : print logs including avarage fps when exit the application. 
 --test-time [second]    : Render the application for some second and then exit, and the application will run 5 min by default.
 --turn-off-vsync        : Unlimit 60 fps. 
 --disable-d3d12-render-pass   : Turn off render pass for dawn_d3d12 and d3d12 backend.


### PR DESCRIPTION
Pass toggle '--print-average-fps' to print the fps when exit the app.
Variance of last 100 fps is calculated to judge if the fps is stable
or not. Print the average fps of last 100 fps if it's stable.