### PR TITLE
Massive clang-formatting

### DIFF
--- a/src/aquarium-direct-map/AttribBuffer.cpp
+++ b/src/aquarium-direct-map/AttribBuffer.cpp
@@ -12,10 +12,10 @@ AttribBuffer::AttribBuffer(int numComponents,
                            int size,
                            const std::string &opt_type)
     : type(opt_type),
-    bufferFloat(buffer),
-    bufferUShort(),
-    numComponents(numComponents),
-    numElements(size / numComponents)
+      bufferFloat(buffer),
+      bufferUShort(),
+      numComponents(numComponents),
+      numElements(size / numComponents)
 {
 }
 
@@ -24,9 +24,9 @@ AttribBuffer::AttribBuffer(int numComponents,
                            int size,
                            const std::string &opt_type)
     : type(opt_type),
-    bufferFloat(),
-    bufferUShort(buffer),
-    numComponents(numComponents),
-    numElements(size / numComponents)
+      bufferFloat(),
+      bufferUShort(buffer),
+      numComponents(numComponents),
+      numElements(size / numComponents)
 {
 }

--- a/src/aquarium-direct-map/AttribBuffer.h
+++ b/src/aquarium-direct-map/AttribBuffer.h
@@ -13,27 +13,30 @@
 
 class AttribBuffer
 {
-public:
-  AttribBuffer() {}
-  AttribBuffer(int numComponents, const std::vector<float> &buffer, int size, const std::string &opt_type);
-  AttribBuffer(int numComponents,
-               const std::vector<unsigned short> &buffer,
-               int size,
-               const std::string &opt_type);
+  public:
+    AttribBuffer() {}
+    AttribBuffer(int numComponents,
+                 const std::vector<float> &buffer,
+                 int size,
+                 const std::string &opt_type);
+    AttribBuffer(int numComponents,
+                 const std::vector<unsigned short> &buffer,
+                 int size,
+                 const std::string &opt_type);
 
-  int getNumComponents() const { return numComponents; }
-  int getNumElements() const { return numElements; }
+    int getNumComponents() const { return numComponents; }
+    int getNumElements() const { return numElements; }
 
-  const std::vector<float> &getBufferFloat() const { return bufferFloat; }
-  const std::vector<unsigned short> &getBufferUShort() const { return bufferUShort; }
-  const std::string &getType() const { return type; }
+    const std::vector<float> &getBufferFloat() const { return bufferFloat; }
+    const std::vector<unsigned short> &getBufferUShort() const { return bufferUShort; }
+    const std::string &getType() const { return type; }
 
-private:
-  std::string type;
-  std::vector<float> bufferFloat;
-  std::vector<unsigned short> bufferUShort;
-  int numComponents;
-  int numElements;
+  private:
+    std::string type;
+    std::vector<float> bufferFloat;
+    std::vector<unsigned short> bufferUShort;
+    int numComponents;
+    int numElements;
 };
 
 #endif  // ATTRIBBUFFER_H

--- a/src/aquarium-direct-map/Buffer.h
+++ b/src/aquarium-direct-map/Buffer.h
@@ -16,29 +16,29 @@
 
 class Buffer
 {
-public:
-  Buffer() {}
-  Buffer(const AttribBuffer &array, GLenum target);
-  ~Buffer();
+  public:
+    Buffer() {}
+    Buffer(const AttribBuffer &array, GLenum target);
+    ~Buffer();
 
-  GLuint getBuffer() const { return mBuf; }
-  int getNumComponents() const { return mNumComponents; }
-  int getNumElements() const { return mNumElements; }
-  int getTotalComponents() const { return mTotalComponents; }
-  GLenum getType() const { return mType; }
-  bool getNormalize() const { return mNormalize; }
-  GLsizei getStride() const { return mStride; }
-  void *getOffset() const { return mOffset; }
+    GLuint getBuffer() const { return mBuf; }
+    int getNumComponents() const { return mNumComponents; }
+    int getNumElements() const { return mNumElements; }
+    int getTotalComponents() const { return mTotalComponents; }
+    GLenum getType() const { return mType; }
+    bool getNormalize() const { return mNormalize; }
+    GLsizei getStride() const { return mStride; }
+    void *getOffset() const { return mOffset; }
 
-private:
-  GLuint mBuf;
-  int mNumComponents;
-  int mNumElements;
-  int mTotalComponents;
-  GLenum mType;
-  bool mNormalize;
-  GLsizei mStride;
-  void *mOffset;
+  private:
+    GLuint mBuf;
+    int mNumComponents;
+    int mNumElements;
+    int mTotalComponents;
+    GLenum mType;
+    bool mNormalize;
+    GLsizei mStride;
+    void *mOffset;
 };
 
 #endif  // BUFFER_H

--- a/src/aquarium-direct-map/Globals.h
+++ b/src/aquarium-direct-map/Globals.h
@@ -29,7 +29,7 @@ class Scene;
 class Program;
 class Texture;
 
-static FPSTimer g_fpsTimer;           // object to measure frames per second;
+static FPSTimer g_fpsTimer;                                // object to measure frames per second;
 static std::unordered_map<std::string, Scene *> g_scenes;  // each of the models
 static std::unordered_map<std::string, std::multimap<std::string, std::vector<float>>>
     g_sceneGroups;  // the placement of the models
@@ -40,30 +40,30 @@ static std::unordered_map<std::string, Texture *>
 constexpr bool g_fog = true;
 
 constexpr float g_tailOffsetMult = 1.0f;
-constexpr float g_speed = 1.0f;
+constexpr float g_speed          = 1.0f;
 
-constexpr int numFishSmall = 100;
-constexpr int numFishMedium = 1000;
-constexpr int numFishBig = 10000;
-constexpr int numFishLeftSmall = 80;
-constexpr int numFishLeftBig = 160;
-constexpr float sand_shininess = 5.0f;
-constexpr float sand_specularFactor = 0.3f;
-constexpr float generic_shininess = 50.0f;
+constexpr int numFishSmall             = 100;
+constexpr int numFishMedium            = 1000;
+constexpr int numFishBig               = 10000;
+constexpr int numFishLeftSmall         = 80;
+constexpr int numFishLeftBig           = 160;
+constexpr float sand_shininess         = 5.0f;
+constexpr float sand_specularFactor    = 0.3f;
+constexpr float generic_shininess      = 50.0f;
 constexpr float generic_specularFactor = 1.0f;
-constexpr float outside_shininess = 50.0f;
+constexpr float outside_shininess      = 50.0f;
 constexpr float outside_specularFactor = 0.0f;
-constexpr float seaweed_shininess = 50.0f;
+constexpr float seaweed_shininess      = 50.0f;
 constexpr float seaweed_specularFactor = 1.0f;
