### PR TITLE
Negate third_party ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,10 +14,18 @@
 *.ini
 
 # Third party libraries
-/third_party/*
-!/third_party/glad
-!/third_party/imgui
-!/third_party/BUILD.gn
+/third_party/SPIRV-Tools/
+/third_party/angle/
+/third_party/dawn/
+/third_party/glfw/
+/third_party/glslang/
+/third_party/googletest/
+/third_party/jsoncpp/
+/third_party/llvm-build/
+/third_party/rapidjson/
+/third_party/stb/
+/third_party/vulkan-headers/
+/third_party/vulkan-validation-layers/
 
 # Gn build dummy folders
 /.cipd/


### PR DESCRIPTION
When trying to check in new files under third_party via "git add .", the original rules are error prone in that one can forget to update .gitignore in advance if "git status" doesn't mention the untracked files.
