### PR TITLE
Change default fish count to 500

### DIFF
--- a/src/aquarium-optimized/Aquarium.cpp
+++ b/src/aquarium-optimized/Aquarium.cpp
@@ -39,7 +39,7 @@ Aquarium::Aquarium()
       mAquariumModels(),
       mContext(nullptr),
       mFpsTimer(),
-      mCurFishCount(1),
+      mCurFishCount(500),
       mPreFishCount(0),
       mTestTime(INT_MAX),
       mBackendType(BACKENDTYPE::BACKENDTYPELAST),


### PR DESCRIPTION
Previously it was set to 1 so no fish could be seen for first many
seconds after running the application. 500 is also the default value of
WebGL version.