-constexpr float inner_shininess = 50.0f;
-constexpr float inner_specularFactor = 1.0f;
-constexpr float fish_shininess = 5.0f;
-constexpr float fish_specularFactor = 0.3f;
+constexpr float inner_shininess        = 50.0f;
+constexpr float inner_specularFactor   = 1.0f;
+constexpr float fish_shininess         = 5.0f;
+constexpr float fish_specularFactor    = 0.3f;
 
 struct G_ui_per
 {
-    const char* obj;
-    const char* name;
+    const char *obj;
+    const char *name;
     float value;
     float max;
     float min;
@@ -72,30 +72,31 @@ struct G_ui_per
 static std::unordered_map<std::string, std::unordered_map<std::string, float>>
     g;  // set min value as initialize value
 
-constexpr float g_fovFudge = 1.0f;
-constexpr float g_net_offset[3] = { 0.0f, 0.0f, 0.0f };
+constexpr float g_fovFudge       = 1.0f;
+constexpr float g_net_offset[3]  = {0.0f, 0.0f, 0.0f};
 constexpr float g_net_offsetMult = 1.21f;
 
-struct G_viewSettings {
-    float targetHeight = 63.3f;
-    float targetRadius = 91.6f;
-    float eyeHeight = 7.5f;
-    float eyeRadius = 13.2f;
-    float eyeSpeed = 0.0258f;
-    float fieldOfView = 82.699f;
-    float ambientRed = 0.218f;
-    float ambientGreen = 0.502f;
-    float ambientBlue = 0.706f;
-    float fogPower = 16.5f;
-    float fogMult = 1.5f; //2.02,
-    float fogOffset = 0.738f;
-    float fogRed = 0.338f;
-    float fogGreen = 0.81f;
-    float fogBlue = 1.0f;
+struct G_viewSettings
+{
+    float targetHeight    = 63.3f;
+    float targetRadius    = 91.6f;
+    float eyeHeight       = 7.5f;
+    float eyeRadius       = 13.2f;
+    float eyeSpeed        = 0.0258f;
+    float fieldOfView     = 82.699f;
+    float ambientRed      = 0.218f;
+    float ambientGreen    = 0.502f;
+    float ambientBlue     = 0.706f;
+    float fogPower        = 16.5f;
+    float fogMult         = 1.5f;  // 2.02,
+    float fogOffset       = 0.738f;
+    float fogRed          = 0.338f;
+    float fogGreen        = 0.81f;
+    float fogBlue         = 1.0f;
     float refractionFudge = 3.0f;
-    float eta = 1.0f;
-    float tankColorFudge = 0.796f;
-}constexpr g_viewSettings;
+    float eta             = 1.0f;
+    float tankColorFudge  = 0.796f;
+} constexpr g_viewSettings;
 
 static std::vector<float> projection(16);
 static std::vector<float> view(16);
@@ -125,7 +126,7 @@ static std::vector<float> specular   = {1.0f, 1.0f, 1.0f, 1.0f};
 static std::vector<float> ambient(4);
 static std::vector<float> fogColor = {1.0f, 1.0f, 1.0f, 1.0f};
 
-//Generic uniforms
+// Generic uniforms
 struct GenericConst
 {
     std::vector<float> *viewProjection;
@@ -191,7 +192,8 @@ struct ConstUniforms
     float fishBendAmount;
 };
 
-struct Fish {
+struct Fish
+{
     std::string name;
     float speed;
     float speedRange;

--- a/src/aquarium-direct-map/Main.cpp
+++ b/src/aquarium-direct-map/Main.cpp
@@ -19,11 +19,11 @@
 #include <Windows.h>
 #include <direct.h>
 #elif __APPLE__
-#include <ctime>
 #include <mach-o/dyld.h>
-#else
 #include <ctime>
+#else
 #include <unistd.h>
+#include <ctime>
 #endif
 
 #define GLFW_INCLUDE_NONE
@@ -41,7 +41,7 @@
 #include "common/AQUARIUM_ASSERT.h"
 #include "include/CmdArgsHelper.h"
 
-#define min(a,b) ((a)<(b)?(a):(b))
+#define min(a, b) ((a) < (b) ? (a) : (b))
 
 void render();
 
@@ -57,62 +57,92 @@ std::string mPath;
 int g_numFish;
 
 // Variables calculate time
-float then = 0.0f;
-float mClock = 0.0f;
+float then     = 0.0f;
+float mClock   = 0.0f;
 float eyeClock = 0.0f;
 
 const G_ui_per g_ui[] = {
-    { "globals", "speed", 1.0f, 4.0f },{ "globals", "targetHeight", 0.0f, 150.0f },
-    { "globals", "targetRadius", 88.0f, 200.0f },{ "globals", "eyeHeight", 19.0f, 150.0f },
-    { "globals", "eyeSpeed", 0.06f, 1.0f },{ "globals", "fieldOfView", 85.0f, 179.0f, 1.0f },
-    { "globals", "ambientRed", 0.22f, 1.0f },{ "globals", "ambientGreen", 0.25f, 1.0f },
-    { "globals", "ambientBlue", 0.39f, 1.0f },{ "globals", "fogPower", 14.5f, 50.0f },
-    { "globals", "fogMult", 1.66f, 10.0f },{ "globals", "fogOffset", 0.53f, 3.0f },
-    { "globals", "fogRed", 0.54f, 1.0f },{ "globals", "fogGreen", 0.86f, 1.0f },
-    { "globals", "fogBlue", 1.0f, 1.0f },{ "fish", "fishHeightRange", 1.0f, 3.0f },
-    { "fish", "fishHeight", 25.0f, 50.0f },{ "fish", "fishSpeed", 0.124f, 2.0f },
-    { "fish", "fishOffset", 0.52f, 2.0f },{ "fish", "fishXClock", 1.0f, 2.0f },
-    { "fish", "fishYClock", 0.556f, 2.0f },{ "fish", "fishZClock", 1.0f, 2.0f },
-    { "fish", "fishTailSpeed", 1.0f, 30.0f },{ "innerConst", "refractionFudge", 3.0f, 50.0f },
-    { "innerConst", "eta", 1.0f, 1.20f },{ "innerConst", "tankColorFudge", 0.8f, 2.0f } };
+    {"globals", "speed", 1.0f, 4.0f},           {"globals", "targetHeight", 0.0f, 150.0f},
+    {"globals", "targetRadius", 88.0f, 200.0f}, {"globals", "eyeHeight", 19.0f, 150.0f},
+    {"globals", "eyeSpeed", 0.06f, 1.0f},       {"globals", "fieldOfView", 85.0f, 179.0f, 1.0f},
+    {"globals", "ambientRed", 0.22f, 1.0f},     {"globals", "ambientGreen", 0.25f, 1.0f},
+    {"globals", "ambientBlue", 0.39f, 1.0f},    {"globals", "fogPower", 14.5f, 50.0f},
+    {"globals", "fogMult", 1.66f, 10.0f},       {"globals", "fogOffset", 0.53f, 3.0f},
+    {"globals", "fogRed", 0.54f, 1.0f},         {"globals", "fogGreen", 0.86f, 1.0f},
+    {"globals", "fogBlue", 1.0f, 1.0f},         {"fish", "fishHeightRange", 1.0f, 3.0f},
+    {"fish", "fishHeight", 25.0f, 50.0f},       {"fish", "fishSpeed", 0.124f, 2.0f},
+    {"fish", "fishOffset", 0.52f, 2.0f},        {"fish", "fishXClock", 1.0f, 2.0f},
+    {"fish", "fishYClock", 0.556f, 2.0f},       {"fish", "fishZClock", 1.0f, 2.0f},
+    {"fish", "fishTailSpeed", 1.0f, 30.0f},     {"innerConst", "refractionFudge", 3.0f, 50.0f},
+    {"innerConst", "eta", 1.0f, 1.20f},         {"innerConst", "tankColorFudge", 0.8f, 2.0f}};
 
-G_sceneInfo g_sceneInfo[] = { { "SmallFishA",{ "fishVertexShader", "fishReflectionFragmentShader" }, true },
-{ "MediumFishA",{ "fishVertexShader", "fishNormalMapFragmentShader" }, true },
-{ "MediumFishB",{ "fishVertexShader", "fishReflectionFragmentShader" }, true },
-{ "BigFishA",{ "fishVertexShader", "fishNormalMapFragmentShader" }, true },
-{ "BigFishB",{ "fishVertexShader", "fishNormalMapFragmentShader" }, true },
-{ "Arch",{ "", "" }, true },
-{ "Coral",{ "", "" }, true },
-{ "CoralStoneA",{ "", "" }, true },
-{ "CoralStoneB",{ "", "" }, true },
-{ "EnvironmentBox",{ "diffuseVertexShader", "diffuseFragmentShader" }, false, "outside" },
-{ "FloorBase_Baked",{ "", "" }, true },
-{ "FloorCenter",{ "", "" }, true },
-{ "GlobeBase",{ "diffuseVertexShader", "diffuseFragmentShader" } },
-{ "GlobeInner",{ "innerRefractionMapVertexShader", "innerRefractionMapFragmentShader" }, true, "inner" },
-{ "RockA",{ "", "" }, true },
-{ "RockB",{ "", "" }, true },
-{ "RockC",{ "", "" }, true },
-{ "RuinColumn",{ "", "" }, true },
-{ "Skybox",{ "diffuseVertexShader", "diffuseFragmentShader" }, false, "outside" },
-{ "Stone",{ "", "" }, true },
-{ "Stones",{ "", "" }, true },
-{ "SunknShip",{ "", "" }, true },
-{ "SunknSub",{ "", "" }, true },
-{ "SupportBeams",{ "", "" }, false, "outside" },
-{ "SeaweedA",{ "seaweedVertexShader", "seaweedFragmentShader" }, false, "seaweed", true },
-{ "SeaweedB",{ "seaweedVertexShader", "seaweedFragmentShader" }, false, "seaweed", true },
-{ "TreasureChest",{ "", "" }, true } };
+G_sceneInfo g_sceneInfo[] = {
+    {"SmallFishA", {"fishVertexShader", "fishReflectionFragmentShader"}, true},
+    {"MediumFishA", {"fishVertexShader", "fishNormalMapFragmentShader"}, true},
+    {"MediumFishB", {"fishVertexShader", "fishReflectionFragmentShader"}, true},
+    {"BigFishA", {"fishVertexShader", "fishNormalMapFragmentShader"}, true},
+    {"BigFishB", {"fishVertexShader", "fishNormalMapFragmentShader"}, true},
+    {"Arch", {"", ""}, true},
+    {"Coral", {"", ""}, true},
+    {"CoralStoneA", {"", ""}, true},
+    {"CoralStoneB", {"", ""}, true},
+    {"EnvironmentBox", {"diffuseVertexShader", "diffuseFragmentShader"}, false, "outside"},
+    {"FloorBase_Baked", {"", ""}, true},
+    {"FloorCenter", {"", ""}, true},
+    {"GlobeBase", {"diffuseVertexShader", "diffuseFragmentShader"}},
+    {"GlobeInner",
+     {"innerRefractionMapVertexShader", "innerRefractionMapFragmentShader"},
+     true,
+     "inner"},
+    {"RockA", {"", ""}, true},
+    {"RockB", {"", ""}, true},
+    {"RockC", {"", ""}, true},
+    {"RuinColumn", {"", ""}, true},
+    {"Skybox", {"diffuseVertexShader", "diffuseFragmentShader"}, false, "outside"},
+    {"Stone", {"", ""}, true},
+    {"Stones", {"", ""}, true},
+    {"SunknShip", {"", ""}, true},
+    {"SunknSub", {"", ""}, true},
+    {"SupportBeams", {"", ""}, false, "outside"},
+    {"SeaweedA", {"seaweedVertexShader", "seaweedFragmentShader"}, false, "seaweed", true},
+    {"SeaweedB", {"seaweedVertexShader", "seaweedFragmentShader"}, false, "seaweed", true},
+    {"TreasureChest", {"", ""}, true}};
 
 std::unordered_map<std::string, G_sceneInfo> g_sceneInfoByName;
 
-Fish g_fishTable[] = { { "SmallFishA", 1.0f, 1.5f, 30.0f, 25.0f, 10.0f, 0.0f, 16.0f,{ 10.0f, 1.0f, 2.0f } },
-{ "MediumFishA", 1.0f, 2.0f, 10.0f, 20.0f, 1.0f, 0.0f, 16.0f,{ 10.0f, -2.0f, 2.0f } },
-{ "MediumFishB", 0.5f, 4.0f, 10.0f, 20.0f, 3.0f, -8.0f, 5.0f,{ 10.0f, -2.0f, 2.0f } },
-{ "BigFishA", 0.5f, 0.5f, 50.0f, 3.0f, 1.5f, 0.0f, 16.0f,{ 10.0f, -1.0f, 0.5f }, true, 0.04f,{ 0.0f, 0.1f, 9.0f },{ 0.3f, 0.3f, 1000.0f } },
-{ "BigFishB", 0.5f, 0.5f, 45.0f, 3.0f, 1.0f, 0.0f, 16.0f,{ 10.0f, -0.7f, 0.3f }, true, 0.04f,{ 0.0f, -0.3f, 9.0f },{ 0.3f, 0.3f, 1000.0f } } };
+Fish g_fishTable[] = {
+    {"SmallFishA", 1.0f, 1.5f, 30.0f, 25.0f, 10.0f, 0.0f, 16.0f, {10.0f, 1.0f, 2.0f}},
+    {"MediumFishA", 1.0f, 2.0f, 10.0f, 20.0f, 1.0f, 0.0f, 16.0f, {10.0f, -2.0f, 2.0f}},
+    {"MediumFishB", 0.5f, 4.0f, 10.0f, 20.0f, 3.0f, -8.0f, 5.0f, {10.0f, -2.0f, 2.0f}},
+    {"BigFishA",
+     0.5f,
+     0.5f,
+     50.0f,
+     3.0f,
+     1.5f,
+     0.0f,
+     16.0f,
+     {10.0f, -1.0f, 0.5f},
+     true,
+     0.04f,
+     {0.0f, 0.1f, 9.0f},
+     {0.3f, 0.3f, 1000.0f}},
+    {"BigFishB",
+     0.5f,
+     0.5f,
+     45.0f,
+     3.0f,
+     1.0f,
+     0.0f,
+     16.0f,
+     {10.0f, -0.7f, 0.3f},
+     true,
+     0.04f,
+     {0.0f, -0.3f, 9.0f},
+     {0.3f, 0.3f, 1000.0f}}};
 
-void setGenericConstMatrix(GenericConst *genericConst) {
+void setGenericConstMatrix(GenericConst *genericConst)
+{
     genericConst->viewProjection = &viewProjection;
     genericConst->viewInverse    = &viewInverse;
     genericConst->lightWorldPos  = &lightWorldPos;
@@ -125,12 +155,13 @@ void setGenericConstMatrix(GenericConst *genericConst) {
 void setGenericPer(GenericPer *genericPer)
 {
     genericPer->world                 = &world;
-    genericPer->worldViewProjection  = &worldViewProjection;
+    genericPer->worldViewProjection   = &worldViewProjection;
     genericPer->worldInverse          = &worldInverse;
     genericPer->worldInverseTranspose = &worldInverseTraspose;
 }
 
-void initializeUniforms() {
+void initializeUniforms()
+{
     sandConst.shininess      = sand_shininess;
     sandConst.specularFactor = sand_specularFactor;
 
@@ -143,11 +174,11 @@ void initializeUniforms() {
     seaweedConst.shininess      = seaweed_shininess;
     seaweedConst.specularFactor = seaweed_specularFactor;
 
-    innerConst.shininess                   = inner_shininess;
-    innerConst.specularFactor              = inner_specularFactor;
-    innerConst.eta                         = g_viewSettings.eta;
-    innerConst.refractionFudge             = g_viewSettings.refractionFudge;
-    innerConst.tankColorFudge              = g_viewSettings.tankColorFudge;
+    innerConst.shininess       = inner_shininess;
+    innerConst.specularFactor  = inner_specularFactor;
+    innerConst.eta             = g_viewSettings.eta;
+    innerConst.refractionFudge = g_viewSettings.refractionFudge;
+    innerConst.tankColorFudge  = g_viewSettings.tankColorFudge;
 
     fishConst.genericConst.shininess      = fish_shininess;
     fishConst.genericConst.specularFactor = fish_specularFactor;
@@ -306,7 +337,7 @@ bool initialize(int argc, char **argv)
     LoadScenes();
 
     // "--num-fish" {numfish}: imply rendering fish count.
-    char* pNext;
+    char *pNext;
     for (int i = 1; i < argc; ++i)
     {
         std::string cmd(argv[i]);
@@ -323,47 +354,48 @@ bool initialize(int argc, char **argv)
 
     // Calculate fish count for each float of fish
     std::string floats[3] = {"Big", "Medium", "Small"};
-    int totalFish = g_numFish;
-        int numLeft = totalFish;
-        for (auto &type : floats)
+    int totalFish         = g_numFish;
+    int numLeft           = totalFish;
+    for (auto &type : floats)
+    {
+        for (auto &fishInfo : g_fishTable)
         {
-            for (auto &fishInfo : g_fishTable)
+            std::string &fishName = fishInfo.name;
+            if (fishName.find(type))
             {
-                std::string &fishName = fishInfo.name;
-                if (fishName.find(type))
-                {
-                    continue;
-                }
-                int numfloat = numLeft;
-                if (type == "Big")
-                {
-                    int temp = totalFish < numFishSmall ? 1 : 2;
-                    numfloat = min(numLeft, temp);
-                }
-                else if (type == "Medium")
-                {
-                    if (totalFish < numFishMedium)
-                    {
-                        numfloat = min(numLeft, totalFish / 10);
-                    }
-                    else if (totalFish < numFishBig)
-                    {
-                        numfloat = min(numLeft, numFishLeftSmall);
-                    }
-                    else
-                    {
-                        numfloat = min(numLeft, numFishLeftBig);
-                    }
-                }
-                numLeft = numLeft - numfloat;
-                fishInfo.num = numfloat;
+                continue;
             }
+            int numfloat = numLeft;
+            if (type == "Big")
+            {
+                int temp = totalFish < numFishSmall ? 1 : 2;
+                numfloat = min(numLeft, temp);
+            }
+            else if (type == "Medium")
+            {
+                if (totalFish < numFishMedium)
+                {
+                    numfloat = min(numLeft, totalFish / 10);
+                }
+                else if (totalFish < numFishBig)
+                {
+                    numfloat = min(numLeft, numFishLeftSmall);
+                }
+                else
+                {
+                    numfloat = min(numLeft, numFishLeftBig);
+                }
+            }
+            numLeft      = numLeft - numfloat;
+            fishInfo.num = numfloat;
+        }
     }
 
     return true;
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
 
     // initialize GLFW
     if (!glfwInit())
@@ -387,10 +419,10 @@ int main(int argc, char **argv) {
     glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);
     glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
 
-    GLFWmonitor *pMonitor = glfwGetPrimaryMonitor();
+    GLFWmonitor *pMonitor   = glfwGetPrimaryMonitor();
     const GLFWvidmode *mode = glfwGetVideoMode(pMonitor);
-    clientWidth = mode->width;
-    clientHeight = mode->height;
+    clientWidth             = mode->width;
+    clientHeight            = mode->height;
 
     window = glfwCreateWindow(clientWidth, clientHeight, "Aquarium", NULL, NULL);
     if (window == NULL)
@@ -484,7 +516,8 @@ void DrawGroup(const std::multimap<std::string, std::vector<float>> &group,
     }
 }
 
-void render() {
+void render()
+{
     // Update our time
 #ifdef _WIN32
     float now = GetTickCount64() / 1000.0f;
@@ -528,14 +561,14 @@ void render() {
     float nearPlane = 1;
     float farPlane  = 25000.0f;
     float aspect    = static_cast<float>(clientWidth) / static_cast<float>(clientHeight);
-    float top       = tan(matrix::degToRad(g_viewSettings.fieldOfView * g_fovFudge) * 0.5f) * nearPlane;
-    float bottom    = -top;
-    float left      = aspect * bottom;
-    float right     = aspect * top;
-    float width     = abs(right - left);
-    float height    = abs(top - bottom);
-    float xOff      = width * g_net_offset[0] * g_net_offsetMult;
-    float yOff      = height * g_net_offset[1] * g_net_offsetMult;
+    float top = tan(matrix::degToRad(g_viewSettings.fieldOfView * g_fovFudge) * 0.5f) * nearPlane;
+    float bottom = -top;
+    float left   = aspect * bottom;
+    float right  = aspect * top;
+    float width  = abs(right - left);
+    float height = abs(top - bottom);
+    float xOff   = width * g_net_offset[0] * g_net_offsetMult;
+    float yOff   = height * g_net_offset[1] * g_net_offsetMult;
 
     matrix::frustum(projection, left + xOff, right + xOff, bottom + yOff, top + yOff, nearPlane,
                     farPlane);
@@ -569,21 +602,21 @@ void render() {
 
     if (g_fog)
     {
-        genericConst.fogPower             = g_viewSettings.fogPower;
-        genericConst.fogMult              = g_viewSettings.fogMult;
-        genericConst.fogOffset            = g_viewSettings.fogOffset;
-        fishConst.genericConst.fogPower   = g_viewSettings.fogPower;
-        fishConst.genericConst.fogMult    = g_viewSettings.fogMult;
-        fishConst.genericConst.fogOffset  = g_viewSettings.fogOffset;
-        innerConst.fogPower               = g_viewSettings.fogPower;
-        innerConst.fogMult                = g_viewSettings.fogMult;
-        innerConst.fogOffset              = g_viewSettings.fogOffset;
-        seaweedConst.fogPower             = g_viewSettings.fogPower;
-        seaweedConst.fogMult              = g_viewSettings.fogMult;
-        seaweedConst.fogOffset            = g_viewSettings.fogOffset;
-        fogColor[0]                     = g_viewSettings.fogRed;
-        fogColor[1]                     = g_viewSettings.fogGreen;
-        fogColor[2]                     = g_viewSettings.fogBlue;
+        genericConst.fogPower            = g_viewSettings.fogPower;
+        genericConst.fogMult             = g_viewSettings.fogMult;
+        genericConst.fogOffset           = g_viewSettings.fogOffset;
+        fishConst.genericConst.fogPower  = g_viewSettings.fogPower;
+        fishConst.genericConst.fogMult   = g_viewSettings.fogMult;
+        fishConst.genericConst.fogOffset = g_viewSettings.fogOffset;
+        innerConst.fogPower              = g_viewSettings.fogPower;
+        innerConst.fogMult               = g_viewSettings.fogMult;
+        innerConst.fogOffset             = g_viewSettings.fogOffset;
+        seaweedConst.fogPower            = g_viewSettings.fogPower;
+        seaweedConst.fogMult             = g_viewSettings.fogMult;
+        seaweedConst.fogOffset           = g_viewSettings.fogOffset;
+        fogColor[0]                      = g_viewSettings.fogRed;
+        fogColor[1]                      = g_viewSettings.fogGreen;
+        fogColor[2]                      = g_viewSettings.fogBlue;
     }
 
     // Draw Scene
@@ -606,13 +639,13 @@ void render() {
             auto &f                 = g["fish"];
             fishConst.constUniforms = fishInfo.constUniforms;
             fish->prepareForDraw(fishConst);
-            float fishBaseClock                  = mClock * f["fishSpeed"];
-            float fishRadius                     = fishInfo.radius;
-            float fishRadiusRange                = fishInfo.radiusRange;
-            float fishSpeed                      = fishInfo.speed;
-            float fishSpeedRange                 = fishInfo.speedRange;
-            float fishTailSpeed                  = fishInfo.tailSpeed * f["fishTailSpeed"];
-            float fishOffset                     = f["fishOffset"];
+            float fishBaseClock   = mClock * f["fishSpeed"];
+            float fishRadius      = fishInfo.radius;
+            float fishRadiusRange = fishInfo.radiusRange;
+            float fishSpeed       = fishInfo.speed;
+            float fishSpeedRange  = fishInfo.speedRange;
+            float fishTailSpeed   = fishInfo.tailSpeed * f["fishTailSpeed"];
+            float fishOffset      = f["fishOffset"];
             // float fishClockSpeed                 = f["fishSpeed"];
             float fishHeight                     = f["fishHeight"] + fishInfo.heightOffset;
             float fishHeightRange                = f["fishHeightRange"] * fishInfo.heightRange;

--- a/src/aquarium-direct-map/Matrix.h
+++ b/src/aquarium-direct-map/Matrix.h
@@ -12,7 +12,8 @@
 #include <cmath>
 #include <vector>
 
-namespace matrix {
+namespace matrix
+{
 static long long RANDOM_RANGE_ = 4294967296;
 
 template <typename T>
@@ -410,6 +411,6 @@ float degToRad(float degrees)
 {
     return static_cast<float>(degrees * M_PI / 180.0);
 }
-}
+}  // namespace matrix
 
 #endif  // MATRIX_H

--- a/src/aquarium-direct-map/Model.cpp
+++ b/src/aquarium-direct-map/Model.cpp
@@ -14,10 +14,7 @@
 Model::Model(Program *program_,
              const std::unordered_map<std::string, const AttribBuffer *> &arrays,
              const std::unordered_map<std::string, Texture *> *textures)
-    : buffers(),
-    textures(textures),
-    program(program_),
-    mode(GL_TRIANGLES)
+    : buffers(), textures(textures), program(program_), mode(GL_TRIANGLES)
 {
     setBuffers(arrays);
 

--- a/src/aquarium-direct-map/Model.h
+++ b/src/aquarium-direct-map/Model.h
@@ -23,31 +23,30 @@ struct GenericPer;
 
 class Model
 {
-public:
-  Model() {}
-  ~Model();
-  Model(Program *program,
-        const std::unordered_map<std::string, const AttribBuffer *> &arrays,
-        const std::unordered_map<std::string, Texture *> *textures);
+  public:
+    Model() {}
+    ~Model();
+    Model(Program *program,
+          const std::unordered_map<std::string, const AttribBuffer *> &arrays,
+          const std::unordered_map<std::string, Texture *> *textures);
 
-  void prepareForDraw(const GenericConst &constUniforms);
-  void prepareForDraw(const FishConst &fishConst);
-  void draw(const GenericPer &perUniforms);
-  void draw(const FishPer &fishPer);
+    void prepareForDraw(const GenericConst &constUniforms);
+    void prepareForDraw(const FishConst &fishConst);
+    void draw(const GenericPer &perUniforms);
+    void draw(const FishPer &fishPer);
 
-private:
-  void setBuffers(const std::unordered_map<std::string, const AttribBuffer *> &arrays);
-  void setBuffer(const std::string &name, const AttribBuffer &array);
-  void applyBuffers() const;
-  void applyTextures() const;
-  void drawFunc();
+  private:
+    void setBuffers(const std::unordered_map<std::string, const AttribBuffer *> &arrays);
+    void setBuffer(const std::string &name, const AttribBuffer &array);
+    void applyBuffers() const;
+    void applyTextures() const;
+    void drawFunc();
 
-  std::unordered_map<std::string, Buffer *> buffers;
-  const std::unordered_map<std::string, Texture *> *textures;
-  Program *program;
+    std::unordered_map<std::string, Buffer *> buffers;
+    const std::unordered_map<std::string, Texture *> *textures;
+    Program *program;
 
-  GLenum mode;
-
+    GLenum mode;
 };
 
 #endif  // MODEL_H

--- a/src/aquarium-direct-map/Program.cpp
+++ b/src/aquarium-direct-map/Program.cpp
@@ -18,10 +18,7 @@
 #include "common/AQUARIUM_ASSERT.h"
 
 Program::Program(const std::string &vId, const std::string &fId)
-    : program(0u),
-    attribLocs(),
-    uniforms(),
-    textureUnits()
+    : program(0u), attribLocs(), uniforms(), textureUnits()
 {
     createProgramFromTags(vId, fId);
     createSetters();
@@ -45,12 +42,12 @@ void Program::createProgramFromTags(const std::string &vId, const std::string &f
 {
     std::ifstream VertexShaderStream(vId, std::ios::in);
     std::string VertexShaderCode((std::istreambuf_iterator<char>(VertexShaderStream)),
-        std::istreambuf_iterator<char>());
+                                 std::istreambuf_iterator<char>());
     VertexShaderStream.close();
 
     std::ifstream FragmentShaderStream(fId, std::ios::in);
     std::string FragmentShaderCode((std::istreambuf_iterator<char>(FragmentShaderStream)),
-        std::istreambuf_iterator<char>());
+                                   std::istreambuf_iterator<char>());
     FragmentShaderStream.close();
 
     const std::string fogUniforms =
@@ -63,9 +60,11 @@ void Program::createProgramFromTags(const std::string &vId, const std::string &f
         clamp(pow((v_position.z / v_position.w), fogPower) * fogMult - fogOffset,0.0,1.0));)";
 
 #ifdef __APPLE__
-    VertexShaderCode = std::regex_replace(VertexShaderCode, std::regex(R"(#version 450 core)"), R"(#version 410 core)");
-    FragmentShaderCode = std::regex_replace(FragmentShaderCode, std::regex(R"(#version 450 core)"), R"(#version 410 core)");
-    #endif
+    VertexShaderCode   = std::regex_replace(VertexShaderCode, std::regex(R"(#version 450 core)"),
+                                          R"(#version 410 core)");
+    FragmentShaderCode = std::regex_replace(FragmentShaderCode, std::regex(R"(#version 450 core)"),
+                                            R"(#version 410 core)");
+#endif
 
     // enable fog, reflection and normalMaps
     FragmentShaderCode =
@@ -199,7 +198,7 @@ void Program::setUniform(const std::string &name, float v)
         return;
     }
     Uniform *uniform = uniforms[name];
-    GLint loc = uniform->getIndex();
+    GLint loc        = uniform->getIndex();
     ASSERT(uniform->getType() == GL_FLOAT);
     glUniform1f(loc, v);
 

--- a/src/aquarium-direct-map/Program.h
+++ b/src/aquarium-direct-map/Program.h
@@ -18,33 +18,33 @@
 
 class Program
 {
-public:
-  Program() {}
-  Program(const std::string &vId, const std::string &fId);
-  ~Program();
-  void use();
-  void setUniform(const std::string &name, float v);
-  void setUniform(const std::string &name, const std::vector<float> &v);
-  void setUniform(const std::string &name, const Texture &texture);
+  public:
+    Program() {}
+    Program(const std::string &vId, const std::string &fId);
+    ~Program();
+    void use();
+    void setUniform(const std::string &name, float v);
+    void setUniform(const std::string &name, const std::vector<float> &v);
+    void setUniform(const std::string &name, const Texture &texture);
 
-  const std::unordered_map<std::string, GLint> &getAttribLocs() const { return attribLocs; }
-  const std::unordered_map<std::string, Uniform *> &getUniforms() const { return uniforms; }
+    const std::unordered_map<std::string, GLint> &getAttribLocs() const { return attribLocs; }
+    const std::unordered_map<std::string, Uniform *> &getUniforms() const { return uniforms; }
 
-  void setTextureUnits(const std::unordered_map<std::string, Texture *> &textureMap);
-  void setAttrib(const Buffer &buf, const std::string &name);
+    void setTextureUnits(const std::unordered_map<std::string, Texture *> &textureMap);
+    void setAttrib(const Buffer &buf, const std::string &name);
 
-  GLuint getProgramId() { return program; }
+    GLuint getProgramId() { return program; }
 
-private:
-  void createProgramFromTags(const std::string &vId, const std::string &fId);
-  GLuint LoadProgram(const std::string &vertexShader, const std::string &fragmentShader);
-  void createSetters();
+  private:
+    void createProgramFromTags(const std::string &vId, const std::string &fId);
+    GLuint LoadProgram(const std::string &vertexShader, const std::string &fragmentShader);
+    void createSetters();
 
-  GLuint program;
-  std::unordered_map<std::string, GLint> attribLocs;    // name, location
-  std::unordered_map<std::string, Uniform *> uniforms;  // name, type
+    GLuint program;
+    std::unordered_map<std::string, GLint> attribLocs;    // name, location
+    std::unordered_map<std::string, Uniform *> uniforms;  // name, type
 
-  std::unordered_map<std::string, int> textureUnits;
+    std::unordered_map<std::string, int> textureUnits;
 };
 
 #endif  // PROGRAM_H

--- a/src/aquarium-direct-map/Scene.h
+++ b/src/aquarium-direct-map/Scene.h
@@ -17,25 +17,26 @@
 
 class Model;
 
-class Scene {
-public:
-  Scene() {}
-  ~Scene();
-  Scene(const std::string opt_programIds[2]);
+class Scene
+{
+  public:
+    Scene() {}
+    ~Scene();
+    Scene(const std::string opt_programIds[2]);
 
-  void load(const std::string &path, const std::string &name);
-  const std::vector<Model *> &getModels() const { return models; }
+    void load(const std::string &path, const std::string &name);
+    const std::vector<Model *> &getModels() const { return models; }
 
-  bool loaded;
+    bool loaded;
 
-private:
-  void setupSkybox(const std::string &path);
+  private:
+    void setupSkybox(const std::string &path);
 
-  std::string programIds[2];
-  std::string url;
-  std::vector<Model *> models;
-  std::unordered_map<std::string, Texture *> textureMap;
-  std::unordered_map<std::string, const AttribBuffer *> arrayMap;
+    std::string programIds[2];
+    std::string url;
+    std::vector<Model *> models;
+    std::unordered_map<std::string, Texture *> textureMap;
+    std::unordered_map<std::string, const AttribBuffer *> arrayMap;
 };
 
 #endif  // SCENE_H

--- a/src/aquarium-direct-map/Texture.cpp
+++ b/src/aquarium-direct-map/Texture.cpp
@@ -17,13 +17,7 @@
 
 // initializs texture 2d
 Texture::Texture(const std::string &url, bool flip)
-    : urls(),
-    target(GL_TEXTURE_2D),
-    texture(0u),
-    params(),
-    width(0),
-    height(0),
-    flip(flip)
+    : urls(), target(GL_TEXTURE_2D), texture(0u), params(), width(0), height(0), flip(flip)
 {
     std::string urlpath = url;
     urls.push_back(urlpath);
@@ -114,7 +108,8 @@ void Texture::uploadTextures()
         for (unsigned int i = 0; i < 6; i++)
         {
             loadImageBySTB(urls[i], &pixels);
-            glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+            glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL_RGBA, width, height, 0, GL_RGBA,
+                         GL_UNSIGNED_BYTE, pixels);
             DestroyImageData(pixels);
         }
         ASSERT(glGetError() == GL_NO_ERROR);

--- a/src/aquarium-direct-map/Texture.h
+++ b/src/aquarium-direct-map/Texture.h
@@ -16,30 +16,30 @@
 
 class Texture
 {
-public:
-  Texture() {}
-  ~Texture();
-  Texture(const std::string &url, bool flip);
-  Texture(const std::vector<std::string> &urls);
+  public:
+    Texture() {}
+    ~Texture();
+    Texture(const std::string &url, bool flip);
+    Texture(const std::vector<std::string> &urls);
 
-  GLuint getTexture() const { return texture; }
-  GLenum getTarget() const { return target; }
-  void setTexture(GLuint texId) { texture = texId; }
-  bool loadImageBySTB(const std::string &filename, uint8_t **pixels);
-  void DestroyImageData(uint8_t *pixels);
+    GLuint getTexture() const { return texture; }
+    GLenum getTarget() const { return target; }
+    void setTexture(GLuint texId) { texture = texId; }
+    bool loadImageBySTB(const std::string &filename, uint8_t **pixels);
+    void DestroyImageData(uint8_t *pixels);
 
-private:
-  void setParameter(GLenum, GLint);
-  void uploadTextures();
-  bool isPowerOf2(int value);
+  private:
+    void setParameter(GLenum, GLint);
+    void uploadTextures();
+    bool isPowerOf2(int value);
 
-  std::vector<std::string> urls;
-  GLenum target;
-  GLuint texture;
-  std::unordered_map<GLenum, GLint> params;
-  int width;
-  int height;
-  bool flip;
+    std::vector<std::string> urls;
+    GLenum target;
+    GLuint texture;
+    std::unordered_map<GLenum, GLint> params;
+    int width;
+    int height;
+    bool flip;
 };
 
 #endif  // TEXTURE_H

--- a/src/aquarium-direct-map/Uniform.cpp
+++ b/src/aquarium-direct-map/Uniform.cpp
@@ -7,10 +7,6 @@
 #include "Uniform.h"
 
 Uniform::Uniform(const std::string &name, GLenum type, int length, int size, GLint index)
-    : name(name),
-    type(type),
-    length(length),
-    size(size),
-    index(index)
+    : name(name), type(type), length(length), size(size), index(index)
 {
 }

--- a/src/aquarium-direct-map/Uniform.h
+++ b/src/aquarium-direct-map/Uniform.h
@@ -14,21 +14,21 @@
 
 class Uniform
 {
-public:
-  Uniform(){}
-  Uniform(const std::string &name, GLenum type, int length, int size, GLint index);
+  public:
+    Uniform() {}
+    Uniform(const std::string &name, GLenum type, int length, int size, GLint index);
 
-  std::string getName() const { return name; }
-  GLenum getType() const { return type; }
-  GLsizei getLength() const { return length; }
-  GLsizei getSize() const { return size; }
-  GLint getIndex() const { return index; }
+    std::string getName() const { return name; }
+    GLenum getType() const { return type; }
+    GLsizei getLength() const { return length; }
+    GLsizei getSize() const { return size; }
+    GLint getIndex() const { return index; }
 
-private:
-  std::string name;
-  GLenum type;
-  GLsizei length, size;
-  GLint index;
+  private:
+    std::string name;
+    GLenum type;
+    GLsizei length, size;
+    GLint index;
 };
 
 #endif  // UNIFORM_H

--- a/src/aquarium-optimized/Aquarium.cpp
+++ b/src/aquarium-optimized/Aquarium.cpp
@@ -50,10 +50,10 @@ Aquarium::Aquarium()
       mBackendType(BACKENDTYPE::BACKENDTYPELAST),
       mFactory(nullptr)
 {
-    g.then          = 0.0;
-    g.mclock        = 0.0;
-    g.eyeClock      = 0.0;
-    g.alpha         = "1";
+    g.then     = 0.0;
+    g.mclock   = 0.0;
+    g.eyeClock = 0.0;
+    g.alpha    = "1";
 
     lightUniforms.lightColor[0] = 1.0f;
     lightUniforms.lightColor[1] = 1.0f;
@@ -162,7 +162,7 @@ BACKENDTYPE Aquarium::getBackendType(const std::string &backendPath)
 
 bool Aquarium::init(int argc, char **argv)
 {
-    int windowWidth = 0;
+    int windowWidth  = 0;
     int windowHeight = 0;
 
     cxxopts::Options options(argv[0], "A native implementation of WebGL Aquarium");
@@ -200,7 +200,7 @@ bool Aquarium::init(int argc, char **argv)
         return false;
     }
     std::string backend = result["backend"].as<std::string>();
-    mBackendType = getBackendType(backend);
+    mBackendType        = getBackendType(backend);
     if (mBackendType == BACKENDTYPE::BACKENDTYPELAST)
     {
         std::cout << "Can not create " << backend << " backend" << std::endl;
@@ -429,7 +429,7 @@ void Aquarium::resetFpsTime()
 #else
     g.start    = clock() / 1000000.0;
 #endif
-    g.then          = g.start;
+    g.then = g.start;
 }
 
 void Aquarium::display()

--- a/src/aquarium-optimized/Buffer.h
+++ b/src/aquarium-optimized/Buffer.h
@@ -14,9 +14,9 @@ class Buffer
 {
   public:
     Buffer() {}
-    Buffer(int numComponents, int numElements, const std::vector<float> &buffer){}
-    Buffer(int numComponents, int numElements, const std::vector<short> &buffer){}
-    virtual ~Buffer(){}
+    Buffer(int numComponents, int numElements, const std::vector<float> &buffer) {}
+    Buffer(int numComponents, int numElements, const std::vector<short> &buffer) {}
+    virtual ~Buffer() {}
 };
 
 #endif  // BUFFER_H

--- a/src/aquarium-optimized/BufferManager.h
+++ b/src/aquarium-optimized/BufferManager.h
@@ -14,8 +14,8 @@
 
 #include "Context.h"
 
-constexpr size_t BUFFER_POOL_MAX_SIZE    = 409600000;
-constexpr size_t BUFFER_MAX_COUNT        = 10;
+constexpr size_t BUFFER_POOL_MAX_SIZE     = 409600000;
+constexpr size_t BUFFER_MAX_COUNT         = 10;
 constexpr size_t BUFFER_PER_ALLOCATE_SIZE = BUFFER_POOL_MAX_SIZE / BUFFER_MAX_COUNT;
 
 class RingBuffer

--- a/src/aquarium-optimized/Context.h
+++ b/src/aquarium-optimized/Context.h
@@ -55,8 +55,8 @@ class Context
     virtual void Terminate()                                                     = 0;
     virtual void Flush() {}
 
-    virtual void preFrame()   = 0;
-    virtual void showWindow() = 0;
+    virtual void preFrame()                                                                   = 0;
+    virtual void showWindow()                                                                 = 0;
     virtual void updateFPS(const FPSTimer &fpsTimer,
                            int *fishCount,
                            std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> *toggleBitset) = 0;

--- a/src/aquarium-optimized/ContextFactory.cpp
+++ b/src/aquarium-optimized/ContextFactory.cpp
@@ -28,30 +28,30 @@ Context *ContextFactory::createContext(BACKENDTYPE backendType)
     {
         case BACKENDTYPE::BACKENDTYPEOPENGL:
         case BACKENDTYPE::BACKENDTYPEANGLE:
-            {
+        {
 #if defined(ENABLE_OPENGL_BACKEND) || defined(ENABLE_ANGLE_BACKEND)
-                mContext = new ContextGL(backendType);
+            mContext = new ContextGL(backendType);
 #endif
-                break;
-            }
+            break;
+        }
         case BACKENDTYPE::BACKENDTYPEDAWND3D12:
         case BACKENDTYPE::BACKENDTYPEDAWNMETAL:
         case BACKENDTYPE::BACKENDTYPEDAWNVULKAN:
-            {
+        {
 #if defined(ENABLE_DAWN_BACKEND)
-                mContext = new ContextDawn(backendType);
+            mContext = new ContextDawn(backendType);
 #endif
-                break;
-            }
-            case BACKENDTYPE::BACKENDTYPED3D12:
-            {
+            break;
+        }
+        case BACKENDTYPE::BACKENDTYPED3D12:
+        {
 #if defined(ENABLE_D3D12_BACKEND)
-                mContext = new ContextD3D12(backendType);
+            mContext = new ContextD3D12(backendType);
 #endif
-                break;
-            }
-            default:
-                break;
+            break;
+        }
+        default:
+            break;
     }
 
     return mContext;

--- a/src/aquarium-optimized/Main.cpp
+++ b/src/aquarium-optimized/Main.cpp
@@ -7,7 +7,8 @@
 
 #include "Aquarium.h"
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
     Aquarium aquarium;
     if (!aquarium.init(argc, argv))
     {

--- a/src/aquarium-optimized/Matrix.h
+++ b/src/aquarium-optimized/Matrix.h
@@ -11,7 +11,8 @@
 
 #include <cmath>
 
-namespace matrix {
+namespace matrix
+{
 static long long RANDOM_RANGE_ = 4294967296;
 
 template <typename T>
@@ -378,6 +379,6 @@ float degToRad(float degrees)
 {
     return static_cast<float>(degrees * M_PI / 180.0);
 }
-}
+}  // namespace matrix
 
 #endif  // MATRIX_H

--- a/src/aquarium-optimized/Model.cpp
+++ b/src/aquarium-optimized/Model.cpp
@@ -10,12 +10,7 @@
 #include "Aquarium.h"
 #include "Buffer.h"
 
-Model::Model()
-    : mProgram(nullptr),
-      mBlend(false),
-      mName(MODELMAX)
-{
-}
+Model::Model() : mProgram(nullptr), mBlend(false), mName(MODELMAX) {}
 
 Model::~Model()
 {

--- a/src/aquarium-optimized/Model.h
+++ b/src/aquarium-optimized/Model.h
@@ -30,11 +30,13 @@ class Model
   public:
     Model();
     Model(MODELGROUP type, MODELNAME name, bool blend)
-        : mProgram(nullptr), mBlend(blend), mName(name) {}
+        : mProgram(nullptr), mBlend(blend), mName(name)
+    {
+    }
     virtual ~Model();
     virtual void prepareForDraw()                                              = 0;
     virtual void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) = 0;
-    virtual void draw() = 0;
+    virtual void draw()                                                        = 0;
 
     void setProgram(Program *program);
     virtual void init() = 0;
@@ -47,7 +49,6 @@ class Model
     Program *mProgram;
     bool mBlend;
     MODELNAME mName;
-
 };
 
 #endif  // MODEL_H

--- a/src/aquarium-optimized/Program.h
+++ b/src/aquarium-optimized/Program.h
@@ -15,7 +15,7 @@ enum UNIFORMNAME : short;
 class Program
 {
   public:
-    Program(){}
+    Program() {}
     Program(const std::string &mVertexShader, const std::string &fragmentShader)
         : mVId(mVertexShader), mFId(fragmentShader)
     {

--- a/src/aquarium-optimized/SeaweedModel.h
+++ b/src/aquarium-optimized/SeaweedModel.h
@@ -13,7 +13,7 @@
 class SeaweedModel : public Model
 {
   public:
-    SeaweedModel(MODELGROUP type, MODELNAME name, bool blend) : Model(type, name, blend){}
+    SeaweedModel(MODELGROUP type, MODELNAME name, bool blend) : Model(type, name, blend) {}
 
     virtual void updateSeaweedModelTime(float time) = 0;
 };

--- a/src/aquarium-optimized/Texture.cpp
+++ b/src/aquarium-optimized/Texture.cpp
@@ -19,11 +19,7 @@
 #include "../common/AQUARIUM_ASSERT.h"
 
 Texture::Texture(const std::string &name, const std::string &url, bool flip)
-    : mUrls(),
-    mWidth(0),
-    mHeight(0),
-    mFlip(flip),
-    mName(name)
+    : mUrls(), mWidth(0), mHeight(0), mFlip(flip), mName(name)
 {
     std::string urlpath = url;
     mUrls.push_back(urlpath);
@@ -32,10 +28,11 @@ Texture::Texture(const std::string &name, const std::string &url, bool flip)
 // Force loading 3 channel images to 4 channel by stb becasue Dawn doesn't support 3 channel
 // formats currently. The group is discussing on whether webgpu shoud support 3 channel format.
 // https://github.com/gpuweb/gpuweb/issues/66#issuecomment-410021505
-bool Texture::loadImage(const std::vector<std::string> &urls, std::vector<uint8_t *>* pixels)
+bool Texture::loadImage(const std::vector<std::string> &urls, std::vector<uint8_t *> *pixels)
 {
     stbi_set_flip_vertically_on_load(mFlip);
-    for (auto filename : urls) {
+    for (auto filename : urls)
+    {
         uint8_t *pixel = stbi_load(filename.c_str(), &mWidth, &mHeight, 0, 4);
         if (pixel == 0)
         {
@@ -53,20 +50,24 @@ bool Texture::isPowerOf2(int value)
 }
 
 // Free image data after upload to gpu
-void Texture::DestoryImageData(std::vector<uint8_t*>& pixelVec)
+void Texture::DestoryImageData(std::vector<uint8_t *> &pixelVec)
 {
-    for (auto& pixels : pixelVec)
+    for (auto &pixels : pixelVec)
     {
         free(pixels);
         pixels = nullptr;
     }
 }
 
-void Texture::copyPaddingBuffer(unsigned char *dst, unsigned char *src, int width, int height, int kPadding)
+void Texture::copyPaddingBuffer(unsigned char *dst,
+                                unsigned char *src,
+                                int width,
+                                int height,
+                                int kPadding)
 {
     unsigned char *s = src;
     unsigned char *d = dst;
-    for(int i = 0; i < height; ++i)
+    for (int i = 0; i < height; ++i)
     {
         memcpy(d, s, width * 4);
         s += width * 4;
@@ -85,10 +86,9 @@ void Texture::generateMipmap(uint8_t *input_pixels,
                              int num_channels,
                              bool is256padding)
 {
-    int mipmapLevel =
-        static_cast<uint32_t>(floor(log2(std::max(output_w, output_h)))) + 1;
+    int mipmapLevel = static_cast<uint32_t>(floor(log2(std::max(output_w, output_h)))) + 1;
     output_pixels.resize(mipmapLevel);
-    int height      = output_h;
+    int height = output_h;
     int width  = output_w;
 
     if (!is256padding)

--- a/src/aquarium-optimized/Texture.h
+++ b/src/aquarium-optimized/Texture.h
@@ -14,9 +14,12 @@
 class Texture
 {
   public:
-    virtual ~Texture(){}
+    virtual ~Texture() {}
     Texture() {}
-    Texture(const std::string &name, const std::vector<std::string> &urls, bool flip) : mUrls(urls), mFlip(flip), mName(name) {}
+    Texture(const std::string &name, const std::vector<std::string> &urls, bool flip)
+        : mUrls(urls), mFlip(flip), mName(name)
+    {
+    }
     Texture(const std::string &name, const std::string &url, bool flip);
     std::string getName() { return mName; }
     virtual void loadTexture() = 0;
@@ -33,8 +36,8 @@ class Texture
 
   protected:
     bool isPowerOf2(int);
-    bool loadImage(const std::vector<std::string> &urls, std::vector<uint8_t *>* pixels);
-    void DestoryImageData(std::vector<uint8_t *>& pixelVec);
+    bool loadImage(const std::vector<std::string> &urls, std::vector<uint8_t *> *pixels);
+    void DestoryImageData(std::vector<uint8_t *> &pixelVec);
     void copyPaddingBuffer(unsigned char *dst,
                            unsigned char *src,
                            int width,

--- a/src/aquarium-optimized/d3d12/ContextD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.cpp
@@ -90,7 +90,7 @@ bool ContextD3D12::initialize(
     int windowWidth,
     int windowHeight)
 {
-    mVsync      = toggleBitset.test(static_cast<size_t>(TOGGLE::TURNOFFVSYNC)) ? 0 : 1;
+    mVsync               = toggleBitset.test(static_cast<size_t>(TOGGLE::TURNOFFVSYNC)) ? 0 : 1;
     mDisableControlPanel = toggleBitset.test(static_cast<TOGGLE>(TOGGLE::DISABLECONTROLPANEL));
 
     // initialise GLFW
@@ -786,7 +786,7 @@ ComPtr<ID3DBlob> ContextD3D12::createShaderModule(const std::string &type,
 void ContextD3D12::createCommittedResource(const D3D12_HEAP_PROPERTIES &properties,
                                            const D3D12_RESOURCE_DESC &desc,
                                            D3D12_RESOURCE_STATES state,
-                                           ComPtr<ID3D12Resource>& resource)
+                                           ComPtr<ID3D12Resource> &resource)
 {
     if (FAILED(mDevice->CreateCommittedResource(&properties, D3D12_HEAP_FLAG_NONE, &desc, state,
                                                 nullptr, IID_PPV_ARGS(&resource))))
@@ -887,12 +887,12 @@ void ContextD3D12::beginRenderPass()
 {
     // Reuse the memory associated with command recording.
     // We can only reset when the associated command lists have finished execution on the GPU.
-    //ThrowIfFailed(mCommandAllocators[m_frameIndex]->Reset());
+    // ThrowIfFailed(mCommandAllocators[m_frameIndex]->Reset());
 
     // A command list can be reset after it has been added to the command queue via
     // ExecuteCommandList.
     // Reusing the command list reuses memory.
-    //ThrowIfFailed(mCommandList->Reset(mCommandAllocators[m_frameIndex].Get(), nullptr));
+    // ThrowIfFailed(mCommandList->Reset(mCommandAllocators[m_frameIndex].Get(), nullptr));
 
     // Set descriptor heaps related to command list.
     ID3D12DescriptorHeap *mDescriptorHeaps[] = {mCbvsrvHeap.Get()};
@@ -1031,7 +1031,7 @@ void ContextD3D12::createDepthStencilView()
 }
 
 void ContextD3D12::createCommandList(ID3D12PipelineState *pInitialState,
-                                     ComPtr<ID3D12GraphicsCommandList4>& commandList)
+                                     ComPtr<ID3D12GraphicsCommandList4> &commandList)
 {
     ThrowIfFailed(mDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT,
                                              mCommandAllocators[0].Get(), pInitialState,
@@ -1041,7 +1041,7 @@ void ContextD3D12::createCommandList(ID3D12PipelineState *pInitialState,
 ComPtr<ID3D12Resource> ContextD3D12::createDefaultBuffer(const void *initData,
                                                          UINT64 initDataSize,
                                                          UINT64 bufferSize,
-                                                         ComPtr<ID3D12Resource>& uploadBuffer) const
+                                                         ComPtr<ID3D12Resource> &uploadBuffer) const
 {
     ComPtr<ID3D12Resource> defaultBuffer;
 
@@ -1078,7 +1078,7 @@ ComPtr<ID3D12Resource> ContextD3D12::createDefaultBuffer(const void *initData,
 
 void ContextD3D12::createRootSignature(
     const D3D12_VERSIONED_ROOT_SIGNATURE_DESC &pRootSignatureDesc,
-    ComPtr<ID3D12RootSignature>& rootSignature) const
+    ComPtr<ID3D12RootSignature> &rootSignature) const
 {
     ComPtr<ID3DBlob> signature = nullptr;
     ComPtr<ID3DBlob> error     = nullptr;
@@ -1096,8 +1096,8 @@ void ContextD3D12::createRootSignature(
 
 void ContextD3D12::createTexture(const D3D12_RESOURCE_DESC &textureDesc,
                                  const std::vector<UINT8 *> &texture,
-                                 ComPtr<ID3D12Resource>& m_texture,
-                                 ComPtr<ID3D12Resource>& textureUploadHeap,
+                                 ComPtr<ID3D12Resource> &m_texture,
+                                 ComPtr<ID3D12Resource> &textureUploadHeap,
                                  int TextureWidth,
                                  int TextureHeight,
                                  int TexturePixelSize,
@@ -1150,10 +1150,10 @@ void ContextD3D12::createTexture(const D3D12_RESOURCE_DESC &textureDesc,
 
 void ContextD3D12::createGraphicsPipelineState(
     const std::vector<D3D12_INPUT_ELEMENT_DESC> &mInputElementDescs,
-    const ComPtr<ID3D12RootSignature>& rootSignature,
-    const ComPtr<ID3DBlob>& mVertexShader,
-    const ComPtr<ID3DBlob>& mPixelShader,
-    ComPtr<ID3D12PipelineState>& mPipelineState,
+    const ComPtr<ID3D12RootSignature> &rootSignature,
+    const ComPtr<ID3DBlob> &mVertexShader,
+    const ComPtr<ID3DBlob> &mPixelShader,
+    ComPtr<ID3D12PipelineState> &mPipelineState,
     bool enableBlend) const
 {
     // Describe and create the graphics mPipeline state object (PSO).

--- a/src/aquarium-optimized/d3d12/ContextD3D12.h
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.h
@@ -62,7 +62,7 @@ class ContextD3D12 : public Context
     void createCommittedResource(const D3D12_HEAP_PROPERTIES &properties,
                                  const D3D12_RESOURCE_DESC &desc,
                                  D3D12_RESOURCE_STATES state,
-                                 ComPtr<ID3D12Resource>& resource);
+                                 ComPtr<ID3D12Resource> &resource);
     void updateSubresources(ID3D12GraphicsCommandList *pCmdList,
                             ID3D12Resource *pDestinationResource,
                             ID3D12Resource *pIntermediate,
@@ -73,20 +73,20 @@ class ContextD3D12 : public Context
     void executeCommandLists(UINT NumCommandLists, ID3D12CommandList *const *ppCommandLists);
 
     void createCommandList(ID3D12PipelineState *pInitialState,
-                           ComPtr<ID3D12GraphicsCommandList4>& commandList);
+                           ComPtr<ID3D12GraphicsCommandList4> &commandList);
 
     ComPtr<ID3D12Resource> createDefaultBuffer(const void *initData,
                                                UINT64 initDataSize,
                                                UINT64 bufferSize,
-                                               ComPtr<ID3D12Resource>& uploadBuffer) const;
+                                               ComPtr<ID3D12Resource> &uploadBuffer) const;
     void createRootSignature(const D3D12_VERSIONED_ROOT_SIGNATURE_DESC &pRootSignatureDesc,
-                             ComPtr<ID3D12RootSignature>& rootSignature) const;
+                             ComPtr<ID3D12RootSignature> &rootSignature) const;
     void createGraphicsPipelineState(
         const std::vector<D3D12_INPUT_ELEMENT_DESC> &mInputElementDescs,
-        const ComPtr<ID3D12RootSignature>& rootSignature,
-        const ComPtr<ID3DBlob>& mVertexShader,
-        const ComPtr<ID3DBlob>& mPixelShader,
-        ComPtr<ID3D12PipelineState>& mPipelineState,
+        const ComPtr<ID3D12RootSignature> &rootSignature,
+        const ComPtr<ID3DBlob> &mVertexShader,
+        const ComPtr<ID3DBlob> &mPixelShader,
+        ComPtr<ID3D12PipelineState> &mPipelineState,
         bool enableBlend) const;
     void buildSrvDescriptor(const ComPtr<ID3D12Resource> resource,
                             const D3D12_SHADER_RESOURCE_VIEW_DESC &mSrvDesc,
@@ -96,8 +96,8 @@ class ContextD3D12 : public Context
     UINT CalcConstantBufferByteSize(UINT byteSize);
     void createTexture(const D3D12_RESOURCE_DESC &textureDesc,
                        const std::vector<UINT8 *> &texture,
-                       ComPtr<ID3D12Resource>& m_texture,
-                       ComPtr<ID3D12Resource>& textureUploadHeap,
+                       ComPtr<ID3D12Resource> &m_texture,
+                       ComPtr<ID3D12Resource> &textureUploadHeap,
                        int TextureWidth,
                        int TextureHeight,
                        int TexturePixelSize,

--- a/src/aquarium-optimized/d3d12/FishModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/FishModelD3D12.cpp
@@ -18,7 +18,7 @@ FishModelD3D12::FishModelD3D12(Context *context,
 {
     mContextD3D12 = static_cast<ContextD3D12 *>(context);
 
-    const Fish &fishInfo              = fishTable[name - MODELNAME::MODELSMALLFISHA];
+    const Fish &fishInfo               = fishTable[name - MODELNAME::MODELSMALLFISHA];
     mFishVertexUniforms.fishLength     = fishInfo.fishLength;
     mFishVertexUniforms.fishBendAmount = fishInfo.fishBendAmount;
     mFishVertexUniforms.fishWaveLength = fishInfo.fishWaveLength;
@@ -30,9 +30,7 @@ FishModelD3D12::FishModelD3D12(Context *context,
     mPreInstance = mCurInstance;
 }
 
-FishModelD3D12::~FishModelD3D12()
-{
-}
+FishModelD3D12::~FishModelD3D12() {}
 
 void FishModelD3D12::init()
 {

--- a/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.cpp
@@ -18,7 +18,7 @@ FishModelInstancedDrawD3D12::FishModelInstancedDrawD3D12(Context *context,
 {
     mContextD3D12 = static_cast<ContextD3D12 *>(context);
 
-    const Fish &fishInfo              = fishTable[name - MODELNAME::MODELSMALLFISHAINSTANCEDDRAWS];
+    const Fish &fishInfo               = fishTable[name - MODELNAME::MODELSMALLFISHAINSTANCEDDRAWS];
     mFishVertexUniforms.fishLength     = fishInfo.fishLength;
     mFishVertexUniforms.fishBendAmount = fishInfo.fishBendAmount;
     mFishVertexUniforms.fishWaveLength = fishInfo.fishWaveLength;
@@ -26,7 +26,7 @@ FishModelInstancedDrawD3D12::FishModelInstancedDrawD3D12(Context *context,
     mLightFactorUniforms.shininess      = 5.0f;
     mLightFactorUniforms.specularFactor = 0.3f;
 
-    instance = aquarium->fishCount[fishInfo.modelName - MODELNAME::MODELSMALLFISHA];
+    instance  = aquarium->fishCount[fishInfo.modelName - MODELNAME::MODELSMALLFISHA];
     mFishPers = new FishPer[instance];
 }
 

--- a/src/aquarium-optimized/d3d12/GenericModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/GenericModelD3D12.cpp
@@ -175,7 +175,8 @@ void GenericModelD3D12::draw()
     if (mTangentBuffer && mBiNormalBuffer && mName != MODELNAME::MODELGLOBEBASE)
     {
         mContextD3D12->mCommandList->IASetVertexBuffers(0, 5, mVertexBufferView);
-    } else
+    }
+    else
     {
         mContextD3D12->mCommandList->IASetVertexBuffers(0, 3, mVertexBufferView);
     }

--- a/src/aquarium-optimized/d3d12/ProgramD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/ProgramD3D12.cpp
@@ -18,7 +18,7 @@ ProgramD3D12::ProgramD3D12(ContextD3D12 *context, const std::string &mVId, const
 
 ProgramD3D12::~ProgramD3D12() {}
 
-void ProgramD3D12::compileProgram(bool enableBlending, const std::string& alpha)
+void ProgramD3D12::compileProgram(bool enableBlending, const std::string &alpha)
 {
     loadProgram();
 

--- a/src/aquarium-optimized/d3d12/SeaweedModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/SeaweedModelD3D12.cpp
@@ -15,7 +15,7 @@ SeaweedModelD3D12::SeaweedModelD3D12(Context *context,
     : SeaweedModel(type, name, blend), instance(0)
 {
     mContextD3D12 = static_cast<ContextD3D12 *>(context);
-    mAquarium    = aquarium;
+    mAquarium     = aquarium;
 
     mLightFactorUniforms.shininess      = 50.0f;
     mLightFactorUniforms.specularFactor = 1.0f;

--- a/src/aquarium-optimized/dawn/BufferDawn.cpp
+++ b/src/aquarium-optimized/dawn/BufferDawn.cpp
@@ -21,7 +21,8 @@ BufferDawn::BufferDawn(ContextDawn *context,
       mOffset(nullptr)
 {
     mSize = numComponents * sizeof(float);
-    // Create buffer for vertex buffer. Because float is multiple of 4 bytes, dummy padding isnt' needed.
+    // Create buffer for vertex buffer. Because float is multiple of 4 bytes, dummy padding isnt'
+    // needed.
     int bufferSize = sizeof(float) * static_cast<int>(buffer->size());
     mBuf           = context->createBuffer(bufferSize, mUsage | wgpu::BufferUsage::CopyDst);
 
@@ -39,8 +40,8 @@ BufferDawn::BufferDawn(ContextDawn *context,
       mOffset(nullptr)
 {
     mSize = numComponents * sizeof(unsigned short);
-    // Create buffer for index buffer. Because unsigned short is multiple of 2 bytes, in order to align
-    // with 4 bytes of dawn metal, dummy padding need to be added.
+    // Create buffer for index buffer. Because unsigned short is multiple of 2 bytes, in order to
+    // align with 4 bytes of dawn metal, dummy padding need to be added.
     if (mTotoalComponents % 2 != 0)
     {
         buffer->push_back(0.0f);

--- a/src/aquarium-optimized/dawn/BufferManagerDawn.cpp
+++ b/src/aquarium-optimized/dawn/BufferManagerDawn.cpp
@@ -86,7 +86,8 @@ size_t RingBufferDawn::allocate(size_t size)
     return mTail - size;
 }
 
-BufferManagerDawn::BufferManagerDawn(ContextDawn *context, bool sync) : mContext(context), mSync(sync)
+BufferManagerDawn::BufferManagerDawn(ContextDawn *context, bool sync)
+    : mContext(context), mSync(sync)
 {
     mEncoder = context->createCommandEncoder();
 }
@@ -174,7 +175,7 @@ RingBufferDawn *BufferManagerDawn::allocate(size_t size, size_t *offset)
 
         // allocate size in the ring buffer
         cur_offset = ringBuffer->allocate(size);
-        *offset = cur_offset;
+        *offset    = cur_offset;
     }
 
     return ringBuffer;

--- a/src/aquarium-optimized/dawn/BufferManagerDawn.h
+++ b/src/aquarium-optimized/dawn/BufferManagerDawn.h
@@ -50,7 +50,7 @@ class RingBufferDawn : public RingBuffer
     void *mPixels;
 };
 
-class BufferManagerDawn: public BufferManager
+class BufferManagerDawn : public BufferManager
 {
   public:
     BufferManagerDawn(ContextDawn *context, bool sync);

--- a/src/aquarium-optimized/dawn/ContextDawn.cpp
+++ b/src/aquarium-optimized/dawn/ContextDawn.cpp
@@ -74,30 +74,30 @@ ContextDawn::~ContextDawn()
         destoryImgUI();
     }
 
-    mSceneRenderTargetView   = nullptr;
-    mSceneDepthStencilView   = nullptr;
+    mSceneRenderTargetView    = nullptr;
+    mSceneDepthStencilView    = nullptr;
     mBackbufferView           = nullptr;
-    mPipeline                = nullptr;
-    mBindGroup               = nullptr;
+    mPipeline                 = nullptr;
+    mBindGroup                = nullptr;
     mLightWorldPositionBuffer = nullptr;
     mLightBuffer              = nullptr;
     mFogBuffer                = nullptr;
-    mCommandEncoder          = nullptr;
+    mCommandEncoder           = nullptr;
     mCommandBuffers.clear();
-    mRenderPass              = nullptr;
-    mRenderPassDescriptor    = {};
-    groupLayoutGeneral       = nullptr;
-    bindGroupGeneral         = nullptr;
-    groupLayoutWorld         = nullptr;
-    bindGroupWorld           = nullptr;
+    mRenderPass           = nullptr;
+    mRenderPassDescriptor = {};
+    groupLayoutGeneral    = nullptr;
+    bindGroupGeneral      = nullptr;
+    groupLayoutWorld      = nullptr;
+    bindGroupWorld        = nullptr;
 
     groupLayoutFishPer = nullptr;
     destoryFishResource();
     delete bufferManager;
 
-    mSwapchain               = nullptr;
-    queue                    = nullptr;
-    mDevice                  = nullptr;
+    mSwapchain = nullptr;
+    queue      = nullptr;
+    mDevice    = nullptr;
 }
 
 bool ContextDawn::initialize(
@@ -269,12 +269,14 @@ bool ContextDawn::initialize(
         ImGui_ImplGlfw_InitForOpenGL(mWindow, true);
         ImGui_ImplDawn_Init(this, mPreferredSwapChainFormat);
     }
-    bufferManager = new BufferManagerDawn(this, !toggleBitset.test(static_cast<TOGGLE>(TOGGLE::BUFFERMAPPINGASYNC)));
+    bufferManager = new BufferManagerDawn(
+        this, !toggleBitset.test(static_cast<TOGGLE>(TOGGLE::BUFFERMAPPINGASYNC)));
 
     return true;
 }
 
-void ContextDawn::framebufferResizeCallback(GLFWwindow *window, int width, int height) {
+void ContextDawn::framebufferResizeCallback(GLFWwindow *window, int width, int height)
+{
     ContextDawn *contextDawn = reinterpret_cast<ContextDawn *>(glfwGetWindowUserPointer(window));
     contextDawn->mIsSwapchainOutOfDate = true;
 }
@@ -288,7 +290,7 @@ bool ContextDawn::GetHardwareAdapter(
     bool enableIntegratedGpu = toggleBitset.test(static_cast<size_t>(TOGGLE::INTEGRATEDGPU));
     bool enableDiscreteGpu   = toggleBitset.test(static_cast<size_t>(TOGGLE::DISCRETEGPU));
     bool useDefaultGpu       = (enableDiscreteGpu | enableIntegratedGpu) == false ? true : false;
-    bool result             = false;
+    bool result              = false;
 
     // Get an adapter for the backend to use, and create the Device.
     for (auto &adapter : instance->GetAdapters())
@@ -427,7 +429,7 @@ wgpu::PipelineLayout ContextDawn::MakeBasicPipelineLayout(
     wgpu::PipelineLayoutDescriptor descriptor;
 
     descriptor.bindGroupLayoutCount = static_cast<uint32_t>(bindingsInitializer.size());
-    descriptor.bindGroupLayouts = bindingsInitializer.data();
+    descriptor.bindGroupLayouts     = bindingsInitializer.data();
 
     return mDevice.CreatePipelineLayout(&descriptor);
 }
@@ -455,9 +457,9 @@ wgpu::RenderPipeline ContextDawn::createRenderPipeline(
     }
 
     wgpu::ColorStateDescriptor ColorStateDescriptor;
-    ColorStateDescriptor.colorBlend     = blendDescriptor;
-    ColorStateDescriptor.alphaBlend     = blendDescriptor;
-    ColorStateDescriptor.writeMask      = wgpu::ColorWriteMask::All;
+    ColorStateDescriptor.colorBlend = blendDescriptor;
+    ColorStateDescriptor.alphaBlend = blendDescriptor;
+    ColorStateDescriptor.writeMask  = wgpu::ColorWriteMask::All;
 
     wgpu::RasterizationStateDescriptor rasterizationState;
     rasterizationState.nextInChain         = nullptr;
@@ -522,7 +524,7 @@ wgpu::TextureView ContextDawn::createDepthStencilView() const
 wgpu::Buffer ContextDawn::createBuffer(uint32_t size, wgpu::BufferUsage bit) const
 {
     wgpu::BufferDescriptor descriptor;
-    descriptor.size = size;
+    descriptor.size  = size;
     descriptor.usage = bit;
 
     wgpu::Buffer buffer = mDevice.CreateBuffer(&descriptor);
@@ -550,7 +552,7 @@ wgpu::BindGroup ContextDawn::makeBindGroup(
     return utils::MakeBindGroup(mDevice, layout, bindingsInitializer);
 }
 
-void ContextDawn::initGeneralResources(Aquarium* aquarium)
+void ContextDawn::initGeneralResources(Aquarium *aquarium)
 {
     // initilize general uniform buffers
     groupLayoutGeneral = MakeBindGroupLayout({
@@ -562,8 +564,8 @@ void ContextDawn::initGeneralResources(Aquarium* aquarium)
                                         sizeof(aquarium->lightUniforms),
                                         wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
     mFogBuffer   = createBufferFromData(&aquarium->fogUniforms, sizeof(aquarium->fogUniforms),
-                                        sizeof(aquarium->fogUniforms),
-                                        wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
+                                      sizeof(aquarium->fogUniforms),
+                                      wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
 
     bindGroupGeneral =
         makeBindGroup(groupLayoutGeneral, {{0, mLightBuffer, 0, sizeof(aquarium->lightUniforms)},
@@ -605,10 +607,11 @@ void ContextDawn::initGeneralResources(Aquarium* aquarium)
         });
     }
 
-    reallocResource(aquarium->getPreFishCount(), aquarium->getCurFishCount(), enableDynamicBufferOffset);
+    reallocResource(aquarium->getPreFishCount(), aquarium->getCurFishCount(),
+                    enableDynamicBufferOffset);
 }
 
-void ContextDawn::updateWorldlUniforms(Aquarium* aquarium)
+void ContextDawn::updateWorldlUniforms(Aquarium *aquarium)
 {
     updateBufferData(mLightWorldPositionBuffer,
                      CalcConstantBufferByteSize(sizeof(LightWorldPositionUniform)),
@@ -617,7 +620,8 @@ void ContextDawn::updateWorldlUniforms(Aquarium* aquarium)
 
 Buffer *ContextDawn::createBuffer(int numComponents, std::vector<float> *buf, bool isIndex)
 {
-    Buffer *buffer = new BufferDawn(this, static_cast<int>(buf->size()), numComponents, buf, isIndex);
+    Buffer *buffer =
+        new BufferDawn(this, static_cast<int>(buf->size()), numComponents, buf, isIndex);
     return buffer;
 }
 
@@ -719,9 +723,11 @@ void ContextDawn::destoryImgUI()
 
 void ContextDawn::preFrame()
 {
-    if (mIsSwapchainOutOfDate) {
+    if (mIsSwapchainOutOfDate)
+    {
         glfwGetFramebufferSize(mWindow, &mClientWidth, &mClientHeight);
-        if (mMSAASampleCount > 1) {
+        if (mMSAASampleCount > 1)
+        {
             mSceneRenderTargetView = createMultisampledRenderTargetView();
         }
         mSceneDepthStencilView = createDepthStencilView();
@@ -736,9 +742,10 @@ void ContextDawn::preFrame()
 
     if (mMSAASampleCount > 1)
     {
-        // If MSAA is enabled, we render to a multisampled texture and then resolve to the backbuffer
-        mRenderPassDescriptor = utils::ComboRenderPassDescriptor({mSceneRenderTargetView},
-                                                                 mSceneDepthStencilView);
+        // If MSAA is enabled, we render to a multisampled texture and then resolve to the
+        // backbuffer
+        mRenderPassDescriptor =
+            utils::ComboRenderPassDescriptor({mSceneRenderTargetView}, mSceneDepthStencilView);
         mRenderPassDescriptor.cColorAttachments[0].resolveTarget = mBackbufferView;
         mRenderPassDescriptor.cColorAttachments[0].loadOp        = wgpu::LoadOp::Clear;
         mRenderPassDescriptor.cColorAttachments[0].storeOp       = wgpu::StoreOp::Clear;
@@ -757,32 +764,32 @@ void ContextDawn::preFrame()
     mRenderPass = mCommandEncoder.BeginRenderPass(&mRenderPassDescriptor);
 }
 
-Model * ContextDawn::createModel(Aquarium* aquarium, MODELGROUP type, MODELNAME name, bool blend)
+Model *ContextDawn::createModel(Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend)
 {
     Model *model;
     switch (type)
     {
-    case MODELGROUP::FISH:
-        model = new FishModelDawn(this, aquarium, type, name, blend);
-        break;
-    case MODELGROUP::FISHINSTANCEDDRAW:
-        model = new FishModelInstancedDrawDawn(this, aquarium, type, name, blend);
-        break;
-    case MODELGROUP::GENERIC:
-        model = new GenericModelDawn(this, aquarium, type, name, blend);
-        break;
-    case MODELGROUP::INNER:
-        model = new InnerModelDawn(this, aquarium, type, name, blend);
-        break;
-    case MODELGROUP::SEAWEED:
-        model = new SeaweedModelDawn(this, aquarium, type, name, blend);
-        break;
-    case MODELGROUP::OUTSIDE:
-        model = new OutsideModelDawn(this, aquarium, type, name, blend);
-        break;
-    default:
-        model = nullptr;
-        std::cout << "can not create model type" << std::endl;
+        case MODELGROUP::FISH:
+            model = new FishModelDawn(this, aquarium, type, name, blend);
+            break;
+        case MODELGROUP::FISHINSTANCEDDRAW:
+            model = new FishModelInstancedDrawDawn(this, aquarium, type, name, blend);
+            break;
+        case MODELGROUP::GENERIC:
+            model = new GenericModelDawn(this, aquarium, type, name, blend);
+            break;
+        case MODELGROUP::INNER:
+            model = new InnerModelDawn(this, aquarium, type, name, blend);
+            break;
+        case MODELGROUP::SEAWEED:
+            model = new SeaweedModelDawn(this, aquarium, type, name, blend);
+            break;
+        case MODELGROUP::OUTSIDE:
+            model = new OutsideModelDawn(this, aquarium, type, name, blend);
+            break;
+        default:
+            model = nullptr;
+            std::cout << "can not create model type" << std::endl;
     }
 
     return model;
@@ -872,9 +879,9 @@ void ContextDawn::updateAllFishData()
     updateBufferData(fishPersBuffer, size, fishPers, sizeof(FishPer) * mCurTotalInstance);
 }
 
-void ContextDawn::updateBufferData(const wgpu::Buffer& buffer,
+void ContextDawn::updateBufferData(const wgpu::Buffer &buffer,
                                    size_t bufferSize,
-                                   void* data,
+                                   void *data,
                                    size_t dataSize) const
 {
     size_t offset              = 0;

--- a/src/aquarium-optimized/dawn/ContextDawn.h
+++ b/src/aquarium-optimized/dawn/ContextDawn.h
@@ -117,11 +117,10 @@ class ContextDawn : public Context
                          int curTotalInstance,
                          bool enableDynamicBufferOffset) override;
     void updateAllFishData() override;
-    void updateBufferData(
-        const wgpu::Buffer &buffer,
-        size_t bufferSize,
-        void *data,
-        size_t dataSize) const;
+    void updateBufferData(const wgpu::Buffer &buffer,
+                          size_t bufferSize,
+                          void *data,
+                          size_t dataSize) const;
     wgpu::CreateBufferMappedResult CreateBufferMapped(wgpu::BufferUsage usage, uint64_t size) const;
     void WaitABit();
     wgpu::CommandEncoder createCommandEncoder() const;

--- a/src/aquarium-optimized/dawn/FishModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/FishModelDawn.cpp
@@ -26,7 +26,7 @@ FishModelDawn::FishModelDawn(Context *context,
     mLightFactorUniforms.shininess      = 5.0f;
     mLightFactorUniforms.specularFactor = 0.3f;
 
-    const Fish &fishInfo              = fishTable[name - MODELNAME::MODELSMALLFISHA];
+    const Fish &fishInfo               = fishTable[name - MODELNAME::MODELSMALLFISHA];
     mFishVertexUniforms.fishLength     = fishInfo.fishLength;
     mFishVertexUniforms.fishBendAmount = fishInfo.fishBendAmount;
     mFishVertexUniforms.fishWaveLength = fishInfo.fishWaveLength;

--- a/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.cpp
+++ b/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.cpp
@@ -21,12 +21,12 @@ FishModelInstancedDrawDawn::FishModelInstancedDrawDawn(Context *context,
     mLightFactorUniforms.shininess      = 5.0f;
     mLightFactorUniforms.specularFactor = 0.3f;
 
-    const Fish &fishInfo              = fishTable[name - MODELNAME::MODELSMALLFISHAINSTANCEDDRAWS];
+    const Fish &fishInfo               = fishTable[name - MODELNAME::MODELSMALLFISHAINSTANCEDDRAWS];
     mFishVertexUniforms.fishLength     = fishInfo.fishLength;
     mFishVertexUniforms.fishBendAmount = fishInfo.fishBendAmount;
     mFishVertexUniforms.fishWaveLength = fishInfo.fishWaveLength;
 
-    instance = aquarium->fishCount[fishInfo.modelName - MODELNAME::MODELSMALLFISHA];
+    instance  = aquarium->fishCount[fishInfo.modelName - MODELNAME::MODELSMALLFISHA];
     mFishPers = new FishPer[instance];
 }
 

--- a/src/aquarium-optimized/dawn/OutsideModelDawn.h
+++ b/src/aquarium-optimized/dawn/OutsideModelDawn.h
@@ -17,37 +17,37 @@
 
 class OutsideModelDawn : public Model
 {
-public:
-  OutsideModelDawn(Context *context,
-                   Aquarium *aquarium,
-                   MODELGROUP type,
-                   MODELNAME name,
-                   bool blend);
-  ~OutsideModelDawn();
+  public:
+    OutsideModelDawn(Context *context,
+                     Aquarium *aquarium,
+                     MODELGROUP type,
+                     MODELNAME name,
+                     bool blend);
+    ~OutsideModelDawn();
 
-  void init() override;
-  void prepareForDraw() override;
-  void draw() override;
+    void init() override;
+    void prepareForDraw() override;
+    void draw() override;
 
-  void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
+    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
 
-  TextureDawn *mDiffuseTexture;
-  TextureDawn *mNormalTexture;
-  TextureDawn *mReflectionTexture;
-  TextureDawn *mSkyboxTexture;
+    TextureDawn *mDiffuseTexture;
+    TextureDawn *mNormalTexture;
+    TextureDawn *mReflectionTexture;
+    TextureDawn *mSkyboxTexture;
 
-  BufferDawn *mPositionBuffer;
-  BufferDawn *mNormalBuffer;
-  BufferDawn *mTexCoordBuffer;
-  BufferDawn *mTangentBuffer;
-  BufferDawn *mBiNormalBuffer;
+    BufferDawn *mPositionBuffer;
+    BufferDawn *mNormalBuffer;
+    BufferDawn *mTexCoordBuffer;
+    BufferDawn *mTangentBuffer;
+    BufferDawn *mBiNormalBuffer;
 
-  BufferDawn *mIndicesBuffer;
+    BufferDawn *mIndicesBuffer;
 
-  struct LightFactorUniforms
-  {
-      float shininess;
-      float specularFactor;
+    struct LightFactorUniforms
+    {
+        float shininess;
+        float specularFactor;
     } mLightFactorUniforms;
 
     WorldUniforms mWorldUniformPer[20];

--- a/src/aquarium-optimized/dawn/ProgramDawn.h
+++ b/src/aquarium-optimized/dawn/ProgramDawn.h
@@ -21,12 +21,12 @@ class ContextDawn;
 
 class ProgramDawn : public Program
 {
-public:
+  public:
     ProgramDawn() {}
     ProgramDawn(ContextDawn *context, const std::string &mVId, const std::string &mFId);
     ~ProgramDawn() override;
 
-    void compileProgram(bool enableAlphaBlending, const std::string& alpha) override;
+    void compileProgram(bool enableAlphaBlending, const std::string &alpha) override;
     wgpu::ShaderModule getVSModule() { return mVsModule; }
     wgpu::ShaderModule getFSModule() { return mFsModule; }
 

--- a/src/aquarium-optimized/dawn/SeaweedModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/SeaweedModelDawn.cpp
@@ -15,7 +15,7 @@ SeaweedModelDawn::SeaweedModelDawn(Context *context,
     : SeaweedModel(type, name, blend), instance(0)
 {
     mContextDawn = static_cast<ContextDawn *>(context);
-    mAquarium   = aquarium;
+    mAquarium    = aquarium;
 
     mLightFactorUniforms.shininess      = 50.0f;
     mLightFactorUniforms.specularFactor = 1.0f;
@@ -155,6 +155,4 @@ void SeaweedModelDawn::updatePerInstanceUniforms(const WorldUniforms &worldUnifo
     instance++;
 }
 
-void SeaweedModelDawn::updateSeaweedModelTime(float time)
-{
-}
+void SeaweedModelDawn::updateSeaweedModelTime(float time) {}

--- a/src/aquarium-optimized/dawn/SeaweedModelDawn.h
+++ b/src/aquarium-optimized/dawn/SeaweedModelDawn.h
@@ -77,7 +77,7 @@ class SeaweedModelDawn : public SeaweedModel
 
     ContextDawn *mContextDawn;
     ProgramDawn *mProgramDawn;
-    Aquarium * mAquarium;
+    Aquarium *mAquarium;
 
     int instance;
 };

--- a/src/aquarium-optimized/dawn/TextureDawn.cpp
+++ b/src/aquarium-optimized/dawn/TextureDawn.cpp
@@ -13,7 +13,8 @@
 #include "ContextDawn.h"
 #include "common/AQUARIUM_ASSERT.h"
 
-TextureDawn::~TextureDawn() {
+TextureDawn::~TextureDawn()
+{
 
     DestoryImageData(mPixelVec);
     DestoryImageData(mResizedVec);
@@ -48,21 +49,21 @@ TextureDawn::TextureDawn(ContextDawn *context,
 void TextureDawn::loadTexture()
 {
     wgpu::SamplerDescriptor samplerDesc = {};
-    const int kPadding = 256;
+    const int kPadding                  = 256;
     loadImage(mUrls, &mPixelVec);
 
     if (mTextureViewDimension == wgpu::TextureViewDimension::Cube)
     {
         wgpu::TextureDescriptor descriptor;
-        descriptor.dimension = mTextureDimension;
-        descriptor.size.width = mWidth;
-        descriptor.size.height = mHeight;
-        descriptor.size.depth = 6;
-        descriptor.sampleCount = 1;
-        descriptor.format = mFormat;
-        descriptor.mipLevelCount   = 1;
-        descriptor.usage           = wgpu::TextureUsage::CopyDst | wgpu::TextureUsage::Sampled;
-        mTexture                   = mContext->createTexture(descriptor);
+        descriptor.dimension     = mTextureDimension;
+        descriptor.size.width    = mWidth;
+        descriptor.size.height   = mHeight;
+        descriptor.size.depth    = 6;
+        descriptor.sampleCount   = 1;
+        descriptor.format        = mFormat;
+        descriptor.mipLevelCount = 1;
+        descriptor.usage         = wgpu::TextureUsage::CopyDst | wgpu::TextureUsage::Sampled;
+        mTexture                 = mContext->createTexture(descriptor);
 
         for (unsigned int i = 0; i < 6; i++)
         {
@@ -82,12 +83,12 @@ void TextureDawn::loadTexture()
         }
 
         wgpu::TextureViewDescriptor viewDescriptor;
-        viewDescriptor.nextInChain = nullptr;
+        viewDescriptor.nextInChain     = nullptr;
         viewDescriptor.dimension       = wgpu::TextureViewDimension::Cube;
-        viewDescriptor.format = mFormat;
-        viewDescriptor.baseMipLevel = 0;
+        viewDescriptor.format          = mFormat;
+        viewDescriptor.baseMipLevel    = 0;
         viewDescriptor.mipLevelCount   = 1;
-        viewDescriptor.baseArrayLayer = 0;
+        viewDescriptor.baseArrayLayer  = 0;
         viewDescriptor.arrayLayerCount = 6;
 
         mTextureView = mTexture.CreateView(&viewDescriptor);
@@ -116,13 +117,13 @@ void TextureDawn::loadTexture()
                        true);
 
         wgpu::TextureDescriptor descriptor;
-        descriptor.dimension = mTextureDimension;
-        descriptor.size.width  = resizedWidth;
-        descriptor.size.height = mHeight;
-        descriptor.size.depth = 1;
-        descriptor.sampleCount = 1;
-        descriptor.format = mFormat;
-        descriptor.mipLevelCount   = static_cast<uint32_t>(std::floor(
+        descriptor.dimension     = mTextureDimension;
+        descriptor.size.width    = resizedWidth;
+        descriptor.size.height   = mHeight;
+        descriptor.size.depth    = 1;
+        descriptor.sampleCount   = 1;
+        descriptor.format        = mFormat;
+        descriptor.mipLevelCount = static_cast<uint32_t>(std::floor(
                                        static_cast<float>(std::log2(std::min(mWidth, mHeight))))) +
                                    1;
         descriptor.usage = wgpu::TextureUsage::CopyDst | wgpu::TextureUsage::Sampled;
@@ -131,8 +132,8 @@ void TextureDawn::loadTexture()
         int count = 0;
         for (unsigned int i = 0; i < descriptor.mipLevelCount; ++i, ++count)
         {
-            int height                 = mHeight >> i;
-            int width                  = resizedWidth >> i;
+            int height = mHeight >> i;
+            int width  = resizedWidth >> i;
             if (height == 0)
             {
                 height = 1;
@@ -155,15 +156,15 @@ void TextureDawn::loadTexture()
         }
 
         wgpu::TextureViewDescriptor viewDescriptor;
-        viewDescriptor.nextInChain = nullptr;
+        viewDescriptor.nextInChain  = nullptr;
         viewDescriptor.dimension    = wgpu::TextureViewDimension::e2D;
-        viewDescriptor.format = mFormat;
+        viewDescriptor.format       = mFormat;
         viewDescriptor.baseMipLevel = 0;
         viewDescriptor.mipLevelCount =
             static_cast<uint32_t>(
                 std::floor(static_cast<float>(std::log2(std::min(mWidth, mHeight))))) +
             1;
-        viewDescriptor.baseArrayLayer = 0;
+        viewDescriptor.baseArrayLayer  = 0;
         viewDescriptor.arrayLayerCount = 1;
 
         mTextureView = mTexture.CreateView(&viewDescriptor);

--- a/src/aquarium-optimized/opengl/ContextGL.cpp
+++ b/src/aquarium-optimized/opengl/ContextGL.cpp
@@ -147,15 +147,10 @@ bool ContextGL::initialize(BACKENDTYPE backend,
     const char *displayExtensions = eglQueryString(mDisplay, EGL_EXTENSIONS);
 
     std::vector<EGLint> configAttributes = {
-        EGL_RED_SIZE,       8,
-        EGL_GREEN_SIZE,     8,
-        EGL_BLUE_SIZE,      8,
-        EGL_ALPHA_SIZE,     8,
-        EGL_DEPTH_SIZE,     24,
-        EGL_STENCIL_SIZE,   8,
-        EGL_SAMPLE_BUFFERS, 0,
-        EGL_SAMPLES,        EGL_DONT_CARE
-    };
+        EGL_RED_SIZE,       8,  EGL_GREEN_SIZE,   8,
+        EGL_BLUE_SIZE,      8,  EGL_ALPHA_SIZE,   8,
+        EGL_DEPTH_SIZE,     24, EGL_STENCIL_SIZE, 8,
+        EGL_SAMPLE_BUFFERS, 0,  EGL_SAMPLES,      EGL_DONT_CARE};
 
     // Add dynamic attributes
     bool hasPixelFormatFloat = strstr(displayExtensions, "EGL_EXT_pixel_format_float") != nullptr;
@@ -478,8 +473,7 @@ void ContextGL::updateFPS(const FPSTimer &fpsTimer,
     }
     // Start the Dear ImGui frame
     ImGui_ImplOpenGL3_NewFrame(
-        mMSAASampleCount,
-        toggleBitset->test(static_cast<TOGGLE>(TOGGLE::ENABLEALPHABLENDING)));
+        mMSAASampleCount, toggleBitset->test(static_cast<TOGGLE>(TOGGLE::ENABLEALPHABLENDING)));
     renderImgui(fpsTimer, fishCount, toggleBitset);
     ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 }

--- a/src/aquarium-optimized/opengl/ContextGL.h
+++ b/src/aquarium-optimized/opengl/ContextGL.h
@@ -30,7 +30,7 @@
 
 class BufferGL;
 class TextureGL;
-enum BACKENDTYPE: short;
+enum BACKENDTYPE : short;
 
 class ContextGL : public Context
 {
@@ -57,7 +57,7 @@ class ContextGL : public Context
 
     Model *createModel(Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend) override;
     int getUniformLocation(unsigned int programId, const std::string &name) const;
-    int getAttribLocation(unsigned int programId, const std::string & name) const;
+    int getAttribLocation(unsigned int programId, const std::string &name) const;
     void setUniform(int index, const float *v, int type) const;
     void setTexture(const TextureGL &texture, int index, int unit) const;
     void setAttribs(const BufferGL &bufferGL, int index) const;

--- a/src/aquarium-optimized/opengl/FishModelGL.cpp
+++ b/src/aquarium-optimized/opengl/FishModelGL.cpp
@@ -32,10 +32,10 @@ FishModelGL::FishModelGL(const ContextGL *mContextGL,
     mViewProjectionUniform.first = aquarium->lightWorldPositionUniform.viewProjection;
     mScaleUniform.first          = 1;
 
-    const Fish &fishInfo              = fishTable[name - MODELNAME::MODELSMALLFISHA];
-    mFishLengthUniform.first          = fishInfo.fishLength;
-    mFishBendAmountUniform.first      = fishInfo.fishBendAmount;
-    mFishWaveLengthUniform.first      = fishInfo.fishWaveLength;
+    const Fish &fishInfo         = fishTable[name - MODELNAME::MODELSMALLFISHA];
+    mFishLengthUniform.first     = fishInfo.fishLength;
+    mFishBendAmountUniform.first = fishInfo.fishBendAmount;
+    mFishWaveLengthUniform.first = fishInfo.fishWaveLength;
 }
 
 void FishModelGL::init()

--- a/src/aquarium-optimized/opengl/FishModelGL.h
+++ b/src/aquarium-optimized/opengl/FishModelGL.h
@@ -19,7 +19,11 @@ class TextureGL;
 class FishModelGL : public FishModel
 {
   public:
-    FishModelGL(const ContextGL *context, Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend);
+    FishModelGL(const ContextGL *context,
+                Aquarium *aquarium,
+                MODELGROUP type,
+                MODELNAME name,
+                bool blend);
     void prepareForDraw() override;
     void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
 

--- a/src/aquarium-optimized/opengl/GenericModelGL.h
+++ b/src/aquarium-optimized/opengl/GenericModelGL.h
@@ -16,7 +16,7 @@ class GenericModelGL : public Model
 {
   public:
     GenericModelGL(const ContextGL *context,
-                   Aquarium* aquarium,
+                   Aquarium *aquarium,
                    MODELGROUP type,
                    MODELNAME name,
                    bool blend);

--- a/src/aquarium-optimized/opengl/InnerModelGL.h
+++ b/src/aquarium-optimized/opengl/InnerModelGL.h
@@ -15,7 +15,11 @@
 class InnerModelGL : public Model
 {
   public:
-    InnerModelGL(const ContextGL *context, Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend);
+    InnerModelGL(const ContextGL *context,
+                 Aquarium *aquarium,
+                 MODELGROUP type,
+                 MODELNAME name,
+                 bool blend);
     void prepareForDraw() override;
     void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
     void init() override;

--- a/src/aquarium-optimized/opengl/ProgramGL.cpp
+++ b/src/aquarium-optimized/opengl/ProgramGL.cpp
@@ -36,8 +36,8 @@
 ProgramGL::ProgramGL(ContextGL *context, std::string mVId, std::string mFId)
     : Program(mVId, mFId), mProgramId(0u), mContext(context)
 {
-    mProgramId= context->generateProgram();
-    mVAO = context->generateVAO();
+    mProgramId = context->generateProgram();
+    mVAO       = context->generateVAO();
 }
 
 ProgramGL::~ProgramGL()
@@ -85,7 +85,8 @@ void ProgramGL::compileProgram(bool enableBlending, const std::string &alpha)
 
     bool status = mContext->compileProgram(mProgramId, VertexShaderCode, FragmentShaderCode);
     ASSERT(status);
-    if (!status) {
+    if (!status)
+    {
         std::cout << "Error occurs in compiling program!" << std::endl;
     }
 }

--- a/src/aquarium-optimized/opengl/ProgramGL.h
+++ b/src/aquarium-optimized/opengl/ProgramGL.h
@@ -22,7 +22,7 @@
 
 class ProgramGL : public Program
 {
-public:
+  public:
     ProgramGL() {}
     ProgramGL(ContextGL *, std::string mVId, std::string mFId);
     ~ProgramGL() override;
@@ -30,7 +30,7 @@ public:
     void setProgram() override;
     GLuint getProgramId() const { return mProgramId; }
     GLuint getVAOId() { return mVAO; }
-    void compileProgram(bool enableAlphaBlending, const std::string& alpha) override;
+    void compileProgram(bool enableAlphaBlending, const std::string &alpha) override;
 
   private:
     GLuint mProgramId;

--- a/src/aquarium-optimized/opengl/TextureGL.h
+++ b/src/aquarium-optimized/opengl/TextureGL.h
@@ -44,7 +44,6 @@ class TextureGL : public Texture
     void loadTexture() override;
 
   private:
-
     unsigned int mTarget;
     unsigned int mTextureId;
     unsigned int mFormat;

--- a/src/common/AQUARIUM_ASSERT.h
+++ b/src/common/AQUARIUM_ASSERT.h
@@ -9,25 +9,29 @@
 
 #include <cstdio>
 
-//TODO(yizhou) : replace this ASSERT by the code template of ANGLE or Chromium
+// TODO(yizhou) : replace this ASSERT by the code template of ANGLE or Chromium
 #ifndef NDEBUG
-#define ASSERT(expression)                { \
-        if (!(expression))                { \
-            printf("Assertion(%s) failed: file \"%s\", line %d\n", \
-                #expression, __FILE__, __LINE__); \
-            abort();                        \
-        }                                   \
+#define ASSERT(expression)                                                                \
+    {                                                                                     \
+        if (!(expression))                                                                \
+        {                                                                                 \
+            printf("Assertion(%s) failed: file \"%s\", line %d\n", #expression, __FILE__, \
+                   __LINE__);                                                             \
+            abort();                                                                      \
+        }                                                                                 \
     }
 #else
 #define ASSERT(expression) NULL;
 #endif
 
 #ifndef NDEBUG
-#define SWALLOW_ERROR(expression)                { \
-        if (!(expression))                { \
-            printf("Assertion(%s) failed: file \"%s\", line %d\n", \
-                #expression, __FILE__, __LINE__); \
-        }                                         \
+#define SWALLOW_ERROR(expression)                                                         \
+    {                                                                                     \
+        if (!(expression))                                                                \
+        {                                                                                 \
+            printf("Assertion(%s) failed: file \"%s\", line %d\n", #expression, __FILE__, \
+                   __LINE__);                                                             \
+        }                                                                                 \
     }
 #else
 #define SWALLOW_ERROR(expression) expression

--- a/src/common/FPSTimer.cpp
+++ b/src/common/FPSTimer.cpp
@@ -19,7 +19,8 @@ FPSTimer::FPSTimer()
       mHistoryFPS(NUM_HISTORY_DATA, 1.0f),
       mHistoryFrameTime(NUM_HISTORY_DATA, 100.0f),
       mAverageFPS(0.0)
-{}
+{
+}
 
 void FPSTimer::update(double elapsedTime, double renderingTime, int testTime)
 {

--- a/src/common/FPSTimer.h
+++ b/src/common/FPSTimer.h
@@ -10,31 +10,31 @@
 
 #include <vector>
 
-constexpr int NUM_HISTORY_DATA = 100;
+constexpr int NUM_HISTORY_DATA      = 100;
 constexpr int NUM_FRAMES_TO_AVERAGE = 128;
 constexpr int FPS_VALID_THRESHOLD   = 5;
 
 class FPSTimer
 {
-public:
-  FPSTimer();
+  public:
+    FPSTimer();
 
-  void update(double elapsedTime, double renderingTime, int testTime);
-  double getAverageFPS() const { return mAverageFPS; }
-  const float *getHistoryFps() const { return mHistoryFPS.data(); }
-  const float *getHistoryFrameTime() const { return mHistoryFrameTime.data(); }
-  int variance() const;
+    void update(double elapsedTime, double renderingTime, int testTime);
+    double getAverageFPS() const { return mAverageFPS; }
+    const float *getHistoryFps() const { return mHistoryFPS.data(); }
+    const float *getHistoryFrameTime() const { return mHistoryFrameTime.data(); }
+    int variance() const;
 
-private:
-  double mTotalTime;
-  std::vector<double> mTimeTable;
-  int mTimeTableCursor;
+  private:
+    double mTotalTime;
+    std::vector<double> mTimeTable;
+    int mTimeTableCursor;
 
-  std::vector<float> mHistoryFPS;
-  std::vector<float> mHistoryFrameTime;
-  std::vector<float> mLogFPS;
+    std::vector<float> mHistoryFPS;
+    std::vector<float> mHistoryFrameTime;
+    std::vector<float> mLogFPS;
 
-  double mAverageFPS;
+    double mAverageFPS;
 };
 
 #endif  // FPSTIMER_H


### PR DESCRIPTION
This is accomplished with:

find src \\
-wholename src/include/d3d12 -prune -o \\
-regex '.+/[a-z0-9_]+\\.[a-z]+' -prune -o \\
'(' -name '\*.h' -o -name '\*.cpp' ')' -exec clang-format -i '{}' ';'

Use of clang-format is recommended, but not enforced. It's almost certain that clang-format may result in visually worse typography in some places, but that's rare and in general the code looks better than before.
