### PR TITLE
Roll Dawn

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -8,7 +8,7 @@ vars = {
   'chromium_git': 'https://chromium.googlesource.com',
   'github_git': 'https://github.com',
   'dawn_git': 'https://dawn.googlesource.com',
-  'dawn_revision': '797fa62b9178ef8a4ac1fdf87177f5756e80f854',
+  'dawn_revision': '8a437947a8d8416d07f457017ed2b57a3a22ce67',
   'angle_root': 'third_party/angle',
   'angle_revision': '6c824a1bc17b286b86cf05a0228ec549875351eb',
   'glslang_revision': '07a55839eed550d84ef62e0c7f503e0d67692708',

--- a/src/aquarium-optimized/dawn/ContextDawn.cpp
+++ b/src/aquarium-optimized/dawn/ContextDawn.cpp
@@ -223,7 +223,7 @@ bool ContextDawn::initialize(
     dawnProcSetProcs(&backendProcs);
     mDevice = wgpu::Device::Acquire(backendDevice);
 
-    queue = mDevice.CreateQueue();
+    queue = mDevice.GetDefaultQueue();
     wgpu::SwapChainDescriptor swapChainDesc;
     swapChainDesc.implementation = binding->GetSwapChainImplementation();
 


### PR DESCRIPTION
This manual intervention is needed because of recent deprecation of Device::CreateQueue():

  https://dawn-review.googlesource.com/c/dawn/+/19724
