### PR TITLE
Dismiss compilation warning about virtual dtor

### DIFF
--- a/src/aquarium-optimized/BufferManager.h
+++ b/src/aquarium-optimized/BufferManager.h
@@ -19,7 +19,7 @@ class RingBuffer
 {
   public:
     RingBuffer(size_t size) : mHead(0), mTail(size), mSize(size) {}
-    ~RingBuffer() {}
+    virtual ~RingBuffer() {}
 
     size_t getSize() const { return mSize; }
     size_t getAvailableSize() const { return mSize - mTail; }

--- a/src/aquarium-optimized/dawn/BufferManagerDawn.cpp
+++ b/src/aquarium-optimized/dawn/BufferManagerDawn.cpp
@@ -210,8 +210,7 @@ void BufferManagerDawn::flush()
         // All buffers are used once in buffer sync mode.
         for (size_t index = 0; index < mEnqueuedBufferList.size(); index++)
         {
-            RingBufferDawn *ringBuffer = static_cast<RingBufferDawn *>(mEnqueuedBufferList[index]);
-            delete ringBuffer;
+            delete mEnqueuedBufferList[index];
         }
         mUsedSize = 0;
     }

--- a/src/aquarium-optimized/dawn/BufferManagerDawn.h
+++ b/src/aquarium-optimized/dawn/BufferManagerDawn.h
@@ -19,7 +19,7 @@ class RingBufferDawn : public RingBuffer
 {
   public:
     RingBufferDawn(BufferManagerDawn *bufferManager, size_t size);
-    ~RingBufferDawn() {}
+    ~RingBufferDawn() override {}
 
     bool push(const wgpu::CommandEncoder &encoder,
               const wgpu::Buffer &destBuffer,


### PR DESCRIPTION
This is to dismiss the warning during compilation as below:
warning: delete called on non-final 'RingBufferDawn' that has virtual
functions but non-virtual destructor for "delete ringBuffer;" in
BufferManagerDawn.cpp(215,13).