### PR TITLE
Move inclusion of ContextGL.h from .cpp to .h file

### DIFF
--- a/src/aquarium-optimized/opengl/FishModelGL.h
+++ b/src/aquarium-optimized/opengl/FishModelGL.h
@@ -12,8 +12,9 @@
 
 #include "../FishModel.h"
 
-class TextureGL;
 class BufferGL;
+class ContextGL;
+class TextureGL;
 
 class FishModelGL : public FishModel
 {


### PR DESCRIPTION
FishModelGL.h actually relies on ContextGL.h, and this CL is to fix
this.