### PR TITLE
Roll Vulkan Validation Layers and Vulkan Headers

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -18,8 +18,8 @@ vars = {
   'spirv_tools_revision': '85f3e93d13f32d45bd7f9999aa51baddf2452aae',
   'jsoncpp_revision': '571788934b5ee8643d53e5d054534abbe6006168',
   'jsoncpp_source_revision': '645250b6690785be60ab6780ce4b58698d884d11',
-  'vulkan-headers_revision':'5b44df19e040fca0048ab30c553a8c2d2cb9623e',
-  'vulkan-validation-layers_revision':'9fba37afae13a11bd49ae942bf82e5bf1098e381',
+  'vulkan-headers_revision': 'e01f13e1f777cf592ebd1a5f4836d4cd10ed85f6',
+  'vulkan-validation-layers_revision': '1533266eac486fae0c34bffe4868c4bc91dbe078',
 }
 
 deps = {

--- a/build_overrides/vulkan_headers.gni
+++ b/build_overrides/vulkan_headers.gni
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2020 The Aquarium Project Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+#
+
+import("//build/config/ui.gni")
+
+vulkan_use_x11 = use_x11

--- a/build_overrides/vulkan_validation_layers.gni
+++ b/build_overrides/vulkan_validation_layers.gni
@@ -4,6 +4,8 @@
 # found in the LICENSE file.
 #
 
+import("//build/config/ui.gni")
+
 vulkan_headers_dir = "//third_party/vulkan-headers"
 vvl_spirv_tools_dir = "//third_party/dawn/third_party/SPIRV-Tools"
 vvl_glslang_dir = "//third_party/glslang"


### PR DESCRIPTION
This manual intervention is needed because Vulkan 1.2 headers are required to build the new Vulkan validation layers. The updated Vulkan headers repository needs //build_overrides/vulkan_headers.gni now. In addition, //build/config/ui.gni is imported in //build_overrides/vulkan_validation_layers.gni for the definition of use_x11.
