### PR TITLE
Roll Dawn

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -149,8 +149,8 @@ executable("aquarium") {
 
     deps += [
       "third_party/dawn/src/dawn:dawn_headers",
+      "third_party/dawn/src/dawn:dawn_proc",
       "third_party/dawn/src/dawn:dawncpp",
-      "third_party/dawn/src/dawn:libdawn_proc",
       "third_party/dawn/src/dawn_native",
       "third_party/dawn/src/utils:dawn_bindings",
       "third_party/dawn/src/utils:dawn_utils",

--- a/DEPS
+++ b/DEPS
@@ -8,7 +8,7 @@ vars = {
   'chromium_git': 'https://chromium.googlesource.com',
   'github_git': 'https://github.com',
   'dawn_git': 'https://dawn.googlesource.com',
-  'dawn_revision': 'd11cc3961acb8a06da337ceb3c7d626563dff95a',
+  'dawn_revision': '797fa62b9178ef8a4ac1fdf87177f5756e80f854',
   'angle_root': 'third_party/angle',
   'angle_revision': '6c824a1bc17b286b86cf05a0228ec549875351eb',
   'glslang_revision': '07a55839eed550d84ef62e0c7f503e0d67692708',


### PR DESCRIPTION
This manual intervention is needed because of recent updates in Dawn's GN build files:

  https://dawn-review.googlesource.com/c/dawn/+/19289
