### PR TITLE
Rebase Dawn

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -8,7 +8,7 @@ vars = {
   'chromium_git': 'https://chromium.googlesource.com',
   'github_git': 'https://github.com',
   'dawn_git': 'https://dawn.googlesource.com',
-  'dawn_revision': 'ce8bf128ec1327b28d933a15e055bda286f31231',
+  'dawn_revision': '631f4258a1ace016d6a10ebf7ff127ea46be8575',
   'angle_root': 'third_party/angle',
   'angle_revision': '6c824a1bc17b286b86cf05a0228ec549875351eb',
   'glslang_revision': '38b4db48f98c4e3a9cc405de3a76547b857e1c37',

--- a/src/aquarium-optimized/dawn/ContextDawn.cpp
+++ b/src/aquarium-optimized/dawn/ContextDawn.cpp
@@ -33,6 +33,7 @@
 #include "imgui_impl_glfw.h"
 #include "utils/BackendBinding.h"
 #include "utils/ComboRenderPipelineDescriptor.h"
+#include "utils/GLFWUtils.h"
 #include "utils/SystemUtils.h"
 
 #include "../Aquarium.h"
@@ -108,28 +109,28 @@ bool ContextDawn::initialize(
     int windowWidth,
     int windowHeight)
 {
-    dawn_native::BackendType backendType = dawn_native::BackendType::Null;
+    wgpu::BackendType backendType = wgpu::BackendType::Null;
 
     switch (backend)
     {
         case BACKENDTYPE::BACKENDTYPEDAWND3D12:
         {
-            backendType = dawn_native::BackendType::D3D12;
+            backendType = wgpu::BackendType::D3D12;
             break;
         }
         case BACKENDTYPE::BACKENDTYPEDAWNVULKAN:
         {
-            backendType = dawn_native::BackendType::Vulkan;
+            backendType = wgpu::BackendType::Vulkan;
             break;
         }
         case BACKENDTYPE::BACKENDTYPEDAWNMETAL:
         {
-            backendType = dawn_native::BackendType::Metal;
+            backendType = wgpu::BackendType::Metal;
             break;
         }
         case BACKENDTYPE::BACKENDTYPEOPENGL:
         {
-            backendType = dawn_native::BackendType::OpenGL;
+            backendType = wgpu::BackendType::OpenGL;
             break;
         }
         default:
@@ -279,7 +280,7 @@ void ContextDawn::framebufferResizeCallback(GLFWwindow *window, int width, int h
 bool ContextDawn::GetHardwareAdapter(
     std::unique_ptr<dawn_native::Instance> &instance,
     dawn_native::Adapter *backendAdapter,
-    dawn_native::BackendType backendType,
+    wgpu::BackendType backendType,
     const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset)
 {
     bool enableIntegratedGpu = toggleBitset.test(static_cast<size_t>(TOGGLE::INTEGRATEDGPU));
@@ -290,7 +291,9 @@ bool ContextDawn::GetHardwareAdapter(
     // Get an adapter for the backend to use, and create the Device.
     for (auto &adapter : instance->GetAdapters())
     {
-        if (adapter.GetBackendType() == backendType)
+        wgpu::AdapterProperties properties;
+        adapter.GetProperties(&properties);
+        if (properties.backendType == backendType)
         {
             if (useDefaultGpu ||
                 (enableDiscreteGpu &&

--- a/src/aquarium-optimized/dawn/ContextDawn.h
+++ b/src/aquarium-optimized/dawn/ContextDawn.h
@@ -131,8 +131,9 @@ class ContextDawn : public Context
     bool GetHardwareAdapter(
         std::unique_ptr<dawn_native::Instance> &instance,
         dawn_native::Adapter *backendAdapter,
-        dawn_native::BackendType backendType,
+        wgpu::BackendType backendType,
         const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset);
+
     void initAvailableToggleBitset(BACKENDTYPE backendType) override;
     static void framebufferResizeCallback(GLFWwindow *window, int width, int height);
     void destoryFishResource();


### PR DESCRIPTION
Backend type is moved from dawn_native namespace to wgpu name space.
But the backend type of dawn_native still exist while lead to
reduntant type cast in Aquarium. This should be fixed in Dawn in the
future.