### PR TITLE
Revert "Fix another out of bound memory access (#135)"

### DIFF
--- a/src/common/FPSTimer.cpp
+++ b/src/common/FPSTimer.cpp
@@ -34,7 +34,7 @@ void FPSTimer::update(double elapsedTime, double renderingTime, int testTime)
 
     mAverageFPS = floor((1.0f / (mTotalTime / static_cast<double>(NUM_FRAMES_TO_AVERAGE))) + 0.5);
 
-    for (int i = 0; i < NUM_HISTORY_DATA - 1; i++)
+    for (int i = 0; i < NUM_HISTORY_DATA; i++)
     {
         mHistoryFPS[i]       = mHistoryFPS[i + 1];
         mHistoryFrameTime[i] = mHistoryFrameTime[i + 1];


### PR DESCRIPTION
This reverts commit fd601207f7aed482b57af6ec04a22752a9c7f988 due to wrong authorship. It should be relanded again with "Rebase and merge", if that helps.
