### PR TITLE
Remove component type from the test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
 
     - uses: './BUILD_CONFIG'
       with:
-        build-config: '${{ github.sha }}${{ matrix.gl }}${{ matrix.target-cpu }}${{ matrix.component-type }}${{ matrix.build-type }}'
+        build-config: '${{ github.sha }}${{ matrix.gl }}${{ matrix.target-cpu }}${{ matrix.build-type }}'
     - uses: './GIT_TEMPLATE_DIR'
     - uses: './GIT_EDITOR'
     - uses: './GN_EDITOR'
@@ -52,5 +52,4 @@ jobs:
         runs-on:        [ 'windows-latest', 'ubuntu-latest' ]
         gl:             [ '' ]
         target-cpu:     [ '' ]
-        component-type: [ '', '-component', '-nocomponent' ]
         build-type:     [ '', '-debug', '-release' ]


### PR DESCRIPTION
Aquarium is not a huge project with gigabytes of symbols, so component build brings little benefit. IOW, it's unlikely that is_component_build needs to be tuned in practice. Since is_component_build defaults to the value of is_debug, the bot can still provide partial coverage with the new test matrix.
