### PR TITLE
Add initial CI scripts

### DIFF
--- a/BUILD_CONFIG/action.yml
+++ b/BUILD_CONFIG/action.yml
@@ -1,0 +1,9 @@
+name: 'BUILD_CONFIG'
+description: ''
+inputs:
+  build-config:
+    description: ''
+    required: false
+runs:
+  using: 'node12'
+  main: 'index.js'

--- a/BUILD_CONFIG/index.js
+++ b/BUILD_CONFIG/index.js
@@ -1,0 +1,15 @@
+// This script should be skipped when running locally.
+
+var assert = require('assert');
+var util = require('util');
+var actions = require('@actions/core');
+
+var build_config;
+switch (process.env['GITHUB_EVENT_NAME']) {
+    case 'pull_request':
+        build_config = actions.getInput('build-config');
+        break;
+    default:
+        assert.fail();
+}
+actions.exportVariable('BUILD_CONFIG', build_config);

--- a/GIT_EDITOR/action.yml
+++ b/GIT_EDITOR/action.yml
@@ -1,0 +1,5 @@
+name: 'GIT_EDITOR'
+description: ''
+runs:
+  using: 'node12'
+  main: 'index.js'

--- a/GIT_EDITOR/index.js
+++ b/GIT_EDITOR/index.js
@@ -1,0 +1,42 @@
+// This script should be skipped when running locally.
+
+var assert = require('assert');
+var path = require('path');
+var util = require('util');
+var actions = require('@actions/core');
+
+var work_dir = 'WORKSPACE_OVERRIDE' in process.env ? process.env['WORKSPACE_OVERRIDE'] :
+               'GITHUB_WORKSPACE' in process.env ? process.env['GITHUB_WORKSPACE'] :
+               process.cwd();
+work_dir = path.resolve(work_dir);
+
+var editor;
+switch (process.platform) {
+    case 'win32':
+        // Git for Windows runs in an MSYS2 environment, so the editor
+        // command is built for that environment.
+        var sep;
+        sep = path.sep;
+        work_dir = work_dir.split(sep).map(function (segment) {
+            if (/^\w+$/.test(segment)) return segment;
+            return segment.replace(/([$`"\\])/g, '\\$1').replace(/(.*)/, '"$1"');
+        });
+        sep = path.posix.sep;
+        editor = util.format("cp $(cygpath %s)%s%s", work_dir[0], sep, work_dir.slice(1).concat('git.txt').join(sep));
+        editor = [ 'sh', '-c', util.format('%s "$@"', editor), 'sh' ];
+        editor = editor.map(function (arg) {
+            if (/^\w+$/.test(arg)) return arg;
+            return arg.replace(/([$`"\\])/g, '\\$1').replace(/(.*)/, '"$1"');
+        }).join(' ');
+        break;
+    case 'linux':
+        editor = [ 'cp', path.join(work_dir, 'git.txt') ];
+        editor = editor.map(function (arg) {
+            if (/^\w+$/.test(arg)) return arg;
+            return arg.replace(/([$`"\\])/g, '\\$1').replace(/(.*)/, '"$1"');
+        }).join(' ');
+        break;
+    default:
+        assert.fail();
+}
+actions.exportVariable('GIT_EDITOR', editor);

--- a/GIT_TEMPLATE_DIR/action.yml
+++ b/GIT_TEMPLATE_DIR/action.yml
@@ -1,0 +1,5 @@
+name: 'GIT_TEMPLATE_DIR'
+description: ''
+runs:
+  using: 'node12'
+  main: 'index.js'

--- a/GIT_TEMPLATE_DIR/index.js
+++ b/GIT_TEMPLATE_DIR/index.js
@@ -1,0 +1,13 @@
+// This script should be skipped when running locally.
+
+var assert = require('assert');
+var path = require('path');
+var util = require('util');
+var actions = require('@actions/core');
+
+var work_dir = 'WORKSPACE_OVERRIDE' in process.env ? process.env['WORKSPACE_OVERRIDE'] :
+               'GITHUB_WORKSPACE' in process.env ? process.env['GITHUB_WORKSPACE'] :
+               process.cwd();
+work_dir = path.resolve(work_dir);
+
+actions.exportVariable('GIT_TEMPLATE_DIR', path.join(work_dir, 'git-templates'));

--- a/GN_EDITOR/action.yml
+++ b/GN_EDITOR/action.yml
@@ -1,0 +1,5 @@
+name: 'GN_EDITOR'
+description: ''
+runs:
+  using: 'node12'
+  main: 'index.js'

--- a/GN_EDITOR/index.js
+++ b/GN_EDITOR/index.js
@@ -1,0 +1,32 @@
+// This script should be skipped when running locally.
+
+var assert = require('assert');
+var path = require('path');
+var util = require('util');
+var actions = require('@actions/core');
+
+var work_dir = 'WORKSPACE_OVERRIDE' in process.env ? process.env['WORKSPACE_OVERRIDE'] :
+               'GITHUB_WORKSPACE' in process.env ? process.env['GITHUB_WORKSPACE'] :
+               process.cwd();
+work_dir = path.resolve(work_dir);
+
+var editor;
+switch (process.platform) {
+    case 'win32':
+        editor = [ 'COPY', path.join(work_dir, 'gn.txt') ];
+        editor = editor.map(function (arg) {
+            if (/^\w+$/.test(arg)) return arg;
+            return arg.replace(/((\\+)("|$))/g, '$2$1').replace(/"/g, '\\"').replace(/(.*)/, '"$1"');
+        }).join(' ');
+        break;
+    case 'linux':
+        editor = [ 'cp', path.join(work_dir, 'gn.txt') ];
+        editor = editor.map(function (arg) {
+            if (/^\w+$/.test(arg)) return arg;
+            return arg.replace(/([$`"\\])/g, '\\$1').replace(/(.*)/, '"$1"');
+        }).join(' ');
+        break;
+    default:
+        assert.fail();
+}
+actions.exportVariable('GN_EDITOR', editor);

--- a/WORKSPACE_OVERRIDE/action.yml
+++ b/WORKSPACE_OVERRIDE/action.yml
@@ -1,0 +1,9 @@
+name: 'WORKSPACE_OVERRIDE'
+description: ''
+inputs:
+  workspace-override:
+    description: ''
+    required: false
+runs:
+  using: 'node12'
+  main: 'index.js'

--- a/WORKSPACE_OVERRIDE/index.js
+++ b/WORKSPACE_OVERRIDE/index.js
@@ -1,0 +1,10 @@
+// This script should be skipped when running locally.
+
+var assert = require('assert');
+var path = require('path');
+var util = require('util');
+var actions = require('@actions/core');
+
+var workspace_override = actions.getInput('workspace-override');
+workspace_override = path.resolve(workspace_override);
+actions.exportVariable('WORKSPACE_OVERRIDE', workspace_override);

--- a/depot_tools/action.yml
+++ b/depot_tools/action.yml
@@ -1,0 +1,5 @@
+name: 'depot_tools'
+description: ''
+runs:
+  using: 'node12'
+  main: 'index.js'

--- a/depot_tools/index.js
+++ b/depot_tools/index.js
@@ -1,0 +1,100 @@
+// The GitHub runner environment is optional for this script, so it can work in local.
+
+var assert = require('assert');
+var child_process = require('child_process');
+var fs = require('fs');
+var glob = require('glob');
+var path = require('path');
+var util = require('util');
+
+var work_dir = 'WORKSPACE_OVERRIDE' in process.env ? process.env['WORKSPACE_OVERRIDE'] :
+               'GITHUB_WORKSPACE' in process.env ? process.env['GITHUB_WORKSPACE'] :
+               process.cwd();
+work_dir = path.resolve(work_dir);
+var temp_dir = fs.mkdtempSync(util.format('%s%s', work_dir, path.sep));
+var sub_work_dir;
+
+var pattern;
+var cmd;
+var options;
+
+fs.mkdirSync(path.join(temp_dir, 'git-templates'));
+
+// Sync directories
+pattern = 'git-templates/**';
+options = {
+    cwd: temp_dir,
+    dot: true,
+    absolute: true,
+};
+var src_dir = glob.sync(pattern, options);
+options = {
+    cwd: work_dir,
+    dot: true,
+    absolute: true,
+};
+var dst_dir = glob.sync(pattern, options);
+while (src_dir[0] || dst_dir[0]) {
+    if (src_dir[0] && dst_dir[0] && path.relative(temp_dir, src_dir[0]) == path.relative(work_dir, dst_dir[0])) {
+        if (fs.statSync(src_dir[0]).isFile() && fs.statSync(dst_dir[0]).isFile()) {
+            fs.copyFileSync(src_dir[0], dst_dir[0]);
+        } else {
+            assert(fs.statSync(src_dir[0]).isDirectory());
+            assert(fs.statSync(dst_dir[0]).isDirectory());
+        }
+        assert(fs.statSync(src_dir[0]).mode == fs.statSync(dst_dir[0]).mode);
+        src_dir = src_dir.slice(1);
+        dst_dir = dst_dir.slice(1);
+    } else if (dst_dir[0] && (!src_dir[0] || path.relative(temp_dir, src_dir[0]) > path.relative(work_dir, dst_dir[0]))) {
+        var i = 0;
+        while (dst_dir[i] && dst_dir[i].startsWith(dst_dir[0])) {
+            i++;
+        }
+        var j = i - 1;
+        while (j >= 0) {
+            if (fs.statSync(dst_dir[j]).isFile()) {
+                fs.unlinkSync(dst_dir[j]);
+            } else {
+                assert(fs.statSync(dst_dir[j]).isDirectory());
+                fs.rmdirSync(dst_dir[j]);
+            }
+            j--;
+        }
+        dst_dir = dst_dir.slice(i);
+    } else if (src_dir[0] && (!dst_dir[0] || path.relative(temp_dir, src_dir[0]) < path.relative(work_dir, dst_dir[0]))) {
+        if (fs.statSync(src_dir[0]).isFile()) {
+            fs.copyFileSync(src_dir[0], path.join(work_dir, path.relative(temp_dir, src_dir[0])));
+        } else {
+            assert(fs.statSync(src_dir[0]).isDirectory());
+            fs.mkdirSync(path.join(work_dir, path.relative(temp_dir, src_dir[0])));
+            fs.chmodSync(path.join(work_dir, path.relative(temp_dir, src_dir[0])), fs.statSync(src_dir[0]).mode);
+        }
+        src_dir = src_dir.slice(1);
+    } else {
+        assert.fail();
+    }
+}
+
+if ('GITHUB_EVENT_NAME' in process.env && 'GITHUB_EVENT_PATH' in process.env) {
+    var payload = fs.readFileSync(process.env['GITHUB_EVENT_PATH'], 'utf8');
+    payload = JSON.parse(payload);
+    switch (process.env['GITHUB_EVENT_NAME']) {
+        case 'pull_request':
+            sub_work_dir = path.join(work_dir, payload.pull_request.head.sha);
+            if (!fs.existsSync(sub_work_dir)) {
+                fs.mkdirSync(sub_work_dir);
+            }
+            break;
+        default:
+            assert.fail();
+    }
+} else {
+    sub_work_dir = work_dir;
+}
+
+cmd = [ 'git', 'clone', 'https://chromium.googlesource.com/chromium/tools/depot_tools.git', 'depot_tools' ];
+options = {
+    cwd: sub_work_dir,
+    stdio: 'inherit',
+};
+child_process.execFileSync(cmd[0], cmd.slice(1), options);

--- a/editor/action.yml
+++ b/editor/action.yml
@@ -1,0 +1,5 @@
+name: 'editor'
+description: ''
+runs:
+  using: 'node12'
+  main: 'index.js'

--- a/editor/index.js
+++ b/editor/index.js
@@ -1,0 +1,94 @@
+// This script should be skipped when running locally.
+
+var assert = require('assert');
+var child_process = require('child_process');
+var fs = require('fs');
+var os = require('os');
+var path = require('path');
+var util = require('util');
+
+var work_dir = 'WORKSPACE_OVERRIDE' in process.env ? process.env['WORKSPACE_OVERRIDE'] :
+               'GITHUB_WORKSPACE' in process.env ? process.env['GITHUB_WORKSPACE'] :
+               process.cwd();
+work_dir = path.resolve(work_dir);
+
+var cmd;
+var options;
+
+switch (process.platform) {
+    case 'win32':
+        // GN does not respect the EDITOR environment variable on
+        // Windows. Instead it opens the program associated with .txt
+        // files. The association is modified below, so that a launcher
+        // script will be used as the default text editor, where the
+        // environment variable is properly honored.
+
+        var node_exe = process.execPath;
+        if (!/^\w+$/.test(node_exe)) {
+            node_exe = node_exe.replace(/((\\+)("|$))/g, '$2$1').replace(/"/g, '\\"').replace(/(.*)/, '"$1"');
+        }
+
+        var editor_bat = path.join(work_dir, 'editor.bat');
+        if (!/^\w+$/.test(editor_bat)) {
+            editor_bat = editor_bat.replace(/((\\+)("|$))/g, '$2$1').replace(/"/g, '\\"').replace(/(.*)/, '"$1"');
+        }
+
+        // It looks rather difficult to handle environment variables
+        // containing quotes or whitespaces in batch, so the launcher
+        // script is mainly implemented in JS here.
+        var editor = (function () {
+            var child_process = require('child_process');
+            var path = require('path');
+            var util = require('util');
+            var editor;
+            if ('EDITOR' in process.env) {
+                editor = process.env['EDITOR'];
+            } else {
+                // Fallback to Notepad if EDITOR is not set
+                editor = path.join('%SystemRoot%', 'system32', 'NOTEPAD.EXE');
+            }
+            var args = process.argv.slice(2).map(function (arg) {
+                if (/^\w+$/.test(arg)) return arg;
+                return arg.replace(/((\\+)("|$))/g, '$2$1').replace(/"/g, '\\"').replace(/(.*)/, '"$1"');
+            }).join(' ');
+            var options = {
+                stdio: 'inherit',
+            };
+            child_process.execSync(util.format("%s %s", editor, args), options);
+        }).toString();
+
+        // Get the function body
+        editor = editor.substring(editor.indexOf('{') + 1, editor.lastIndexOf('}')).trim().split('\n').map(function (line) {
+            return line.trim();
+        }).join(os.EOL);
+
+        // Embed JS into a batch script
+        editor = [
+            "REM (); /*",                                   // This is a comment in batch, but a function call in JS.
+                                                            // Note it's totally valid to place a JS function call before its declaration, even in strict mode.
+            "@ECHO OFF",
+            util.format("%s %s %%*", node_exe, editor_bat), // self-execute as a Node.js script
+            "EXIT /B",                                      // Batch script ends here. The following JS will be ignored by CMD.EXE.
+            "*/",
+            "function REM() {",
+            editor,
+            "}",
+        ].join(os.EOL);
+        fs.writeFileSync(path.join(work_dir, 'editor.bat'), editor);
+
+        // Change current user's default editor in registry
+        var key_name = 'HKCU\\Software\\Classes\\txtfile\\shell\\open\\command';
+        var type = 'REG_EXPAND_SZ';
+        var data = util.format('%s "%%0" %%*', editor_bat);
+        cmd = [ 'REG', 'ADD', key_name, '/ve', '/t', type, '/d', data, '/f' ];
+        options = {
+            stdio: 'inherit',
+        };
+        child_process.execFileSync(cmd[0], cmd.slice(1), options);
+
+        break;
+    case 'linux':
+        break;
+    default:
+        assert.fail();
+}

--- a/gclient-sync/action.yml
+++ b/gclient-sync/action.yml
@@ -1,0 +1,5 @@
+name: 'gclient sync'
+description: ''
+runs:
+  using: 'node12'
+  main: 'index.js'

--- a/gclient-sync/index.js
+++ b/gclient-sync/index.js
@@ -1,0 +1,131 @@
+// The GitHub runner environment is optional for this script, so it can work in local.
+
+var assert = require('assert');
+var child_process = require('child_process');
+var fs = require('fs');
+var glob = require('glob');
+var path = require('path');
+var util = require('util');
+
+var work_dir = 'WORKSPACE_OVERRIDE' in process.env ? process.env['WORKSPACE_OVERRIDE'] :
+               'GITHUB_WORKSPACE' in process.env ? process.env['GITHUB_WORKSPACE'] :
+               process.cwd();
+work_dir = path.resolve(work_dir);
+var temp_dir = fs.mkdtempSync(util.format('%s%s', work_dir, path.sep));
+var sub_work_dir;
+
+var pattern;
+var cmd;
+var env;
+var shell;
+var options;
+
+switch (process.platform) {
+    case 'win32':
+        shell = true;
+        break;
+    case 'linux':
+        shell = false;
+        break;
+    default:
+        assert.fail();
+}
+
+fs.mkdirSync(path.join(temp_dir, 'git-templates'));
+
+// Sync directories
+pattern = 'git-templates/**';
+options = {
+    cwd: temp_dir,
+    dot: true,
+    absolute: true,
+};
+var src_dir = glob.sync(pattern, options);
+options = {
+    cwd: work_dir,
+    dot: true,
+    absolute: true,
+};
+var dst_dir = glob.sync(pattern, options);
+while (src_dir[0] || dst_dir[0]) {
+    if (src_dir[0] && dst_dir[0] && path.relative(temp_dir, src_dir[0]) == path.relative(work_dir, dst_dir[0])) {
+        if (fs.statSync(src_dir[0]).isFile() && fs.statSync(dst_dir[0]).isFile()) {
+            fs.copyFileSync(src_dir[0], dst_dir[0]);
+        } else {
+            assert(fs.statSync(src_dir[0]).isDirectory());
+            assert(fs.statSync(dst_dir[0]).isDirectory());
+        }
+        assert(fs.statSync(src_dir[0]).mode == fs.statSync(dst_dir[0]).mode);
+        src_dir = src_dir.slice(1);
+        dst_dir = dst_dir.slice(1);
+    } else if (dst_dir[0] && (!src_dir[0] || path.relative(temp_dir, src_dir[0]) > path.relative(work_dir, dst_dir[0]))) {
+        var i = 0;
+        while (dst_dir[i] && dst_dir[i].startsWith(dst_dir[0])) {
+            i++;
+        }
+        var j = i - 1;
+        while (j >= 0) {
+            if (fs.statSync(dst_dir[j]).isFile()) {
+                fs.unlinkSync(dst_dir[j]);
+            } else {
+                assert(fs.statSync(dst_dir[j]).isDirectory());
+                fs.rmdirSync(dst_dir[j]);
+            }
+            j--;
+        }
+        dst_dir = dst_dir.slice(i);
+    } else if (src_dir[0] && (!dst_dir[0] || path.relative(temp_dir, src_dir[0]) < path.relative(work_dir, dst_dir[0]))) {
+        if (fs.statSync(src_dir[0]).isFile()) {
+            fs.copyFileSync(src_dir[0], path.join(work_dir, path.relative(temp_dir, src_dir[0])));
+        } else {
+            assert(fs.statSync(src_dir[0]).isDirectory());
+            fs.mkdirSync(path.join(work_dir, path.relative(temp_dir, src_dir[0])));
+            fs.chmodSync(path.join(work_dir, path.relative(temp_dir, src_dir[0])), fs.statSync(src_dir[0]).mode);
+        }
+        src_dir = src_dir.slice(1);
+    } else {
+        assert.fail();
+    }
+}
+
+if ('GITHUB_EVENT_NAME' in process.env && 'GITHUB_EVENT_PATH' in process.env) {
+    var payload = fs.readFileSync(process.env['GITHUB_EVENT_PATH'], 'utf8');
+    payload = JSON.parse(payload);
+    switch (process.env['GITHUB_EVENT_NAME']) {
+        case 'pull_request':
+            sub_work_dir = path.join(work_dir, payload.pull_request.head.sha);
+            if (!fs.existsSync(sub_work_dir)) {
+                fs.mkdirSync(sub_work_dir);
+            }
+            break;
+        default:
+            assert.fail();
+    }
+} else {
+    sub_work_dir = work_dir;
+}
+
+env = Object.create(process.env);
+env['DEPOT_TOOLS_METRICS'] = '0';
+env['DEPOT_TOOLS_UPDATE'] = '0';
+switch (process.platform) {
+    case 'win32':
+        env['Path'] = util.format('%s%s%s', path.join(sub_work_dir, 'depot_tools'), path.delimiter, env['Path']);
+        env['DEPOT_TOOLS_WIN_TOOLCHAIN'] = '0';
+        env['GYP_MSVS_VERSION'] = '2019';
+        break;
+    case 'linux':
+        env['PATH'] = util.format('%s%s%s', env['PATH'], path.delimiter, path.join(sub_work_dir, 'depot_tools'));
+        break;
+    default:
+        assert.fail();
+}
+
+cmd = [ 'gclient', 'sync' ];
+options = {
+    cwd: path.join(sub_work_dir, 'aquarium'),
+    stdio: 'inherit',
+    env: env,
+    shell: shell,
+};
+child_process.execFileSync(cmd[0], cmd.slice(1), options);

--- a/git-clone/action.yml
+++ b/git-clone/action.yml
@@ -1,0 +1,5 @@
+name: 'git clone'
+description: ''
+runs:
+  using: 'node12'
+  main: 'index.js'

--- a/git-clone/index.js
+++ b/git-clone/index.js
@@ -1,0 +1,177 @@
+// The GitHub runner environment is optional for this script, so it can work in local.
+
+var assert = require('assert');
+var child_process = require('child_process');
+var fs = require('fs');
+var glob = require('glob');
+var path = require('path');
+var util = require('util');
+
+var work_dir = 'WORKSPACE_OVERRIDE' in process.env ? process.env['WORKSPACE_OVERRIDE'] :
+               'GITHUB_WORKSPACE' in process.env ? process.env['GITHUB_WORKSPACE'] :
+               process.cwd();
+work_dir = path.resolve(work_dir);
+var temp_dir = fs.mkdtempSync(util.format('%s%s', work_dir, path.sep));
+var sub_work_dir;
+
+var pattern;
+var cmd;
+var options;
+
+var post_checkout;
+if ('GITHUB_SHA' in process.env && 'BUILD_CONFIG' in process.env && 'GITHUB_EVENT_NAME' in process.env) {
+    // The post-checkout hook will be executed at the end of git-clone.
+    // The purpose of this hook is to create a special commit tagged as
+    // GITHUB_SHA, which has three parent commits:
+    //
+    // * GITHUB_SHA^1: head of the base branch when the workflow starts
+    // * GITHUB_SHA^2: head of the commits for testing
+    // * GITHUB_SHA^3: squash of the commits for testing
+
+    var build_config = process.env['BUILD_CONFIG'].split('-');
+
+    assert(build_config[0]);
+    assert(/^[0-9a-f]+$/.test(build_config[0]));
+
+    switch (process.env['GITHUB_EVENT_NAME']) {
+        case 'pull_request':
+            post_checkout = [
+                util.format("#!/bin/sh"),
+
+                // Do nothing if there's already a tag named GITHUB_SHA
+                util.format("SHA=$(git rev-parse --verify --quiet refs/tags/GITHUB_SHA)"),
+                util.format("if [ -n \"$SHA\" ]"),
+                util.format("then"),
+                util.format("    exit"),
+                util.format("fi"),
+
+                // Validate the first field of the build config gives a
+                // valid commit hash, either complete or abbreviated
+                util.format("SHA=$(git rev-parse --verify --quiet \"%s^{commit}\")", build_config[0]),
+                util.format("if [ -n \"$SHA\" ]"),
+                util.format("then"),
+                util.format("    if [ \"$SHA\" != \"%s\" ]", build_config[0]),
+                util.format("    then"),
+                util.format("        SHA=$(git show --pretty=%%h --no-patch \"%s\")", build_config[0]),
+                util.format("        if [ \"$SHA\" != \"%s\" ]", build_config[0]),
+                util.format("        then"),
+                util.format("            exit 1"),
+                util.format("        fi"),
+                util.format("    fi"),
+                util.format("else"),
+                util.format("    exit 1"),
+                util.format("fi"),
+
+                // Create the squashed commit
+                util.format("MERGE_BASE=$(git merge-base \"%s^1\" \"%s^2\")", process.env['GITHUB_SHA'], build_config[0]),
+                util.format("SHA=$(printf \"\" | git commit-tree \"%s^2^{tree}\" -p \"$MERGE_BASE\")", build_config[0]),
+
+                // Calculate the SHA of an empty tree (but no need to
+                // write to the object database since it's hardcoded in
+                // Git), and create a merge commit based on that (in
+                // fact the tree object of the commit is unimportant)
+                util.format("EMPTY_TREE=$(printf \"\" | git hash-object -t tree --stdin)"),
+                util.format("SHA=$(printf \"\" | git commit-tree \"$EMPTY_TREE\" -p \"%s^1\" -p \"%s^2\" -p \"$SHA\")", process.env['GITHUB_SHA'], build_config[0]),
+                util.format("git tag GITHUB_SHA \"$SHA\""),
+            ].join('\n');
+            break;
+        default:
+            assert.fail();
+    }
+} else {
+    post_checkout = "#!/bin/true";
+}
+
+// Populate the template directory
+var fd;
+fs.mkdirSync(path.join(temp_dir, 'git-templates'));
+fs.mkdirSync(path.join(temp_dir, 'git-templates', 'hooks'));
+fd = fs.openSync(path.join(temp_dir, 'git-templates', 'hooks', 'post-checkout'), 'w');
+fs.writeSync(fd, post_checkout);
+fs.fchmodSync(fd, fs.fstatSync(fd).mode | 0o111);
+fs.closeSync(fd);
+
+// Sync directories
+pattern = 'git-templates/**';
+options = {
+    cwd: temp_dir,
+    dot: true,
+    absolute: true,
+};
+var src_dir = glob.sync(pattern, options);
+options = {
+    cwd: work_dir,
+    dot: true,
+    absolute: true,
+};
+var dst_dir = glob.sync(pattern, options);
+while (src_dir[0] || dst_dir[0]) {
+    if (src_dir[0] && dst_dir[0] && path.relative(temp_dir, src_dir[0]) == path.relative(work_dir, dst_dir[0])) {
+        if (fs.statSync(src_dir[0]).isFile() && fs.statSync(dst_dir[0]).isFile()) {
+            fs.copyFileSync(src_dir[0], dst_dir[0]);
+        } else {
+            assert(fs.statSync(src_dir[0]).isDirectory());
+            assert(fs.statSync(dst_dir[0]).isDirectory());
+        }
+        assert(fs.statSync(src_dir[0]).mode == fs.statSync(dst_dir[0]).mode);
+        src_dir = src_dir.slice(1);
+        dst_dir = dst_dir.slice(1);
+    } else if (dst_dir[0] && (!src_dir[0] || path.relative(temp_dir, src_dir[0]) > path.relative(work_dir, dst_dir[0]))) {
+        var i = 0;
+        while (dst_dir[i] && dst_dir[i].startsWith(dst_dir[0])) {
+            i++;
+        }
+        var j = i - 1;
+        while (j >= 0) {
+            if (fs.statSync(dst_dir[j]).isFile()) {
+                fs.unlinkSync(dst_dir[j]);
+            } else {
+                assert(fs.statSync(dst_dir[j]).isDirectory());
+                fs.rmdirSync(dst_dir[j]);
+            }
+            j--;
+        }
+        dst_dir = dst_dir.slice(i);
+    } else if (src_dir[0] && (!dst_dir[0] || path.relative(temp_dir, src_dir[0]) < path.relative(work_dir, dst_dir[0]))) {
+        if (fs.statSync(src_dir[0]).isFile()) {
+            fs.copyFileSync(src_dir[0], path.join(work_dir, path.relative(temp_dir, src_dir[0])));
+        } else {
+            assert(fs.statSync(src_dir[0]).isDirectory());
+            fs.mkdirSync(path.join(work_dir, path.relative(temp_dir, src_dir[0])));
+            fs.chmodSync(path.join(work_dir, path.relative(temp_dir, src_dir[0])), fs.statSync(src_dir[0]).mode);
+        }
+        src_dir = src_dir.slice(1);
+    } else {
+        assert.fail();
+    }
+}
+
+if ('GITHUB_EVENT_NAME' in process.env && 'GITHUB_EVENT_PATH' in process.env) {
+    var payload = fs.readFileSync(process.env['GITHUB_EVENT_PATH'], 'utf8');
+    payload = JSON.parse(payload);
+    switch (process.env['GITHUB_EVENT_NAME']) {
+        case 'pull_request':
+            sub_work_dir = path.join(work_dir, payload.pull_request.head.sha);
+            if (!fs.existsSync(sub_work_dir)) {
+                fs.mkdirSync(sub_work_dir);
+            }
+            break;
+        default:
+            assert.fail();
+    }
+} else {
+    sub_work_dir = work_dir;
+}
+
+cmd = [
+    'git',
+    'clone',
+    '-c', 'remote.origin.fetch=+refs/pull/*/merge:refs/pull/origin/*/merge',
+    util.format('https://github.com/%s.git', process.env['GITHUB_REPOSITORY']),
+    'aquarium',
+];
+options = {
+    cwd: sub_work_dir,
+    stdio: 'inherit',
+};
+child_process.execFileSync(cmd[0], cmd.slice(1), options);

--- a/git-rebase/action.yml
+++ b/git-rebase/action.yml
@@ -1,0 +1,5 @@
+name: 'git rebase'
+description: ''
+runs:
+  using: 'node12'
+  main: 'index.js'

--- a/git-rebase/index.js
+++ b/git-rebase/index.js
@@ -1,0 +1,91 @@
+// This script should be skipped when running locally.
+
+// When running in GitHub hosted runners, the script writes the todo
+// list to a staging file first, and then a copy of the file is read by
+// Git during interactive rebase. The latter works because Git would
+// fire up the command given by the GIT_EDITOR environment variable,
+// which has been set to system-specific file copy commands beforehand,
+// with the staging file being the source.
+
+var assert = require('assert');
+var child_process = require('child_process');
+var fs = require('fs');
+var path = require('path');
+var util = require('util');
+
+var work_dir = 'WORKSPACE_OVERRIDE' in process.env ? process.env['WORKSPACE_OVERRIDE'] :
+               'GITHUB_WORKSPACE' in process.env ? process.env['GITHUB_WORKSPACE'] :
+               process.cwd();
+work_dir = path.resolve(work_dir);
+var temp_dir = fs.mkdtempSync(util.format('%s%s', work_dir, path.sep));
+var sub_work_dir;
+
+var cmd;
+var options;
+
+var payload = fs.readFileSync(process.env['GITHUB_EVENT_PATH'], 'utf8');
+payload = JSON.parse(payload);
+switch (process.env['GITHUB_EVENT_NAME']) {
+    case 'pull_request':
+        sub_work_dir = path.join(work_dir, payload.pull_request.head.sha);
+        if (!fs.existsSync(sub_work_dir)) {
+            fs.mkdirSync(sub_work_dir);
+        }
+        break;
+    default:
+        assert.fail();
+}
+
+var merge_base;
+cmd = [ 'git', 'merge-base', 'refs/tags/GITHUB_SHA^1', 'refs/tags/GITHUB_SHA^2' ];
+options = {
+    cwd: path.join(sub_work_dir, 'aquarium'),
+    encoding: 'utf8',
+};
+merge_base = child_process.execFileSync(cmd[0], cmd.slice(1), options);
+merge_base = merge_base.trim();
+
+var commits; // commits for testing
+cmd = [ 'git', 'rev-list', util.format('^%s', merge_base), 'refs/tags/GITHUB_SHA^2' ];
+options = {
+    cwd: path.join(sub_work_dir, 'aquarium'),
+    encoding: 'utf8',
+};
+commits = child_process.execFileSync(cmd[0], cmd.slice(1), options);
+commits = commits.trim().split('\n');
+
+var commit; // the squashed commit
+cmd = [ 'git', 'rev-parse', 'refs/tags/GITHUB_SHA^3' ];
+options = {
+    cwd: path.join(sub_work_dir, 'aquarium'),
+    encoding: 'utf8',
+};
+commit = child_process.execFileSync(cmd[0], cmd.slice(1), options);
+commit = commit.trim();
+
+// Build the todo list for interactive rebase
+var todo_list;
+if (commits.length) {
+    // Pick the squashed commit, and reword the commit message using that of the oldest unmerged commit
+    todo_list = [
+        util.format("pick %s", commit),
+        util.format("exec git show --pretty=%%B --no-patch %s | git commit --amend --file=-", commits[commits.length - 1]),
+    ].join('\n');
+} else {
+    // Maybe GITHUB_SHA refers to something already merged
+    todo_list = "";
+}
+
+fs.writeFileSync(path.join(temp_dir, 'git.txt'), todo_list);
+if (fs.existsSync(path.join(work_dir, 'git.txt'))) {
+    assert(fs.statSync(path.join(work_dir, 'git.txt')).isFile());
+    assert(fs.statSync(path.join(temp_dir, 'git.txt')).mode == fs.statSync(path.join(work_dir, 'git.txt')).mode);
+}
+fs.copyFileSync(path.join(temp_dir, 'git.txt'), path.join(work_dir, 'git.txt'));
+
+cmd = [ 'git', 'rebase', '-i', '--onto', 'refs/tags/GITHUB_SHA^1', 'refs/tags/GITHUB_SHA^1' ];
+options = {
+    cwd: path.join(sub_work_dir, 'aquarium'),
+    stdio: 'inherit',
+};
+child_process.execFileSync(cmd[0], cmd.slice(1), options);

--- a/git/action.yml
+++ b/git/action.yml
@@ -1,0 +1,5 @@
+name: 'git'
+description: ''
+runs:
+  using: 'node12'
+  main: 'index.js'

--- a/git/index.js
+++ b/git/index.js
@@ -1,0 +1,92 @@
+// This script should be skipped when running locally.
+
+var assert = require('assert');
+var child_process = require('child_process');
+var os = require('os');
+var util = require('util');
+switch (process.platform) {
+    case 'win32':
+        var dns = require('dns');
+        break;
+    case 'linux':
+        var dbus = require('dbus-native');
+        break;
+    default:
+        assert.fail();
+}
+
+var cmd;
+var options;
+
+util.promisify(function (callback) {
+    callback();
+})().then(function () {
+    // Get FQDN
+    switch (process.platform) {
+        case 'win32':
+            return util.promisify(function (callback) {
+                callback();
+            })().then(function () {
+                return util.promisify(dns.lookup)(os.hostname());
+            }).then(function (addr_info) {
+                return util.promisify(dns.lookupService)(addr_info.address, 0);
+            }).then(function (name_info) {
+                return name_info.hostname;
+            });
+            break;
+        case 'linux':
+            // https://www.freedesktop.org/wiki/Software/systemd/resolved/
+            var bus;
+            return util.promisify(function (callback) {
+                callback();
+            })().then(function () {
+                bus = dbus.systemBus();
+
+                var msg = {
+                    path:        '/org/freedesktop/resolve1',
+                    interface:   'org.freedesktop.DBus.Properties',
+                    destination: 'org.freedesktop.resolve1',
+                    member:      'Get',
+                    signature:   'ss',
+                    body:        [ 'org.freedesktop.resolve1.Manager', 'Domains' ],
+                };
+                return util.promisify(bus.invoke).call(bus, msg);
+            }).then(function (reply) {
+                bus.connection.end();
+
+                var signature = reply[0]; // 'a(isb)'
+                var value = reply[1];
+                var domains = value[0];
+                var domain = domains[0]; // poor man's way to pick a domain name
+                var ifindex = domain[0];
+                var domain_name = domain[1];
+                var route_only = domain[2];
+                return util.format('%s.%s', os.hostname(), domain_name);
+            });
+            break;
+        default:
+            assert.fail();
+    }
+}).then(function (fqdn) {
+    var user = os.userInfo().username;
+
+    cmd = [ 'git', 'config', '--global', 'user.name', user ];
+    options = {
+        stdio: 'inherit',
+    };
+    child_process.execFileSync(cmd[0], cmd.slice(1), options);
+
+    cmd = [ 'git', 'config', '--global', 'user.email', util.format('%s@%s', user, fqdn) ];
+    options = {
+        stdio: 'inherit',
+    };
+    child_process.execFileSync(cmd[0], cmd.slice(1), options);
+
+    if (process.platform == 'win32') {
+        cmd = [ 'git', 'config', '--global', 'core.longpaths', 'true' ];
+        options = {
+            stdio: 'inherit',
+        };
+        child_process.execFileSync(cmd[0], cmd.slice(1), options);
+    }
+});

--- a/gn-args/action.yml
+++ b/gn-args/action.yml
@@ -1,0 +1,5 @@
+name: 'gn args'
+description: ''
+runs:
+  using: 'node12'
+  main: 'index.js'

--- a/gn-args/index.js
+++ b/gn-args/index.js
@@ -1,0 +1,128 @@
+// The GitHub runner environment is optional for this script, so it can work in local.
+
+// When running in GitHub hosted runners, the script translates
+// mnemonics in the BUILD_CONFIG environment variable to GN arguments,
+// writes the arguments to a staging file, and copies the file to
+// args.gn during "gn args" time. This works because GN would launch the
+// command given by the GN_EDITOR environment variable on POSIX, and
+// with additional configuration it can work in a similar manner on
+// Windows. Thus, path to args.gn will be passed to system-specific file
+// copy commands as the destination, with the staging file being the
+// source.
+
+var assert = require('assert');
+var child_process = require('child_process');
+var fs = require('fs');
+var os = require('os');
+var path = require('path');
+var util = require('util');
+
+var work_dir = 'WORKSPACE_OVERRIDE' in process.env ? process.env['WORKSPACE_OVERRIDE'] :
+               'GITHUB_WORKSPACE' in process.env ? process.env['GITHUB_WORKSPACE'] :
+               process.cwd();
+work_dir = path.resolve(work_dir);
+var temp_dir = fs.mkdtempSync(util.format('%s%s', work_dir, path.sep));
+var sub_work_dir;
+
+var cmd;
+var env;
+var shell;
+var options;
+
+switch (process.platform) {
+    case 'win32':
+        shell = true;
+        break;
+    case 'linux':
+        shell = false;
+        break;
+    default:
+        assert.fail();
+}
+
+var gn_args;
+if ('BUILD_CONFIG' in process.env) {
+    var build_config = process.env['BUILD_CONFIG'].split('-');
+
+    gn_args = build_config.slice(1).map(function (arg) {
+        switch (arg) {
+            case 'angle':       return [ 'enable_angle',       'true'  ];
+            case 'noangle':     return [ 'enable_angle',       'false' ];
+            case 'x86':         return [ 'target_cpu',         '"x86"' ];
+            case 'x64':         return [ 'target_cpu',         '"x64"' ];
+            case 'component':   return [ 'is_component_build', 'true'  ];
+            case 'nocomponent': return [ 'is_component_build', 'false' ];
+            case 'debug':       return [ 'is_debug',           'true'  ];
+            case 'release':     return [ 'is_debug',           'false' ];
+            default: assert.fail();
+        }
+    });
+
+    // Ensure there's no conflict or duplication in GN arguments
+    gn_args.map(function (arg) {
+        return arg[0];
+    }).forEach(function (value, index, array) {
+        assert(array.indexOf(value) == index);
+    });
+
+    gn_args = gn_args.map(function (arg) {
+        return util.format("%s = %s", arg[0], arg[1]);
+    }).join(os.EOL);
+} else {
+    gn_args = "";
+}
+
+fs.writeFileSync(path.join(temp_dir, 'gn.txt'), gn_args);
+if (fs.existsSync(path.join(work_dir, 'gn.txt'))) {
+    assert(fs.statSync(path.join(work_dir, 'gn.txt')).isFile());
+    assert(fs.statSync(path.join(temp_dir, 'gn.txt')).mode == fs.statSync(path.join(work_dir, 'gn.txt')).mode);
+}
+fs.copyFileSync(path.join(temp_dir, 'gn.txt'), path.join(work_dir, 'gn.txt'));
+
+if ('GITHUB_EVENT_NAME' in process.env && 'GITHUB_EVENT_PATH' in process.env) {
+    var payload = fs.readFileSync(process.env['GITHUB_EVENT_PATH'], 'utf8');
+    payload = JSON.parse(payload);
+    switch (process.env['GITHUB_EVENT_NAME']) {
+        case 'pull_request':
+            sub_work_dir = path.join(work_dir, payload.pull_request.head.sha);
+            if (!fs.existsSync(sub_work_dir)) {
+                fs.mkdirSync(sub_work_dir);
+            }
+            break;
+        default:
+            assert.fail();
+    }
+} else {
+    sub_work_dir = work_dir;
+}
+
+env = Object.create(process.env);
+env['DEPOT_TOOLS_METRICS'] = '0';
+env['DEPOT_TOOLS_UPDATE'] = '0';
+switch (process.platform) {
+    case 'win32':
+        env['Path'] = util.format('%s%s%s', path.join(sub_work_dir, 'depot_tools'), path.delimiter, env['Path']);
+        env['DEPOT_TOOLS_WIN_TOOLCHAIN'] = '0';
+        env['GYP_MSVS_VERSION'] = '2019';
+        break;
+    case 'linux':
+        env['PATH'] = util.format('%s%s%s', env['PATH'], path.delimiter, path.join(sub_work_dir, 'depot_tools'));
+        break;
+    default:
+        assert.fail();
+}
+if ('GN_EDITOR' in env) {
+    // Teach GN on Windows about GN_EDITOR by making EDITOR an alias of
+    // it (GN_EDITOR takes precedence over EDITOR on POSIX, so
+    // overwriting EDITOR is a no-op there)
+    env['EDITOR'] = env['GN_EDITOR'];
+}
+
+cmd = [ 'gn', 'args', 'out' ];
+options = {
+    cwd: path.join(sub_work_dir, 'aquarium'),
+    stdio: 'inherit',
+    env: env,
+    shell: shell,
+};
+child_process.execFileSync(cmd[0], cmd.slice(1), options);

--- a/ninja/action.yml
+++ b/ninja/action.yml
@@ -1,0 +1,5 @@
+name: 'ninja'
+description: ''
+runs:
+  using: 'node12'
+  main: 'index.js'

--- a/ninja/index.js
+++ b/ninja/index.js
@@ -1,0 +1,58 @@
+// The GitHub runner environment is optional for this script, so it can work in local.
+
+var assert = require('assert');
+var child_process = require('child_process');
+var fs = require('fs');
+var path = require('path');
+var util = require('util');
+
+var work_dir = 'WORKSPACE_OVERRIDE' in process.env ? process.env['WORKSPACE_OVERRIDE'] :
+               'GITHUB_WORKSPACE' in process.env ? process.env['GITHUB_WORKSPACE'] :
+               process.cwd();
+work_dir = path.resolve(work_dir);
+var sub_work_dir;
+
+var cmd;
+var env;
+var options;
+
+if ('GITHUB_EVENT_NAME' in process.env && 'GITHUB_EVENT_PATH' in process.env) {
+    var payload = fs.readFileSync(process.env['GITHUB_EVENT_PATH'], 'utf8');
+    payload = JSON.parse(payload);
+    switch (process.env['GITHUB_EVENT_NAME']) {
+        case 'pull_request':
+            sub_work_dir = path.join(work_dir, payload.pull_request.head.sha);
+            if (!fs.existsSync(sub_work_dir)) {
+                fs.mkdirSync(sub_work_dir);
+            }
+            break;
+        default:
+            assert.fail();
+    }
+} else {
+    sub_work_dir = work_dir;
+}
+
+env = Object.create(process.env);
+env['DEPOT_TOOLS_METRICS'] = '0';
+env['DEPOT_TOOLS_UPDATE'] = '0';
+switch (process.platform) {
+    case 'win32':
+        env['Path'] = util.format('%s%s%s', path.join(sub_work_dir, 'depot_tools'), path.delimiter, env['Path']);
+        env['DEPOT_TOOLS_WIN_TOOLCHAIN'] = '0';
+        env['GYP_MSVS_VERSION'] = '2019';
+        break;
+    case 'linux':
+        env['PATH'] = util.format('%s%s%s', env['PATH'], path.delimiter, path.join(sub_work_dir, 'depot_tools'));
+        break;
+    default:
+        assert.fail();
+}
+
+cmd = [ 'ninja', '-C', 'out' ];
+options = {
+    cwd: path.join(sub_work_dir, 'aquarium'),
+    stdio: 'inherit',
+    env: env,
+};
+child_process.execFileSync(cmd[0], cmd.slice(1), options);

--- a/npm-init/action.yml
+++ b/npm-init/action.yml
@@ -1,0 +1,5 @@
+name: 'npm init'
+description: ''
+runs:
+  using: 'node12'
+  main: 'index.js'

--- a/npm-init/index.js
+++ b/npm-init/index.js
@@ -1,0 +1,31 @@
+// The GitHub runner environment is optional for this script, so it can work in local.
+
+var assert = require('assert');
+var child_process = require('child_process');
+var path = require('path');
+var util = require('util');
+
+var work_dir = 'WORKSPACE_OVERRIDE' in process.env ? process.env['WORKSPACE_OVERRIDE'] :
+               'GITHUB_WORKSPACE' in process.env ? process.env['GITHUB_WORKSPACE'] :
+               process.cwd();
+work_dir = path.resolve(work_dir);
+
+var shell;
+switch (process.platform) {
+    case 'win32':
+        shell = true;
+        break;
+    case 'linux':
+        shell = false;
+        break;
+    default:
+        assert.fail();
+}
+
+var cmd = [ 'npm', 'init', '-y' ];
+var options = {
+    cwd: work_dir,
+    stdio: 'inherit',
+    shell: shell,
+};
+child_process.execFileSync(cmd[0], cmd.slice(1), options);

--- a/npm-install/action.yml
+++ b/npm-install/action.yml
@@ -1,0 +1,5 @@
+name: 'npm install'
+description: ''
+runs:
+  using: 'node12'
+  main: 'index.js'

--- a/npm-install/index.js
+++ b/npm-install/index.js
@@ -1,0 +1,44 @@
+// The GitHub runner environment is optional for this script, so it can work in local.
+
+var assert = require('assert');
+var child_process = require('child_process');
+var path = require('path');
+var util = require('util');
+
+var work_dir = 'WORKSPACE_OVERRIDE' in process.env ? process.env['WORKSPACE_OVERRIDE'] :
+               'GITHUB_WORKSPACE' in process.env ? process.env['GITHUB_WORKSPACE'] :
+               process.cwd();
+work_dir = path.resolve(work_dir);
+
+var shell;
+switch (process.platform) {
+    case 'win32':
+        shell = true;
+        break;
+    case 'linux':
+        shell = false;
+        break;
+    default:
+        assert.fail();
+}
+
+var cmd;
+switch (process.platform) {
+    case 'win32':
+        cmd = [ 'npm', 'install', 'glob', '@actions/core' ];
+        break;
+    case 'linux':
+        // Git needs a fake email address in this workflow. During the
+        // construction of the address, the D-Bus protocol will be used
+        // for the domain name part of the FQDN.
+        cmd = [ 'npm', 'install', 'glob', '@actions/core', 'dbus-native' ];
+        break;
+    default:
+        assert.fail();
+}
+var options = {
+    cwd: work_dir,
+    stdio: 'inherit',
+    shell: shell,
+};
+child_process.execFileSync(cmd[0], cmd.slice(1), options);

--- a/update_depot_tools/action.yml
+++ b/update_depot_tools/action.yml
@@ -1,0 +1,5 @@
+name: 'update_depot_tools'
+description: ''
+runs:
+  using: 'node12'
+  main: 'index.js'

--- a/update_depot_tools/index.js
+++ b/update_depot_tools/index.js
@@ -1,0 +1,70 @@
+// The GitHub runner environment is optional for this script, so it can work in local.
+
+var assert = require('assert');
+var child_process = require('child_process');
+var fs = require('fs');
+var path = require('path');
+var util = require('util');
+
+var work_dir = 'WORKSPACE_OVERRIDE' in process.env ? process.env['WORKSPACE_OVERRIDE'] :
+               'GITHUB_WORKSPACE' in process.env ? process.env['GITHUB_WORKSPACE'] :
+               process.cwd();
+work_dir = path.resolve(work_dir);
+var sub_work_dir;
+
+var cmd;
+var env;
+var shell;
+var options;
+
+switch (process.platform) {
+    case 'win32':
+        shell = true;
+        break;
+    case 'linux':
+        shell = false;
+        break;
+    default:
+        assert.fail();
+}
+
+if ('GITHUB_EVENT_NAME' in process.env && 'GITHUB_EVENT_PATH' in process.env) {
+    var payload = fs.readFileSync(process.env['GITHUB_EVENT_PATH'], 'utf8');
+    payload = JSON.parse(payload);
+    switch (process.env['GITHUB_EVENT_NAME']) {
+        case 'pull_request':
+            sub_work_dir = path.join(work_dir, payload.pull_request.head.sha);
+            if (!fs.existsSync(sub_work_dir)) {
+                fs.mkdirSync(sub_work_dir);
+            }
+            break;
+        default:
+            assert.fail();
+    }
+} else {
+    sub_work_dir = work_dir;
+}
+
+env = Object.create(process.env);
+env['DEPOT_TOOLS_METRICS'] = '0';
+switch (process.platform) {
+    case 'win32':
+        env['Path'] = util.format('%s%s%s', path.join(sub_work_dir, 'depot_tools'), path.delimiter, env['Path']);
+        env['DEPOT_TOOLS_WIN_TOOLCHAIN'] = '0';
+        env['GYP_MSVS_VERSION'] = '2019';
+        break;
+    case 'linux':
+        env['PATH'] = util.format('%s%s%s', env['PATH'], path.delimiter, path.join(sub_work_dir, 'depot_tools'));
+        break;
+    default:
+        assert.fail();
+}
+
+cmd = [ 'update_depot_tools' ];
+options = {
+    cwd: path.join(sub_work_dir, 'depot_tools'),
+    stdio: 'inherit',
+    env: env,
+    shell: shell,
+};
+child_process.execFileSync(cmd[0], cmd.slice(1), options);


### PR DESCRIPTION
These scripts are intended to serve the GitHub Actions workflow triggered by pull request events. The workflow configuration file will be added to the master branch in a separate commit soon.

Currently, commits in a pull request are squashed and applied onto master. In the future, the scripts may be extended to use rebase instead, as long as each message title matches a certain pattern. In
that case, the commits are going to be checked one by one.

Another potential next step is to handle the repository dispatch event. This could be useful in firing up a build with customized configuration.

Some of the scripts can run locally without the GitHub runner environment, see the comments at the beginning of these files.

See also https://help.github.com/en/actions for more info about GitHub Actions.
