### PR TITLE
Roll Dawn

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -8,7 +8,7 @@ vars = {
   'chromium_git': 'https://chromium.googlesource.com',
   'github_git': 'https://github.com',
   'dawn_git': 'https://dawn.googlesource.com',
-  'dawn_revision': '4234d78201afa98e208fef71250c1efe1ee3ad81',
+  'dawn_revision': '984493d0ac077cccbe4e5b83ab6028aaa5d40357',
   'angle_root': 'third_party/angle',
   'angle_revision': '6c824a1bc17b286b86cf05a0228ec549875351eb',
   'glslang_revision': 'b5f003d7a3ece37db45578a8a3140b370036fc64',

--- a/src/aquarium-optimized/dawn/ContextDawn.cpp
+++ b/src/aquarium-optimized/dawn/ContextDawn.cpp
@@ -381,11 +381,10 @@ wgpu::BufferCopyView ContextDawn::createBufferCopyView(const wgpu::Buffer &buffe
 
 wgpu::TextureCopyView ContextDawn::createTextureCopyView(wgpu::Texture texture,
                                                          uint32_t level,
-                                                         uint32_t slice,
                                                          wgpu::Origin3D origin)
 {
 
-    return utils::CreateTextureCopyView(texture, level, slice, origin);
+    return utils::CreateTextureCopyView(texture, level, origin);
 }
 
 wgpu::CommandBuffer ContextDawn::copyBufferToTexture(const wgpu::BufferCopyView &bufferCopyView,

--- a/src/aquarium-optimized/dawn/ContextDawn.h
+++ b/src/aquarium-optimized/dawn/ContextDawn.h
@@ -77,7 +77,6 @@ class ContextDawn : public Context
 
     wgpu::TextureCopyView createTextureCopyView(wgpu::Texture texture,
                                                 uint32_t level,
-                                                uint32_t slice,
                                                 wgpu::Origin3D origin);
     wgpu::ShaderModule createShaderModule(utils::SingleShaderStage stage,
                                           const std::string &str) const;

--- a/src/aquarium-optimized/dawn/TextureDawn.cpp
+++ b/src/aquarium-optimized/dawn/TextureDawn.cpp
@@ -74,7 +74,7 @@ void TextureDawn::loadTexture()
             wgpu::BufferCopyView bufferCopyView =
                 mContext->createBufferCopyView(result.buffer, 0, mWidth * 4, mHeight);
             wgpu::TextureCopyView textureCopyView =
-                mContext->createTextureCopyView(mTexture, 0, i, {0, 0, 0});
+                mContext->createTextureCopyView(mTexture, 0, {0, 0, i});
             wgpu::Extent3D copySize = {static_cast<uint32_t>(mWidth),
                                        static_cast<uint32_t>(mHeight), 1};
             mContext->mCommandBuffers.emplace_back(
@@ -147,7 +147,7 @@ void TextureDawn::loadTexture()
             wgpu::BufferCopyView bufferCopyView =
                 mContext->createBufferCopyView(result.buffer, 0, resizedWidth * 4, height);
             wgpu::TextureCopyView textureCopyView =
-                mContext->createTextureCopyView(mTexture, i, 0, {0, 0, 0});
+                mContext->createTextureCopyView(mTexture, i, {0, 0, 0});
             wgpu::Extent3D copySize = {static_cast<uint32_t>(width), static_cast<uint32_t>(height),
                                        1};
             mContext->mCommandBuffers.emplace_back(

--- a/src/aquarium-optimized/dawn/imgui_impl_dawn.cpp
+++ b/src/aquarium-optimized/dawn/imgui_impl_dawn.cpp
@@ -203,7 +203,7 @@ static void ImGui_ImplDawn_CreateFontsTexture(bool enableAlphaBlending)
         wgpu::BufferCopyView bufferCopyView =
             mContextDawn->createBufferCopyView(result.buffer, 0, width * 4, height);
         wgpu::TextureCopyView textureCopyView =
-            mContextDawn->createTextureCopyView(mTexture, 0, 0, {0, 0, 0});
+            mContextDawn->createTextureCopyView(mTexture, 0, {0, 0, 0});
         wgpu::Extent3D copySize = {static_cast<uint32_t>(width), static_cast<uint32_t>(height), 1};
         wgpu::CommandBuffer copyCommand =
             mContextDawn->copyBufferToTexture(bufferCopyView, textureCopyView, copySize);


### PR DESCRIPTION
This manual intervention is needed because of recent deprecation of wgpu::TextureCopyView::arrayLayer:

https://dawn-review.googlesource.com/c/dawn/+/23104
