### PR TITLE
Refactor createBufferFromData

### DIFF
--- a/src/aquarium-optimized/dawn/ContextDawn.cpp
+++ b/src/aquarium-optimized/dawn/ContextDawn.cpp
@@ -359,9 +359,12 @@ wgpu::Sampler ContextDawn::createSampler(const wgpu::SamplerDescriptor &descript
 
 wgpu::Buffer ContextDawn::createBufferFromData(const void *pixels,
                                                int size,
-                                               wgpu::BufferUsage usage) const
+                                               wgpu::BufferUsage usage)
 {
-    return utils::CreateBufferFromData(mDevice, pixels, size, usage);
+    wgpu::Buffer buffer = createBuffer(size, usage | wgpu::BufferUsage::CopyDst);
+
+    setBufferData(buffer, 0, size, pixels);
+    return buffer;
 }
 
 wgpu::BufferCopyView ContextDawn::createBufferCopyView(const wgpu::Buffer &buffer,

--- a/src/aquarium-optimized/dawn/ContextDawn.h
+++ b/src/aquarium-optimized/dawn/ContextDawn.h
@@ -61,7 +61,7 @@ class ContextDawn : public Context
     Texture *createTexture(const std::string &name, const std::vector<std::string> &urls) override;
     wgpu::Texture createTexture(const wgpu::TextureDescriptor &descriptor) const;
     wgpu::Sampler createSampler(const wgpu::SamplerDescriptor &descriptor) const;
-    wgpu::Buffer createBufferFromData(const void *pixels, int size, wgpu::BufferUsage usage) const;
+    wgpu::Buffer createBufferFromData(const void *pixels, int size, wgpu::BufferUsage usage);
     wgpu::BufferCopyView createBufferCopyView(const wgpu::Buffer &buffer,
                                               uint32_t offset,
                                               uint32_t rowPitch,

--- a/src/aquarium-optimized/dawn/imgui_impl_dawn.cpp
+++ b/src/aquarium-optimized/dawn/imgui_impl_dawn.cpp
@@ -195,10 +195,13 @@ static void ImGui_ImplDawn_CreateFontsTexture(bool enableAlphaBlending)
         descriptor.usage           = wgpu::TextureUsage::CopyDst | wgpu::TextureUsage::Sampled;
         mTexture                   = mContextDawn->createTexture(descriptor);
 
-        mStagingBuffer = mContextDawn->createBufferFromData(pixels, width * height * 4,
-                                                            wgpu::BufferUsage::CopySrc);
+        wgpu::CreateBufferMappedResult result = mContextDawn->CreateBufferMapped(
+            wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::MapWrite, width * height * 4);
+        memcpy(result.data, pixels, width * height * 4);
+        result.buffer.Unmap();
+
         wgpu::BufferCopyView bufferCopyView =
-            mContextDawn->createBufferCopyView(mStagingBuffer, 0, width * 4, height);
+            mContextDawn->createBufferCopyView(result.buffer, 0, width * 4, height);
         wgpu::TextureCopyView textureCopyView =
             mContextDawn->createTextureCopyView(mTexture, 0, 0, {0, 0, 0});
         wgpu::Extent3D copySize = {static_cast<uint32_t>(width), static_cast<uint32_t>(height), 1};


### PR DESCRIPTION
createBufferFromData uses setBufferData from dawn utils.
Refactor the function and use buffer mapping instead.

Refactor texture uploading of imgui Dawn.