### PR TITLE
Use the default 80 column limit

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -10,17 +10,10 @@ BasedOnStyle: Chromium
 # Allow double brackets such as std::vector<std::vector<int>>.
 Standard: Cpp11
 
-# Indent 4 spaces at a time.
-IndentWidth: 4
-
-# Keep lines under 100 columns long.
-ColumnLimit: 100
-
 # Always break before braces
 BreakBeforeBraces: Allman
 
-# Indent case labels.
-IndentCaseLabels: true
+IndentCaseLabels: false
 
 # Right-align pointers and references
 PointerAlignment: Right

--- a/src/aquarium-direct-map/AttribBuffer.h
+++ b/src/aquarium-direct-map/AttribBuffer.h
@@ -3,7 +3,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 //
-// AttribBuffer.h: Define AttribBuffer Class. Store vertex attributes such as positions and indexes.
+// AttribBuffer.h: Define AttribBuffer Class. Store vertex attributes such as
+// positions and indexes.
 
 #ifndef ATTRIBBUFFER_H
 #define ATTRIBBUFFER_H
@@ -13,30 +14,33 @@
 
 class AttribBuffer
 {
-  public:
-    AttribBuffer() {}
-    AttribBuffer(int numComponents,
-                 const std::vector<float> &buffer,
-                 int size,
-                 const std::string &opt_type);
-    AttribBuffer(int numComponents,
-                 const std::vector<unsigned short> &buffer,
-                 int size,
-                 const std::string &opt_type);
+public:
+  AttribBuffer() {}
+  AttribBuffer(int numComponents,
+               const std::vector<float> &buffer,
+               int size,
+               const std::string &opt_type);
+  AttribBuffer(int numComponents,
+               const std::vector<unsigned short> &buffer,
+               int size,
+               const std::string &opt_type);
 
-    int getNumComponents() const { return numComponents; }
-    int getNumElements() const { return numElements; }
+  int getNumComponents() const { return numComponents; }
+  int getNumElements() const { return numElements; }
 
-    const std::vector<float> &getBufferFloat() const { return bufferFloat; }
-    const std::vector<unsigned short> &getBufferUShort() const { return bufferUShort; }
-    const std::string &getType() const { return type; }
+  const std::vector<float> &getBufferFloat() const { return bufferFloat; }
+  const std::vector<unsigned short> &getBufferUShort() const
+  {
+    return bufferUShort;
+  }
+  const std::string &getType() const { return type; }
 
-  private:
-    std::string type;
-    std::vector<float> bufferFloat;
-    std::vector<unsigned short> bufferUShort;
-    int numComponents;
-    int numElements;
+private:
+  std::string type;
+  std::vector<float> bufferFloat;
+  std::vector<unsigned short> bufferUShort;
+  int numComponents;
+  int numElements;
 };
 
 #endif  // ATTRIBBUFFER_H

--- a/src/aquarium-direct-map/Buffer.cpp
+++ b/src/aquarium-direct-map/Buffer.cpp
@@ -3,7 +3,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 //
-// Buffer.cpp: Implement the index or vertex buffer wrappers and resource bindings of OpenGL.
+// Buffer.cpp: Implement the index or vertex buffer wrappers and resource
+// bindings of OpenGL.
 
 #include "Buffer.h"
 
@@ -22,37 +23,37 @@ Buffer::Buffer(const AttribBuffer &attribBuffer, GLenum target)
       mOffset(nullptr)
 
 {
-    glGenBuffers(1, &mBuf);
+  glGenBuffers(1, &mBuf);
 
-    glBindBuffer(target, mBuf);
+  glBindBuffer(target, mBuf);
 
-    mTotalComponents = mNumComponents * mNumElements;
+  mTotalComponents = mNumComponents * mNumElements;
 
-    auto bufferFloat  = attribBuffer.getBufferFloat();
-    auto bufferUShort = attribBuffer.getBufferUShort();
+  auto bufferFloat  = attribBuffer.getBufferFloat();
+  auto bufferUShort = attribBuffer.getBufferUShort();
 
-    if (attribBuffer.getType() == "Float32Array")
-    {
-        mType      = GL_FLOAT;
-        mNormalize = false;
-        glBufferData(target, sizeof(GLfloat) * bufferFloat.size(), bufferFloat.data(),
-                     GL_STATIC_DRAW);
-    }
-    else if (attribBuffer.getType() == "Uint16Array")
-    {
-        mType = GL_UNSIGNED_SHORT;
-        glBufferData(target, sizeof(GLushort) * bufferUShort.size(), bufferUShort.data(),
-                     GL_STATIC_DRAW);
-    }
-    else
-    {
-        std::cout << "bindBufferData undefined type." << std::endl;
-    }
+  if (attribBuffer.getType() == "Float32Array")
+  {
+    mType      = GL_FLOAT;
+    mNormalize = false;
+    glBufferData(target, sizeof(GLfloat) * bufferFloat.size(),
+                 bufferFloat.data(), GL_STATIC_DRAW);
+  }
+  else if (attribBuffer.getType() == "Uint16Array")
+  {
+    mType = GL_UNSIGNED_SHORT;
+    glBufferData(target, sizeof(GLushort) * bufferUShort.size(),
+                 bufferUShort.data(), GL_STATIC_DRAW);
+  }
+  else
+  {
+    std::cout << "bindBufferData undefined type." << std::endl;
+  }
 
-    ASSERT(glGetError() == GL_NO_ERROR);
+  ASSERT(glGetError() == GL_NO_ERROR);
 }
 
 Buffer::~Buffer()
 {
-    glDeleteBuffers(1, &mBuf);
+  glDeleteBuffers(1, &mBuf);
 }

--- a/src/aquarium-direct-map/Buffer.h
+++ b/src/aquarium-direct-map/Buffer.h
@@ -16,29 +16,29 @@
 
 class Buffer
 {
-  public:
-    Buffer() {}
-    Buffer(const AttribBuffer &array, GLenum target);
-    ~Buffer();
+public:
+  Buffer() {}
+  Buffer(const AttribBuffer &array, GLenum target);
+  ~Buffer();
 
-    GLuint getBuffer() const { return mBuf; }
-    int getNumComponents() const { return mNumComponents; }
-    int getNumElements() const { return mNumElements; }
-    int getTotalComponents() const { return mTotalComponents; }
-    GLenum getType() const { return mType; }
-    bool getNormalize() const { return mNormalize; }
-    GLsizei getStride() const { return mStride; }
-    void *getOffset() const { return mOffset; }
+  GLuint getBuffer() const { return mBuf; }
+  int getNumComponents() const { return mNumComponents; }
+  int getNumElements() const { return mNumElements; }
+  int getTotalComponents() const { return mTotalComponents; }
+  GLenum getType() const { return mType; }
+  bool getNormalize() const { return mNormalize; }
+  GLsizei getStride() const { return mStride; }
+  void *getOffset() const { return mOffset; }
 
-  private:
-    GLuint mBuf;
-    int mNumComponents;
-    int mNumElements;
-    int mTotalComponents;
-    GLenum mType;
-    bool mNormalize;
-    GLsizei mStride;
-    void *mOffset;
+private:
+  GLuint mBuf;
+  int mNumComponents;
+  int mNumElements;
+  int mTotalComponents;
+  GLenum mType;
+  bool mNormalize;
+  GLsizei mStride;
+  void *mOffset;
 };
 
 #endif  // BUFFER_H

--- a/src/aquarium-direct-map/Globals.h
+++ b/src/aquarium-direct-map/Globals.h
@@ -3,8 +3,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 //
-// Globals.h: Define global variables, constant variables, global texture map, program map and
-// scene map.
+// Globals.h: Define global variables, constant variables, global texture map,
+// program map and scene map.
 
 #ifndef GLOBALS_H
 #define GLOBALS_H
@@ -18,7 +18,8 @@
 #include "Scene.h"
 #include "common/FPSTimer.h"
 
-#if defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
+#if defined(WIN32) || defined(_WIN32) || \
+    defined(__WIN32) && !defined(__CYGWIN__)
 const std::string slash = "\\";
 #define M_PI 3.141592653589793
 #else
@@ -29,9 +30,10 @@ class Scene;
 class Program;
 class Texture;
 
-static FPSTimer g_fpsTimer;                                // object to measure frames per second;
+static FPSTimer g_fpsTimer;  // object to measure frames per second;
 static std::unordered_map<std::string, Scene *> g_scenes;  // each of the models
-static std::unordered_map<std::string, std::multimap<std::string, std::vector<float>>>
+static std::unordered_map<std::string,
+                          std::multimap<std::string, std::vector<float>>>
     g_sceneGroups;  // the placement of the models
 static std::unordered_map<std::string, Program *>
     g_programMap;  // store all compiled program in this map
@@ -62,11 +64,11 @@ constexpr float fish_specularFactor    = 0.3f;
 
 struct G_ui_per
 {
-    const char *obj;
-    const char *name;
-    float value;
-    float max;
-    float min;
+  const char *obj;
+  const char *name;
+  float value;
+  float max;
+  float min;
 };
 
 static std::unordered_map<std::string, std::unordered_map<std::string, float>>
@@ -78,24 +80,24 @@ constexpr float g_net_offsetMult = 1.21f;
 
 struct G_viewSettings
 {
-    float targetHeight    = 63.3f;
-    float targetRadius    = 91.6f;
-    float eyeHeight       = 7.5f;
-    float eyeRadius       = 13.2f;
-    float eyeSpeed        = 0.0258f;
-    float fieldOfView     = 82.699f;
-    float ambientRed      = 0.218f;
-    float ambientGreen    = 0.502f;
-    float ambientBlue     = 0.706f;
-    float fogPower        = 16.5f;
-    float fogMult         = 1.5f;  // 2.02,
-    float fogOffset       = 0.738f;
-    float fogRed          = 0.338f;
-    float fogGreen        = 0.81f;
-    float fogBlue         = 1.0f;
-    float refractionFudge = 3.0f;
-    float eta             = 1.0f;
-    float tankColorFudge  = 0.796f;
+  float targetHeight    = 63.3f;
+  float targetRadius    = 91.6f;
+  float eyeHeight       = 7.5f;
+  float eyeRadius       = 13.2f;
+  float eyeSpeed        = 0.0258f;
+  float fieldOfView     = 82.699f;
+  float ambientRed      = 0.218f;
+  float ambientGreen    = 0.502f;
+  float ambientBlue     = 0.706f;
+  float fogPower        = 16.5f;
+  float fogMult         = 1.5f;  // 2.02,
+  float fogOffset       = 0.738f;
+  float fogRed          = 0.338f;
+  float fogGreen        = 0.81f;
+  float fogBlue         = 1.0f;
+  float refractionFudge = 3.0f;
+  float eta             = 1.0f;
+  float tankColorFudge  = 0.796f;
 } constexpr g_viewSettings;
 
 static std::vector<float> projection(16);
@@ -129,93 +131,95 @@ static std::vector<float> fogColor = {1.0f, 1.0f, 1.0f, 1.0f};
 // Generic uniforms
 struct GenericConst
 {
-    std::vector<float> *viewProjection;
-    std::vector<float> *viewInverse;
-    std::vector<float> *lightWorldPos;
-    std::vector<float> *lightColor;
-    std::vector<float> *specular;
-    std::vector<float> *ambient;
-    std::vector<float> *fogColor;
-    float shininess;
-    float specularFactor;
-    float fogPower;
-    float fogMult;
-    float fogOffset;
+  std::vector<float> *viewProjection;
+  std::vector<float> *viewInverse;
+  std::vector<float> *lightWorldPos;
+  std::vector<float> *lightColor;
+  std::vector<float> *specular;
+  std::vector<float> *ambient;
+  std::vector<float> *fogColor;
+  float shininess;
+  float specularFactor;
+  float fogPower;
+  float fogMult;
+  float fogOffset;
 
-    float eta;
-    float tankColorFudge;
-    float refractionFudge;
+  float eta;
+  float tankColorFudge;
+  float refractionFudge;
 };
-static GenericConst sandConst, genericConst, seaweedConst, outsideConst, innerConst;
+static GenericConst sandConst, genericConst, seaweedConst, outsideConst,
+    innerConst;
 
 struct GenericPer
 {
-    std::vector<float> *world;
-    std::vector<float> *worldViewProjection;
-    std::vector<float> *worldInverse;
-    std::vector<float> *worldInverseTranspose;
-    float time;
+  std::vector<float> *world;
+  std::vector<float> *worldViewProjection;
+  std::vector<float> *worldInverse;
+  std::vector<float> *worldInverseTranspose;
+  float time;
 };
 
-static GenericPer sandPer, genericPer, seaweedPer, outsidePer, innerPer, laserPer, skyPer;
+static GenericPer sandPer, genericPer, seaweedPer, outsidePer, innerPer,
+    laserPer, skyPer;
 
 struct SkyConst
 {
-    std::vector<float> *viewProjectionInverse;
+  std::vector<float> *viewProjectionInverse;
 };
 
 static SkyConst skyConst;
 
 struct FishPer
 {
-    std::vector<float> worldPosition;
-    std::vector<float> nextPosition;
-    float scale;
-    float time;
+  std::vector<float> worldPosition;
+  std::vector<float> nextPosition;
+  float scale;
+  float time;
 };
 
 static FishPer fishPer;
 
 struct G_sceneInfo
 {
-    std::string name;
-    std::string program[2];
-    bool fog;
-    std::string group;
-    bool blend;
+  std::string name;
+  std::string program[2];
+  bool fog;
+  std::string group;
+  bool blend;
 };
 
 struct ConstUniforms
 {
-    float fishLength;
-    float fishWaveLength;
-    float fishBendAmount;
+  float fishLength;
+  float fishWaveLength;
+  float fishBendAmount;
 };
 
 struct Fish
 {
-    std::string name;
-    float speed;
-    float speedRange;
-    float radius;
-    float radiusRange;
-    float tailSpeed;
-    float heightOffset;
-    float heightRange;
+  std::string name;
+  float speed;
+  float speedRange;
+  float radius;
+  float radiusRange;
+  float tailSpeed;
+  float heightOffset;
+  float heightRange;
 
-    ConstUniforms constUniforms;
+  ConstUniforms constUniforms;
 
-    bool lasers;
-    float laserRot;
-    float laserOff[3];
-    float laserScale[3];
-    int num;
+  bool lasers;
+  float laserRot;
+  float laserOff[3];
+  float laserScale[3];
+  int num;
 };
 
 struct FishConst
 {
-    GenericConst genericConst;
-    ConstUniforms constUniforms;
+  GenericConst genericConst;
+  ConstUniforms constUniforms;
 };
 
 static FishConst fishConst;

--- a/src/aquarium-direct-map/Main.cpp
+++ b/src/aquarium-direct-map/Main.cpp
@@ -61,20 +61,32 @@ float then     = 0.0f;
 float mClock   = 0.0f;
 float eyeClock = 0.0f;
 
-const G_ui_per g_ui[] = {
-    {"globals", "speed", 1.0f, 4.0f},           {"globals", "targetHeight", 0.0f, 150.0f},
-    {"globals", "targetRadius", 88.0f, 200.0f}, {"globals", "eyeHeight", 19.0f, 150.0f},
-    {"globals", "eyeSpeed", 0.06f, 1.0f},       {"globals", "fieldOfView", 85.0f, 179.0f, 1.0f},
-    {"globals", "ambientRed", 0.22f, 1.0f},     {"globals", "ambientGreen", 0.25f, 1.0f},
-    {"globals", "ambientBlue", 0.39f, 1.0f},    {"globals", "fogPower", 14.5f, 50.0f},
-    {"globals", "fogMult", 1.66f, 10.0f},       {"globals", "fogOffset", 0.53f, 3.0f},
-    {"globals", "fogRed", 0.54f, 1.0f},         {"globals", "fogGreen", 0.86f, 1.0f},
-    {"globals", "fogBlue", 1.0f, 1.0f},         {"fish", "fishHeightRange", 1.0f, 3.0f},
-    {"fish", "fishHeight", 25.0f, 50.0f},       {"fish", "fishSpeed", 0.124f, 2.0f},
-    {"fish", "fishOffset", 0.52f, 2.0f},        {"fish", "fishXClock", 1.0f, 2.0f},
-    {"fish", "fishYClock", 0.556f, 2.0f},       {"fish", "fishZClock", 1.0f, 2.0f},
-    {"fish", "fishTailSpeed", 1.0f, 30.0f},     {"innerConst", "refractionFudge", 3.0f, 50.0f},
-    {"innerConst", "eta", 1.0f, 1.20f},         {"innerConst", "tankColorFudge", 0.8f, 2.0f}};
+const G_ui_per g_ui[] = {{"globals", "speed", 1.0f, 4.0f},
+                         {"globals", "targetHeight", 0.0f, 150.0f},
+                         {"globals", "targetRadius", 88.0f, 200.0f},
+                         {"globals", "eyeHeight", 19.0f, 150.0f},
+                         {"globals", "eyeSpeed", 0.06f, 1.0f},
+                         {"globals", "fieldOfView", 85.0f, 179.0f, 1.0f},
+                         {"globals", "ambientRed", 0.22f, 1.0f},
+                         {"globals", "ambientGreen", 0.25f, 1.0f},
+                         {"globals", "ambientBlue", 0.39f, 1.0f},
+                         {"globals", "fogPower", 14.5f, 50.0f},
+                         {"globals", "fogMult", 1.66f, 10.0f},
+                         {"globals", "fogOffset", 0.53f, 3.0f},
+                         {"globals", "fogRed", 0.54f, 1.0f},
+                         {"globals", "fogGreen", 0.86f, 1.0f},
+                         {"globals", "fogBlue", 1.0f, 1.0f},
+                         {"fish", "fishHeightRange", 1.0f, 3.0f},
+                         {"fish", "fishHeight", 25.0f, 50.0f},
+                         {"fish", "fishSpeed", 0.124f, 2.0f},
+                         {"fish", "fishOffset", 0.52f, 2.0f},
+                         {"fish", "fishXClock", 1.0f, 2.0f},
+                         {"fish", "fishYClock", 0.556f, 2.0f},
+                         {"fish", "fishZClock", 1.0f, 2.0f},
+                         {"fish", "fishTailSpeed", 1.0f, 30.0f},
+                         {"innerConst", "refractionFudge", 3.0f, 50.0f},
+                         {"innerConst", "eta", 1.0f, 1.20f},
+                         {"innerConst", "tankColorFudge", 0.8f, 2.0f}};
 
 G_sceneInfo g_sceneInfo[] = {
     {"SmallFishA", {"fishVertexShader", "fishReflectionFragmentShader"}, true},
@@ -86,7 +98,10 @@ G_sceneInfo g_sceneInfo[] = {
     {"Coral", {"", ""}, true},
     {"CoralStoneA", {"", ""}, true},
     {"CoralStoneB", {"", ""}, true},
-    {"EnvironmentBox", {"diffuseVertexShader", "diffuseFragmentShader"}, false, "outside"},
+    {"EnvironmentBox",
+     {"diffuseVertexShader", "diffuseFragmentShader"},
+     false,
+     "outside"},
     {"FloorBase_Baked", {"", ""}, true},
     {"FloorCenter", {"", ""}, true},
     {"GlobeBase", {"diffuseVertexShader", "diffuseFragmentShader"}},
@@ -98,608 +113,653 @@ G_sceneInfo g_sceneInfo[] = {
     {"RockB", {"", ""}, true},
     {"RockC", {"", ""}, true},
     {"RuinColumn", {"", ""}, true},
-    {"Skybox", {"diffuseVertexShader", "diffuseFragmentShader"}, false, "outside"},
+    {"Skybox",
+     {"diffuseVertexShader", "diffuseFragmentShader"},
+     false,
+     "outside"},
     {"Stone", {"", ""}, true},
     {"Stones", {"", ""}, true},
     {"SunknShip", {"", ""}, true},
     {"SunknSub", {"", ""}, true},
     {"SupportBeams", {"", ""}, false, "outside"},
-    {"SeaweedA", {"seaweedVertexShader", "seaweedFragmentShader"}, false, "seaweed", true},
-    {"SeaweedB", {"seaweedVertexShader", "seaweedFragmentShader"}, false, "seaweed", true},
+    {"SeaweedA",
+     {"seaweedVertexShader", "seaweedFragmentShader"},
+     false,
+     "seaweed",
+     true},
+    {"SeaweedB",
+     {"seaweedVertexShader", "seaweedFragmentShader"},
+     false,
+     "seaweed",
+     true},
     {"TreasureChest", {"", ""}, true}};
 
 std::unordered_map<std::string, G_sceneInfo> g_sceneInfoByName;
 
-Fish g_fishTable[] = {
-    {"SmallFishA", 1.0f, 1.5f, 30.0f, 25.0f, 10.0f, 0.0f, 16.0f, {10.0f, 1.0f, 2.0f}},
-    {"MediumFishA", 1.0f, 2.0f, 10.0f, 20.0f, 1.0f, 0.0f, 16.0f, {10.0f, -2.0f, 2.0f}},
-    {"MediumFishB", 0.5f, 4.0f, 10.0f, 20.0f, 3.0f, -8.0f, 5.0f, {10.0f, -2.0f, 2.0f}},
-    {"BigFishA",
-     0.5f,
-     0.5f,
-     50.0f,
-     3.0f,
-     1.5f,
-     0.0f,
-     16.0f,
-     {10.0f, -1.0f, 0.5f},
-     true,
-     0.04f,
-     {0.0f, 0.1f, 9.0f},
-     {0.3f, 0.3f, 1000.0f}},
-    {"BigFishB",
-     0.5f,
-     0.5f,
-     45.0f,
-     3.0f,
-     1.0f,
-     0.0f,
-     16.0f,
-     {10.0f, -0.7f, 0.3f},
-     true,
-     0.04f,
-     {0.0f, -0.3f, 9.0f},
-     {0.3f, 0.3f, 1000.0f}}};
+Fish g_fishTable[] = {{"SmallFishA",
+                       1.0f,
+                       1.5f,
+                       30.0f,
+                       25.0f,
+                       10.0f,
+                       0.0f,
+                       16.0f,
+                       {10.0f, 1.0f, 2.0f}},
+                      {"MediumFishA",
+                       1.0f,
+                       2.0f,
+                       10.0f,
+                       20.0f,
+                       1.0f,
+                       0.0f,
+                       16.0f,
+                       {10.0f, -2.0f, 2.0f}},
+                      {"MediumFishB",
+                       0.5f,
+                       4.0f,
+                       10.0f,
+                       20.0f,
+                       3.0f,
+                       -8.0f,
+                       5.0f,
+                       {10.0f, -2.0f, 2.0f}},
+                      {"BigFishA",
+                       0.5f,
+                       0.5f,
+                       50.0f,
+                       3.0f,
+                       1.5f,
+                       0.0f,
+                       16.0f,
+                       {10.0f, -1.0f, 0.5f},
+                       true,
+                       0.04f,
+                       {0.0f, 0.1f, 9.0f},
+                       {0.3f, 0.3f, 1000.0f}},
+                      {"BigFishB",
+                       0.5f,
+                       0.5f,
+                       45.0f,
+                       3.0f,
+                       1.0f,
+                       0.0f,
+                       16.0f,
+                       {10.0f, -0.7f, 0.3f},
+                       true,
+                       0.04f,
+                       {0.0f, -0.3f, 9.0f},
+                       {0.3f, 0.3f, 1000.0f}}};
 
 void setGenericConstMatrix(GenericConst *genericConst)
 {
-    genericConst->viewProjection = &viewProjection;
-    genericConst->viewInverse    = &viewInverse;
-    genericConst->lightWorldPos  = &lightWorldPos;
-    genericConst->lightColor     = &lightColor;
-    genericConst->specular       = &specular;
-    genericConst->ambient        = &ambient;
-    genericConst->fogColor       = &fogColor;
+  genericConst->viewProjection = &viewProjection;
+  genericConst->viewInverse    = &viewInverse;
+  genericConst->lightWorldPos  = &lightWorldPos;
+  genericConst->lightColor     = &lightColor;
+  genericConst->specular       = &specular;
+  genericConst->ambient        = &ambient;
+  genericConst->fogColor       = &fogColor;
 }
 
 void setGenericPer(GenericPer *genericPer)
 {
-    genericPer->world                 = &world;
-    genericPer->worldViewProjection   = &worldViewProjection;
-    genericPer->worldInverse          = &worldInverse;
-    genericPer->worldInverseTranspose = &worldInverseTraspose;
+  genericPer->world                 = &world;
+  genericPer->worldViewProjection   = &worldViewProjection;
+  genericPer->worldInverse          = &worldInverse;
+  genericPer->worldInverseTranspose = &worldInverseTraspose;
 }
 
 void initializeUniforms()
 {
-    sandConst.shininess      = sand_shininess;
-    sandConst.specularFactor = sand_specularFactor;
+  sandConst.shininess      = sand_shininess;
+  sandConst.specularFactor = sand_specularFactor;
 
-    genericConst.shininess      = generic_shininess;
-    genericConst.specularFactor = generic_specularFactor;
+  genericConst.shininess      = generic_shininess;
+  genericConst.specularFactor = generic_specularFactor;
 
-    outsideConst.shininess      = outside_shininess;
-    outsideConst.specularFactor = outside_shininess;
+  outsideConst.shininess      = outside_shininess;
+  outsideConst.specularFactor = outside_shininess;
 
-    seaweedConst.shininess      = seaweed_shininess;
-    seaweedConst.specularFactor = seaweed_specularFactor;
+  seaweedConst.shininess      = seaweed_shininess;
+  seaweedConst.specularFactor = seaweed_specularFactor;
 
-    innerConst.shininess       = inner_shininess;
-    innerConst.specularFactor  = inner_specularFactor;
-    innerConst.eta             = g_viewSettings.eta;
-    innerConst.refractionFudge = g_viewSettings.refractionFudge;
-    innerConst.tankColorFudge  = g_viewSettings.tankColorFudge;
+  innerConst.shininess       = inner_shininess;
+  innerConst.specularFactor  = inner_specularFactor;
+  innerConst.eta             = g_viewSettings.eta;
+  innerConst.refractionFudge = g_viewSettings.refractionFudge;
+  innerConst.tankColorFudge  = g_viewSettings.tankColorFudge;
 
-    fishConst.genericConst.shininess      = fish_shininess;
-    fishConst.genericConst.specularFactor = fish_specularFactor;
+  fishConst.genericConst.shininess      = fish_shininess;
+  fishConst.genericConst.specularFactor = fish_specularFactor;
 
-    setGenericConstMatrix(&sandConst);
-    setGenericConstMatrix(&genericConst);
-    setGenericConstMatrix(&seaweedConst);
-    setGenericConstMatrix(&innerConst);
-    setGenericConstMatrix(&outsideConst);
-    setGenericConstMatrix(&fishConst.genericConst);
-    setGenericPer(&sandPer);
-    setGenericPer(&genericPer);
-    setGenericPer(&seaweedPer);
-    setGenericPer(&innerPer);
-    setGenericPer(&outsidePer);
-    setGenericPer(&laserPer);
+  setGenericConstMatrix(&sandConst);
+  setGenericConstMatrix(&genericConst);
+  setGenericConstMatrix(&seaweedConst);
+  setGenericConstMatrix(&innerConst);
+  setGenericConstMatrix(&outsideConst);
+  setGenericConstMatrix(&fishConst.genericConst);
+  setGenericPer(&sandPer);
+  setGenericPer(&genericPer);
+  setGenericPer(&seaweedPer);
+  setGenericPer(&innerPer);
+  setGenericPer(&outsidePer);
+  setGenericPer(&laserPer);
 
-    skyConst.viewProjectionInverse = &viewProjectionInverse;
+  skyConst.viewProjectionInverse = &viewProjectionInverse;
 
-    fishPer.worldPosition.resize(3);
-    fishPer.nextPosition.resize(3);
+  fishPer.worldPosition.resize(3);
+  fishPer.nextPosition.resize(3);
 }
 
 void initializeGlobalInfo()
 {
-    for (auto &value : g_ui)
-    {
-        g[value.obj][value.name] = value.value;
-    }
+  for (auto &value : g_ui)
+  {
+    g[value.obj][value.name] = value.value;
+  }
 }
 
 // Load json file from assets. Initialize g_sceneGroups and classify groups.
 void LoadPlacement()
 {
-    std::ostringstream oss;
-    oss << mPath << resourceFolder << slash << "PropPlacement.js";
-    std::string proppath = oss.str();
-    std::ifstream PlacementStream(proppath, std::ios::in);
-    rapidjson::IStreamWrapper isPlacement(PlacementStream);
-    rapidjson::Document document;
-    document.ParseStream(isPlacement);
+  std::ostringstream oss;
+  oss << mPath << resourceFolder << slash << "PropPlacement.js";
+  std::string proppath = oss.str();
+  std::ifstream PlacementStream(proppath, std::ios::in);
+  rapidjson::IStreamWrapper isPlacement(PlacementStream);
+  rapidjson::Document document;
+  document.ParseStream(isPlacement);
 
-    ASSERT(document.IsObject());
+  ASSERT(document.IsObject());
 
-    ASSERT(document.HasMember("objects"));
-    const rapidjson::Value &objects = document["objects"];
-    ASSERT(objects.IsArray());
+  ASSERT(document.HasMember("objects"));
+  const rapidjson::Value &objects = document["objects"];
+  ASSERT(objects.IsArray());
 
-    for (auto &info : g_sceneInfo)
+  for (auto &info : g_sceneInfo)
+  {
+    g_sceneInfoByName[info.name] = info;
+  }
+
+  for (rapidjson::SizeType i = 0; i < objects.Size(); ++i)
+  {
+    const rapidjson::Value &name        = objects[i]["name"];
+    const rapidjson::Value &worldMatrix = objects[i]["worldMatrix"];
+    ASSERT(worldMatrix.IsArray() && worldMatrix.Size() == 16);
+
+    std::string groupName = g_sceneInfoByName[name.GetString()].group;
+    if (groupName == "")
     {
-        g_sceneInfoByName[info.name] = info;
+      groupName = "base";
     }
 
-    for (rapidjson::SizeType i = 0; i < objects.Size(); ++i)
+    std::multimap<std::string, std::vector<float>> &group =
+        g_sceneGroups[groupName];
+
+    std::vector<float> matrix;
+    for (rapidjson::SizeType j = 0; j < worldMatrix.Size(); ++j)
     {
-        const rapidjson::Value &name        = objects[i]["name"];
-        const rapidjson::Value &worldMatrix = objects[i]["worldMatrix"];
-        ASSERT(worldMatrix.IsArray() && worldMatrix.Size() == 16);
-
-        std::string groupName = g_sceneInfoByName[name.GetString()].group;
-        if (groupName == "")
-        {
-            groupName = "base";
-        }
-
-        std::multimap<std::string, std::vector<float>> &group = g_sceneGroups[groupName];
-
-        std::vector<float> matrix;
-        for (rapidjson::SizeType j = 0; j < worldMatrix.Size(); ++j)
-        {
-            matrix.push_back(worldMatrix[j].GetFloat());
-        }
-        group.insert(make_pair(name.GetString(), matrix));
+      matrix.push_back(worldMatrix[j].GetFloat());
     }
+    group.insert(make_pair(name.GetString(), matrix));
+  }
 }
 
 Scene *loadScene(const std::string &name, const std::string opt_programIds[2])
 {
-    Scene *scene = new Scene(opt_programIds);
-    scene->load(mPath, name);
-    return scene;
+  Scene *scene = new Scene(opt_programIds);
+  scene->load(mPath, name);
+  return scene;
 }
 
 // Initialize g_scenes.
 void LoadScenes()
 {
-    for (auto &info : g_sceneInfo)
-    {
-        g_scenes[info.name] = loadScene(info.name, info.program);
-    }
+  for (auto &info : g_sceneInfo)
+  {
+    g_scenes[info.name] = loadScene(info.name, info.program);
+  }
 }
 
 void onDestroy()
 {
-    for (auto &program : g_programMap)
+  for (auto &program : g_programMap)
+  {
+    if (program.second != nullptr)
     {
-        if (program.second != nullptr)
-        {
-            delete program.second;
-            program.second = nullptr;
-        }
+      delete program.second;
+      program.second = nullptr;
     }
+  }
 
-    for (auto &texture : g_textureMap)
+  for (auto &texture : g_textureMap)
+  {
+    if (texture.second != nullptr)
     {
-        if (texture.second != nullptr)
-        {
-            delete texture.second;
-            texture.second = nullptr;
-        }
+      delete texture.second;
+      texture.second = nullptr;
     }
+  }
 
-    for (auto &scene : g_scenes)
-    {
-        delete scene.second;
-    }
+  for (auto &scene : g_scenes)
+  {
+    delete scene.second;
+  }
 }
 
 void getCurrentPath()
 {
-    // Get path of current build.
+  // Get path of current build.
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32)
-    TCHAR temp[200];
-    GetModuleFileName(NULL, temp, MAX_PATH);
-    std::wstring ws(temp);
-    mPath       = std::string(ws.begin(), ws.end());
-    size_t nPos = mPath.find_last_of(slash);
-    mPath       = mPath.substr(0, nPos) + slash + ".." + slash + ".." + slash;
+  TCHAR temp[200];
+  GetModuleFileName(NULL, temp, MAX_PATH);
+  std::wstring ws(temp);
+  mPath       = std::string(ws.begin(), ws.end());
+  size_t nPos = mPath.find_last_of(slash);
+  mPath       = mPath.substr(0, nPos) + slash + ".." + slash + ".." + slash;
 #elif __APPLE__
-    char temp[200];
-    uint32_t size = sizeof(temp);
-    _NSGetExecutablePath(temp, &size);
-    mPath    = std::string(temp);
-    int nPos = mPath.find_last_of(slash);
-    mPath    = mPath.substr(0, nPos) + slash + ".." + slash + ".." + slash;
+  char temp[200];
+  uint32_t size = sizeof(temp);
+  _NSGetExecutablePath(temp, &size);
+  mPath    = std::string(temp);
+  int nPos = mPath.find_last_of(slash);
+  mPath    = mPath.substr(0, nPos) + slash + ".." + slash + ".." + slash;
 #else
-    char temp[200];
-    readlink("/proc/self/exe", temp, sizeof(temp));
-    mPath    = std::string(temp);
-    int nPos = mPath.find_last_of(slash);
-    mPath    = mPath.substr(0, nPos) + slash + ".." + slash + ".." + slash;
+  char temp[200];
+  readlink("/proc/self/exe", temp, sizeof(temp));
+  mPath    = std::string(temp);
+  int nPos = mPath.find_last_of(slash);
+  mPath    = mPath.substr(0, nPos) + slash + ".." + slash + ".." + slash;
 #endif
 }
 
 bool initialize(int argc, char **argv)
 {
-    getCurrentPath();
+  getCurrentPath();
 
-    glEnable(GL_DEPTH_TEST);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+  glEnable(GL_DEPTH_TEST);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-    initializeGlobalInfo();
-    initializeUniforms();
-    LoadPlacement();
+  initializeGlobalInfo();
+  initializeUniforms();
+  LoadPlacement();
 
-    LoadScenes();
+  LoadScenes();
 
-    // "--num-fish" {numfish}: imply rendering fish count.
-    char *pNext;
-    for (int i = 1; i < argc; ++i)
+  // "--num-fish" {numfish}: imply rendering fish count.
+  char *pNext;
+  for (int i = 1; i < argc; ++i)
+  {
+    std::string cmd(argv[i]);
+    if (cmd == "--h" || cmd == "-h")
     {
-        std::string cmd(argv[i]);
-        if (cmd == "--h" || cmd == "-h")
-        {
-            std::cout << cmdArgsStrAquariumDirectMap << std::endl;
-            return false;
-        }
-        else if (cmd == "--num-fish")
-        {
-            g_numFish = strtol(argv[i++ + 1], &pNext, 10);
-        }
+      std::cout << cmdArgsStrAquariumDirectMap << std::endl;
+      return false;
     }
-
-    // Calculate fish count for each float of fish
-    std::string floats[3] = {"Big", "Medium", "Small"};
-    int totalFish         = g_numFish;
-    int numLeft           = totalFish;
-    for (auto &type : floats)
+    else if (cmd == "--num-fish")
     {
-        for (auto &fishInfo : g_fishTable)
-        {
-            std::string &fishName = fishInfo.name;
-            if (fishName.find(type))
-            {
-                continue;
-            }
-            int numfloat = numLeft;
-            if (type == "Big")
-            {
-                int temp = totalFish < numFishSmall ? 1 : 2;
-                numfloat = min(numLeft, temp);
-            }
-            else if (type == "Medium")
-            {
-                if (totalFish < numFishMedium)
-                {
-                    numfloat = min(numLeft, totalFish / 10);
-                }
-                else if (totalFish < numFishBig)
-                {
-                    numfloat = min(numLeft, numFishLeftSmall);
-                }
-                else
-                {
-                    numfloat = min(numLeft, numFishLeftBig);
-                }
-            }
-            numLeft      = numLeft - numfloat;
-            fishInfo.num = numfloat;
-        }
+      g_numFish = strtol(argv[i++ + 1], &pNext, 10);
     }
+  }
 
-    return true;
+  // Calculate fish count for each float of fish
+  std::string floats[3] = {"Big", "Medium", "Small"};
+  int totalFish         = g_numFish;
+  int numLeft           = totalFish;
+  for (auto &type : floats)
+  {
+    for (auto &fishInfo : g_fishTable)
+    {
+      std::string &fishName = fishInfo.name;
+      if (fishName.find(type))
+      {
+        continue;
+      }
+      int numfloat = numLeft;
+      if (type == "Big")
+      {
+        int temp = totalFish < numFishSmall ? 1 : 2;
+        numfloat = min(numLeft, temp);
+      }
+      else if (type == "Medium")
+      {
+        if (totalFish < numFishMedium)
+        {
+          numfloat = min(numLeft, totalFish / 10);
+        }
+        else if (totalFish < numFishBig)
+        {
+          numfloat = min(numLeft, numFishLeftSmall);
+        }
+        else
+        {
+          numfloat = min(numLeft, numFishLeftBig);
+        }
+      }
+      numLeft      = numLeft - numfloat;
+      fishInfo.num = numfloat;
+    }
+  }
+
+  return true;
 }
 
 int main(int argc, char **argv)
 {
 
-    // initialize GLFW
-    if (!glfwInit())
-    {
-        std::cout << stderr << "Failed to initialize GLFW" << std::endl;
-        return -1;
-    }
+  // initialize GLFW
+  if (!glfwInit())
+  {
+    std::cout << stderr << "Failed to initialize GLFW" << std::endl;
+    return -1;
+  }
 
-    glfwWindowHint(GLFW_SAMPLES, 4);
+  glfwWindowHint(GLFW_SAMPLES, 4);
 
 #ifdef __APPLE__
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
 #elif _WIN32 || __linux__
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 5);
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 5);
 #endif
 
-    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
-    glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);
-    glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+  glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+  glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
+  glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);
+  glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
 
-    GLFWmonitor *pMonitor   = glfwGetPrimaryMonitor();
-    const GLFWvidmode *mode = glfwGetVideoMode(pMonitor);
-    clientWidth             = mode->width;
-    clientHeight            = mode->height;
+  GLFWmonitor *pMonitor   = glfwGetPrimaryMonitor();
+  const GLFWvidmode *mode = glfwGetVideoMode(pMonitor);
+  clientWidth             = mode->width;
+  clientHeight            = mode->height;
 
-    window = glfwCreateWindow(clientWidth, clientHeight, "Aquarium", NULL, NULL);
-    if (window == NULL)
-    {
-        std::cout << "Failed to open GLFW window." << std::endl;
-        glfwTerminate();
-        return -1;
-    }
-    glfwWindowHint(GLFW_DECORATED, GLFW_FALSE);
-    glfwMakeContextCurrent(window);
-
-    if (!gladLoadGL())
-    {
-        std::cout << "Something went wrong!" << std::endl;
-        exit(-1);
-    }
-
-    if (!initialize(argc, argv))
-    {
-        return -1;
-    }
-
-    const char *renderer = (const char *)glGetString(GL_RENDERER);
-    std::cout << renderer << std::endl;
-
-    // Get the resolution of screen. The resolution on mac is about 4 times larger than size of
-    // window.
-    glfwGetFramebufferSize(window, &clientWidth, &clientHeight);
-    glViewport(0, 0, clientWidth, clientHeight);
-
-    glfwShowWindow(window);
-
-    while (!glfwWindowShouldClose(window))
-    {
-        if (glfwGetKey(window, GLFW_KEY_ESCAPE) == GLFW_PRESS)
-            glfwSetWindowShouldClose(window, GLFW_TRUE);
-
-        render();
-
-        glfwSwapBuffers(window);
-        glfwPollEvents();
-    }
-
+  window = glfwCreateWindow(clientWidth, clientHeight, "Aquarium", NULL, NULL);
+  if (window == NULL)
+  {
+    std::cout << "Failed to open GLFW window." << std::endl;
     glfwTerminate();
+    return -1;
+  }
+  glfwWindowHint(GLFW_DECORATED, GLFW_FALSE);
+  glfwMakeContextCurrent(window);
 
-    onDestroy();
+  if (!gladLoadGL())
+  {
+    std::cout << "Something went wrong!" << std::endl;
+    exit(-1);
+  }
 
-    return 0;
+  if (!initialize(argc, argv))
+  {
+    return -1;
+  }
+
+  const char *renderer = (const char *)glGetString(GL_RENDERER);
+  std::cout << renderer << std::endl;
+
+  // Get the resolution of screen. The resolution on mac is about 4 times larger
+  // than size of window.
+  glfwGetFramebufferSize(window, &clientWidth, &clientHeight);
+  glViewport(0, 0, clientWidth, clientHeight);
+
+  glfwShowWindow(window);
+
+  while (!glfwWindowShouldClose(window))
+  {
+    if (glfwGetKey(window, GLFW_KEY_ESCAPE) == GLFW_PRESS)
+      glfwSetWindowShouldClose(window, GLFW_TRUE);
+
+    render();
+
+    glfwSwapBuffers(window);
+    glfwPollEvents();
+  }
+
+  glfwTerminate();
+
+  onDestroy();
+
+  return 0;
 }
 
 void DrawGroup(const std::multimap<std::string, std::vector<float>> &group,
                const GenericConst &constUniforms,
                GenericPer *perUniforms)
 {
-    Model *currentModel = nullptr;
-    int ii              = 0;
-    for (auto &object : group)
+  Model *currentModel = nullptr;
+  int ii              = 0;
+  for (auto &object : group)
+  {
+    if (g_scenes.find(object.first) == g_scenes.end())
     {
-        if (g_scenes.find(object.first) == g_scenes.end())
-        {
-            continue;
-        }
-        auto &scene = g_scenes[object.first];
-        auto &info  = g_sceneInfoByName[object.first];
-
-        if (info.blend)
-        {
-            glEnable(GL_BLEND);
-        }
-        else
-        {
-            glDisable(GL_BLEND);
-        }
-
-        auto &models = scene->getModels();
-        for (auto &model : models)
-        {
-            if (model != currentModel)
-            {
-                currentModel = model;
-                model->prepareForDraw(constUniforms);
-            }
-
-            world = std::vector<float>(object.second.begin(), object.second.end());
-            matrix::mulMatrixMatrix4(worldViewProjection, world, viewProjection);
-            matrix::inverse4(worldInverse, world);
-            matrix::transpose4(worldInverseTraspose, worldInverse);
-            perUniforms->time = mClock + (ii++);
-            model->draw(*perUniforms);
-        }
+      continue;
     }
+    auto &scene = g_scenes[object.first];
+    auto &info  = g_sceneInfoByName[object.first];
+
+    if (info.blend)
+    {
+      glEnable(GL_BLEND);
+    }
+    else
+    {
+      glDisable(GL_BLEND);
+    }
+
+    auto &models = scene->getModels();
+    for (auto &model : models)
+    {
+      if (model != currentModel)
+      {
+        currentModel = model;
+        model->prepareForDraw(constUniforms);
+      }
+
+      world = std::vector<float>(object.second.begin(), object.second.end());
+      matrix::mulMatrixMatrix4(worldViewProjection, world, viewProjection);
+      matrix::inverse4(worldInverse, world);
+      matrix::transpose4(worldInverseTraspose, worldInverse);
+      perUniforms->time = mClock + (ii++);
+      model->draw(*perUniforms);
+    }
+  }
 }
 
 void render()
 {
-    // Update our time
+  // Update our time
 #ifdef _WIN32
-    float now = GetTickCount64() / 1000.0f;
+  float now = GetTickCount64() / 1000.0f;
 #else
-    float now = clock() / 1000000.0f;
+  float now = clock() / 1000000.0f;
 #endif
-    float elapsedTime = 0.0f;
-    if (then == 0.0f)
+  float elapsedTime = 0.0f;
+  if (then == 0.0f)
+  {
+    elapsedTime = 0.0f;
+  }
+  else
+  {
+    elapsedTime = now - then;
+  }
+  then = now;
+
+  g_fpsTimer.update(elapsedTime, 0, 1);
+  std::string text =
+      "Aquarium FPS: " +
+      std::to_string(static_cast<unsigned int>(g_fpsTimer.getAverageFPS()));
+  glfwSetWindowTitle(window, text.c_str());
+
+  mClock += elapsedTime * g_speed;
+  eyeClock += elapsedTime * g_viewSettings.eyeSpeed;
+
+  eyePosition[0] = sin(eyeClock) * g_viewSettings.eyeRadius;
+  eyePosition[1] = g_viewSettings.eyeHeight;
+  eyePosition[2] = cos(eyeClock) * g_viewSettings.eyeRadius;
+  target[0] =
+      static_cast<float>(sin(eyeClock + M_PI)) * g_viewSettings.targetRadius;
+  target[1] = g_viewSettings.targetHeight;
+  target[2] =
+      static_cast<float>(cos(eyeClock + M_PI)) * g_viewSettings.targetRadius;
+
+  ambient[0] = g_viewSettings.ambientRed;
+  ambient[1] = g_viewSettings.ambientGreen;
+  ambient[2] = g_viewSettings.ambientBlue;
+
+  glColorMask(true, true, true, true);
+  glClearColor(0, 0.8f, 1, 0);
+  glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+
+  float nearPlane = 1;
+  float farPlane  = 25000.0f;
+  float aspect =
+      static_cast<float>(clientWidth) / static_cast<float>(clientHeight);
+  float top =
+      tan(matrix::degToRad(g_viewSettings.fieldOfView * g_fovFudge) * 0.5f) *
+      nearPlane;
+  float bottom = -top;
+  float left   = aspect * bottom;
+  float right  = aspect * top;
+  float width  = abs(right - left);
+  float height = abs(top - bottom);
+  float xOff   = width * g_net_offset[0] * g_net_offsetMult;
+  float yOff   = height * g_net_offset[1] * g_net_offsetMult;
+
+  matrix::frustum(projection, left + xOff, right + xOff, bottom + yOff,
+                  top + yOff, nearPlane, farPlane);
+  matrix::cameraLookAt(viewInverse, eyePosition, target, up);
+  matrix::inverse4(view, viewInverse);
+  matrix::mulMatrixMatrix4(viewProjection, view, projection);
+  matrix::inverse4(viewProjectionInverse, viewProjection);
+
+  skyView     = view;
+  skyView[12] = 0.0;
+  skyView[13] = 0.0;
+  skyView[14] = 0.0;
+  matrix::mulMatrixMatrix4(skyViewProjection, skyView, projection);
+  matrix::inverse4(skyViewProjectionInverse, skyViewProjection);
+
+  matrix::getAxis(v3t0, viewInverse, 0);
+  matrix::getAxis(v3t1, viewInverse, 1);
+  matrix::mulScalarVector(20.0f, v3t0);
+  matrix::mulScalarVector(30.0f, v3t1);
+  matrix::addVector(lightWorldPos, eyePosition, v3t0);
+  matrix::addVector(lightWorldPos, lightWorldPos, v3t1);
+
+  glDisable(GL_BLEND);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+  glBlendEquation(GL_FUNC_ADD);
+  glEnable(GL_CULL_FACE);
+
+  matrix::resetPseudoRandom();
+
+  glDepthMask(true);
+
+  if (g_fog)
+  {
+    genericConst.fogPower            = g_viewSettings.fogPower;
+    genericConst.fogMult             = g_viewSettings.fogMult;
+    genericConst.fogOffset           = g_viewSettings.fogOffset;
+    fishConst.genericConst.fogPower  = g_viewSettings.fogPower;
+    fishConst.genericConst.fogMult   = g_viewSettings.fogMult;
+    fishConst.genericConst.fogOffset = g_viewSettings.fogOffset;
+    innerConst.fogPower              = g_viewSettings.fogPower;
+    innerConst.fogMult               = g_viewSettings.fogMult;
+    innerConst.fogOffset             = g_viewSettings.fogOffset;
+    seaweedConst.fogPower            = g_viewSettings.fogPower;
+    seaweedConst.fogMult             = g_viewSettings.fogMult;
+    seaweedConst.fogOffset           = g_viewSettings.fogOffset;
+    fogColor[0]                      = g_viewSettings.fogRed;
+    fogColor[1]                      = g_viewSettings.fogGreen;
+    fogColor[2]                      = g_viewSettings.fogBlue;
+  }
+
+  // Draw Scene
+  if (g_sceneGroups.find("base") != g_sceneGroups.end())
+  {
+    DrawGroup(g_sceneGroups["base"], genericConst, &genericPer);
+  }
+
+  // Draw Fishes
+  glEnable(GL_BLEND);
+  for (auto &fishInfo : g_fishTable)
+  {
+    std::string &fishName = fishInfo.name;
+    int numFish           = fishInfo.num;
+
+    Scene *scene = g_scenes[fishName];
+    if (scene->loaded)
     {
-        elapsedTime = 0.0f;
+      Model *fish             = scene->getModels()[0];
+      auto &f                 = g["fish"];
+      fishConst.constUniforms = fishInfo.constUniforms;
+      fish->prepareForDraw(fishConst);
+      float fishBaseClock   = mClock * f["fishSpeed"];
+      float fishRadius      = fishInfo.radius;
+      float fishRadiusRange = fishInfo.radiusRange;
+      float fishSpeed       = fishInfo.speed;
+      float fishSpeedRange  = fishInfo.speedRange;
+      float fishTailSpeed   = fishInfo.tailSpeed * f["fishTailSpeed"];
+      float fishOffset      = f["fishOffset"];
+      // float fishClockSpeed                 = f["fishSpeed"];
+      float fishHeight      = f["fishHeight"] + fishInfo.heightOffset;
+      float fishHeightRange = f["fishHeightRange"] * fishInfo.heightRange;
+      float fishXClock      = f["fishXClock"];
+      float fishYClock      = f["fishYClock"];
+      float fishZClock      = f["fishZClock"];
+      std::vector<float> &fishPosition     = fishPer.worldPosition;
+      std::vector<float> &fishNextPosition = fishPer.nextPosition;
+      for (int ii = 0; ii < numFish; ++ii)
+      {
+        float fishClock = fishBaseClock + ii * fishOffset;
+        float speed = fishSpeed + static_cast<float>(matrix::pseudoRandom()) *
+                                      fishSpeedRange;
+        float scale = 1.0f + static_cast<float>(matrix::pseudoRandom()) * 1;
+        float xRadius =
+            fishRadius +
+            static_cast<float>(matrix::pseudoRandom()) * fishRadiusRange;
+        float yRadius =
+            2.0f + static_cast<float>(matrix::pseudoRandom()) * fishHeightRange;
+        float zRadius =
+            fishRadius +
+            static_cast<float>(matrix::pseudoRandom()) * fishRadiusRange;
+        float fishSpeedClock = fishClock * speed;
+        float xClock         = fishSpeedClock * fishXClock;
+        float yClock         = fishSpeedClock * fishYClock;
+        float zClock         = fishSpeedClock * fishZClock;
+
+        fishPosition[0]     = sin(xClock) * xRadius;
+        fishPosition[1]     = sin(yClock) * yRadius + fishHeight;
+        fishPosition[2]     = cos(zClock) * zRadius;
+        fishNextPosition[0] = sin(xClock - 0.04f) * xRadius;
+        fishNextPosition[1] = sin(yClock - 0.01f) * yRadius + fishHeight;
+        fishNextPosition[2] = cos(zClock - 0.04f) * zRadius;
+        fishPer.scale       = scale;
+
+        fishPer.time =
+            fmod((mClock + ii * g_tailOffsetMult) * fishTailSpeed * speed,
+                 static_cast<float>(M_PI) * 2);
+        fish->draw(fishPer);
+      }
     }
-    else
-    {
-        elapsedTime = now - then;
-    }
-    then = now;
+  }
 
-    g_fpsTimer.update(elapsedTime, 0, 1);
-    std::string text =
-        "Aquarium FPS: " + std::to_string(static_cast<unsigned int>(g_fpsTimer.getAverageFPS()));
-    glfwSetWindowTitle(window, text.c_str());
+  // Draw tank
+  if (g_sceneGroups.find("inner") != g_sceneGroups.end())
+  {
+    DrawGroup(g_sceneGroups["inner"], innerConst, &innerPer);
+  }
 
-    mClock += elapsedTime * g_speed;
-    eyeClock += elapsedTime * g_viewSettings.eyeSpeed;
+  // Draw seaweed
+  if (g_sceneGroups.find("seaweed") != g_sceneGroups.end())
+  {
+    DrawGroup(g_sceneGroups["seaweed"], seaweedConst, &seaweedPer);
+  }
 
-    eyePosition[0] = sin(eyeClock) * g_viewSettings.eyeRadius;
-    eyePosition[1] = g_viewSettings.eyeHeight;
-    eyePosition[2] = cos(eyeClock) * g_viewSettings.eyeRadius;
-    target[0]      = static_cast<float>(sin(eyeClock + M_PI)) * g_viewSettings.targetRadius;
-    target[1]      = g_viewSettings.targetHeight;
-    target[2]      = static_cast<float>(cos(eyeClock + M_PI)) * g_viewSettings.targetRadius;
-
-    ambient[0] = g_viewSettings.ambientRed;
-    ambient[1] = g_viewSettings.ambientGreen;
-    ambient[2] = g_viewSettings.ambientBlue;
-
-    glColorMask(true, true, true, true);
-    glClearColor(0, 0.8f, 1, 0);
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
-
-    float nearPlane = 1;
-    float farPlane  = 25000.0f;
-    float aspect    = static_cast<float>(clientWidth) / static_cast<float>(clientHeight);
-    float top = tan(matrix::degToRad(g_viewSettings.fieldOfView * g_fovFudge) * 0.5f) * nearPlane;
-    float bottom = -top;
-    float left   = aspect * bottom;
-    float right  = aspect * top;
-    float width  = abs(right - left);
-    float height = abs(top - bottom);
-    float xOff   = width * g_net_offset[0] * g_net_offsetMult;
-    float yOff   = height * g_net_offset[1] * g_net_offsetMult;
-
-    matrix::frustum(projection, left + xOff, right + xOff, bottom + yOff, top + yOff, nearPlane,
-                    farPlane);
-    matrix::cameraLookAt(viewInverse, eyePosition, target, up);
-    matrix::inverse4(view, viewInverse);
-    matrix::mulMatrixMatrix4(viewProjection, view, projection);
-    matrix::inverse4(viewProjectionInverse, viewProjection);
-
-    skyView     = view;
-    skyView[12] = 0.0;
-    skyView[13] = 0.0;
-    skyView[14] = 0.0;
-    matrix::mulMatrixMatrix4(skyViewProjection, skyView, projection);
-    matrix::inverse4(skyViewProjectionInverse, skyViewProjection);
-
-    matrix::getAxis(v3t0, viewInverse, 0);
-    matrix::getAxis(v3t1, viewInverse, 1);
-    matrix::mulScalarVector(20.0f, v3t0);
-    matrix::mulScalarVector(30.0f, v3t1);
-    matrix::addVector(lightWorldPos, eyePosition, v3t0);
-    matrix::addVector(lightWorldPos, lightWorldPos, v3t1);
-
-    glDisable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glBlendEquation(GL_FUNC_ADD);
-    glEnable(GL_CULL_FACE);
-
-    matrix::resetPseudoRandom();
-
-    glDepthMask(true);
-
-    if (g_fog)
-    {
-        genericConst.fogPower            = g_viewSettings.fogPower;
-        genericConst.fogMult             = g_viewSettings.fogMult;
-        genericConst.fogOffset           = g_viewSettings.fogOffset;
-        fishConst.genericConst.fogPower  = g_viewSettings.fogPower;
-        fishConst.genericConst.fogMult   = g_viewSettings.fogMult;
-        fishConst.genericConst.fogOffset = g_viewSettings.fogOffset;
-        innerConst.fogPower              = g_viewSettings.fogPower;
-        innerConst.fogMult               = g_viewSettings.fogMult;
-        innerConst.fogOffset             = g_viewSettings.fogOffset;
-        seaweedConst.fogPower            = g_viewSettings.fogPower;
-        seaweedConst.fogMult             = g_viewSettings.fogMult;
-        seaweedConst.fogOffset           = g_viewSettings.fogOffset;
-        fogColor[0]                      = g_viewSettings.fogRed;
-        fogColor[1]                      = g_viewSettings.fogGreen;
-        fogColor[2]                      = g_viewSettings.fogBlue;
-    }
-
-    // Draw Scene
-    if (g_sceneGroups.find("base") != g_sceneGroups.end())
-    {
-        DrawGroup(g_sceneGroups["base"], genericConst, &genericPer);
-    }
-
-    // Draw Fishes
-    glEnable(GL_BLEND);
-    for (auto &fishInfo : g_fishTable)
-    {
-        std::string &fishName = fishInfo.name;
-        int numFish           = fishInfo.num;
-
-        Scene *scene = g_scenes[fishName];
-        if (scene->loaded)
-        {
-            Model *fish             = scene->getModels()[0];
-            auto &f                 = g["fish"];
-            fishConst.constUniforms = fishInfo.constUniforms;
-            fish->prepareForDraw(fishConst);
-            float fishBaseClock   = mClock * f["fishSpeed"];
-            float fishRadius      = fishInfo.radius;
-            float fishRadiusRange = fishInfo.radiusRange;
-            float fishSpeed       = fishInfo.speed;
-            float fishSpeedRange  = fishInfo.speedRange;
-            float fishTailSpeed   = fishInfo.tailSpeed * f["fishTailSpeed"];
-            float fishOffset      = f["fishOffset"];
-            // float fishClockSpeed                 = f["fishSpeed"];
-            float fishHeight                     = f["fishHeight"] + fishInfo.heightOffset;
-            float fishHeightRange                = f["fishHeightRange"] * fishInfo.heightRange;
-            float fishXClock                     = f["fishXClock"];
-            float fishYClock                     = f["fishYClock"];
-            float fishZClock                     = f["fishZClock"];
-            std::vector<float> &fishPosition     = fishPer.worldPosition;
-            std::vector<float> &fishNextPosition = fishPer.nextPosition;
-            for (int ii = 0; ii < numFish; ++ii)
-            {
-                float fishClock = fishBaseClock + ii * fishOffset;
-                float speed =
-                    fishSpeed + static_cast<float>(matrix::pseudoRandom()) * fishSpeedRange;
-                float scale = 1.0f + static_cast<float>(matrix::pseudoRandom()) * 1;
-                float xRadius =
-                    fishRadius + static_cast<float>(matrix::pseudoRandom()) * fishRadiusRange;
-                float yRadius = 2.0f + static_cast<float>(matrix::pseudoRandom()) * fishHeightRange;
-                float zRadius =
-                    fishRadius + static_cast<float>(matrix::pseudoRandom()) * fishRadiusRange;
-                float fishSpeedClock = fishClock * speed;
-                float xClock         = fishSpeedClock * fishXClock;
-                float yClock         = fishSpeedClock * fishYClock;
-                float zClock         = fishSpeedClock * fishZClock;
-
-                fishPosition[0]     = sin(xClock) * xRadius;
-                fishPosition[1]     = sin(yClock) * yRadius + fishHeight;
-                fishPosition[2]     = cos(zClock) * zRadius;
-                fishNextPosition[0] = sin(xClock - 0.04f) * xRadius;
-                fishNextPosition[1] = sin(yClock - 0.01f) * yRadius + fishHeight;
-                fishNextPosition[2] = cos(zClock - 0.04f) * zRadius;
-                fishPer.scale       = scale;
-
-                fishPer.time = fmod((mClock + ii * g_tailOffsetMult) * fishTailSpeed * speed,
-                                    static_cast<float>(M_PI) * 2);
-                fish->draw(fishPer);
-            }
-        }
-    }
-
-    // Draw tank
-    if (g_sceneGroups.find("inner") != g_sceneGroups.end())
-    {
-        DrawGroup(g_sceneGroups["inner"], innerConst, &innerPer);
-    }
-
-    // Draw seaweed
-    if (g_sceneGroups.find("seaweed") != g_sceneGroups.end())
-    {
-        DrawGroup(g_sceneGroups["seaweed"], seaweedConst, &seaweedPer);
-    }
-
-    // Draw outside
-    if (g_sceneGroups.find("outside") != g_sceneGroups.end())
-    {
-        DrawGroup(g_sceneGroups["outside"], outsideConst, &outsidePer);
-    }
+  // Draw outside
+  if (g_sceneGroups.find("outside") != g_sceneGroups.end())
+  {
+    DrawGroup(g_sceneGroups["outside"], outsideConst, &outsidePer);
+  }
 }

--- a/src/aquarium-direct-map/Matrix.h
+++ b/src/aquarium-direct-map/Matrix.h
@@ -17,301 +17,319 @@ namespace matrix
 static long long RANDOM_RANGE_ = 4294967296;
 
 template <typename T>
-void mulMatrixMatrix4(std::vector<T> &dst, const std::vector<T> &a, const std::vector<T> &b)
+void mulMatrixMatrix4(std::vector<T> &dst,
+                      const std::vector<T> &a,
+                      const std::vector<T> &b)
 {
-    T a00   = a[0];
-    T a01   = a[1];
-    T a02   = a[2];
-    T a03   = a[3];
-    T a10   = a[4 + 0];
-    T a11   = a[4 + 1];
-    T a12   = a[4 + 2];
-    T a13   = a[4 + 3];
-    T a20   = a[8 + 0];
-    T a21   = a[8 + 1];
-    T a22   = a[8 + 2];
-    T a23   = a[8 + 3];
-    T a30   = a[12 + 0];
-    T a31   = a[12 + 1];
-    T a32   = a[12 + 2];
-    T a33   = a[12 + 3];
-    T b00   = b[0];
-    T b01   = b[1];
-    T b02   = b[2];
-    T b03   = b[3];
-    T b10   = b[4 + 0];
-    T b11   = b[4 + 1];
-    T b12   = b[4 + 2];
-    T b13   = b[4 + 3];
-    T b20   = b[8 + 0];
-    T b21   = b[8 + 1];
-    T b22   = b[8 + 2];
-    T b23   = b[8 + 3];
-    T b30   = b[12 + 0];
-    T b31   = b[12 + 1];
-    T b32   = b[12 + 2];
-    T b33   = b[12 + 3];
-    dst[0]  = a00 * b00 + a01 * b10 + a02 * b20 + a03 * b30;
-    dst[1]  = a00 * b01 + a01 * b11 + a02 * b21 + a03 * b31;
-    dst[2]  = a00 * b02 + a01 * b12 + a02 * b22 + a03 * b32;
-    dst[3]  = a00 * b03 + a01 * b13 + a02 * b23 + a03 * b33;
-    dst[4]  = a10 * b00 + a11 * b10 + a12 * b20 + a13 * b30;
-    dst[5]  = a10 * b01 + a11 * b11 + a12 * b21 + a13 * b31;
-    dst[6]  = a10 * b02 + a11 * b12 + a12 * b22 + a13 * b32;
-    dst[7]  = a10 * b03 + a11 * b13 + a12 * b23 + a13 * b33;
-    dst[8]  = a20 * b00 + a21 * b10 + a22 * b20 + a23 * b30;
-    dst[9]  = a20 * b01 + a21 * b11 + a22 * b21 + a23 * b31;
-    dst[10] = a20 * b02 + a21 * b12 + a22 * b22 + a23 * b32;
-    dst[11] = a20 * b03 + a21 * b13 + a22 * b23 + a23 * b33;
-    dst[12] = a30 * b00 + a31 * b10 + a32 * b20 + a33 * b30;
-    dst[13] = a30 * b01 + a31 * b11 + a32 * b21 + a33 * b31;
-    dst[14] = a30 * b02 + a31 * b12 + a32 * b22 + a33 * b32;
-    dst[15] = a30 * b03 + a31 * b13 + a32 * b23 + a33 * b33;
+  T a00   = a[0];
+  T a01   = a[1];
+  T a02   = a[2];
+  T a03   = a[3];
+  T a10   = a[4 + 0];
+  T a11   = a[4 + 1];
+  T a12   = a[4 + 2];
+  T a13   = a[4 + 3];
+  T a20   = a[8 + 0];
+  T a21   = a[8 + 1];
+  T a22   = a[8 + 2];
+  T a23   = a[8 + 3];
+  T a30   = a[12 + 0];
+  T a31   = a[12 + 1];
+  T a32   = a[12 + 2];
+  T a33   = a[12 + 3];
+  T b00   = b[0];
+  T b01   = b[1];
+  T b02   = b[2];
+  T b03   = b[3];
+  T b10   = b[4 + 0];
+  T b11   = b[4 + 1];
+  T b12   = b[4 + 2];
+  T b13   = b[4 + 3];
+  T b20   = b[8 + 0];
+  T b21   = b[8 + 1];
+  T b22   = b[8 + 2];
+  T b23   = b[8 + 3];
+  T b30   = b[12 + 0];
+  T b31   = b[12 + 1];
+  T b32   = b[12 + 2];
+  T b33   = b[12 + 3];
+  dst[0]  = a00 * b00 + a01 * b10 + a02 * b20 + a03 * b30;
+  dst[1]  = a00 * b01 + a01 * b11 + a02 * b21 + a03 * b31;
+  dst[2]  = a00 * b02 + a01 * b12 + a02 * b22 + a03 * b32;
+  dst[3]  = a00 * b03 + a01 * b13 + a02 * b23 + a03 * b33;
+  dst[4]  = a10 * b00 + a11 * b10 + a12 * b20 + a13 * b30;
+  dst[5]  = a10 * b01 + a11 * b11 + a12 * b21 + a13 * b31;
+  dst[6]  = a10 * b02 + a11 * b12 + a12 * b22 + a13 * b32;
+  dst[7]  = a10 * b03 + a11 * b13 + a12 * b23 + a13 * b33;
+  dst[8]  = a20 * b00 + a21 * b10 + a22 * b20 + a23 * b30;
+  dst[9]  = a20 * b01 + a21 * b11 + a22 * b21 + a23 * b31;
+  dst[10] = a20 * b02 + a21 * b12 + a22 * b22 + a23 * b32;
+  dst[11] = a20 * b03 + a21 * b13 + a22 * b23 + a23 * b33;
+  dst[12] = a30 * b00 + a31 * b10 + a32 * b20 + a33 * b30;
+  dst[13] = a30 * b01 + a31 * b11 + a32 * b21 + a33 * b31;
+  dst[14] = a30 * b02 + a31 * b12 + a32 * b22 + a33 * b32;
+  dst[15] = a30 * b03 + a31 * b13 + a32 * b23 + a33 * b33;
 }
 
 template <typename T>
 void inverse4(std::vector<T> &dst, const std::vector<T> &m)
 {
-    T m00    = m[0 * 4 + 0];
-    T m01    = m[0 * 4 + 1];
-    T m02    = m[0 * 4 + 2];
-    T m03    = m[0 * 4 + 3];
-    T m10    = m[1 * 4 + 0];
-    T m11    = m[1 * 4 + 1];
-    T m12    = m[1 * 4 + 2];
-    T m13    = m[1 * 4 + 3];
-    T m20    = m[2 * 4 + 0];
-    T m21    = m[2 * 4 + 1];
-    T m22    = m[2 * 4 + 2];
-    T m23    = m[2 * 4 + 3];
-    T m30    = m[3 * 4 + 0];
-    T m31    = m[3 * 4 + 1];
-    T m32    = m[3 * 4 + 2];
-    T m33    = m[3 * 4 + 3];
-    T tmp_0  = m22 * m33;
-    T tmp_1  = m32 * m23;
-    T tmp_2  = m12 * m33;
-    T tmp_3  = m32 * m13;
-    T tmp_4  = m12 * m23;
-    T tmp_5  = m22 * m13;
-    T tmp_6  = m02 * m33;
-    T tmp_7  = m32 * m03;
-    T tmp_8  = m02 * m23;
-    T tmp_9  = m22 * m03;
-    T tmp_10 = m02 * m13;
-    T tmp_11 = m12 * m03;
-    T tmp_12 = m20 * m31;
-    T tmp_13 = m30 * m21;
-    T tmp_14 = m10 * m31;
-    T tmp_15 = m30 * m11;
-    T tmp_16 = m10 * m21;
-    T tmp_17 = m20 * m11;
-    T tmp_18 = m00 * m31;
-    T tmp_19 = m30 * m01;
-    T tmp_20 = m00 * m21;
-    T tmp_21 = m20 * m01;
-    T tmp_22 = m00 * m11;
-    T tmp_23 = m10 * m01;
+  T m00    = m[0 * 4 + 0];
+  T m01    = m[0 * 4 + 1];
+  T m02    = m[0 * 4 + 2];
+  T m03    = m[0 * 4 + 3];
+  T m10    = m[1 * 4 + 0];
+  T m11    = m[1 * 4 + 1];
+  T m12    = m[1 * 4 + 2];
+  T m13    = m[1 * 4 + 3];
+  T m20    = m[2 * 4 + 0];
+  T m21    = m[2 * 4 + 1];
+  T m22    = m[2 * 4 + 2];
+  T m23    = m[2 * 4 + 3];
+  T m30    = m[3 * 4 + 0];
+  T m31    = m[3 * 4 + 1];
+  T m32    = m[3 * 4 + 2];
+  T m33    = m[3 * 4 + 3];
+  T tmp_0  = m22 * m33;
+  T tmp_1  = m32 * m23;
+  T tmp_2  = m12 * m33;
+  T tmp_3  = m32 * m13;
+  T tmp_4  = m12 * m23;
+  T tmp_5  = m22 * m13;
+  T tmp_6  = m02 * m33;
+  T tmp_7  = m32 * m03;
+  T tmp_8  = m02 * m23;
+  T tmp_9  = m22 * m03;
+  T tmp_10 = m02 * m13;
+  T tmp_11 = m12 * m03;
+  T tmp_12 = m20 * m31;
+  T tmp_13 = m30 * m21;
+  T tmp_14 = m10 * m31;
+  T tmp_15 = m30 * m11;
+  T tmp_16 = m10 * m21;
+  T tmp_17 = m20 * m11;
+  T tmp_18 = m00 * m31;
+  T tmp_19 = m30 * m01;
+  T tmp_20 = m00 * m21;
+  T tmp_21 = m20 * m01;
+  T tmp_22 = m00 * m11;
+  T tmp_23 = m10 * m01;
 
-    T t0 = (tmp_0 * m11 + tmp_3 * m21 + tmp_4 * m31) - (tmp_1 * m11 + tmp_2 * m21 + tmp_5 * m31);
-    T t1 = (tmp_1 * m01 + tmp_6 * m21 + tmp_9 * m31) - (tmp_0 * m01 + tmp_7 * m21 + tmp_8 * m31);
-    T t2 = (tmp_2 * m01 + tmp_7 * m11 + tmp_10 * m31) - (tmp_3 * m01 + tmp_6 * m11 + tmp_11 * m31);
-    T t3 = (tmp_5 * m01 + tmp_8 * m11 + tmp_11 * m21) - (tmp_4 * m01 + tmp_9 * m11 + tmp_10 * m21);
+  T t0 = (tmp_0 * m11 + tmp_3 * m21 + tmp_4 * m31) -
+         (tmp_1 * m11 + tmp_2 * m21 + tmp_5 * m31);
+  T t1 = (tmp_1 * m01 + tmp_6 * m21 + tmp_9 * m31) -
+         (tmp_0 * m01 + tmp_7 * m21 + tmp_8 * m31);
+  T t2 = (tmp_2 * m01 + tmp_7 * m11 + tmp_10 * m31) -
+         (tmp_3 * m01 + tmp_6 * m11 + tmp_11 * m31);
+  T t3 = (tmp_5 * m01 + tmp_8 * m11 + tmp_11 * m21) -
+         (tmp_4 * m01 + tmp_9 * m11 + tmp_10 * m21);
 
-    T d = static_cast<T>(1.0) / (m00 * t0 + m10 * t1 + m20 * t2 + m30 * t3);
+  T d = static_cast<T>(1.0) / (m00 * t0 + m10 * t1 + m20 * t2 + m30 * t3);
 
-    dst[0] = d * t0;
-    dst[1] = d * t1;
-    dst[2] = d * t2;
-    dst[3] = d * t3;
-    dst[4] =
-        d * ((tmp_1 * m10 + tmp_2 * m20 + tmp_5 * m30) - (tmp_0 * m10 + tmp_3 * m20 + tmp_4 * m30));
-    dst[5] =
-        d * ((tmp_0 * m00 + tmp_7 * m20 + tmp_8 * m30) - (tmp_1 * m00 + tmp_6 * m20 + tmp_9 * m30));
-    dst[6]  = d * ((tmp_3 * m00 + tmp_6 * m10 + tmp_11 * m30) -
-                  (tmp_2 * m00 + tmp_7 * m10 + tmp_10 * m30));
-    dst[7]  = d * ((tmp_4 * m00 + tmp_9 * m10 + tmp_10 * m20) -
-                  (tmp_5 * m00 + tmp_8 * m10 + tmp_11 * m20));
-    dst[8]  = d * ((tmp_12 * m13 + tmp_15 * m23 + tmp_16 * m33) -
-                  (tmp_13 * m13 + tmp_14 * m23 + tmp_17 * m33));
-    dst[9]  = d * ((tmp_13 * m03 + tmp_18 * m23 + tmp_21 * m33) -
-                  (tmp_12 * m03 + tmp_19 * m23 + tmp_20 * m33));
-    dst[10] = d * ((tmp_14 * m03 + tmp_19 * m13 + tmp_22 * m33) -
-                   (tmp_15 * m03 + tmp_18 * m13 + tmp_23 * m33));
-    dst[11] = d * ((tmp_17 * m03 + tmp_20 * m13 + tmp_23 * m23) -
-                   (tmp_16 * m03 + tmp_21 * m13 + tmp_22 * m23));
-    dst[12] = d * ((tmp_14 * m22 + tmp_17 * m32 + tmp_13 * m12) -
-                   (tmp_16 * m32 + tmp_12 * m12 + tmp_15 * m22));
-    dst[13] = d * ((tmp_20 * m32 + tmp_12 * m02 + tmp_19 * m22) -
-                   (tmp_18 * m22 + tmp_21 * m32 + tmp_13 * m02));
-    dst[14] = d * ((tmp_18 * m12 + tmp_23 * m32 + tmp_15 * m02) -
-                   (tmp_22 * m32 + tmp_14 * m02 + tmp_19 * m12));
-    dst[15] = d * ((tmp_22 * m22 + tmp_16 * m02 + tmp_21 * m12) -
-                   (tmp_20 * m12 + tmp_23 * m22 + tmp_17 * m02));
+  dst[0]  = d * t0;
+  dst[1]  = d * t1;
+  dst[2]  = d * t2;
+  dst[3]  = d * t3;
+  dst[4]  = d * ((tmp_1 * m10 + tmp_2 * m20 + tmp_5 * m30) -
+                (tmp_0 * m10 + tmp_3 * m20 + tmp_4 * m30));
+  dst[5]  = d * ((tmp_0 * m00 + tmp_7 * m20 + tmp_8 * m30) -
+                (tmp_1 * m00 + tmp_6 * m20 + tmp_9 * m30));
+  dst[6]  = d * ((tmp_3 * m00 + tmp_6 * m10 + tmp_11 * m30) -
+                (tmp_2 * m00 + tmp_7 * m10 + tmp_10 * m30));
+  dst[7]  = d * ((tmp_4 * m00 + tmp_9 * m10 + tmp_10 * m20) -
+                (tmp_5 * m00 + tmp_8 * m10 + tmp_11 * m20));
+  dst[8]  = d * ((tmp_12 * m13 + tmp_15 * m23 + tmp_16 * m33) -
+                (tmp_13 * m13 + tmp_14 * m23 + tmp_17 * m33));
+  dst[9]  = d * ((tmp_13 * m03 + tmp_18 * m23 + tmp_21 * m33) -
+                (tmp_12 * m03 + tmp_19 * m23 + tmp_20 * m33));
+  dst[10] = d * ((tmp_14 * m03 + tmp_19 * m13 + tmp_22 * m33) -
+                 (tmp_15 * m03 + tmp_18 * m13 + tmp_23 * m33));
+  dst[11] = d * ((tmp_17 * m03 + tmp_20 * m13 + tmp_23 * m23) -
+                 (tmp_16 * m03 + tmp_21 * m13 + tmp_22 * m23));
+  dst[12] = d * ((tmp_14 * m22 + tmp_17 * m32 + tmp_13 * m12) -
+                 (tmp_16 * m32 + tmp_12 * m12 + tmp_15 * m22));
+  dst[13] = d * ((tmp_20 * m32 + tmp_12 * m02 + tmp_19 * m22) -
+                 (tmp_18 * m22 + tmp_21 * m32 + tmp_13 * m02));
+  dst[14] = d * ((tmp_18 * m12 + tmp_23 * m32 + tmp_15 * m02) -
+                 (tmp_22 * m32 + tmp_14 * m02 + tmp_19 * m12));
+  dst[15] = d * ((tmp_22 * m22 + tmp_16 * m02 + tmp_21 * m12) -
+                 (tmp_20 * m12 + tmp_23 * m22 + tmp_17 * m02));
 }
 
 template <typename T>
 void transpose4(std::vector<T> &dst, std::vector<T> &m)
 {
-    if (dst == m)
-    {
-        T t;
+  if (dst == m)
+  {
+    T t;
 
-        t    = m[1];
-        m[1] = m[4];
-        m[4] = t;
+    t    = m[1];
+    m[1] = m[4];
+    m[4] = t;
 
-        t    = m[2];
-        m[2] = m[8];
-        m[8] = t;
+    t    = m[2];
+    m[2] = m[8];
+    m[8] = t;
 
-        t     = m[3];
-        m[3]  = m[12];
-        m[12] = t;
+    t     = m[3];
+    m[3]  = m[12];
+    m[12] = t;
 
-        t    = m[6];
-        m[6] = m[9];
-        m[9] = t;
+    t    = m[6];
+    m[6] = m[9];
+    m[9] = t;
 
-        t     = m[7];
-        m[7]  = m[13];
-        m[13] = t;
+    t     = m[7];
+    m[7]  = m[13];
+    m[13] = t;
 
-        t     = m[11];
-        m[11] = m[14];
-        m[14] = t;
-    }
+    t     = m[11];
+    m[11] = m[14];
+    m[14] = t;
+  }
 
-    T m00 = m[0 * 4 + 0];
-    T m01 = m[0 * 4 + 1];
-    T m02 = m[0 * 4 + 2];
-    T m03 = m[0 * 4 + 3];
-    T m10 = m[1 * 4 + 0];
-    T m11 = m[1 * 4 + 1];
-    T m12 = m[1 * 4 + 2];
-    T m13 = m[1 * 4 + 3];
-    T m20 = m[2 * 4 + 0];
-    T m21 = m[2 * 4 + 1];
-    T m22 = m[2 * 4 + 2];
-    T m23 = m[2 * 4 + 3];
-    T m30 = m[3 * 4 + 0];
-    T m31 = m[3 * 4 + 1];
-    T m32 = m[3 * 4 + 2];
-    T m33 = m[3 * 4 + 3];
+  T m00 = m[0 * 4 + 0];
+  T m01 = m[0 * 4 + 1];
+  T m02 = m[0 * 4 + 2];
+  T m03 = m[0 * 4 + 3];
+  T m10 = m[1 * 4 + 0];
+  T m11 = m[1 * 4 + 1];
+  T m12 = m[1 * 4 + 2];
+  T m13 = m[1 * 4 + 3];
+  T m20 = m[2 * 4 + 0];
+  T m21 = m[2 * 4 + 1];
+  T m22 = m[2 * 4 + 2];
+  T m23 = m[2 * 4 + 3];
+  T m30 = m[3 * 4 + 0];
+  T m31 = m[3 * 4 + 1];
+  T m32 = m[3 * 4 + 2];
+  T m33 = m[3 * 4 + 3];
 
-    dst[0]  = m00;
-    dst[1]  = m10;
-    dst[2]  = m20;
-    dst[3]  = m30;
-    dst[4]  = m01;
-    dst[5]  = m11;
-    dst[6]  = m21;
-    dst[7]  = m31;
-    dst[8]  = m02;
-    dst[9]  = m12;
-    dst[10] = m22;
-    dst[11] = m32;
-    dst[12] = m03;
-    dst[13] = m13;
-    dst[14] = m23;
-    dst[15] = m33;
+  dst[0]  = m00;
+  dst[1]  = m10;
+  dst[2]  = m20;
+  dst[3]  = m30;
+  dst[4]  = m01;
+  dst[5]  = m11;
+  dst[6]  = m21;
+  dst[7]  = m31;
+  dst[8]  = m02;
+  dst[9]  = m12;
+  dst[10] = m22;
+  dst[11] = m32;
+  dst[12] = m03;
+  dst[13] = m13;
+  dst[14] = m23;
+  dst[15] = m33;
 }
 
 template <typename T>
-void frustum(std::vector<T> &dst, T left, T right, T bottom, T top, T near_, T far_)
+void frustum(std::vector<T> &dst,
+             T left,
+             T right,
+             T bottom,
+             T top,
+             T near_,
+             T far_)
 {
-    T dx = right - left;
-    T dy = top - bottom;
-    T dz = near_ - far_;
+  T dx = right - left;
+  T dy = top - bottom;
+  T dz = near_ - far_;
 
-    dst[0]  = 2 * near_ / dx;
-    dst[1]  = 0;
-    dst[2]  = 0;
-    dst[3]  = 0;
-    dst[4]  = 0;
-    dst[5]  = 2 * near_ / dy;
-    dst[6]  = 0;
-    dst[7]  = 0;
-    dst[8]  = (left + right) / dx;
-    dst[9]  = (top + bottom) / dy;
-    dst[10] = far_ / dz;
-    dst[11] = -1;
-    dst[12] = 0;
-    dst[13] = 0;
-    dst[14] = near_ * far_ / dz;
-    dst[15] = 0;
+  dst[0]  = 2 * near_ / dx;
+  dst[1]  = 0;
+  dst[2]  = 0;
+  dst[3]  = 0;
+  dst[4]  = 0;
+  dst[5]  = 2 * near_ / dy;
+  dst[6]  = 0;
+  dst[7]  = 0;
+  dst[8]  = (left + right) / dx;
+  dst[9]  = (top + bottom) / dy;
+  dst[10] = far_ / dz;
+  dst[11] = -1;
+  dst[12] = 0;
+  dst[13] = 0;
+  dst[14] = near_ * far_ / dz;
+  dst[15] = 0;
 }
 
 template <typename T>
 void getAxis(std::vector<T> &dst, const std::vector<T> &m, int axis)
 {
-    int off = axis * 4;
-    dst[0]  = m[off + 0];
-    dst[1]  = m[off + 1];
-    dst[2]  = m[off + 2];
+  int off = axis * 4;
+  dst[0]  = m[off + 0];
+  dst[1]  = m[off + 1];
+  dst[2]  = m[off + 2];
 }
 
 template <typename T>
 void mulScalarVector(T k, std::vector<T> &v)
 {
-    for (auto &value : v)
-    {
-        value = value * k;
-    }
+  for (auto &value : v)
+  {
+    value = value * k;
+  }
 }
 
 template <typename T>
-void addVector(std::vector<T> &dst, const std::vector<T> &a, const std::vector<T> &b)
+void addVector(std::vector<T> &dst,
+               const std::vector<T> &a,
+               const std::vector<T> &b)
 {
-    int aLength = static_cast<int>(a.size());
-    for (int i = 0; i < aLength; ++i)
-    {
-        dst[i] = a[i] + b[i];
-    }
+  int aLength = static_cast<int>(a.size());
+  for (int i = 0; i < aLength; ++i)
+  {
+    dst[i] = a[i] + b[i];
+  }
 }
 
 template <typename T>
 void normalize(std::vector<T> &dst, const std::vector<T> &a)
 {
-    T n            = 0.0;
-    size_t aLength = a.size();
+  T n            = 0.0;
+  size_t aLength = a.size();
+  for (size_t i = 0; i < aLength; ++i)
+    n += a[i] * a[i];
+  n = sqrt(n);
+  if (n > 0.00001)
+  {
     for (size_t i = 0; i < aLength; ++i)
-        n += a[i] * a[i];
-    n = sqrt(n);
-    if (n > 0.00001)
-    {
-        for (size_t i = 0; i < aLength; ++i)
-            dst[i] = a[i] / n;
-    }
-    else
-    {
-        for (size_t i = 0; i < aLength; ++i)
-            dst[i] = 0;
-    }
+      dst[i] = a[i] / n;
+  }
+  else
+  {
+    for (size_t i = 0; i < aLength; ++i)
+      dst[i] = 0;
+  }
 }
 
 template <typename T>
-void subVector(std::vector<T> &dst, const std::vector<T> &a, const std::vector<T> &b)
+void subVector(std::vector<T> &dst,
+               const std::vector<T> &a,
+               const std::vector<T> &b)
 {
-    size_t aLength = a.size();
-    for (size_t i = 0; i < aLength; ++i)
-    {
-        dst[i] = a[i] - b[i];
-    }
+  size_t aLength = a.size();
+  for (size_t i = 0; i < aLength; ++i)
+  {
+    dst[i] = a[i] - b[i];
+  }
 }
 
 template <typename T>
-void cross(std::vector<T> &dst, const std::vector<T> &a, const std::vector<T> &b)
+void cross(std::vector<T> &dst,
+           const std::vector<T> &a,
+           const std::vector<T> &b)
 {
-    dst[0] = a[1] * b[2] - a[2] * b[1];
-    dst[1] = a[2] * b[0] - a[0] * b[2];
-    dst[2] = a[0] * b[1] - a[1] * b[0];
+  dst[0] = a[1] * b[2] - a[2] * b[1];
+  dst[1] = a[2] * b[0] - a[0] * b[2];
+  dst[2] = a[0] * b[1] - a[1] * b[0];
 }
 
 template <typename T>
 T dot(std::vector<T> &a, std::vector<T> &b)
 {
-    return (a[0] * b[0]) + (a[1] * b[1]) + (a[2] * b[2]);
+  return (a[0] * b[0]) + (a[1] * b[1]) + (a[2] * b[2]);
 }
 
 template <typename T>
@@ -320,96 +338,96 @@ void cameraLookAt(std::vector<T> &dst,
                   const std::vector<T> &target,
                   const std::vector<T> &up)
 {
-    std::vector<T> t0(3), t1(3), t2(3);
-    subVector(t0, eye, target);
-    normalize(t0, t0);
-    cross(t1, up, t0);
-    normalize(t1, t1);
-    cross(t2, t0, t1);
+  std::vector<T> t0(3), t1(3), t2(3);
+  subVector(t0, eye, target);
+  normalize(t0, t0);
+  cross(t1, up, t0);
+  normalize(t1, t1);
+  cross(t2, t0, t1);
 
-    dst[0]  = t1[0];
-    dst[1]  = t1[1];
-    dst[2]  = t1[2];
-    dst[3]  = 0;
-    dst[4]  = t2[0];
-    dst[5]  = t2[1];
-    dst[6]  = t2[2];
-    dst[7]  = 0;
-    dst[8]  = t0[0];
-    dst[9]  = t0[1];
-    dst[10] = t0[2];
-    dst[11] = 0;
-    dst[12] = eye[0];
-    dst[13] = eye[1];
-    dst[14] = eye[2];
-    dst[15] = 1;
+  dst[0]  = t1[0];
+  dst[1]  = t1[1];
+  dst[2]  = t1[2];
+  dst[3]  = 0;
+  dst[4]  = t2[0];
+  dst[5]  = t2[1];
+  dst[6]  = t2[2];
+  dst[7]  = 0;
+  dst[8]  = t0[0];
+  dst[9]  = t0[1];
+  dst[10] = t0[2];
+  dst[11] = 0;
+  dst[12] = eye[0];
+  dst[13] = eye[1];
+  dst[14] = eye[2];
+  dst[15] = 1;
 }
 
 static long long randomSeed_;
 static void resetPseudoRandom()
 {
-    randomSeed_ = 0;
+  randomSeed_ = 0;
 }
 
 static double pseudoRandom()
 {
-    randomSeed_ = (134775813 * randomSeed_ + 1) % RANDOM_RANGE_;
-    return static_cast<double>(randomSeed_) / static_cast<double>(RANDOM_RANGE_);
+  randomSeed_ = (134775813 * randomSeed_ + 1) % RANDOM_RANGE_;
+  return static_cast<double>(randomSeed_) / static_cast<double>(RANDOM_RANGE_);
 }
 
 template <typename T>
 void translation(std::vector<T> &dst, const std::vector<T> &v)
 {
-    dst[0]  = 1;
-    dst[1]  = 0;
-    dst[2]  = 0;
-    dst[3]  = 0;
-    dst[4]  = 0;
-    dst[5]  = 1;
-    dst[6]  = 0;
-    dst[7]  = 0;
-    dst[8]  = 0;
-    dst[9]  = 0;
-    dst[10] = 1;
-    dst[11] = 0;
-    dst[12] = v[0];
-    dst[13] = v[1];
-    dst[14] = v[2];
-    dst[15] = 1;
+  dst[0]  = 1;
+  dst[1]  = 0;
+  dst[2]  = 0;
+  dst[3]  = 0;
+  dst[4]  = 0;
+  dst[5]  = 1;
+  dst[6]  = 0;
+  dst[7]  = 0;
+  dst[8]  = 0;
+  dst[9]  = 0;
+  dst[10] = 1;
+  dst[11] = 0;
+  dst[12] = v[0];
+  dst[13] = v[1];
+  dst[14] = v[2];
+  dst[15] = 1;
 }
 
 template <typename T>
 void translate(std::vector<T> &m, const std::vector<T> &v)
 {
-    T v0  = v[0];
-    T v1  = v[1];
-    T v2  = v[2];
-    T m00 = m[0];
-    T m01 = m[1];
-    T m02 = m[2];
-    T m03 = m[3];
-    T m10 = m[1 * 4 + 0];
-    T m11 = m[1 * 4 + 1];
-    T m12 = m[1 * 4 + 2];
-    T m13 = m[1 * 4 + 3];
-    T m20 = m[2 * 4 + 0];
-    T m21 = m[2 * 4 + 1];
-    T m22 = m[2 * 4 + 2];
-    T m23 = m[2 * 4 + 3];
-    T m30 = m[3 * 4 + 0];
-    T m31 = m[3 * 4 + 1];
-    T m32 = m[3 * 4 + 2];
-    T m33 = m[3 * 4 + 3];
+  T v0  = v[0];
+  T v1  = v[1];
+  T v2  = v[2];
+  T m00 = m[0];
+  T m01 = m[1];
+  T m02 = m[2];
+  T m03 = m[3];
+  T m10 = m[1 * 4 + 0];
+  T m11 = m[1 * 4 + 1];
+  T m12 = m[1 * 4 + 2];
+  T m13 = m[1 * 4 + 3];
+  T m20 = m[2 * 4 + 0];
+  T m21 = m[2 * 4 + 1];
+  T m22 = m[2 * 4 + 2];
+  T m23 = m[2 * 4 + 3];
+  T m30 = m[3 * 4 + 0];
+  T m31 = m[3 * 4 + 1];
+  T m32 = m[3 * 4 + 2];
+  T m33 = m[3 * 4 + 3];
 
-    m[12] = m00 * v0 + m10 * v1 + m20 * v2 + m30;
-    m[13] = m01 * v0 + m11 * v1 + m21 * v2 + m31;
-    m[14] = m02 * v0 + m12 * v1 + m22 * v2 + m32;
-    m[15] = m03 * v0 + m13 * v1 + m23 * v2 + m33;
+  m[12] = m00 * v0 + m10 * v1 + m20 * v2 + m30;
+  m[13] = m01 * v0 + m11 * v1 + m21 * v2 + m31;
+  m[14] = m02 * v0 + m12 * v1 + m22 * v2 + m32;
+  m[15] = m03 * v0 + m13 * v1 + m23 * v2 + m33;
 }
 
 float degToRad(float degrees)
 {
-    return static_cast<float>(degrees * M_PI / 180.0);
+  return static_cast<float>(degrees * M_PI / 180.0);
 }
 }  // namespace matrix
 

--- a/src/aquarium-direct-map/Model.cpp
+++ b/src/aquarium-direct-map/Model.cpp
@@ -11,149 +11,152 @@
 #include "Globals.h"
 #include "common/AQUARIUM_ASSERT.h"
 
-Model::Model(Program *program_,
-             const std::unordered_map<std::string, const AttribBuffer *> &arrays,
-             const std::unordered_map<std::string, Texture *> *textures)
+Model::Model(
+    Program *program_,
+    const std::unordered_map<std::string, const AttribBuffer *> &arrays,
+    const std::unordered_map<std::string, Texture *> *textures)
     : buffers(), textures(textures), program(program_), mode(GL_TRIANGLES)
 {
-    setBuffers(arrays);
+  setBuffers(arrays);
 
-    program->setTextureUnits(*textures);
+  program->setTextureUnits(*textures);
 }
 
 Model::~Model()
 {
-    for (auto &buffer : buffers)
-    {
-        delete buffer.second;
-        buffer.second = nullptr;
-    }
+  for (auto &buffer : buffers)
+  {
+    delete buffer.second;
+    buffer.second = nullptr;
+  }
 }
 
 void Model::setBuffer(const std::string &name, const AttribBuffer &array)
 {
-    GLenum target = name == "indices" ? GL_ELEMENT_ARRAY_BUFFER : GL_ARRAY_BUFFER;
+  GLenum target = name == "indices" ? GL_ELEMENT_ARRAY_BUFFER : GL_ARRAY_BUFFER;
 
-    if (buffers.find(name) == buffers.end())
-    {
-        buffers[name] = new Buffer(array, target);
-    }
+  if (buffers.find(name) == buffers.end())
+  {
+    buffers[name] = new Buffer(array, target);
+  }
 }
 
-void Model::setBuffers(const std::unordered_map<std::string, const AttribBuffer *> &arrays)
+void Model::setBuffers(
+    const std::unordered_map<std::string, const AttribBuffer *> &arrays)
 {
-    for (auto iter = arrays.cbegin(); iter != arrays.cend(); ++iter)
-    {
-        setBuffer(iter->first, *iter->second);
-    }
+  for (auto iter = arrays.cbegin(); iter != arrays.cend(); ++iter)
+  {
+    setBuffer(iter->first, *iter->second);
+  }
 }
 
 void Model::applyBuffers() const
 {
-    GLuint mVAO;
-    glGenVertexArrays(1, &mVAO);
-    glBindVertexArray(mVAO);
+  GLuint mVAO;
+  glGenVertexArrays(1, &mVAO);
+  glBindVertexArray(mVAO);
 
-    // Apply array buffer and element buffer
-    for (const auto &buffer : buffers)
+  // Apply array buffer and element buffer
+  for (const auto &buffer : buffers)
+  {
+    if (buffer.first == "indices")
     {
-        if (buffer.first == "indices")
-        {
-            glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, buffer.second->getBuffer());
-        }
-        else
-        {
-            glBindBuffer(GL_ARRAY_BUFFER, buffer.second->getBuffer());
-            auto &attribLocs = program->getAttribLocs();
-            if (attribLocs.find(buffer.first) == attribLocs.end())
-            {
-                continue;
-            }
-            program->setAttrib(*buffer.second, buffer.first);
-        }
+      glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, buffer.second->getBuffer());
     }
+    else
+    {
+      glBindBuffer(GL_ARRAY_BUFFER, buffer.second->getBuffer());
+      auto &attribLocs = program->getAttribLocs();
+      if (attribLocs.find(buffer.first) == attribLocs.end())
+      {
+        continue;
+      }
+      program->setAttrib(*buffer.second, buffer.first);
+    }
+  }
 }
 
 void Model::applyTextures() const
 {
-    // Apply textures
-    for (auto it = textures->cbegin(); it != textures->cend(); ++it)
-    {
-        program->setUniform(it->first, *it->second);
-    }
+  // Apply textures
+  for (auto it = textures->cbegin(); it != textures->cend(); ++it)
+  {
+    program->setUniform(it->first, *it->second);
+  }
 }
 
 void Model::prepareForDraw(const GenericConst &constUniforms)
 {
-    program->use();
+  program->use();
 
-    applyBuffers();
-    applyTextures();
+  applyBuffers();
+  applyTextures();
 
-    // Apply other uniforms
-    program->setUniform("ambient", *constUniforms.ambient);
-    program->setUniform("fogColor", *constUniforms.fogColor);
-    program->setUniform("fogMult", constUniforms.fogMult);
-    program->setUniform("fogOffset", constUniforms.fogOffset);
-    program->setUniform("fogPower", constUniforms.fogPower);
-    program->setUniform("lightColor", *constUniforms.lightColor);
-    program->setUniform("shininess", constUniforms.shininess);
-    program->setUniform("specular", *constUniforms.specular);
-    program->setUniform("specularFactor", constUniforms.specularFactor);
-    program->setUniform("lightWorldPos", *constUniforms.lightWorldPos);
-    program->setUniform("viewInverse", *constUniforms.viewInverse);
-    program->setUniform("viewProjection", *constUniforms.viewProjection);
+  // Apply other uniforms
+  program->setUniform("ambient", *constUniforms.ambient);
+  program->setUniform("fogColor", *constUniforms.fogColor);
+  program->setUniform("fogMult", constUniforms.fogMult);
+  program->setUniform("fogOffset", constUniforms.fogOffset);
+  program->setUniform("fogPower", constUniforms.fogPower);
+  program->setUniform("lightColor", *constUniforms.lightColor);
+  program->setUniform("shininess", constUniforms.shininess);
+  program->setUniform("specular", *constUniforms.specular);
+  program->setUniform("specularFactor", constUniforms.specularFactor);
+  program->setUniform("lightWorldPos", *constUniforms.lightWorldPos);
+  program->setUniform("viewInverse", *constUniforms.viewInverse);
+  program->setUniform("viewProjection", *constUniforms.viewProjection);
 
-    // The belowing uniforms belongs to innerConst
-    program->setUniform("eta", constUniforms.eta);
-    program->setUniform("refractionFudge", constUniforms.refractionFudge);
-    program->setUniform("tankColorFudge", constUniforms.tankColorFudge);
+  // The belowing uniforms belongs to innerConst
+  program->setUniform("eta", constUniforms.eta);
+  program->setUniform("refractionFudge", constUniforms.refractionFudge);
+  program->setUniform("tankColorFudge", constUniforms.tankColorFudge);
 }
 
 void Model::prepareForDraw(const FishConst &fishConst)
 {
-    prepareForDraw(fishConst.genericConst);
+  prepareForDraw(fishConst.genericConst);
 
-    program->setUniform("fishBendAmount", fishConst.constUniforms.fishBendAmount);
-    program->setUniform("fishLength", fishConst.constUniforms.fishLength);
-    program->setUniform("fishWaveLength", fishConst.constUniforms.fishWaveLength);
+  program->setUniform("fishBendAmount", fishConst.constUniforms.fishBendAmount);
+  program->setUniform("fishLength", fishConst.constUniforms.fishLength);
+  program->setUniform("fishWaveLength", fishConst.constUniforms.fishWaveLength);
 }
 
 void Model::drawFunc()
 {
-    int totalComponents = 0;
+  int totalComponents = 0;
 
-    if (buffers.find("indices") != buffers.end())
-    {
-        totalComponents = buffers["indices"]->getTotalComponents();
-        GLenum type     = buffers["indices"]->getType();
-        glDrawElements(mode, totalComponents, type, 0);
-    }
-    else
-    {
-        totalComponents = buffers["positions"]->getNumElements();
-        glDrawArrays(mode, 0, totalComponents);
-    }
+  if (buffers.find("indices") != buffers.end())
+  {
+    totalComponents = buffers["indices"]->getTotalComponents();
+    GLenum type     = buffers["indices"]->getType();
+    glDrawElements(mode, totalComponents, type, 0);
+  }
+  else
+  {
+    totalComponents = buffers["positions"]->getNumElements();
+    glDrawArrays(mode, 0, totalComponents);
+  }
 }
 
 void Model::draw(const GenericPer &perUniforms)
 {
-    program->setUniform("world", *perUniforms.world);
-    program->setUniform("worldInverse", *perUniforms.worldInverse);
-    program->setUniform("worldInverseTranspose", *perUniforms.worldInverseTranspose);
-    program->setUniform("worldViewProjection", *perUniforms.worldViewProjection);
+  program->setUniform("world", *perUniforms.world);
+  program->setUniform("worldInverse", *perUniforms.worldInverse);
+  program->setUniform("worldInverseTranspose",
+                      *perUniforms.worldInverseTranspose);
+  program->setUniform("worldViewProjection", *perUniforms.worldViewProjection);
 
-    drawFunc();
-    ASSERT(glGetError() == GL_NO_ERROR);
+  drawFunc();
+  ASSERT(glGetError() == GL_NO_ERROR);
 }
 
 void Model::draw(const FishPer &fishPer)
 {
-    program->setUniform("worldPosition", fishPer.worldPosition);
-    program->setUniform("nextPosition", fishPer.nextPosition);
-    program->setUniform("scale", fishPer.scale);
-    program->setUniform("time", fishPer.time);
+  program->setUniform("worldPosition", fishPer.worldPosition);
+  program->setUniform("nextPosition", fishPer.nextPosition);
+  program->setUniform("scale", fishPer.scale);
+  program->setUniform("time", fishPer.time);
 
-    drawFunc();
-    ASSERT(glGetError() == GL_NO_ERROR);
+  drawFunc();
+  ASSERT(glGetError() == GL_NO_ERROR);
 }

--- a/src/aquarium-direct-map/Model.h
+++ b/src/aquarium-direct-map/Model.h
@@ -23,30 +23,31 @@ struct GenericPer;
 
 class Model
 {
-  public:
-    Model() {}
-    ~Model();
-    Model(Program *program,
-          const std::unordered_map<std::string, const AttribBuffer *> &arrays,
-          const std::unordered_map<std::string, Texture *> *textures);
+public:
+  Model() {}
+  ~Model();
+  Model(Program *program,
+        const std::unordered_map<std::string, const AttribBuffer *> &arrays,
+        const std::unordered_map<std::string, Texture *> *textures);
 
-    void prepareForDraw(const GenericConst &constUniforms);
-    void prepareForDraw(const FishConst &fishConst);
-    void draw(const GenericPer &perUniforms);
-    void draw(const FishPer &fishPer);
+  void prepareForDraw(const GenericConst &constUniforms);
+  void prepareForDraw(const FishConst &fishConst);
+  void draw(const GenericPer &perUniforms);
+  void draw(const FishPer &fishPer);
 
-  private:
-    void setBuffers(const std::unordered_map<std::string, const AttribBuffer *> &arrays);
-    void setBuffer(const std::string &name, const AttribBuffer &array);
-    void applyBuffers() const;
-    void applyTextures() const;
-    void drawFunc();
+private:
+  void setBuffers(
+      const std::unordered_map<std::string, const AttribBuffer *> &arrays);
+  void setBuffer(const std::string &name, const AttribBuffer &array);
+  void applyBuffers() const;
+  void applyTextures() const;
+  void drawFunc();
 
-    std::unordered_map<std::string, Buffer *> buffers;
-    const std::unordered_map<std::string, Texture *> *textures;
-    Program *program;
+  std::unordered_map<std::string, Buffer *> buffers;
+  const std::unordered_map<std::string, Texture *> *textures;
+  Program *program;
 
-    GLenum mode;
+  GLenum mode;
 };
 
 #endif  // MODEL_H

--- a/src/aquarium-direct-map/Program.cpp
+++ b/src/aquarium-direct-map/Program.cpp
@@ -20,257 +20,268 @@
 Program::Program(const std::string &vId, const std::string &fId)
     : program(0u), attribLocs(), uniforms(), textureUnits()
 {
-    createProgramFromTags(vId, fId);
-    createSetters();
+  createProgramFromTags(vId, fId);
+  createSetters();
 }
 
 Program::~Program()
 {
-    glDeleteProgram(program);
+  glDeleteProgram(program);
 
-    for (auto &uniform : uniforms)
+  for (auto &uniform : uniforms)
+  {
+    if (uniform.second != nullptr)
     {
-        if (uniform.second != nullptr)
-        {
-            delete uniform.second;
-            uniform.second = nullptr;
-        }
+      delete uniform.second;
+      uniform.second = nullptr;
     }
+  }
 }
 
-void Program::createProgramFromTags(const std::string &vId, const std::string &fId)
+void Program::createProgramFromTags(const std::string &vId,
+                                    const std::string &fId)
 {
-    std::ifstream VertexShaderStream(vId, std::ios::in);
-    std::string VertexShaderCode((std::istreambuf_iterator<char>(VertexShaderStream)),
-                                 std::istreambuf_iterator<char>());
-    VertexShaderStream.close();
+  std::ifstream VertexShaderStream(vId, std::ios::in);
+  std::string VertexShaderCode(
+      (std::istreambuf_iterator<char>(VertexShaderStream)),
+      std::istreambuf_iterator<char>());
+  VertexShaderStream.close();
 
-    std::ifstream FragmentShaderStream(fId, std::ios::in);
-    std::string FragmentShaderCode((std::istreambuf_iterator<char>(FragmentShaderStream)),
-                                   std::istreambuf_iterator<char>());
-    FragmentShaderStream.close();
+  std::ifstream FragmentShaderStream(fId, std::ios::in);
+  std::string FragmentShaderCode(
+      (std::istreambuf_iterator<char>(FragmentShaderStream)),
+      std::istreambuf_iterator<char>());
+  FragmentShaderStream.close();
 
-    const std::string fogUniforms =
-        R"(uniform float fogPower;
+  const std::string fogUniforms =
+      R"(uniform float fogPower;
         uniform float fogMult;
         uniform float fogOffset;
         uniform vec4 fogColor;)";
-    const std::string fogCode =
-        R"(outColor = mix(outColor, vec4(fogColor.rgb, diffuseColor.a),
+  const std::string fogCode =
+      R"(outColor = mix(outColor, vec4(fogColor.rgb, diffuseColor.a),
         clamp(pow((v_position.z / v_position.w), fogPower) * fogMult - fogOffset,0.0,1.0));)";
 
 #ifdef __APPLE__
-    VertexShaderCode   = std::regex_replace(VertexShaderCode, std::regex(R"(#version 450 core)"),
-                                          R"(#version 410 core)");
-    FragmentShaderCode = std::regex_replace(FragmentShaderCode, std::regex(R"(#version 450 core)"),
-                                            R"(#version 410 core)");
+  VertexShaderCode =
+      std::regex_replace(VertexShaderCode, std::regex(R"(#version 450 core)"),
+                         R"(#version 410 core)");
+  FragmentShaderCode =
+      std::regex_replace(FragmentShaderCode, std::regex(R"(#version 450 core)"),
+                         R"(#version 410 core)");
 #endif
 
-    // enable fog, reflection and normalMaps
-    FragmentShaderCode =
-        std::regex_replace(FragmentShaderCode, std::regex(R"(// #fogUniforms)"), fogUniforms);
-    FragmentShaderCode =
-        std::regex_replace(FragmentShaderCode, std::regex(R"(// #fogCode)"), fogCode);
+  // enable fog, reflection and normalMaps
+  FragmentShaderCode = std::regex_replace(
+      FragmentShaderCode, std::regex(R"(// #fogUniforms)"), fogUniforms);
+  FragmentShaderCode = std::regex_replace(
+      FragmentShaderCode, std::regex(R"(// #fogCode)"), fogCode);
 
-    FragmentShaderCode =
-        std::regex_replace(FragmentShaderCode, std::regex(R"(\n.*?// #noReflection)"), "");
-    FragmentShaderCode =
-        std::regex_replace(FragmentShaderCode, std::regex(R"(\n.*?// #noNormalMap)"), "");
+  FragmentShaderCode = std::regex_replace(
+      FragmentShaderCode, std::regex(R"(\n.*?// #noReflection)"), "");
+  FragmentShaderCode = std::regex_replace(
+      FragmentShaderCode, std::regex(R"(\n.*?// #noNormalMap)"), "");
 
-    program = LoadProgram(VertexShaderCode, FragmentShaderCode);
+  program = LoadProgram(VertexShaderCode, FragmentShaderCode);
 }
 
 void Program::createSetters()
 {
-    int params;
-    GLsizei length, size;
-    GLenum type;
-    char name[100];
+  int params;
+  GLsizei length, size;
+  GLenum type;
+  char name[100];
 
-    glUseProgram(program);
+  glUseProgram(program);
 
-    // Look up attributes
-    glGetProgramiv(program, GL_ACTIVE_ATTRIBUTES, &params);
-    for (int i = 0; i < params; ++i)
-    {
-        glGetActiveAttrib(program, i, 1024, &length, &size, &type, name);
-        GLint index = glGetAttribLocation(program, name);
-        ASSERT(index != -1);
-        std::string namestr(name);
-        namestr.erase(namestr.find_last_not_of(' ') + 1);
-        attribLocs[namestr] = index;
-    }
+  // Look up attributes
+  glGetProgramiv(program, GL_ACTIVE_ATTRIBUTES, &params);
+  for (int i = 0; i < params; ++i)
+  {
+    glGetActiveAttrib(program, i, 1024, &length, &size, &type, name);
+    GLint index = glGetAttribLocation(program, name);
+    ASSERT(index != -1);
+    std::string namestr(name);
+    namestr.erase(namestr.find_last_not_of(' ') + 1);
+    attribLocs[namestr] = index;
+  }
 
-    // Look up uniforms
-    glGetProgramiv(program, GL_ACTIVE_UNIFORMS, &params);
-    for (int i = 0; i < params; ++i)
-    {
-        glGetActiveUniform(program, i, 1024, &length, &size, &type, name);
-        std::string namestr(name);
-        GLint index = glGetUniformLocation(program, name);
-        ASSERT(index != -1);
-        uniforms[namestr] = new Uniform(namestr, type, length, size, index);
-    }
+  // Look up uniforms
+  glGetProgramiv(program, GL_ACTIVE_UNIFORMS, &params);
+  for (int i = 0; i < params; ++i)
+  {
+    glGetActiveUniform(program, i, 1024, &length, &size, &type, name);
+    std::string namestr(name);
+    GLint index = glGetUniformLocation(program, name);
+    ASSERT(index != -1);
+    uniforms[namestr] = new Uniform(namestr, type, length, size, index);
+  }
 }
 
 void Program::setAttrib(const Buffer &buf, const std::string &name)
 {
-    glBindBuffer(GL_ARRAY_BUFFER, buf.getBuffer());
-    GLuint index = attribLocs[name];
-    glEnableVertexAttribArray(index);
-    glVertexAttribPointer(index, static_cast<GLint>(buf.getNumComponents()), buf.getType(),
-                          buf.getNormalize(), buf.getStride(), buf.getOffset());
+  glBindBuffer(GL_ARRAY_BUFFER, buf.getBuffer());
+  GLuint index = attribLocs[name];
+  glEnableVertexAttribArray(index);
+  glVertexAttribPointer(index, static_cast<GLint>(buf.getNumComponents()),
+                        buf.getType(), buf.getNormalize(), buf.getStride(),
+                        buf.getOffset());
 
-    ASSERT(glGetError() == GL_NO_ERROR);
+  ASSERT(glGetError() == GL_NO_ERROR);
 }
 
 GLuint Program::LoadProgram(const std::string &VertexShaderCode,
                             const std::string &FragmentShaderCode)
 {
 
-    // Create the shaders
-    GLuint VertexShaderID   = glCreateShader(GL_VERTEX_SHADER);
-    GLuint FragmentShaderID = glCreateShader(GL_FRAGMENT_SHADER);
+  // Create the shaders
+  GLuint VertexShaderID   = glCreateShader(GL_VERTEX_SHADER);
+  GLuint FragmentShaderID = glCreateShader(GL_FRAGMENT_SHADER);
 
-    GLint Result = GL_FALSE;
-    int InfoLogLength;
+  GLint Result = GL_FALSE;
+  int InfoLogLength;
 
-    // Compile Vertex Shader
-    char const *VertexSourcePointer = VertexShaderCode.c_str();
-    glShaderSource(VertexShaderID, 1, &VertexSourcePointer, NULL);
-    glCompileShader(VertexShaderID);
+  // Compile Vertex Shader
+  char const *VertexSourcePointer = VertexShaderCode.c_str();
+  glShaderSource(VertexShaderID, 1, &VertexSourcePointer, NULL);
+  glCompileShader(VertexShaderID);
 
-    // Check Vertex Shader
-    glGetShaderiv(VertexShaderID, GL_COMPILE_STATUS, &Result);
-    if (!Result)
-    {
-        glGetShaderiv(VertexShaderID, GL_INFO_LOG_LENGTH, &InfoLogLength);
-        std::vector<char> VertexShaderErrorMessage(InfoLogLength);
-        glGetShaderInfoLog(VertexShaderID, InfoLogLength, NULL, &VertexShaderErrorMessage[0]);
-        std::cout << stdout << &VertexShaderErrorMessage[0] << std::endl;
-    }
+  // Check Vertex Shader
+  glGetShaderiv(VertexShaderID, GL_COMPILE_STATUS, &Result);
+  if (!Result)
+  {
+    glGetShaderiv(VertexShaderID, GL_INFO_LOG_LENGTH, &InfoLogLength);
+    std::vector<char> VertexShaderErrorMessage(InfoLogLength);
+    glGetShaderInfoLog(VertexShaderID, InfoLogLength, NULL,
+                       &VertexShaderErrorMessage[0]);
+    std::cout << stdout << &VertexShaderErrorMessage[0] << std::endl;
+  }
 
-    // Compile Fragment Shader
-    char const *FragmentSourcePointer = FragmentShaderCode.c_str();
-    glShaderSource(FragmentShaderID, 1, &FragmentSourcePointer, NULL);
-    glCompileShader(FragmentShaderID);
+  // Compile Fragment Shader
+  char const *FragmentSourcePointer = FragmentShaderCode.c_str();
+  glShaderSource(FragmentShaderID, 1, &FragmentSourcePointer, NULL);
+  glCompileShader(FragmentShaderID);
 
-    // Check Fragment Shader
-    glGetShaderiv(FragmentShaderID, GL_COMPILE_STATUS, &Result);
-    if (!Result)
-    {
-        glGetShaderiv(FragmentShaderID, GL_INFO_LOG_LENGTH, &InfoLogLength);
-        std::vector<char> FragmentShaderErrorMessage(InfoLogLength);
-        glGetShaderInfoLog(FragmentShaderID, InfoLogLength, NULL, &FragmentShaderErrorMessage[0]);
-        std::cout << stdout << &FragmentShaderErrorMessage[0] << std::endl;
-    }
+  // Check Fragment Shader
+  glGetShaderiv(FragmentShaderID, GL_COMPILE_STATUS, &Result);
+  if (!Result)
+  {
+    glGetShaderiv(FragmentShaderID, GL_INFO_LOG_LENGTH, &InfoLogLength);
+    std::vector<char> FragmentShaderErrorMessage(InfoLogLength);
+    glGetShaderInfoLog(FragmentShaderID, InfoLogLength, NULL,
+                       &FragmentShaderErrorMessage[0]);
+    std::cout << stdout << &FragmentShaderErrorMessage[0] << std::endl;
+  }
 
-    // Link the program
-    GLuint ProgramID = glCreateProgram();
-    glAttachShader(ProgramID, VertexShaderID);
-    glAttachShader(ProgramID, FragmentShaderID);
-    glLinkProgram(ProgramID);
+  // Link the program
+  GLuint ProgramID = glCreateProgram();
+  glAttachShader(ProgramID, VertexShaderID);
+  glAttachShader(ProgramID, FragmentShaderID);
+  glLinkProgram(ProgramID);
 
-    // Check the program
-    glGetProgramiv(ProgramID, GL_LINK_STATUS, &Result);
-    if (!Result)
-    {
-        glGetProgramiv(ProgramID, GL_INFO_LOG_LENGTH, &InfoLogLength);
-        std::vector<char> ProgramErrorMessage(std::max(InfoLogLength, int(1)));
-        glGetProgramInfoLog(ProgramID, InfoLogLength, NULL, &ProgramErrorMessage[0]);
-        std::cout << stdout << &ProgramErrorMessage[0] << std::endl;
-    }
-    glDeleteShader(VertexShaderID);
-    glDeleteShader(FragmentShaderID);
+  // Check the program
+  glGetProgramiv(ProgramID, GL_LINK_STATUS, &Result);
+  if (!Result)
+  {
+    glGetProgramiv(ProgramID, GL_INFO_LOG_LENGTH, &InfoLogLength);
+    std::vector<char> ProgramErrorMessage(std::max(InfoLogLength, int(1)));
+    glGetProgramInfoLog(ProgramID, InfoLogLength, NULL,
+                        &ProgramErrorMessage[0]);
+    std::cout << stdout << &ProgramErrorMessage[0] << std::endl;
+  }
+  glDeleteShader(VertexShaderID);
+  glDeleteShader(FragmentShaderID);
 
-    return ProgramID;
+  return ProgramID;
 }
 
 void Program::use()
 {
-    glUseProgram(program);
+  glUseProgram(program);
 }
 
 void Program::setUniform(const std::string &name, float v)
 {
-    if (uniforms.find(name) == uniforms.end())
-    {
-        return;
-    }
-    Uniform *uniform = uniforms[name];
-    GLint loc        = uniform->getIndex();
-    ASSERT(uniform->getType() == GL_FLOAT);
-    glUniform1f(loc, v);
+  if (uniforms.find(name) == uniforms.end())
+  {
+    return;
+  }
+  Uniform *uniform = uniforms[name];
+  GLint loc        = uniform->getIndex();
+  ASSERT(uniform->getType() == GL_FLOAT);
+  glUniform1f(loc, v);
 
-    ASSERT(glGetError() == GL_NO_ERROR);
+  ASSERT(glGetError() == GL_NO_ERROR);
 }
 
 void Program::setUniform(const std::string &name, const std::vector<float> &v)
 {
-    if (uniforms.find(name) == uniforms.end())
-    {
-        return;
-    }
+  if (uniforms.find(name) == uniforms.end())
+  {
+    return;
+  }
 
-    Uniform *uniform = uniforms[name];
-    GLenum type      = uniform->getType();
-    GLint loc        = uniform->getIndex();
+  Uniform *uniform = uniforms[name];
+  GLenum type      = uniform->getType();
+  GLint loc        = uniform->getIndex();
 
-    switch (type)
-    {
-        case GL_FLOAT_VEC4:
-        {
-            glUniform4fv(loc, 1, v.data());
-            break;
-        }
-        case GL_FLOAT_VEC3:
-        {
-            glUniform3fv(loc, 1, v.data());
-            break;
-        }
-        case GL_FLOAT_VEC2:
-        {
-            glUniform2fv(loc, 1, v.data());
-            break;
-        }
-        case GL_FLOAT_MAT4:
-        {
-            glUniformMatrix4fv(loc, 1, false, v.data());
-            break;
-        }
-        default:
-        {
-            std::cout << "set uniform error" << std::endl;
-        }
-    }
+  switch (type)
+  {
+  case GL_FLOAT_VEC4:
+  {
+    glUniform4fv(loc, 1, v.data());
+    break;
+  }
+  case GL_FLOAT_VEC3:
+  {
+    glUniform3fv(loc, 1, v.data());
+    break;
+  }
+  case GL_FLOAT_VEC2:
+  {
+    glUniform2fv(loc, 1, v.data());
+    break;
+  }
+  case GL_FLOAT_MAT4:
+  {
+    glUniformMatrix4fv(loc, 1, false, v.data());
+    break;
+  }
+  default:
+  {
+    std::cout << "set uniform error" << std::endl;
+  }
+  }
 
-    ASSERT(glGetError() == GL_NO_ERROR);
+  ASSERT(glGetError() == GL_NO_ERROR);
 }
 
 void Program::setUniform(const std::string &name, const Texture &texture)
 {
-    if (uniforms.find(name) == uniforms.end())
-    {
-        return;
-    }
+  if (uniforms.find(name) == uniforms.end())
+  {
+    return;
+  }
 
-    Uniform *uniform = uniforms[name];
-    ASSERT(uniform->getType() == GL_SAMPLER_2D || uniform->getType() == GL_SAMPLER_CUBE);
-    GLint loc = uniform->getIndex();
+  Uniform *uniform = uniforms[name];
+  ASSERT(uniform->getType() == GL_SAMPLER_2D ||
+         uniform->getType() == GL_SAMPLER_CUBE);
+  GLint loc = uniform->getIndex();
 
-    glUniform1i(loc, textureUnits[name]);
-    glActiveTexture(GL_TEXTURE0 + textureUnits[name]);
-    ASSERT(textureUnits[name] < 16);
-    glBindTexture(texture.getTarget(), texture.getTexture());
+  glUniform1i(loc, textureUnits[name]);
+  glActiveTexture(GL_TEXTURE0 + textureUnits[name]);
+  ASSERT(textureUnits[name] < 16);
+  glBindTexture(texture.getTarget(), texture.getTexture());
 
-    ASSERT(glGetError() == GL_NO_ERROR);
+  ASSERT(glGetError() == GL_NO_ERROR);
 }
 
-void Program::setTextureUnits(const std::unordered_map<std::string, Texture *> &textureMap)
+void Program::setTextureUnits(
+    const std::unordered_map<std::string, Texture *> &textureMap)
 {
-    int unit = 0;
-    for (auto &texture : textureMap)
-    {
-        textureUnits[texture.first] = unit++;
-    }
+  int unit = 0;
+  for (auto &texture : textureMap)
+  {
+    textureUnits[texture.first] = unit++;
+  }
 }

--- a/src/aquarium-direct-map/Program.h
+++ b/src/aquarium-direct-map/Program.h
@@ -18,33 +18,41 @@
 
 class Program
 {
-  public:
-    Program() {}
-    Program(const std::string &vId, const std::string &fId);
-    ~Program();
-    void use();
-    void setUniform(const std::string &name, float v);
-    void setUniform(const std::string &name, const std::vector<float> &v);
-    void setUniform(const std::string &name, const Texture &texture);
+public:
+  Program() {}
+  Program(const std::string &vId, const std::string &fId);
+  ~Program();
+  void use();
+  void setUniform(const std::string &name, float v);
+  void setUniform(const std::string &name, const std::vector<float> &v);
+  void setUniform(const std::string &name, const Texture &texture);
 
-    const std::unordered_map<std::string, GLint> &getAttribLocs() const { return attribLocs; }
-    const std::unordered_map<std::string, Uniform *> &getUniforms() const { return uniforms; }
+  const std::unordered_map<std::string, GLint> &getAttribLocs() const
+  {
+    return attribLocs;
+  }
+  const std::unordered_map<std::string, Uniform *> &getUniforms() const
+  {
+    return uniforms;
+  }
 
-    void setTextureUnits(const std::unordered_map<std::string, Texture *> &textureMap);
-    void setAttrib(const Buffer &buf, const std::string &name);
+  void setTextureUnits(
+      const std::unordered_map<std::string, Texture *> &textureMap);
+  void setAttrib(const Buffer &buf, const std::string &name);
 
-    GLuint getProgramId() { return program; }
+  GLuint getProgramId() { return program; }
 
-  private:
-    void createProgramFromTags(const std::string &vId, const std::string &fId);
-    GLuint LoadProgram(const std::string &vertexShader, const std::string &fragmentShader);
-    void createSetters();
+private:
+  void createProgramFromTags(const std::string &vId, const std::string &fId);
+  GLuint LoadProgram(const std::string &vertexShader,
+                     const std::string &fragmentShader);
+  void createSetters();
 
-    GLuint program;
-    std::unordered_map<std::string, GLint> attribLocs;    // name, location
-    std::unordered_map<std::string, Uniform *> uniforms;  // name, type
+  GLuint program;
+  std::unordered_map<std::string, GLint> attribLocs;    // name, location
+  std::unordered_map<std::string, Uniform *> uniforms;  // name, type
 
-    std::unordered_map<std::string, int> textureUnits;
+  std::unordered_map<std::string, int> textureUnits;
 };
 
 #endif  // PROGRAM_H

--- a/src/aquarium-direct-map/Scene.h
+++ b/src/aquarium-direct-map/Scene.h
@@ -19,24 +19,24 @@ class Model;
 
 class Scene
 {
-  public:
-    Scene() {}
-    ~Scene();
-    Scene(const std::string opt_programIds[2]);
+public:
+  Scene() {}
+  ~Scene();
+  Scene(const std::string opt_programIds[2]);
 
-    void load(const std::string &path, const std::string &name);
-    const std::vector<Model *> &getModels() const { return models; }
+  void load(const std::string &path, const std::string &name);
+  const std::vector<Model *> &getModels() const { return models; }
 
-    bool loaded;
+  bool loaded;
 
-  private:
-    void setupSkybox(const std::string &path);
+private:
+  void setupSkybox(const std::string &path);
 
-    std::string programIds[2];
-    std::string url;
-    std::vector<Model *> models;
-    std::unordered_map<std::string, Texture *> textureMap;
-    std::unordered_map<std::string, const AttribBuffer *> arrayMap;
+  std::string programIds[2];
+  std::string url;
+  std::vector<Model *> models;
+  std::unordered_map<std::string, Texture *> textureMap;
+  std::unordered_map<std::string, const AttribBuffer *> arrayMap;
 };
 
 #endif  // SCENE_H

--- a/src/aquarium-direct-map/Texture.h
+++ b/src/aquarium-direct-map/Texture.h
@@ -16,30 +16,30 @@
 
 class Texture
 {
-  public:
-    Texture() {}
-    ~Texture();
-    Texture(const std::string &url, bool flip);
-    Texture(const std::vector<std::string> &urls);
+public:
+  Texture() {}
+  ~Texture();
+  Texture(const std::string &url, bool flip);
+  Texture(const std::vector<std::string> &urls);
 
-    GLuint getTexture() const { return texture; }
-    GLenum getTarget() const { return target; }
-    void setTexture(GLuint texId) { texture = texId; }
-    bool loadImageBySTB(const std::string &filename, uint8_t **pixels);
-    void DestroyImageData(uint8_t *pixels);
+  GLuint getTexture() const { return texture; }
+  GLenum getTarget() const { return target; }
+  void setTexture(GLuint texId) { texture = texId; }
+  bool loadImageBySTB(const std::string &filename, uint8_t **pixels);
+  void DestroyImageData(uint8_t *pixels);
 
-  private:
-    void setParameter(GLenum, GLint);
-    void uploadTextures();
-    bool isPowerOf2(int value);
+private:
+  void setParameter(GLenum, GLint);
+  void uploadTextures();
+  bool isPowerOf2(int value);
 
-    std::vector<std::string> urls;
-    GLenum target;
-    GLuint texture;
-    std::unordered_map<GLenum, GLint> params;
-    int width;
-    int height;
-    bool flip;
+  std::vector<std::string> urls;
+  GLenum target;
+  GLuint texture;
+  std::unordered_map<GLenum, GLint> params;
+  int width;
+  int height;
+  bool flip;
 };
 
 #endif  // TEXTURE_H

--- a/src/aquarium-direct-map/Uniform.cpp
+++ b/src/aquarium-direct-map/Uniform.cpp
@@ -6,7 +6,11 @@
 
 #include "Uniform.h"
 
-Uniform::Uniform(const std::string &name, GLenum type, int length, int size, GLint index)
+Uniform::Uniform(const std::string &name,
+                 GLenum type,
+                 int length,
+                 int size,
+                 GLint index)
     : name(name), type(type), length(length), size(size), index(index)
 {
 }

--- a/src/aquarium-direct-map/Uniform.h
+++ b/src/aquarium-direct-map/Uniform.h
@@ -14,21 +14,25 @@
 
 class Uniform
 {
-  public:
-    Uniform() {}
-    Uniform(const std::string &name, GLenum type, int length, int size, GLint index);
+public:
+  Uniform() {}
+  Uniform(const std::string &name,
+          GLenum type,
+          int length,
+          int size,
+          GLint index);
 
-    std::string getName() const { return name; }
-    GLenum getType() const { return type; }
-    GLsizei getLength() const { return length; }
-    GLsizei getSize() const { return size; }
-    GLint getIndex() const { return index; }
+  std::string getName() const { return name; }
+  GLenum getType() const { return type; }
+  GLsizei getLength() const { return length; }
+  GLsizei getSize() const { return size; }
+  GLint getIndex() const { return index; }
 
-  private:
-    std::string name;
-    GLenum type;
-    GLsizei length, size;
-    GLint index;
+private:
+  std::string name;
+  GLenum type;
+  GLsizei length, size;
+  GLint index;
 };
 
 #endif  // UNIFORM_H

--- a/src/aquarium-optimized/Aquarium.cpp
+++ b/src/aquarium-optimized/Aquarium.cpp
@@ -50,1046 +50,1101 @@ Aquarium::Aquarium()
       mBackendType(BACKENDTYPE::BACKENDTYPELAST),
       mFactory(nullptr)
 {
-    g.then     = 0.0;
-    g.mclock   = 0.0;
-    g.eyeClock = 0.0;
-    g.alpha    = "1";
+  g.then     = 0.0;
+  g.mclock   = 0.0;
+  g.eyeClock = 0.0;
+  g.alpha    = "1";
 
-    lightUniforms.lightColor[0] = 1.0f;
-    lightUniforms.lightColor[1] = 1.0f;
-    lightUniforms.lightColor[2] = 1.0f;
-    lightUniforms.lightColor[3] = 1.0f;
+  lightUniforms.lightColor[0] = 1.0f;
+  lightUniforms.lightColor[1] = 1.0f;
+  lightUniforms.lightColor[2] = 1.0f;
+  lightUniforms.lightColor[3] = 1.0f;
 
-    lightUniforms.specular[0] = 1.0f;
-    lightUniforms.specular[1] = 1.0f;
-    lightUniforms.specular[2] = 1.0f;
-    lightUniforms.specular[3] = 1.0f;
+  lightUniforms.specular[0] = 1.0f;
+  lightUniforms.specular[1] = 1.0f;
+  lightUniforms.specular[2] = 1.0f;
+  lightUniforms.specular[3] = 1.0f;
 
-    fogUniforms.fogColor[0] = g_fogRed;
-    fogUniforms.fogColor[1] = g_fogGreen;
-    fogUniforms.fogColor[2] = g_fogBlue;
-    fogUniforms.fogColor[3] = 1.0f;
+  fogUniforms.fogColor[0] = g_fogRed;
+  fogUniforms.fogColor[1] = g_fogGreen;
+  fogUniforms.fogColor[2] = g_fogBlue;
+  fogUniforms.fogColor[3] = 1.0f;
 
-    fogUniforms.fogPower  = g_fogPower;
-    fogUniforms.fogMult   = g_fogMult;
-    fogUniforms.fogOffset = g_fogOffset;
+  fogUniforms.fogPower  = g_fogPower;
+  fogUniforms.fogMult   = g_fogMult;
+  fogUniforms.fogOffset = g_fogOffset;
 
-    lightUniforms.ambient[0] = g_ambientRed;
-    lightUniforms.ambient[1] = g_ambientGreen;
-    lightUniforms.ambient[2] = g_ambientBlue;
-    lightUniforms.ambient[3] = 0.0f;
+  lightUniforms.ambient[0] = g_ambientRed;
+  lightUniforms.ambient[1] = g_ambientGreen;
+  lightUniforms.ambient[2] = g_ambientBlue;
+  lightUniforms.ambient[3] = 0.0f;
 
-    memset(fishCount, 0, 5);
+  memset(fishCount, 0, 5);
 }
 
 Aquarium::~Aquarium()
 {
-    for (auto &tex : mTextureMap)
+  for (auto &tex : mTextureMap)
+  {
+    if (tex.second != nullptr)
     {
-        if (tex.second != nullptr)
-        {
-            delete tex.second;
-            tex.second = nullptr;
-        }
+      delete tex.second;
+      tex.second = nullptr;
     }
+  }
 
-    for (auto &program : mProgramMap)
+  for (auto &program : mProgramMap)
+  {
+    if (program.second != nullptr)
     {
-        if (program.second != nullptr)
-        {
-            delete program.second;
-            program.second = nullptr;
-        }
+      delete program.second;
+      program.second = nullptr;
     }
+  }
 
-    for (int i = 0; i < MODELNAME::MODELMAX; ++i)
+  for (int i = 0; i < MODELNAME::MODELMAX; ++i)
+  {
+    delete mAquariumModels[i];
+  }
+
+  if (toggleBitset.test(static_cast<size_t>(TOGGLE::SIMULATINGFISHCOMEANDGO)))
+  {
+    while (!mFishBehavior.empty())
     {
-        delete mAquariumModels[i];
+      Behavior *behave = mFishBehavior.front();
+      mFishBehavior.pop();
+      delete behave;
     }
+  }
 
-    if (toggleBitset.test(static_cast<size_t>(TOGGLE::SIMULATINGFISHCOMEANDGO)))
-    {
-        while (!mFishBehavior.empty())
-        {
-            Behavior *behave = mFishBehavior.front();
-            mFishBehavior.pop();
-            delete behave;
-        }
-    }
-
-    delete mFactory;
+  delete mFactory;
 }
 
 BACKENDTYPE Aquarium::getBackendType(const std::string &backendPath)
 {
-    if (backendPath == "opengl")
-    {
-        return BACKENDTYPE::BACKENDTYPEOPENGL;
-    }
-    else if (backendPath == "dawn_d3d12")
-    {
+  if (backendPath == "opengl")
+  {
+    return BACKENDTYPE::BACKENDTYPEOPENGL;
+  }
+  else if (backendPath == "dawn_d3d12")
+  {
 #if defined(WIN32) || defined(_WIN32)
-        return BACKENDTYPE::BACKENDTYPEDAWND3D12;
+    return BACKENDTYPE::BACKENDTYPEDAWND3D12;
 #endif
-    }
-    else if (backendPath == "dawn_metal")
-    {
+  }
+  else if (backendPath == "dawn_metal")
+  {
 #if defined(__APPLE__)
-        return BACKENDTYPE::BACKENDTYPEDAWNMETAL;
+    return BACKENDTYPE::BACKENDTYPEDAWNMETAL;
 #endif
-    }
-    else if (backendPath == "dawn_vulkan")
-    {
+  }
+  else if (backendPath == "dawn_vulkan")
+  {
 #if defined(WIN32) || defined(_WIN32) || defined(__linux__)
-        return BACKENDTYPE::BACKENDTYPEDAWNVULKAN;
+    return BACKENDTYPE::BACKENDTYPEDAWNVULKAN;
 #endif
-    }
-    else if (backendPath == "angle")
-    {
+  }
+  else if (backendPath == "angle")
+  {
 #if defined(WIN32) || defined(_WIN32)
-        return BACKENDTYPE::BACKENDTYPEANGLE;
+    return BACKENDTYPE::BACKENDTYPEANGLE;
 #endif
-    }
-    else if (backendPath == "d3d12")
-    {
+  }
+  else if (backendPath == "d3d12")
+  {
 #if defined(WIN32) || defined(_WIN32)
-        return BACKENDTYPED3D12;
+    return BACKENDTYPED3D12;
 #endif
-    }
+  }
 
-    return BACKENDTYPELAST;
+  return BACKENDTYPELAST;
 }
 
 bool Aquarium::init(int argc, char **argv)
 {
-    int windowWidth  = 0;
-    int windowHeight = 0;
+  int windowWidth  = 0;
+  int windowHeight = 0;
 
-    cxxopts::Options options(argv[0], "A native implementation of WebGL Aquarium");
-    cxxopts::OptionAdder oa = options.allow_unrecognised_options().add_options();
-    oa("backend", "Set a backend, like 'dawn_d3d12' or 'd3d12'", cxxopts::value<std::string>());
-    oa("alpha-blending", "Format is <0-1|false>. Set alpha blending",
-       cxxopts::value<std::string>());
-    oa("buffer-mapping-async", "Upload uniforms by buffer mapping async for Dawn backend");
-    oa("disable-control-panel", "Turn off control panel");
-    oa("disable-d3d12-render-pass", "Turn off render pass for dawn_d3d12 and d3d12 backend");
-    oa("disable-dawn-validation", "Turn off dawn validation");
-    oa("disable-dynamic-buffer-offset", "Create many binding groups for a single draw. Dawn only");
-    oa("discrete-gpu", "Choose discrete gpu to render the application. Dawn and D3D12 only.");
-    oa("integrated-gpu", "Choose integrated gpu to render the application. Dawn and D3D12 only.");
-    oa("enable-full-screen-mode", "Render aquarium in full screen mode instead of window mode");
-    oa("msaa-sample-count", "Set MSAA sample count. 1 for non-MSAA", cxxopts::value<int>());
-    oa("num-fish", "Set how many fishes will be rendered.", cxxopts::value<int>(mCurFishCount));
-    oa("print-log", "Print logs including avarage fps when exit the application.");
-    oa("simulating-fish-come-and-go", "Load fish behavior from FishBehavior.json. Dawn only.");
-    oa("test-time", "Render for some seconds then exit.", cxxopts::value<int>(mTestTime));
-    oa("turn-off-vsync", "Unlimit 60 fps");
-    oa("window-size", "Format is <width,height>. Set window size", cxxopts::value<std::string>());
-    oa("help", "Print help");
-    auto result = options.parse(argc, argv);
+  cxxopts::Options options(argv[0],
+                           "A native implementation of WebGL Aquarium");
+  cxxopts::OptionAdder oa = options.allow_unrecognised_options().add_options();
+  oa("backend", "Set a backend, like 'dawn_d3d12' or 'd3d12'",
+     cxxopts::value<std::string>());
+  oa("alpha-blending", "Format is <0-1|false>. Set alpha blending",
+     cxxopts::value<std::string>());
+  oa("buffer-mapping-async",
+     "Upload uniforms by buffer mapping async for Dawn backend");
+  oa("disable-control-panel", "Turn off control panel");
+  oa("disable-d3d12-render-pass",
+     "Turn off render pass for dawn_d3d12 and d3d12 backend");
+  oa("disable-dawn-validation", "Turn off dawn validation");
+  oa("disable-dynamic-buffer-offset",
+     "Create many binding groups for a single draw. Dawn only");
+  oa("discrete-gpu",
+     "Choose discrete gpu to render the application. Dawn and D3D12 only.");
+  oa("integrated-gpu",
+     "Choose integrated gpu to render the application. Dawn and D3D12 only.");
+  oa("enable-full-screen-mode",
+     "Render aquarium in full screen mode instead of window mode");
+  oa("msaa-sample-count", "Set MSAA sample count. 1 for non-MSAA",
+     cxxopts::value<int>());
+  oa("num-fish", "Set how many fishes will be rendered.",
+     cxxopts::value<int>(mCurFishCount));
+  oa("print-log",
+     "Print logs including avarage fps when exit the application.");
+  oa("simulating-fish-come-and-go",
+     "Load fish behavior from FishBehavior.json. Dawn only.");
+  oa("test-time", "Render for some seconds then exit.",
+     cxxopts::value<int>(mTestTime));
+  oa("turn-off-vsync", "Unlimit 60 fps");
+  oa("window-size", "Format is <width,height>. Set window size",
+     cxxopts::value<std::string>());
+  oa("help", "Print help");
+  auto result = options.parse(argc, argv);
 
-    if (result.count("help"))
+  if (result.count("help"))
+  {
+    std::cout << options.help() << std::endl;
+    return false;
+  }
+
+  if (!result.count("backend"))
+  {
+    std::cout << "Option --backend needs to be designated" << std::endl;
+    return false;
+  }
+  std::string backend = result["backend"].as<std::string>();
+  mBackendType        = getBackendType(backend);
+  if (mBackendType == BACKENDTYPE::BACKENDTYPELAST)
+  {
+    std::cout << "Can not create " << backend << " backend" << std::endl;
+    return false;
+  }
+  mFactory = new ContextFactory();
+  mContext = mFactory->createContext(mBackendType);
+  if (mContext == nullptr)
+  {
+    std::cout << "Failed to create context." << std::endl;
+    return false;
+  }
+  std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> availableToggleBitset =
+      mContext->getAvailableToggleBitset();
+  if (availableToggleBitset.test(
+          static_cast<size_t>(TOGGLE::UPATEANDDRAWFOREACHMODEL)))
+  {
+    toggleBitset.set(static_cast<size_t>(TOGGLE::UPATEANDDRAWFOREACHMODEL));
+  }
+  if (availableToggleBitset.test(
+          static_cast<size_t>(TOGGLE::ENABLEDYNAMICBUFFEROFFSET)))
+  {
+    toggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEDYNAMICBUFFEROFFSET));
+  }
+  toggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEALPHABLENDING));
+
+  if (result.count("alpha-blending"))
+  {
+    g.alpha = result["alpha-blending"].as<std::string>();
+    if (g.alpha == "false")
     {
-        std::cout << options.help() << std::endl;
-        return false;
+      toggleBitset.reset(static_cast<size_t>(TOGGLE::ENABLEALPHABLENDING));
+    }
+  }
+
+  if (result.count("buffer-mapping-async"))
+  {
+    if (!availableToggleBitset.test(
+            static_cast<size_t>(TOGGLE::BUFFERMAPPINGASYNC)))
+    {
+      std::cerr << "Buffer mapping async isn't supported for the backend."
+                << std::endl;
+      return false;
     }
 
-    if (!result.count("backend"))
-    {
-        std::cout << "Option --backend needs to be designated" << std::endl;
-        return false;
-    }
-    std::string backend = result["backend"].as<std::string>();
-    mBackendType        = getBackendType(backend);
-    if (mBackendType == BACKENDTYPE::BACKENDTYPELAST)
-    {
-        std::cout << "Can not create " << backend << " backend" << std::endl;
-        return false;
-    }
-    mFactory = new ContextFactory();
-    mContext = mFactory->createContext(mBackendType);
-    if (mContext == nullptr)
-    {
-        std::cout << "Failed to create context." << std::endl;
-        return false;
-    }
-    std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> availableToggleBitset =
-        mContext->getAvailableToggleBitset();
-    if (availableToggleBitset.test(static_cast<size_t>(TOGGLE::UPATEANDDRAWFOREACHMODEL)))
-    {
-        toggleBitset.set(static_cast<size_t>(TOGGLE::UPATEANDDRAWFOREACHMODEL));
-    }
-    if (availableToggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEDYNAMICBUFFEROFFSET)))
-    {
-        toggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEDYNAMICBUFFEROFFSET));
-    }
-    toggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEALPHABLENDING));
+    toggleBitset.set(static_cast<size_t>(TOGGLE::BUFFERMAPPINGASYNC));
+  }
 
-    if (result.count("alpha-blending"))
+  if (result.count("disable-control-panel"))
+  {
+    toggleBitset.set(static_cast<size_t>(TOGGLE::DISABLECONTROLPANEL));
+  }
+
+  if (result.count("disable-d3d12-render-pass"))
+  {
+    if (!availableToggleBitset.test(
+            static_cast<size_t>(TOGGLE::DISABLED3D12RENDERPASS)))
     {
-        g.alpha = result["alpha-blending"].as<std::string>();
-        if (g.alpha == "false")
-        {
-            toggleBitset.reset(static_cast<size_t>(TOGGLE::ENABLEALPHABLENDING));
-        }
+      std::cerr
+          << "Render pass is only supported for dawn_d3d12 backend. This "
+             "feature "
+             "is only supported on Intel gen 10 or more advanced platforms. "
+             "Windows 1809 or later version is also required."
+          << std::endl;
+      return false;
     }
+    toggleBitset.set(static_cast<size_t>(TOGGLE::DISABLED3D12RENDERPASS));
+  }
 
-    if (result.count("buffer-mapping-async"))
+  if (result.count("disable-dawn-validation"))
+  {
+    if (!availableToggleBitset.test(
+            static_cast<size_t>(TOGGLE::DISABLEDAWNVALIDATION)))
     {
-        if (!availableToggleBitset.test(static_cast<size_t>(TOGGLE::BUFFERMAPPINGASYNC)))
-        {
-            std::cerr << "Buffer mapping async isn't supported for the backend." << std::endl;
-            return false;
-        }
-
-        toggleBitset.set(static_cast<size_t>(TOGGLE::BUFFERMAPPINGASYNC));
+      std::cerr << "Disable validation for Dawn backend." << std::endl;
+      return false;
     }
+    toggleBitset.set(static_cast<size_t>(TOGGLE::DISABLEDAWNVALIDATION));
+  }
 
-    if (result.count("disable-control-panel"))
+  if (result.count("disable-dynamic-buffer-offset"))
+  {
+    if (!availableToggleBitset.test(
+            static_cast<size_t>(TOGGLE::ENABLEDYNAMICBUFFEROFFSET)))
     {
-        toggleBitset.set(static_cast<size_t>(TOGGLE::DISABLECONTROLPANEL));
+      std::cerr
+          << "Dynamic buffer offset is only implemented for Dawn Vulkan, Dawn "
+             "Metal and D3D12 backend."
+          << std::endl;
+      return false;
     }
+    toggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEDYNAMICBUFFEROFFSET),
+                     false);
+  }
 
-    if (result.count("disable-d3d12-render-pass"))
+  if (result.count("discrete-gpu"))
+  {
+    if (!availableToggleBitset.test(
+            static_cast<size_t>(TOGGLE::INTEGRATEDGPU)) &&
+        !availableToggleBitset.test(static_cast<size_t>(TOGGLE::DISCRETEGPU)))
     {
-        if (!availableToggleBitset.test(static_cast<size_t>(TOGGLE::DISABLED3D12RENDERPASS)))
-        {
-            std::cerr << "Render pass is only supported for dawn_d3d12 backend. This feature "
-                         "is only supported on Intel gen 10 or more advanced platforms. "
-                         "Windows 1809 or later version is also required."
-                      << std::endl;
-            return false;
-        }
-        toggleBitset.set(static_cast<size_t>(TOGGLE::DISABLED3D12RENDERPASS));
+      std::cerr << "Dynamically choose gpu isn't supported for the backend."
+                << std::endl;
+      return false;
     }
-
-    if (result.count("disable-dawn-validation"))
+    if (toggleBitset.test(static_cast<size_t>(TOGGLE::INTEGRATEDGPU)))
     {
-        if (!availableToggleBitset.test(static_cast<size_t>(TOGGLE::DISABLEDAWNVALIDATION)))
-        {
-            std::cerr << "Disable validation for Dawn backend." << std::endl;
-            return false;
-        }
-        toggleBitset.set(static_cast<size_t>(TOGGLE::DISABLEDAWNVALIDATION));
+      std::cerr << "Integrated and Discrete gpu cannot be used simultaneosly.";
     }
+    toggleBitset.set(static_cast<size_t>(TOGGLE::DISCRETEGPU));
+  }
 
-    if (result.count("disable-dynamic-buffer-offset"))
+  if (result.count("integrated-gpu"))
+  {
+    if (!availableToggleBitset.test(
+            static_cast<size_t>(TOGGLE::INTEGRATEDGPU)) &&
+        !availableToggleBitset.test(static_cast<size_t>(TOGGLE::DISCRETEGPU)))
     {
-        if (!availableToggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEDYNAMICBUFFEROFFSET)))
-        {
-            std::cerr << "Dynamic buffer offset is only implemented for Dawn Vulkan, Dawn "
-                         "Metal and D3D12 backend."
-                      << std::endl;
-            return false;
-        }
-        toggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEDYNAMICBUFFEROFFSET), false);
+      std::cerr << "Dynamically choose gpu isn't supported for the backend."
+                << std::endl;
+      return false;
     }
-
-    if (result.count("discrete-gpu"))
+    if (toggleBitset.test(static_cast<size_t>(TOGGLE::DISCRETEGPU)))
     {
-        if (!availableToggleBitset.test(static_cast<size_t>(TOGGLE::INTEGRATEDGPU)) &&
-            !availableToggleBitset.test(static_cast<size_t>(TOGGLE::DISCRETEGPU)))
-        {
-            std::cerr << "Dynamically choose gpu isn't supported for the backend." << std::endl;
-            return false;
-        }
-        if (toggleBitset.test(static_cast<size_t>(TOGGLE::INTEGRATEDGPU)))
-        {
-            std::cerr << "Integrated and Discrete gpu cannot be used simultaneosly.";
-        }
-        toggleBitset.set(static_cast<size_t>(TOGGLE::DISCRETEGPU));
+      std::cerr << "Integrated and Discrete gpu cannot be used simultaneosly.";
+    }
+    toggleBitset.set(static_cast<size_t>(TOGGLE::INTEGRATEDGPU));
+  }
+
+  if (result.count("enable-full-screen-mode"))
+  {
+    if (!availableToggleBitset.test(
+            static_cast<size_t>(TOGGLE::ENABLEFULLSCREENMODE)))
+    {
+      std::cerr << "Full screen mode isn't supported for the backend."
+                << std::endl;
+      return false;
     }
 
-    if (result.count("integrated-gpu"))
+    toggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEFULLSCREENMODE));
+  }
+
+  if (result.count("enable-instanced-draws"))
+  {
+    /*if
+    (!availableToggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS)))
     {
-        if (!availableToggleBitset.test(static_cast<size_t>(TOGGLE::INTEGRATEDGPU)) &&
-            !availableToggleBitset.test(static_cast<size_t>(TOGGLE::DISCRETEGPU)))
-        {
-            std::cerr << "Dynamically choose gpu isn't supported for the backend." << std::endl;
-            return false;
-        }
-        if (toggleBitset.test(static_cast<size_t>(TOGGLE::DISCRETEGPU)))
-        {
-            std::cerr << "Integrated and Discrete gpu cannot be used simultaneosly.";
-        }
-        toggleBitset.set(static_cast<size_t>(TOGGLE::INTEGRATEDGPU));
+        std::cerr << "Instanced draw path isn't implemented for the backend." <<
+    std::endl; return false;
+    }
+    toggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS));
+    // Disable map write aync for instanced draw mode
+    toggleBitset.reset(static_cast<size_t>(TOGGLE::BUFFERMAPPINGASYNC));*/
+    std::cerr << "Instanced draw path is deprecated." << std::endl;
+    return false;
+  }
+
+  if (result.count("msaa-sample-count"))
+  {
+    mContext->setMSAASampleCount(result["msaa-sample-count"].as<int>());
+  }
+
+  if (result.count("print-log"))
+  {
+    toggleBitset.set(static_cast<size_t>(TOGGLE::PRINTLOG));
+  }
+
+  if (result.count("simulating-fish-come-and-go"))
+  {
+    if (!availableToggleBitset.test(
+            static_cast<size_t>(TOGGLE::SIMULATINGFISHCOMEANDGO)))
+    {
+      std::cerr
+          << "Simulating fish come and go is only implemented for Dawn backend."
+          << std::endl;
+      return false;
     }
 
-    if (result.count("enable-full-screen-mode"))
-    {
-        if (!availableToggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEFULLSCREENMODE)))
-        {
-            std::cerr << "Full screen mode isn't supported for the backend." << std::endl;
-            return false;
-        }
+    toggleBitset.set(static_cast<size_t>(TOGGLE::SIMULATINGFISHCOMEANDGO));
+  }
 
-        toggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEFULLSCREENMODE));
+  if (result.count("test-time"))
+  {
+    toggleBitset.set(static_cast<size_t>(TOGGLE::AUTOSTOP));
+  }
+
+  if (result.count("turn-off-vsync"))
+  {
+    if (!availableToggleBitset.test(static_cast<size_t>(TOGGLE::TURNOFFVSYNC)))
+    {
+      std::cerr << "Turn off vsync isn't supported for the backend."
+                << std::endl;
+      return false;
     }
 
-    if (result.count("enable-instanced-draws"))
+    toggleBitset.set(static_cast<size_t>(TOGGLE::TURNOFFVSYNC));
+  }
+
+  if (result.count("window-size"))
+  {
+    std::string windowSize = result["window-size"].as<std::string>();
+    size_t pos             = windowSize.find(",");
+    windowWidth            = stoi(windowSize.substr(0, pos + 1));
+    windowHeight           = stoi(windowSize.substr(pos + 1));
+    if (windowWidth == 0 || windowHeight == 0)
     {
-        /*if (!availableToggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS)))
-        {
-            std::cerr << "Instanced draw path isn't implemented for the backend." << std::endl;
-            return false;
-        }
-        toggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS));
-        // Disable map write aync for instanced draw mode
-        toggleBitset.reset(static_cast<size_t>(TOGGLE::BUFFERMAPPINGASYNC));*/
-        std::cerr << "Instanced draw path is deprecated." << std::endl;
-        return false;
+      std::cerr << "Please designate window size correctly.";
     }
+  }
 
-    if (result.count("msaa-sample-count"))
-    {
-        mContext->setMSAASampleCount(result["msaa-sample-count"].as<int>());
-    }
+  if (!mContext->initialize(mBackendType, toggleBitset, windowWidth,
+                            windowHeight))
+  {
+    return false;
+  }
 
-    if (result.count("print-log"))
-    {
-        toggleBitset.set(static_cast<size_t>(TOGGLE::PRINTLOG));
-    }
+  calculateFishCount();
 
-    if (result.count("simulating-fish-come-and-go"))
-    {
-        if (!availableToggleBitset.test(static_cast<size_t>(TOGGLE::SIMULATINGFISHCOMEANDGO)))
-        {
-            std::cerr << "Simulating fish come and go is only implemented for Dawn backend."
-                      << std::endl;
-            return false;
-        }
+  std::cout << "Init resources ..." << std::endl;
+  getElapsedTime();
 
-        toggleBitset.set(static_cast<size_t>(TOGGLE::SIMULATINGFISHCOMEANDGO));
-    }
+  const ResourceHelper *resourceHelper = mContext->getResourceHelper();
+  std::vector<std::string> skyUrls;
+  resourceHelper->getSkyBoxUrls(&skyUrls);
+  mTextureMap["skybox"] = mContext->createTexture("skybox", skyUrls);
 
-    if (result.count("test-time"))
-    {
-        toggleBitset.set(static_cast<size_t>(TOGGLE::AUTOSTOP));
-    }
+  // Init general buffer and binding groups for dawn backend.
+  mContext->initGeneralResources(this);
+  // Avoid resource allocation in the first render loop
+  mPreFishCount = mCurFishCount;
 
-    if (result.count("turn-off-vsync"))
-    {
-        if (!availableToggleBitset.test(static_cast<size_t>(TOGGLE::TURNOFFVSYNC)))
-        {
-            std::cerr << "Turn off vsync isn't supported for the backend." << std::endl;
-            return false;
-        }
+  setupModelEnumMap();
+  loadReource();
+  mContext->Flush();
 
-        toggleBitset.set(static_cast<size_t>(TOGGLE::TURNOFFVSYNC));
-    }
+  std::cout << "End loading.\nCost " << getElapsedTime() << "s totally."
+            << std::endl;
+  mContext->showWindow();
 
-    if (result.count("window-size"))
-    {
-        std::string windowSize = result["window-size"].as<std::string>();
-        size_t pos             = windowSize.find(",");
-        windowWidth            = stoi(windowSize.substr(0, pos + 1));
-        windowHeight           = stoi(windowSize.substr(pos + 1));
-        if (windowWidth == 0 || windowHeight == 0)
-        {
-            std::cerr << "Please designate window size correctly.";
-        }
-    }
+  resetFpsTime();
 
-    if (!mContext->initialize(mBackendType, toggleBitset, windowWidth, windowHeight))
-    {
-        return false;
-    }
-
-    calculateFishCount();
-
-    std::cout << "Init resources ..." << std::endl;
-    getElapsedTime();
-
-    const ResourceHelper *resourceHelper = mContext->getResourceHelper();
-    std::vector<std::string> skyUrls;
-    resourceHelper->getSkyBoxUrls(&skyUrls);
-    mTextureMap["skybox"] = mContext->createTexture("skybox", skyUrls);
-
-    // Init general buffer and binding groups for dawn backend.
-    mContext->initGeneralResources(this);
-    // Avoid resource allocation in the first render loop
-    mPreFishCount = mCurFishCount;
-
-    setupModelEnumMap();
-    loadReource();
-    mContext->Flush();
-
-    std::cout << "End loading.\nCost " << getElapsedTime() << "s totally." << std::endl;
-    mContext->showWindow();
-
-    resetFpsTime();
-
-    return true;
+  return true;
 }
 
 void Aquarium::resetFpsTime()
 {
 #ifdef _WIN32
-    g.start = GetTickCount64() / 1000.0;
+  g.start = GetTickCount64() / 1000.0;
 #else
-    g.start    = clock() / 1000000.0;
+  g.start    = clock() / 1000000.0;
 #endif
-    g.then = g.start;
+  g.then = g.start;
 }
 
 void Aquarium::display()
 {
-    while (!mContext->ShouldQuit())
+  while (!mContext->ShouldQuit())
+  {
+    mContext->KeyBoardQuit();
+    render();
+
+    mContext->DoFlush(toggleBitset);
+
+    if (toggleBitset.test(static_cast<size_t>(TOGGLE::AUTOSTOP)) &&
+        (g.then - g.start) > mTestTime)
     {
-        mContext->KeyBoardQuit();
-        render();
-
-        mContext->DoFlush(toggleBitset);
-
-        if (toggleBitset.test(static_cast<size_t>(TOGGLE::AUTOSTOP)) &&
-            (g.then - g.start) > mTestTime)
-        {
-            break;
-        }
+      break;
     }
+  }
 
-    mContext->Terminate();
+  mContext->Terminate();
 
-    if (toggleBitset.test(static_cast<size_t>(TOGGLE::PRINTLOG)))
-    {
-        printAvgFps();
-    }
+  if (toggleBitset.test(static_cast<size_t>(TOGGLE::PRINTLOG)))
+  {
+    printAvgFps();
+  }
 }
 
 void Aquarium::loadReource()
 {
-    loadModels();
-    loadPlacement();
-    if (toggleBitset.test(static_cast<size_t>(TOGGLE::SIMULATINGFISHCOMEANDGO)))
-    {
-        loadFishScenario();
-    }
+  loadModels();
+  loadPlacement();
+  if (toggleBitset.test(static_cast<size_t>(TOGGLE::SIMULATINGFISHCOMEANDGO)))
+  {
+    loadFishScenario();
+  }
 }
 
 void Aquarium::setupModelEnumMap()
 {
-    for (auto &info : g_sceneInfo)
-    {
-        mModelEnumMap[info.namestr] = info.name;
-    }
+  for (auto &info : g_sceneInfo)
+  {
+    mModelEnumMap[info.namestr] = info.name;
+  }
 }
 
 // Load world matrices of models from json file.
 void Aquarium::loadPlacement()
 {
-    const ResourceHelper *resourceHelper = mContext->getResourceHelper();
-    std::string proppath                 = resourceHelper->getPropPlacementPath();
-    std::ifstream PlacementStream(proppath, std::ios::in);
-    rapidjson::IStreamWrapper isPlacement(PlacementStream);
-    rapidjson::Document document;
-    document.ParseStream(isPlacement);
+  const ResourceHelper *resourceHelper = mContext->getResourceHelper();
+  std::string proppath                 = resourceHelper->getPropPlacementPath();
+  std::ifstream PlacementStream(proppath, std::ios::in);
+  rapidjson::IStreamWrapper isPlacement(PlacementStream);
+  rapidjson::Document document;
+  document.ParseStream(isPlacement);
 
-    ASSERT(document.IsObject());
+  ASSERT(document.IsObject());
 
-    ASSERT(document.HasMember("objects"));
-    const rapidjson::Value &objects = document["objects"];
-    ASSERT(objects.IsArray());
+  ASSERT(document.HasMember("objects"));
+  const rapidjson::Value &objects = document["objects"];
+  ASSERT(objects.IsArray());
 
-    for (rapidjson::SizeType i = 0; i < objects.Size(); ++i)
+  for (rapidjson::SizeType i = 0; i < objects.Size(); ++i)
+  {
+    const rapidjson::Value &name        = objects[i]["name"];
+    const rapidjson::Value &worldMatrix = objects[i]["worldMatrix"];
+    ASSERT(worldMatrix.IsArray() && worldMatrix.Size() == 16);
+
+    std::vector<float> matrix;
+    for (rapidjson::SizeType j = 0; j < worldMatrix.Size(); ++j)
     {
-        const rapidjson::Value &name        = objects[i]["name"];
-        const rapidjson::Value &worldMatrix = objects[i]["worldMatrix"];
-        ASSERT(worldMatrix.IsArray() && worldMatrix.Size() == 16);
-
-        std::vector<float> matrix;
-        for (rapidjson::SizeType j = 0; j < worldMatrix.Size(); ++j)
-        {
-            matrix.push_back(worldMatrix[j].GetFloat());
-        }
-
-        MODELNAME modelname = mModelEnumMap[name.GetString()];
-        // MODELFIRST means the model is not found in the Map
-        if (modelname != MODELNAME::MODELFIRST)
-        {
-            mAquariumModels[modelname]->worldmatrices.push_back(matrix);
-        }
+      matrix.push_back(worldMatrix[j].GetFloat());
     }
+
+    MODELNAME modelname = mModelEnumMap[name.GetString()];
+    // MODELFIRST means the model is not found in the Map
+    if (modelname != MODELNAME::MODELFIRST)
+    {
+      mAquariumModels[modelname]->worldmatrices.push_back(matrix);
+    }
+  }
 }
 
 void Aquarium::loadModels()
 {
-    bool enableInstanceddraw = toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS));
-    for (const auto &info : g_sceneInfo)
+  bool enableInstanceddraw =
+      toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS));
+  for (const auto &info : g_sceneInfo)
+  {
+    if ((enableInstanceddraw && info.type == MODELGROUP::FISH) ||
+        ((!enableInstanceddraw) && info.type == MODELGROUP::FISHINSTANCEDDRAW))
     {
-        if ((enableInstanceddraw && info.type == MODELGROUP::FISH) ||
-            ((!enableInstanceddraw) && info.type == MODELGROUP::FISHINSTANCEDDRAW))
-        {
-            continue;
-        }
-        loadModel(info);
+      continue;
     }
+    loadModel(info);
+  }
 }
 
 void Aquarium::loadFishScenario()
 {
-    const ResourceHelper *resourceHelper = mContext->getResourceHelper();
-    std::string fishBehaviorPath         = resourceHelper->getFishBehaviorPath();
+  const ResourceHelper *resourceHelper = mContext->getResourceHelper();
+  std::string fishBehaviorPath         = resourceHelper->getFishBehaviorPath();
 
-    std::ifstream FishStream(fishBehaviorPath, std::ios::in);
-    rapidjson::IStreamWrapper is(FishStream);
-    rapidjson::Document document;
-    document.ParseStream(is);
-    ASSERT(document.IsObject());
-    const rapidjson::Value &behaviors = document["behaviors"];
-    ASSERT(behaviors.IsArray());
+  std::ifstream FishStream(fishBehaviorPath, std::ios::in);
+  rapidjson::IStreamWrapper is(FishStream);
+  rapidjson::Document document;
+  document.ParseStream(is);
+  ASSERT(document.IsObject());
+  const rapidjson::Value &behaviors = document["behaviors"];
+  ASSERT(behaviors.IsArray());
 
-    for (rapidjson::SizeType i = 0; i < behaviors.Size(); ++i)
-    {
-        int frame      = behaviors[i]["frame"].GetInt();
-        std::string op = behaviors[i]["op"].GetString();
-        int count      = behaviors[i]["count"].GetInt();
+  for (rapidjson::SizeType i = 0; i < behaviors.Size(); ++i)
+  {
+    int frame      = behaviors[i]["frame"].GetInt();
+    std::string op = behaviors[i]["op"].GetString();
+    int count      = behaviors[i]["count"].GetInt();
 
-        Behavior *behave = new Behavior(frame, op, count);
-        mFishBehavior.push(behave);
-    }
+    Behavior *behave = new Behavior(frame, op, count);
+    mFishBehavior.push(behave);
+  }
 }
 
 // Load vertex and index buffers, textures and program for each model.
 void Aquarium::loadModel(const G_sceneInfo &info)
 {
-    const ResourceHelper *resourceHelper = mContext->getResourceHelper();
-    std::string imagePath                = resourceHelper->getImagePath();
-    std::string programPath              = resourceHelper->getProgramPath();
-    std::string modelPath                = resourceHelper->getModelPath(std::string(info.namestr));
+  const ResourceHelper *resourceHelper = mContext->getResourceHelper();
+  std::string imagePath                = resourceHelper->getImagePath();
+  std::string programPath              = resourceHelper->getProgramPath();
+  std::string modelPath =
+      resourceHelper->getModelPath(std::string(info.namestr));
 
-    std::ifstream ModelStream(modelPath, std::ios::in);
-    rapidjson::IStreamWrapper is(ModelStream);
-    rapidjson::Document document;
-    document.ParseStream(is);
-    ASSERT(document.IsObject());
-    const rapidjson::Value &models = document["models"];
-    ASSERT(models.IsArray());
+  std::ifstream ModelStream(modelPath, std::ios::in);
+  rapidjson::IStreamWrapper is(ModelStream);
+  rapidjson::Document document;
+  document.ParseStream(is);
+  ASSERT(document.IsObject());
+  const rapidjson::Value &models = document["models"];
+  ASSERT(models.IsArray());
 
-    Model *model;
-    if (toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEALPHABLENDING)) &&
-        info.type != MODELGROUP::INNER && info.type != MODELGROUP::OUTSIDE)
+  Model *model;
+  if (toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEALPHABLENDING)) &&
+      info.type != MODELGROUP::INNER && info.type != MODELGROUP::OUTSIDE)
+  {
+    model = mContext->createModel(this, info.type, info.name, true);
+  }
+  else
+  {
+    model = mContext->createModel(this, info.type, info.name, info.blend);
+  }
+  mAquariumModels[info.name] = model;
+
+  auto &value = models.GetArray()[models.GetArray().Size() - 1];
+  {
+    // set up textures
+    const rapidjson::Value &textures = value["textures"];
+    for (rapidjson::Value::ConstMemberIterator itr = textures.MemberBegin();
+         itr != textures.MemberEnd(); ++itr)
     {
-        model = mContext->createModel(this, info.type, info.name, true);
+      std::string name  = itr->name.GetString();
+      std::string image = itr->value.GetString();
+
+      if (mTextureMap.find(image) == mTextureMap.end())
+      {
+        mTextureMap[image] = mContext->createTexture(name, imagePath + image);
+      }
+
+      model->textureMap[name] = mTextureMap[image];
+    }
+
+    // set up vertices
+    const rapidjson::Value &arrays = value["fields"];
+    for (rapidjson::Value::ConstMemberIterator itr = arrays.MemberBegin();
+         itr != arrays.MemberEnd(); ++itr)
+    {
+      std::string name  = itr->name.GetString();
+      int numComponents = itr->value["numComponents"].GetInt();
+      std::string type  = itr->value["type"].GetString();
+      Buffer *buffer;
+      if (name == "indices")
+      {
+        std::vector<unsigned short> vec;
+        for (auto &data : itr->value["data"].GetArray())
+        {
+          vec.push_back(data.GetInt());
+        }
+        buffer = mContext->createBuffer(numComponents, &vec, true);
+      }
+      else
+      {
+        std::vector<float> vec;
+        for (auto &data : itr->value["data"].GetArray())
+        {
+          vec.push_back(data.GetFloat());
+        }
+        buffer = mContext->createBuffer(numComponents, &vec, false);
+      }
+
+      model->bufferMap[name] = buffer;
+    }
+
+    // setup program
+    // There are 3 programs
+    // DM
+    // DM+NM
+    // DM+NM+RM
+    std::string vsId;
+    std::string fsId;
+
+    vsId = info.program[0];
+    fsId = info.program[1];
+
+    if (vsId != "" && fsId != "")
+    {
+      model->textureMap["skybox"] = mTextureMap["skybox"];
+    }
+    else if (model->textureMap["reflection"] != nullptr)
+    {
+      vsId = "reflectionMapVertexShader";
+      fsId = "reflectionMapFragmentShader";
+
+      model->textureMap["skybox"] = mTextureMap["skybox"];
+    }
+    else if (model->textureMap["normalMap"] != nullptr)
+    {
+      vsId = "normalMapVertexShader";
+      fsId = "normalMapFragmentShader";
     }
     else
     {
-        model = mContext->createModel(this, info.type, info.name, info.blend);
+      vsId = "diffuseVertexShader";
+      fsId = "diffuseFragmentShader";
     }
-    mAquariumModels[info.name] = model;
 
-    auto &value = models.GetArray()[models.GetArray().Size() - 1];
+    Program *program;
+    if (mProgramMap.find(vsId + fsId) != mProgramMap.end())
     {
-        // set up textures
-        const rapidjson::Value &textures = value["textures"];
-        for (rapidjson::Value::ConstMemberIterator itr = textures.MemberBegin();
-             itr != textures.MemberEnd(); ++itr)
-        {
-            std::string name  = itr->name.GetString();
-            std::string image = itr->value.GetString();
-
-            if (mTextureMap.find(image) == mTextureMap.end())
-            {
-                mTextureMap[image] = mContext->createTexture(name, imagePath + image);
-            }
-
-            model->textureMap[name] = mTextureMap[image];
-        }
-
-        // set up vertices
-        const rapidjson::Value &arrays = value["fields"];
-        for (rapidjson::Value::ConstMemberIterator itr = arrays.MemberBegin();
-             itr != arrays.MemberEnd(); ++itr)
-        {
-            std::string name  = itr->name.GetString();
-            int numComponents = itr->value["numComponents"].GetInt();
-            std::string type  = itr->value["type"].GetString();
-            Buffer *buffer;
-            if (name == "indices")
-            {
-                std::vector<unsigned short> vec;
-                for (auto &data : itr->value["data"].GetArray())
-                {
-                    vec.push_back(data.GetInt());
-                }
-                buffer = mContext->createBuffer(numComponents, &vec, true);
-            }
-            else
-            {
-                std::vector<float> vec;
-                for (auto &data : itr->value["data"].GetArray())
-                {
-                    vec.push_back(data.GetFloat());
-                }
-                buffer = mContext->createBuffer(numComponents, &vec, false);
-            }
-
-            model->bufferMap[name] = buffer;
-        }
-
-        // setup program
-        // There are 3 programs
-        // DM
-        // DM+NM
-        // DM+NM+RM
-        std::string vsId;
-        std::string fsId;
-
-        vsId = info.program[0];
-        fsId = info.program[1];
-
-        if (vsId != "" && fsId != "")
-        {
-            model->textureMap["skybox"] = mTextureMap["skybox"];
-        }
-        else if (model->textureMap["reflection"] != nullptr)
-        {
-            vsId = "reflectionMapVertexShader";
-            fsId = "reflectionMapFragmentShader";
-
-            model->textureMap["skybox"] = mTextureMap["skybox"];
-        }
-        else if (model->textureMap["normalMap"] != nullptr)
-        {
-            vsId = "normalMapVertexShader";
-            fsId = "normalMapFragmentShader";
-        }
-        else
-        {
-            vsId = "diffuseVertexShader";
-            fsId = "diffuseFragmentShader";
-        }
-
-        Program *program;
-        if (mProgramMap.find(vsId + fsId) != mProgramMap.end())
-        {
-            program = mProgramMap[vsId + fsId];
-        }
-        else
-        {
-            program = mContext->createProgram(programPath + vsId, programPath + fsId);
-            if (toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEALPHABLENDING)) &&
-                info.type != MODELGROUP::INNER && info.type != MODELGROUP::OUTSIDE)
-            {
-                program->compileProgram(true, g.alpha);
-            }
-            else
-            {
-                program->compileProgram(false, g.alpha);
-            }
-            mProgramMap[vsId + fsId] = program;
-        }
-
-        model->setProgram(program);
-        model->init();
+      program = mProgramMap[vsId + fsId];
     }
+    else
+    {
+      program = mContext->createProgram(programPath + vsId, programPath + fsId);
+      if (toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEALPHABLENDING)) &&
+          info.type != MODELGROUP::INNER && info.type != MODELGROUP::OUTSIDE)
+      {
+        program->compileProgram(true, g.alpha);
+      }
+      else
+      {
+        program->compileProgram(false, g.alpha);
+      }
+      mProgramMap[vsId + fsId] = program;
+    }
+
+    model->setProgram(program);
+    model->init();
+  }
 }
 
 void Aquarium::calculateFishCount()
 {
-    // Calculate fish count for each type of fish
-    int numLeft = mCurFishCount;
-    for (int i = 0; i < FISHENUM::MAX; ++i)
+  // Calculate fish count for each type of fish
+  int numLeft = mCurFishCount;
+  for (int i = 0; i < FISHENUM::MAX; ++i)
+  {
+    for (auto &fishInfo : fishTable)
     {
-        for (auto &fishInfo : fishTable)
+      if (fishInfo.type != i)
+      {
+        continue;
+      }
+      int numfloat = numLeft;
+      if (i == FISHENUM::BIG)
+      {
+        int temp = mCurFishCount < g_numFishSmall ? 1 : 2;
+        numfloat = std::min(numLeft, temp);
+      }
+      else if (i == FISHENUM::MEDIUM)
+      {
+        if (mCurFishCount < g_numFishMedium)
         {
-            if (fishInfo.type != i)
-            {
-                continue;
-            }
-            int numfloat = numLeft;
-            if (i == FISHENUM::BIG)
-            {
-                int temp = mCurFishCount < g_numFishSmall ? 1 : 2;
-                numfloat = std::min(numLeft, temp);
-            }
-            else if (i == FISHENUM::MEDIUM)
-            {
-                if (mCurFishCount < g_numFishMedium)
-                {
-                    numfloat = std::min(numLeft, mCurFishCount / 10);
-                }
-                else if (mCurFishCount < g_numFishBig)
-                {
-                    numfloat = std::min(numLeft, g_numFishLeftSmall);
-                }
-                else
-                {
-                    numfloat = std::min(numLeft, g_numFishLeftBig);
-                }
-            }
-            numLeft                                                    = numLeft - numfloat;
-            fishCount[fishInfo.modelName - MODELNAME::MODELSMALLFISHA] = numfloat;
+          numfloat = std::min(numLeft, mCurFishCount / 10);
         }
+        else if (mCurFishCount < g_numFishBig)
+        {
+          numfloat = std::min(numLeft, g_numFishLeftSmall);
+        }
+        else
+        {
+          numfloat = std::min(numLeft, g_numFishLeftBig);
+        }
+      }
+      numLeft = numLeft - numfloat;
+      fishCount[fishInfo.modelName - MODELNAME::MODELSMALLFISHA] = numfloat;
     }
+  }
 }
 
 double Aquarium::getElapsedTime()
 {
-    // Update our time
+  // Update our time
 #ifdef _WIN32
-    double now = GetTickCount64() / 1000.0;
+  double now = GetTickCount64() / 1000.0;
 #else
-    double now = clock() / 1000000.0;
+  double now = clock() / 1000000.0;
 #endif
-    double elapsedTime = 0.0;
-    if (g.then == 0.0)
-    {
-        elapsedTime = 0.0;
-    }
-    else
-    {
-        elapsedTime = now - g.then;
-    }
-    g.then = now;
+  double elapsedTime = 0.0;
+  if (g.then == 0.0)
+  {
+    elapsedTime = 0.0;
+  }
+  else
+  {
+    elapsedTime = now - g.then;
+  }
+  g.then = now;
 
-    return elapsedTime;
+  return elapsedTime;
 }
 
 void Aquarium::printAvgFps()
 {
-    int avg = mFpsTimer.variance();
+  int avg = mFpsTimer.variance();
 
-    std::cout << "Avg FPS: " << avg << std::endl;
-    if (avg == 0)
-    {
-        std::cout << "Invalid value. The fps is unstable." << std::endl;
-    }
+  std::cout << "Avg FPS: " << avg << std::endl;
+  if (avg == 0)
+  {
+    std::cout << "Invalid value. The fps is unstable." << std::endl;
+  }
 }
 
 void Aquarium::updateGlobalUniforms()
 {
-    double elapsedTime   = getElapsedTime();
-    double renderingTime = g.then - g.start;
+  double elapsedTime   = getElapsedTime();
+  double renderingTime = g.then - g.start;
 
-    mFpsTimer.update(elapsedTime, renderingTime, mTestTime);
-    g.mclock += elapsedTime * g_speed;
-    g.eyeClock += elapsedTime * g_eyeSpeed;
+  mFpsTimer.update(elapsedTime, renderingTime, mTestTime);
+  g.mclock += elapsedTime * g_speed;
+  g.eyeClock += elapsedTime * g_eyeSpeed;
 
-    g.eyePosition[0] = sin(g.eyeClock) * g_eyeRadius;
-    g.eyePosition[1] = g_eyeHeight;
-    g.eyePosition[2] = cos(g.eyeClock) * g_eyeRadius;
-    g.target[0]      = static_cast<float>(sin(g.eyeClock + M_PI)) * g_targetRadius;
-    g.target[1]      = g_targetHeight;
-    g.target[2]      = static_cast<float>(cos(g.eyeClock + M_PI)) * g_targetRadius;
+  g.eyePosition[0] = sin(g.eyeClock) * g_eyeRadius;
+  g.eyePosition[1] = g_eyeHeight;
+  g.eyePosition[2] = cos(g.eyeClock) * g_eyeRadius;
+  g.target[0] = static_cast<float>(sin(g.eyeClock + M_PI)) * g_targetRadius;
+  g.target[1] = g_targetHeight;
+  g.target[2] = static_cast<float>(cos(g.eyeClock + M_PI)) * g_targetRadius;
 
-    float nearPlane = 1;
-    float farPlane  = 25000.0f;
-    float aspect    = static_cast<float>(mContext->getClientWidth()) /
-                   static_cast<float>(mContext->getclientHeight());
-    float top    = tan(matrix::degToRad(g_fieldOfView * g_fovFudge) * 0.5f) * nearPlane;
-    float bottom = -top;
-    float left   = aspect * bottom;
-    float right  = aspect * top;
-    float width  = abs(right - left);
-    float height = abs(top - bottom);
-    float xOff   = width * g_net_offset[0] * g_net_offsetMult;
-    float yOff   = height * g_net_offset[1] * g_net_offsetMult;
+  float nearPlane = 1;
+  float farPlane  = 25000.0f;
+  float aspect    = static_cast<float>(mContext->getClientWidth()) /
+                 static_cast<float>(mContext->getclientHeight());
+  float top =
+      tan(matrix::degToRad(g_fieldOfView * g_fovFudge) * 0.5f) * nearPlane;
+  float bottom = -top;
+  float left   = aspect * bottom;
+  float right  = aspect * top;
+  float width  = abs(right - left);
+  float height = abs(top - bottom);
+  float xOff   = width * g_net_offset[0] * g_net_offsetMult;
+  float yOff   = height * g_net_offset[1] * g_net_offsetMult;
 
-    // set frustm and camera look at
-    matrix::frustum(g.projection, left + xOff, right + xOff, bottom + yOff, top + yOff, nearPlane,
-                    farPlane);
-    matrix::cameraLookAt(lightWorldPositionUniform.viewInverse, g.eyePosition, g.target, g.up);
-    matrix::inverse4(g.view, lightWorldPositionUniform.viewInverse);
-    matrix::mulMatrixMatrix4(lightWorldPositionUniform.viewProjection, g.view, g.projection);
-    matrix::inverse4(g.viewProjectionInverse, lightWorldPositionUniform.viewProjection);
+  // set frustm and camera look at
+  matrix::frustum(g.projection, left + xOff, right + xOff, bottom + yOff,
+                  top + yOff, nearPlane, farPlane);
+  matrix::cameraLookAt(lightWorldPositionUniform.viewInverse, g.eyePosition,
+                       g.target, g.up);
+  matrix::inverse4(g.view, lightWorldPositionUniform.viewInverse);
+  matrix::mulMatrixMatrix4(lightWorldPositionUniform.viewProjection, g.view,
+                           g.projection);
+  matrix::inverse4(g.viewProjectionInverse,
+                   lightWorldPositionUniform.viewProjection);
 
-    memcpy(g.skyView, g.view, 16 * sizeof(float));
-    g.skyView[12] = 0.0;
-    g.skyView[13] = 0.0;
-    g.skyView[14] = 0.0;
-    matrix::mulMatrixMatrix4(g.skyViewProjection, g.skyView, g.projection);
-    matrix::inverse4(g.skyViewProjectionInverse, g.skyViewProjection);
+  memcpy(g.skyView, g.view, 16 * sizeof(float));
+  g.skyView[12] = 0.0;
+  g.skyView[13] = 0.0;
+  g.skyView[14] = 0.0;
+  matrix::mulMatrixMatrix4(g.skyViewProjection, g.skyView, g.projection);
+  matrix::inverse4(g.skyViewProjectionInverse, g.skyViewProjection);
 
-    matrix::getAxis(g.v3t0, lightWorldPositionUniform.viewInverse, 0);
-    matrix::getAxis(g.v3t1, lightWorldPositionUniform.viewInverse, 1);
-    matrix::mulScalarVector(20.0f, g.v3t0, 3);
-    matrix::mulScalarVector(30.0f, g.v3t1, 3);
-    matrix::addVector(lightWorldPositionUniform.lightWorldPos, g.eyePosition, g.v3t0, 3);
-    matrix::addVector(lightWorldPositionUniform.lightWorldPos,
-                      lightWorldPositionUniform.lightWorldPos, g.v3t1, 3);
+  matrix::getAxis(g.v3t0, lightWorldPositionUniform.viewInverse, 0);
+  matrix::getAxis(g.v3t1, lightWorldPositionUniform.viewInverse, 1);
+  matrix::mulScalarVector(20.0f, g.v3t0, 3);
+  matrix::mulScalarVector(30.0f, g.v3t1, 3);
+  matrix::addVector(lightWorldPositionUniform.lightWorldPos, g.eyePosition,
+                    g.v3t0, 3);
+  matrix::addVector(lightWorldPositionUniform.lightWorldPos,
+                    lightWorldPositionUniform.lightWorldPos, g.v3t1, 3);
 
-    // update world uniforms for dawn backend
-    mContext->updateWorldlUniforms(this);
+  // update world uniforms for dawn backend
+  mContext->updateWorldlUniforms(this);
 }
 
 void Aquarium::render()
 {
-    matrix::resetPseudoRandom();
+  matrix::resetPseudoRandom();
 
-    mContext->preFrame();
+  mContext->preFrame();
 
-    // Global Uniforms should update after command reallocation.
-    updateGlobalUniforms();
+  // Global Uniforms should update after command reallocation.
+  updateGlobalUniforms();
 
-    if (toggleBitset.test(static_cast<size_t>(TOGGLE::SIMULATINGFISHCOMEANDGO)))
+  if (toggleBitset.test(static_cast<size_t>(TOGGLE::SIMULATINGFISHCOMEANDGO)))
+  {
+    if (!mFishBehavior.empty())
     {
-        if (!mFishBehavior.empty())
+      Behavior *behave = mFishBehavior.front();
+      int frame        = behave->getFrame();
+      if (frame == 0)
+      {
+        mFishBehavior.pop();
+        if (behave->getOp() == "+")
         {
-            Behavior *behave = mFishBehavior.front();
-            int frame        = behave->getFrame();
-            if (frame == 0)
-            {
-                mFishBehavior.pop();
-                if (behave->getOp() == "+")
-                {
-                    mCurFishCount += behave->getCount();
-                }
-                else
-                {
-                    mCurFishCount -= behave->getCount();
-                }
-                std::cout << "Fish count" << mCurFishCount << std::endl;
-            }
-            else
-            {
-                behave->setFrame(--frame);
-            }
+          mCurFishCount += behave->getCount();
         }
-    }
-
-    // TODO(yizhou): Functionality of reallocate fish count during rendering
-    // isn't supported for instanced draw.
-    // To try this functionality now, use composition of "--backend dawn_xxx", or
-    // "--backend dawn_xxx --disable-dyanmic-buffer-offset"
-    if (!toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS)))
-        if (mCurFishCount != mPreFishCount)
+        else
         {
-            calculateFishCount();
-            bool enableDynamicBufferOffset =
-                toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEDYNAMICBUFFEROFFSET));
-            mContext->reallocResource(mPreFishCount, mCurFishCount, enableDynamicBufferOffset);
-            mPreFishCount = mCurFishCount;
-
-            resetFpsTime();
+          mCurFishCount -= behave->getCount();
         }
-
-    bool updateAndDrawForEachFish =
-        toggleBitset.test(static_cast<size_t>(TOGGLE::UPATEANDDRAWFOREACHMODEL));
-
-    if (updateAndDrawForEachFish)
-    {
-        updateAndDrawBackground();
-        updateAndDrawFishes();
-        mContext->updateFPS(mFpsTimer, &mCurFishCount, &toggleBitset);
+        std::cout << "Fish count" << mCurFishCount << std::endl;
+      }
+      else
+      {
+        behave->setFrame(--frame);
+      }
     }
-    else
+  }
+
+  // TODO(yizhou): Functionality of reallocate fish count during rendering
+  // isn't supported for instanced draw.
+  // To try this functionality now, use composition of "--backend dawn_xxx", or
+  // "--backend dawn_xxx --disable-dyanmic-buffer-offset"
+  if (!toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS)))
+    if (mCurFishCount != mPreFishCount)
     {
-        updateBackground();
-        updateFishes();
-        mContext->updateFPS(mFpsTimer, &mCurFishCount, &toggleBitset);
+      calculateFishCount();
+      bool enableDynamicBufferOffset = toggleBitset.test(
+          static_cast<size_t>(TOGGLE::ENABLEDYNAMICBUFFEROFFSET));
+      mContext->reallocResource(mPreFishCount, mCurFishCount,
+                                enableDynamicBufferOffset);
+      mPreFishCount = mCurFishCount;
 
-        // Begin render pass
-        mContext->beginRenderPass();
-
-        drawBackground();
-        drawFishes();
-        mContext->showFPS();
-
-        // End renderpass
+      resetFpsTime();
     }
+
+  bool updateAndDrawForEachFish =
+      toggleBitset.test(static_cast<size_t>(TOGGLE::UPATEANDDRAWFOREACHMODEL));
+
+  if (updateAndDrawForEachFish)
+  {
+    updateAndDrawBackground();
+    updateAndDrawFishes();
+    mContext->updateFPS(mFpsTimer, &mCurFishCount, &toggleBitset);
+  }
+  else
+  {
+    updateBackground();
+    updateFishes();
+    mContext->updateFPS(mFpsTimer, &mCurFishCount, &toggleBitset);
+
+    // Begin render pass
+    mContext->beginRenderPass();
+
+    drawBackground();
+    drawFishes();
+    mContext->showFPS();
+
+    // End renderpass
+  }
 }
 
 void Aquarium::updateAndDrawBackground()
 {
-    Model *model = mAquariumModels[MODELNAME::MODELRUINCOlOMN];
-    for (int i = MODELNAME::MODELRUINCOlOMN; i <= MODELNAME::MODELSEAWEEDB; ++i)
-    {
-        model = mAquariumModels[i];
-        updateWorldMatrixAndDraw(model);
-    }
+  Model *model = mAquariumModels[MODELNAME::MODELRUINCOlOMN];
+  for (int i = MODELNAME::MODELRUINCOlOMN; i <= MODELNAME::MODELSEAWEEDB; ++i)
+  {
+    model = mAquariumModels[i];
+    updateWorldMatrixAndDraw(model);
+  }
 }
 
 void Aquarium::drawBackground()
 {
-    Model *model = mAquariumModels[MODELNAME::MODELRUINCOlOMN];
-    for (int i = MODELNAME::MODELRUINCOlOMN; i <= MODELNAME::MODELSEAWEEDB; ++i)
-    {
-        model = mAquariumModels[i];
-        model->draw();
-    }
+  Model *model = mAquariumModels[MODELNAME::MODELRUINCOlOMN];
+  for (int i = MODELNAME::MODELRUINCOlOMN; i <= MODELNAME::MODELSEAWEEDB; ++i)
+  {
+    model = mAquariumModels[i];
+    model->draw();
+  }
 }
 
 void Aquarium::updateAndDrawFishes()
 {
-    int begin = toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS))
-                    ? MODELNAME::MODELSMALLFISHAINSTANCEDDRAWS
-                    : MODELNAME::MODELSMALLFISHA;
-    int end = toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS))
-                  ? MODELNAME::MODELBIGFISHBINSTANCEDDRAWS
-                  : MODELNAME::MODELBIGFISHB;
+  int begin =
+      toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS))
+          ? MODELNAME::MODELSMALLFISHAINSTANCEDDRAWS
+          : MODELNAME::MODELSMALLFISHA;
+  int end = toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS))
+                ? MODELNAME::MODELBIGFISHBINSTANCEDDRAWS
+                : MODELNAME::MODELBIGFISHB;
 
-    for (int i = begin; i <= end; ++i)
+  for (int i = begin; i <= end; ++i)
+  {
+    FishModel *model = static_cast<FishModel *>(mAquariumModels[i]);
+
+    const Fish &fishInfo = fishTable[i - begin];
+    int numFish          = fishCount[i - begin];
+
+    model->prepareForDraw();
+
+    float fishBaseClock   = g.mclock * g_fishSpeed;
+    float fishRadius      = fishInfo.radius;
+    float fishRadiusRange = fishInfo.radiusRange;
+    float fishSpeed       = fishInfo.speed;
+    float fishSpeedRange  = fishInfo.speedRange;
+    float fishTailSpeed   = fishInfo.tailSpeed * g_fishTailSpeed;
+    float fishOffset      = g_fishOffset;
+    // float fishClockSpeed  = g_fishSpeed;
+    float fishHeight      = g_fishHeight + fishInfo.heightOffset;
+    float fishHeightRange = g_fishHeightRange * fishInfo.heightRange;
+    float fishXClock      = g_fishXClock;
+    float fishYClock      = g_fishYClock;
+    float fishZClock      = g_fishZClock;
+
+    for (int ii = 0; ii < numFish; ++ii)
     {
-        FishModel *model = static_cast<FishModel *>(mAquariumModels[i]);
+      float fishClock = fishBaseClock + ii * fishOffset;
+      float speed     = fishSpeed +
+                    static_cast<float>(matrix::pseudoRandom()) * fishSpeedRange;
+      float scale   = 1.0f + static_cast<float>(matrix::pseudoRandom()) * 1;
+      float xRadius = fishRadius + static_cast<float>(matrix::pseudoRandom()) *
+                                       fishRadiusRange;
+      float yRadius =
+          2.0f + static_cast<float>(matrix::pseudoRandom()) * fishHeightRange;
+      float zRadius = fishRadius + static_cast<float>(matrix::pseudoRandom()) *
+                                       fishRadiusRange;
+      float fishSpeedClock = fishClock * speed;
+      float xClock         = fishSpeedClock * fishXClock;
+      float yClock         = fishSpeedClock * fishYClock;
+      float zClock         = fishSpeedClock * fishZClock;
 
-        const Fish &fishInfo = fishTable[i - begin];
-        int numFish          = fishCount[i - begin];
+      model->updateFishPerUniforms(
+          sin(xClock) * xRadius, sin(yClock) * yRadius + fishHeight,
+          cos(zClock) * zRadius, sin(xClock - 0.04f) * xRadius,
+          sin(yClock - 0.01f) * yRadius + fishHeight,
+          cos(zClock - 0.04f) * zRadius, scale,
+          fmod((g.mclock + ii * g_tailOffsetMult) * fishTailSpeed * speed,
+               static_cast<float>(M_PI) * 2),
+          ii);
 
-        model->prepareForDraw();
-
-        float fishBaseClock   = g.mclock * g_fishSpeed;
-        float fishRadius      = fishInfo.radius;
-        float fishRadiusRange = fishInfo.radiusRange;
-        float fishSpeed       = fishInfo.speed;
-        float fishSpeedRange  = fishInfo.speedRange;
-        float fishTailSpeed   = fishInfo.tailSpeed * g_fishTailSpeed;
-        float fishOffset      = g_fishOffset;
-        // float fishClockSpeed  = g_fishSpeed;
-        float fishHeight      = g_fishHeight + fishInfo.heightOffset;
-        float fishHeightRange = g_fishHeightRange * fishInfo.heightRange;
-        float fishXClock      = g_fishXClock;
-        float fishYClock      = g_fishYClock;
-        float fishZClock      = g_fishZClock;
-
-        for (int ii = 0; ii < numFish; ++ii)
-        {
-            float fishClock = fishBaseClock + ii * fishOffset;
-            float speed = fishSpeed + static_cast<float>(matrix::pseudoRandom()) * fishSpeedRange;
-            float scale = 1.0f + static_cast<float>(matrix::pseudoRandom()) * 1;
-            float xRadius =
-                fishRadius + static_cast<float>(matrix::pseudoRandom()) * fishRadiusRange;
-            float yRadius = 2.0f + static_cast<float>(matrix::pseudoRandom()) * fishHeightRange;
-            float zRadius =
-                fishRadius + static_cast<float>(matrix::pseudoRandom()) * fishRadiusRange;
-            float fishSpeedClock = fishClock * speed;
-            float xClock         = fishSpeedClock * fishXClock;
-            float yClock         = fishSpeedClock * fishYClock;
-            float zClock         = fishSpeedClock * fishZClock;
-
-            model->updateFishPerUniforms(
-                sin(xClock) * xRadius, sin(yClock) * yRadius + fishHeight, cos(zClock) * zRadius,
-                sin(xClock - 0.04f) * xRadius, sin(yClock - 0.01f) * yRadius + fishHeight,
-                cos(zClock - 0.04f) * zRadius, scale,
-                fmod((g.mclock + ii * g_tailOffsetMult) * fishTailSpeed * speed,
-                     static_cast<float>(M_PI) * 2),
-                ii);
-
-            model->updatePerInstanceUniforms(worldUniforms);
-            model->draw();
-        }
+      model->updatePerInstanceUniforms(worldUniforms);
+      model->draw();
     }
+  }
 }
 
 void Aquarium::updateBackground()
 {
-    Model *model = mAquariumModels[MODELNAME::MODELRUINCOlOMN];
-    for (int i = MODELNAME::MODELRUINCOlOMN; i <= MODELNAME::MODELSEAWEEDB; ++i)
-    {
-        model = mAquariumModels[i];
-        updateWorldMatrix(model);
-    }
+  Model *model = mAquariumModels[MODELNAME::MODELRUINCOlOMN];
+  for (int i = MODELNAME::MODELRUINCOlOMN; i <= MODELNAME::MODELSEAWEEDB; ++i)
+  {
+    model = mAquariumModels[i];
+    updateWorldMatrix(model);
+  }
 }
 
 void Aquarium::updateFishes()
 {
-    int begin = toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS))
-                    ? MODELNAME::MODELSMALLFISHAINSTANCEDDRAWS
-                    : MODELNAME::MODELSMALLFISHA;
-    int end = toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS))
-                  ? MODELNAME::MODELBIGFISHBINSTANCEDDRAWS
-                  : MODELNAME::MODELBIGFISHB;
+  int begin =
+      toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS))
+          ? MODELNAME::MODELSMALLFISHAINSTANCEDDRAWS
+          : MODELNAME::MODELSMALLFISHA;
+  int end = toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS))
+                ? MODELNAME::MODELBIGFISHBINSTANCEDDRAWS
+                : MODELNAME::MODELBIGFISHB;
 
-    for (int i = begin; i <= end; ++i)
+  for (int i = begin; i <= end; ++i)
+  {
+    FishModel *model = static_cast<FishModel *>(mAquariumModels[i]);
+
+    const Fish &fishInfo = fishTable[i - begin];
+    int numFish          = fishCount[i - begin];
+
+    model->prepareForDraw();
+
+    float fishBaseClock   = g.mclock * g_fishSpeed;
+    float fishRadius      = fishInfo.radius;
+    float fishRadiusRange = fishInfo.radiusRange;
+    float fishSpeed       = fishInfo.speed;
+    float fishSpeedRange  = fishInfo.speedRange;
+    float fishTailSpeed   = fishInfo.tailSpeed * g_fishTailSpeed;
+    float fishOffset      = g_fishOffset;
+    // float fishClockSpeed  = g_fishSpeed;
+    float fishHeight      = g_fishHeight + fishInfo.heightOffset;
+    float fishHeightRange = g_fishHeightRange * fishInfo.heightRange;
+    float fishXClock      = g_fishXClock;
+    float fishYClock      = g_fishYClock;
+    float fishZClock      = g_fishZClock;
+
+    for (int ii = 0; ii < numFish; ++ii)
     {
-        FishModel *model = static_cast<FishModel *>(mAquariumModels[i]);
+      float fishClock = fishBaseClock + ii * fishOffset;
+      float speed     = fishSpeed +
+                    static_cast<float>(matrix::pseudoRandom()) * fishSpeedRange;
+      float scale   = 1.0f + static_cast<float>(matrix::pseudoRandom()) * 1;
+      float xRadius = fishRadius + static_cast<float>(matrix::pseudoRandom()) *
+                                       fishRadiusRange;
+      float yRadius =
+          2.0f + static_cast<float>(matrix::pseudoRandom()) * fishHeightRange;
+      float zRadius = fishRadius + static_cast<float>(matrix::pseudoRandom()) *
+                                       fishRadiusRange;
+      float fishSpeedClock = fishClock * speed;
+      float xClock         = fishSpeedClock * fishXClock;
+      float yClock         = fishSpeedClock * fishYClock;
+      float zClock         = fishSpeedClock * fishZClock;
 
-        const Fish &fishInfo = fishTable[i - begin];
-        int numFish          = fishCount[i - begin];
-
-        model->prepareForDraw();
-
-        float fishBaseClock   = g.mclock * g_fishSpeed;
-        float fishRadius      = fishInfo.radius;
-        float fishRadiusRange = fishInfo.radiusRange;
-        float fishSpeed       = fishInfo.speed;
-        float fishSpeedRange  = fishInfo.speedRange;
-        float fishTailSpeed   = fishInfo.tailSpeed * g_fishTailSpeed;
-        float fishOffset      = g_fishOffset;
-        // float fishClockSpeed  = g_fishSpeed;
-        float fishHeight      = g_fishHeight + fishInfo.heightOffset;
-        float fishHeightRange = g_fishHeightRange * fishInfo.heightRange;
-        float fishXClock      = g_fishXClock;
-        float fishYClock      = g_fishYClock;
-        float fishZClock      = g_fishZClock;
-
-        for (int ii = 0; ii < numFish; ++ii)
-        {
-            float fishClock = fishBaseClock + ii * fishOffset;
-            float speed = fishSpeed + static_cast<float>(matrix::pseudoRandom()) * fishSpeedRange;
-            float scale = 1.0f + static_cast<float>(matrix::pseudoRandom()) * 1;
-            float xRadius =
-                fishRadius + static_cast<float>(matrix::pseudoRandom()) * fishRadiusRange;
-            float yRadius = 2.0f + static_cast<float>(matrix::pseudoRandom()) * fishHeightRange;
-            float zRadius =
-                fishRadius + static_cast<float>(matrix::pseudoRandom()) * fishRadiusRange;
-            float fishSpeedClock = fishClock * speed;
-            float xClock         = fishSpeedClock * fishXClock;
-            float yClock         = fishSpeedClock * fishYClock;
-            float zClock         = fishSpeedClock * fishZClock;
-
-            model->updateFishPerUniforms(
-                sin(xClock) * xRadius, sin(yClock) * yRadius + fishHeight, cos(zClock) * zRadius,
-                sin(xClock - 0.04f) * xRadius, sin(yClock - 0.01f) * yRadius + fishHeight,
-                cos(zClock - 0.04f) * zRadius, scale,
-                fmod((g.mclock + ii * g_tailOffsetMult) * fishTailSpeed * speed,
-                     static_cast<float>(M_PI) * 2),
-                ii);
-        }
+      model->updateFishPerUniforms(
+          sin(xClock) * xRadius, sin(yClock) * yRadius + fishHeight,
+          cos(zClock) * zRadius, sin(xClock - 0.04f) * xRadius,
+          sin(yClock - 0.01f) * yRadius + fishHeight,
+          cos(zClock - 0.04f) * zRadius, scale,
+          fmod((g.mclock + ii * g_tailOffsetMult) * fishTailSpeed * speed,
+               static_cast<float>(M_PI) * 2),
+          ii);
     }
+  }
 
-    mContext->updateAllFishData();
+  mContext->updateAllFishData();
 }
 
 void Aquarium::drawFishes()
 {
-    int begin = toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS))
-                    ? MODELNAME::MODELSMALLFISHAINSTANCEDDRAWS
-                    : MODELNAME::MODELSMALLFISHA;
-    int end = toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS))
-                  ? MODELNAME::MODELBIGFISHBINSTANCEDDRAWS
-                  : MODELNAME::MODELBIGFISHB;
+  int begin =
+      toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS))
+          ? MODELNAME::MODELSMALLFISHAINSTANCEDDRAWS
+          : MODELNAME::MODELSMALLFISHA;
+  int end = toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS))
+                ? MODELNAME::MODELBIGFISHBINSTANCEDDRAWS
+                : MODELNAME::MODELBIGFISHB;
 
-    for (int i = begin; i <= end; ++i)
-    {
-        FishModel *model = static_cast<FishModel *>(mAquariumModels[i]);
-        model->draw();
-    }
+  for (int i = begin; i <= end; ++i)
+  {
+    FishModel *model = static_cast<FishModel *>(mAquariumModels[i]);
+    model->draw();
+  }
 }
 
 void Aquarium::updateWorldProjections(const std::vector<float> &w)
 {
-    ASSERT(w.size() == 16);
-    memcpy(worldUniforms.world, w.data(), 16 * sizeof(float));
-    matrix::mulMatrixMatrix4(worldUniforms.worldViewProjection, worldUniforms.world,
-                             lightWorldPositionUniform.viewProjection);
-    matrix::inverse4(g.worldInverse, worldUniforms.world);
-    matrix::transpose4(worldUniforms.worldInverseTranspose, g.worldInverse);
+  ASSERT(w.size() == 16);
+  memcpy(worldUniforms.world, w.data(), 16 * sizeof(float));
+  matrix::mulMatrixMatrix4(worldUniforms.worldViewProjection,
+                           worldUniforms.world,
+                           lightWorldPositionUniform.viewProjection);
+  matrix::inverse4(g.worldInverse, worldUniforms.world);
+  matrix::transpose4(worldUniforms.worldInverseTranspose, g.worldInverse);
 }
 
 void Aquarium::updateWorldMatrixAndDraw(Model *model)
 {
-    if (model->worldmatrices.size())
+  if (model->worldmatrices.size())
+  {
+    for (auto &world : model->worldmatrices)
     {
-        for (auto &world : model->worldmatrices)
-        {
-            updateWorldProjections(world);
-            model->prepareForDraw();
-            model->updatePerInstanceUniforms(worldUniforms);
-            model->draw();
-        }
+      updateWorldProjections(world);
+      model->prepareForDraw();
+      model->updatePerInstanceUniforms(worldUniforms);
+      model->draw();
     }
+  }
 }
 
 void Aquarium::updateWorldMatrix(Model *model)
 {
-    if (model->worldmatrices.size())
+  if (model->worldmatrices.size())
+  {
+    for (auto &world : model->worldmatrices)
     {
-        for (auto &world : model->worldmatrices)
-        {
-            updateWorldProjections(world);
-            model->updatePerInstanceUniforms(worldUniforms);
-        }
+      updateWorldProjections(world);
+      model->updatePerInstanceUniforms(worldUniforms);
     }
+  }
 
-    model->prepareForDraw();
+  model->prepareForDraw();
 }

--- a/src/aquarium-optimized/Aquarium.h
+++ b/src/aquarium-optimized/Aquarium.h
@@ -3,7 +3,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 //
-// Aquarium.h: Define global variables, enums, constant variables and Class Aquarium.
+// Aquarium.h: Define global variables, enums, constant variables and Class
+// Aquarium.
 
 #ifndef AQUARIUM_H
 #define AQUARIUM_H
@@ -22,7 +23,8 @@ class Texture;
 class Program;
 class Model;
 
-#if defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
+#if defined(WIN32) || defined(_WIN32) || \
+    defined(__WIN32) && !defined(__CYGWIN__)
 #define M_PI 3.141592653589793
 #else
 #include "math.h"
@@ -30,118 +32,118 @@ class Model;
 
 enum BACKENDTYPE : short
 {
-    BACKENDTYPEANGLE,
-    BACKENDTYPEDAWND3D12,
-    BACKENDTYPEDAWNMETAL,
-    BACKENDTYPEDAWNVULKAN,
-    BACKENDTYPED3D12,
-    BACKENDTYPEOPENGL,
-    BACKENDTYPELAST
+  BACKENDTYPEANGLE,
+  BACKENDTYPEDAWND3D12,
+  BACKENDTYPEDAWNMETAL,
+  BACKENDTYPEDAWNVULKAN,
+  BACKENDTYPED3D12,
+  BACKENDTYPEOPENGL,
+  BACKENDTYPELAST
 };
 
 enum MODELNAME : short
 {
-    MODELFIRST,
-    MODELRUINCOlOMN,
-    MODELARCH,
-    MODELROCKA,
-    MODELROCKB,
-    MODELROCKC,
-    MODELSUNKNSHIPBOXES,
-    MODELSUNKNSHIPDECK,
-    MODELSUNKNSHIPHULL,
-    MODELFLOORBASE_BAKED,
-    MODELSUNKNSUB,
-    MODELCORAL,
-    MODELSTONE,
-    MODELCORALSTONEA,
-    MODELCORALSTONEB,
-    MODELGLOBEBASE,
-    MODELTREASURECHEST,
-    MODELENVIRONMENTBOX,
-    MODELSUPPORTBEAMS,
-    MODELSKYBOX,
-    MODELGLOBEINNER,
-    MODELSEAWEEDA,
-    MODELSEAWEEDB,
-    MODELSMALLFISHA,
-    MODELMEDIUMFISHA,
-    MODELMEDIUMFISHB,
-    MODELBIGFISHA,
-    MODELBIGFISHB,
-    MODELSMALLFISHAINSTANCEDDRAWS,
-    MODELMEDIUMFISHAINSTANCEDDRAWS,
-    MODELMEDIUMFISHBINSTANCEDDRAWS,
-    MODELBIGFISHAINSTANCEDDRAWS,
-    MODELBIGFISHBINSTANCEDDRAWS,
-    MODELMAX
+  MODELFIRST,
+  MODELRUINCOlOMN,
+  MODELARCH,
+  MODELROCKA,
+  MODELROCKB,
+  MODELROCKC,
+  MODELSUNKNSHIPBOXES,
+  MODELSUNKNSHIPDECK,
+  MODELSUNKNSHIPHULL,
+  MODELFLOORBASE_BAKED,
+  MODELSUNKNSUB,
+  MODELCORAL,
+  MODELSTONE,
+  MODELCORALSTONEA,
+  MODELCORALSTONEB,
+  MODELGLOBEBASE,
+  MODELTREASURECHEST,
+  MODELENVIRONMENTBOX,
+  MODELSUPPORTBEAMS,
+  MODELSKYBOX,
+  MODELGLOBEINNER,
+  MODELSEAWEEDA,
+  MODELSEAWEEDB,
+  MODELSMALLFISHA,
+  MODELMEDIUMFISHA,
+  MODELMEDIUMFISHB,
+  MODELBIGFISHA,
+  MODELBIGFISHB,
+  MODELSMALLFISHAINSTANCEDDRAWS,
+  MODELMEDIUMFISHAINSTANCEDDRAWS,
+  MODELMEDIUMFISHBINSTANCEDDRAWS,
+  MODELBIGFISHAINSTANCEDDRAWS,
+  MODELBIGFISHBINSTANCEDDRAWS,
+  MODELMAX
 };
 
 enum MODELGROUP : short
 {
-    FISH,
-    FISHINSTANCEDDRAW,
-    INNER,
-    SEAWEED,
-    GENERIC,
-    OUTSIDE,
-    GROUPMAX
+  FISH,
+  FISHINSTANCEDDRAW,
+  INNER,
+  SEAWEED,
+  GENERIC,
+  OUTSIDE,
+  GROUPMAX
 };
 
 struct G_sceneInfo
 {
-    const char *namestr;
-    MODELNAME name;
-    const char *program[2];
-    bool fog;
-    MODELGROUP type;
-    bool blend;
+  const char *namestr;
+  MODELNAME name;
+  const char *program[2];
+  bool fog;
+  MODELGROUP type;
+  bool blend;
 };
 
 enum FISHENUM : short
 {
-    BIG,
-    MEDIUM,
-    SMALL,
-    MAX
+  BIG,
+  MEDIUM,
+  SMALL,
+  MAX
 };
 
 enum TOGGLE : short
 {
-    // Stop rendering after specified time.
-    AUTOSTOP,
-    // Enable alpha blending.
-    ENABLEALPHABLENDING,
-    // Go through instanced draw.
-    ENABLEINSTANCEDDRAWS,
-    // The toggle is only supported on Dawn backend.
-    // By default, the app will enable dynamic buffer offset.
-    // The toggle is to disable dbo feature.
-    ENABLEDYNAMICBUFFEROFFSET,
-    // Turn off render pass on dawn_d3d12
-    DISABLED3D12RENDERPASS,
-    // Turn off dawn validation,
-    DISABLEDAWNVALIDATION,
-    // Disable control panel,
-    DISABLECONTROLPANEL,
-    // Select integrated gpu if available.
-    INTEGRATEDGPU,
-    // Select discrete gpu if available.
-    DISCRETEGPU,
-    // Update and draw for each model on OpenGL and Angle backend, but draw once per frame on other
-    // backend.
-    UPATEANDDRAWFOREACHMODEL,
-    // Support Full Screen mode
-    ENABLEFULLSCREENMODE,
-    // Print logs such as avg fps
-    PRINTLOG,
-    // Use async buffer mapping to upload data
-    BUFFERMAPPINGASYNC,
-    // Simulate fish come and go for Dawn backend
-    SIMULATINGFISHCOMEANDGO,
-    // Turn off vsync, donot limit fps to 60
-    TURNOFFVSYNC,
-    TOGGLEMAX
+  // Stop rendering after specified time.
+  AUTOSTOP,
+  // Enable alpha blending.
+  ENABLEALPHABLENDING,
+  // Go through instanced draw.
+  ENABLEINSTANCEDDRAWS,
+  // The toggle is only supported on Dawn backend.
+  // By default, the app will enable dynamic buffer offset.
+  // The toggle is to disable dbo feature.
+  ENABLEDYNAMICBUFFEROFFSET,
+  // Turn off render pass on dawn_d3d12
+  DISABLED3D12RENDERPASS,
+  // Turn off dawn validation,
+  DISABLEDAWNVALIDATION,
+  // Disable control panel,
+  DISABLECONTROLPANEL,
+  // Select integrated gpu if available.
+  INTEGRATEDGPU,
+  // Select discrete gpu if available.
+  DISCRETEGPU,
+  // Update and draw for each model on OpenGL and Angle backend, but draw once
+  // per frame on other backend.
+  UPATEANDDRAWFOREACHMODEL,
+  // Support Full Screen mode
+  ENABLEFULLSCREENMODE,
+  // Print logs such as avg fps
+  PRINTLOG,
+  // Use async buffer mapping to upload data
+  BUFFERMAPPINGASYNC,
+  // Simulate fish come and go for Dawn backend
+  SIMULATINGFISHCOMEANDGO,
+  // Turn off vsync, donot limit fps to 60
+  TURNOFFVSYNC,
+  TOGGLEMAX
 };
 
 const G_sceneInfo g_sceneInfo[] = {
@@ -197,14 +199,26 @@ const G_sceneInfo g_sceneInfo[] = {
      MODELGROUP::FISHINSTANCEDDRAW},
     {"Arch", MODELNAME::MODELARCH, {"", ""}, true, MODELGROUP::GENERIC},
     {"Coral", MODELNAME::MODELCORAL, {"", ""}, true, MODELGROUP::GENERIC},
-    {"CoralStoneA", MODELNAME::MODELCORALSTONEA, {"", ""}, true, MODELGROUP::GENERIC},
-    {"CoralStoneB", MODELNAME::MODELCORALSTONEB, {"", ""}, true, MODELGROUP::GENERIC},
+    {"CoralStoneA",
+     MODELNAME::MODELCORALSTONEA,
+     {"", ""},
+     true,
+     MODELGROUP::GENERIC},
+    {"CoralStoneB",
+     MODELNAME::MODELCORALSTONEB,
+     {"", ""},
+     true,
+     MODELGROUP::GENERIC},
     {"EnvironmentBox",
      MODELNAME::MODELENVIRONMENTBOX,
      {"diffuseVertexShader", "diffuseFragmentShader"},
      false,
      MODELGROUP::OUTSIDE},
-    {"FloorBase_Baked", MODELNAME::MODELFLOORBASE_BAKED, {"", ""}, true, MODELGROUP::GENERIC},
+    {"FloorBase_Baked",
+     MODELNAME::MODELFLOORBASE_BAKED,
+     {"", ""},
+     true,
+     MODELGROUP::GENERIC},
     {"GlobeBase",
      MODELNAME::MODELGLOBEBASE,
      {"diffuseVertexShader", "diffuseFragmentShader"},
@@ -218,11 +232,27 @@ const G_sceneInfo g_sceneInfo[] = {
     {"RockA", MODELNAME::MODELROCKA, {"", ""}, true, MODELGROUP::GENERIC},
     {"RockB", MODELNAME::MODELROCKB, {"", ""}, true, MODELGROUP::GENERIC},
     {"RockC", MODELNAME::MODELROCKC, {"", ""}, true, MODELGROUP::GENERIC},
-    {"RuinColumn", MODELNAME::MODELRUINCOlOMN, {"", ""}, true, MODELGROUP::GENERIC},
+    {"RuinColumn",
+     MODELNAME::MODELRUINCOlOMN,
+     {"", ""},
+     true,
+     MODELGROUP::GENERIC},
     {"Stone", MODELNAME::MODELSTONE, {"", ""}, true, MODELGROUP::GENERIC},
-    {"SunknShipBoxes", MODELNAME::MODELSUNKNSHIPBOXES, {"", ""}, true, MODELGROUP::GENERIC},
-    {"SunknShipDeck", MODELNAME::MODELSUNKNSHIPDECK, {"", ""}, true, MODELGROUP::GENERIC},
-    {"SunknShipHull", MODELNAME::MODELSUNKNSHIPHULL, {"", ""}, true, MODELGROUP::GENERIC},
+    {"SunknShipBoxes",
+     MODELNAME::MODELSUNKNSHIPBOXES,
+     {"", ""},
+     true,
+     MODELGROUP::GENERIC},
+    {"SunknShipDeck",
+     MODELNAME::MODELSUNKNSHIPDECK,
+     {"", ""},
+     true,
+     MODELGROUP::GENERIC},
+    {"SunknShipHull",
+     MODELNAME::MODELSUNKNSHIPHULL,
+     {"", ""},
+     true,
+     MODELGROUP::GENERIC},
     {"SunknSub", MODELNAME::MODELSUNKNSUB, {"", ""}, true, MODELGROUP::GENERIC},
     {"SeaweedA",
      MODELNAME::MODELSEAWEEDA,
@@ -239,72 +269,81 @@ const G_sceneInfo g_sceneInfo[] = {
      {"diffuseVertexShader", "diffuseFragmentShader"},
      false,
      MODELGROUP::OUTSIDE},
-    {"SupportBeams", MODELNAME::MODELSUPPORTBEAMS, {"", ""}, false, MODELGROUP::OUTSIDE},
-    {"TreasureChest", MODELNAME::MODELTREASURECHEST, {"", ""}, true, MODELGROUP::GENERIC}};
+    {"SupportBeams",
+     MODELNAME::MODELSUPPORTBEAMS,
+     {"", ""},
+     false,
+     MODELGROUP::OUTSIDE},
+    {"TreasureChest",
+     MODELNAME::MODELTREASURECHEST,
+     {"", ""},
+     true,
+     MODELGROUP::GENERIC}};
 
 struct Fish
 {
-    const char *name;
-    MODELNAME modelName;
-    FISHENUM type;
-    float speed;
-    float speedRange;
-    float radius;
-    float radiusRange;
-    float tailSpeed;
-    float heightOffset;
-    float heightRange;
+  const char *name;
+  MODELNAME modelName;
+  FISHENUM type;
+  float speed;
+  float speedRange;
+  float radius;
+  float radiusRange;
+  float tailSpeed;
+  float heightOffset;
+  float heightRange;
 
-    float fishLength;
-    float fishWaveLength;
-    float fishBendAmount;
+  float fishLength;
+  float fishWaveLength;
+  float fishBendAmount;
 
-    bool lasers;
-    float laserRot;
-    float laserOff[3];
-    float laserScale[3];
+  bool lasers;
+  float laserRot;
+  float laserOff[3];
+  float laserScale[3];
 };
 
-const Fish fishTable[] = {{"SmallFishA", MODELNAME::MODELSMALLFISHA, FISHENUM::SMALL, 1.0f, 1.5f,
-                           30.0f, 25.0f, 10.0f, 0.0f, 16.0f, 10.0f, 1.0f, 2.0f},
-                          {"MediumFishA", MODELNAME::MODELMEDIUMFISHA, FISHENUM::MEDIUM, 1.0f, 2.0f,
-                           10.0f, 20.0f, 1.0f, 0.0f, 16.0f, 10.0f, -2.0f, 2.0f},
-                          {"MediumFishB", MODELNAME::MODELMEDIUMFISHB, FISHENUM::MEDIUM, 0.5f, 4.0f,
-                           10.0f, 20.0f, 3.0f, -8.0f, 5.0f, 10.0f, -2.0f, 2.0f},
-                          {"BigFishA",
-                           MODELNAME::MODELBIGFISHA,
-                           FISHENUM::BIG,
-                           0.5f,
-                           0.5f,
-                           50.0f,
-                           3.0f,
-                           1.5f,
-                           0.0f,
-                           16.0f,
-                           10.0f,
-                           -1.0f,
-                           0.5f,
-                           true,
-                           0.04f,
-                           {0.0f, 0.1f, 9.0f},
-                           {0.3f, 0.3f, 1000.0f}},
-                          {"BigFishB",
-                           MODELNAME::MODELBIGFISHB,
-                           FISHENUM::BIG,
-                           0.5f,
-                           0.5f,
-                           45.0f,
-                           3.0f,
-                           1.0f,
-                           0.0f,
-                           16.0f,
-                           10.0f,
-                           -0.7f,
-                           0.3f,
-                           true,
-                           0.04f,
-                           {0.0f, -0.3f, 9.0f},
-                           {0.3f, 0.3f, 1000.0f}}};
+const Fish fishTable[] = {
+    {"SmallFishA", MODELNAME::MODELSMALLFISHA, FISHENUM::SMALL, 1.0f, 1.5f,
+     30.0f, 25.0f, 10.0f, 0.0f, 16.0f, 10.0f, 1.0f, 2.0f},
+    {"MediumFishA", MODELNAME::MODELMEDIUMFISHA, FISHENUM::MEDIUM, 1.0f, 2.0f,
+     10.0f, 20.0f, 1.0f, 0.0f, 16.0f, 10.0f, -2.0f, 2.0f},
+    {"MediumFishB", MODELNAME::MODELMEDIUMFISHB, FISHENUM::MEDIUM, 0.5f, 4.0f,
+     10.0f, 20.0f, 3.0f, -8.0f, 5.0f, 10.0f, -2.0f, 2.0f},
+    {"BigFishA",
+     MODELNAME::MODELBIGFISHA,
+     FISHENUM::BIG,
+     0.5f,
+     0.5f,
+     50.0f,
+     3.0f,
+     1.5f,
+     0.0f,
+     16.0f,
+     10.0f,
+     -1.0f,
+     0.5f,
+     true,
+     0.04f,
+     {0.0f, 0.1f, 9.0f},
+     {0.3f, 0.3f, 1000.0f}},
+    {"BigFishB",
+     MODELNAME::MODELBIGFISHB,
+     FISHENUM::BIG,
+     0.5f,
+     0.5f,
+     45.0f,
+     3.0f,
+     1.0f,
+     0.0f,
+     16.0f,
+     10.0f,
+     -0.7f,
+     0.3f,
+     true,
+     0.04f,
+     {0.0f, -0.3f, 9.0f},
+     {0.3f, 0.3f, 1000.0f}}};
 
 constexpr float g_tailOffsetMult      = 1.0f;
 constexpr float g_endOfDome           = static_cast<float>(M_PI / 8);
@@ -385,129 +424,130 @@ constexpr float g_fieldOfView     = 82.699f;
 
 struct Global
 {
-    float projection[16];
-    float view[16];
-    float worldInverse[16];
-    float viewProjectionInverse[16];
-    float skyView[16];
-    float skyViewProjection[16];
-    float skyViewProjectionInverse[16];
-    float eyePosition[3];
-    float target[3];
-    float up[3] = {0, 1, 0};
-    float v3t0[3];
-    float v3t1[3];
-    float m4t0[16];
-    float m4t1[16];
-    float m4t2[16];
-    float m4t3[16];
-    float colorMult[4] = {1, 1, 1, 1};
-    double then;
-    double start;
-    float mclock;
-    float eyeClock;
-    std::string alpha;
+  float projection[16];
+  float view[16];
+  float worldInverse[16];
+  float viewProjectionInverse[16];
+  float skyView[16];
+  float skyViewProjection[16];
+  float skyViewProjectionInverse[16];
+  float eyePosition[3];
+  float target[3];
+  float up[3] = {0, 1, 0};
+  float v3t0[3];
+  float v3t1[3];
+  float m4t0[16];
+  float m4t1[16];
+  float m4t2[16];
+  float m4t3[16];
+  float colorMult[4] = {1, 1, 1, 1};
+  double then;
+  double start;
+  float mclock;
+  float eyeClock;
+  std::string alpha;
 };
 
 struct LightWorldPositionUniform
 {
-    float lightWorldPos[3];
-    float padding;
-    float viewProjection[16];
-    float viewInverse[16];
+  float lightWorldPos[3];
+  float padding;
+  float viewProjection[16];
+  float viewInverse[16];
 };
 
 struct WorldUniforms
 {
-    float world[16];
-    float worldInverseTranspose[16];
-    float worldViewProjection[16];
+  float world[16];
+  float worldInverseTranspose[16];
+  float worldViewProjection[16];
 };
 
 struct LightUniforms
 {
-    float lightColor[4];
-    float specular[4];
-    float ambient[4];
+  float lightColor[4];
+  float specular[4];
+  float ambient[4];
 };
 
 struct FogUniforms
 {
-    float fogPower;
-    float fogMult;
-    float fogOffset;
-    float padding;
-    float fogColor[4];
+  float fogPower;
+  float fogMult;
+  float fogOffset;
+  float padding;
+  float fogColor[4];
 };
 
 struct FishPer
 {
-    float worldPosition[3];
-    float scale;
-    float nextPosition[3];
-    float time;
-    float padding[56];  // TODO(yizhou): the padding is to align with 256 byte offset.
+  float worldPosition[3];
+  float scale;
+  float nextPosition[3];
+  float time;
+  float padding[56];  // TODO(yizhou): the padding is to align with 256 byte
+                      // offset.
 };
 
 class Aquarium
 {
-  public:
-    Aquarium();
-    ~Aquarium();
-    bool init(int argc, char **argv);
-    void display();
-    Texture *getSkybox() { return mTextureMap["skybox"]; }
-    int getCurFishCount() const { return mCurFishCount; }
-    int getPreFishCount() const { return mPreFishCount; }
+public:
+  Aquarium();
+  ~Aquarium();
+  bool init(int argc, char **argv);
+  void display();
+  Texture *getSkybox() { return mTextureMap["skybox"]; }
+  int getCurFishCount() const { return mCurFishCount; }
+  int getPreFishCount() const { return mPreFishCount; }
 
-    std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> toggleBitset;
-    LightWorldPositionUniform lightWorldPositionUniform;
-    WorldUniforms worldUniforms;
-    LightUniforms lightUniforms;
-    FogUniforms fogUniforms;
-    Global g;
-    int fishCount[5];
+  std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> toggleBitset;
+  LightWorldPositionUniform lightWorldPositionUniform;
+  WorldUniforms worldUniforms;
+  LightUniforms lightUniforms;
+  FogUniforms fogUniforms;
+  Global g;
+  int fishCount[5];
 
-  private:
-    void render();
-    void loadReource();
-    void loadPlacement();
-    void loadModels();
-    void loadFishScenario();
-    void loadModel(const G_sceneInfo &info);
-    void setupModelEnumMap();
-    void calculateFishCount();
-    void updateWorldMatrixAndDraw(Model *model);
-    void updateGlobalUniforms();
+private:
+  void render();
+  void loadReource();
+  void loadPlacement();
+  void loadModels();
+  void loadFishScenario();
+  void loadModel(const G_sceneInfo &info);
+  void setupModelEnumMap();
+  void calculateFishCount();
+  void updateWorldMatrixAndDraw(Model *model);
+  void updateGlobalUniforms();
 
-    void updateWorldProjections(const std::vector<float> &w);
-    BACKENDTYPE getBackendType(const std::string &backendPath);
-    double getElapsedTime();
-    void printAvgFps();
-    void resetFpsTime();
-    void updateWorldMatrix(Model *model);
+  void updateWorldProjections(const std::vector<float> &w);
+  BACKENDTYPE getBackendType(const std::string &backendPath);
+  double getElapsedTime();
+  void printAvgFps();
+  void resetFpsTime();
+  void updateWorldMatrix(Model *model);
 
-    void updateAndDrawFishes();
-    void updateAndDrawBackground();
+  void updateAndDrawFishes();
+  void updateAndDrawBackground();
 
-    void updateBackground();
-    void drawBackground();
-    void updateFishes();
-    void drawFishes();
+  void updateBackground();
+  void drawBackground();
+  void updateFishes();
+  void drawFishes();
 
-    std::unordered_map<std::string, MODELNAME> mModelEnumMap;
-    std::unordered_map<std::string, Texture *> mTextureMap;
-    std::unordered_map<std::string, Program *> mProgramMap;
-    Model *mAquariumModels[MODELNAME::MODELMAX];
-    Context *mContext;
-    FPSTimer mFpsTimer;  // object to measure frames per second;
-    int mCurFishCount;
-    int mPreFishCount;
-    int mTestTime;
-    BACKENDTYPE mBackendType;
-    ContextFactory *mFactory;
-    std::vector<std::string> mSkyUrls;
-    std::queue<Behavior *> mFishBehavior;
+  std::unordered_map<std::string, MODELNAME> mModelEnumMap;
+  std::unordered_map<std::string, Texture *> mTextureMap;
+  std::unordered_map<std::string, Program *> mProgramMap;
+  Model *mAquariumModels[MODELNAME::MODELMAX];
+  Context *mContext;
+  FPSTimer mFpsTimer;  // object to measure frames per second;
+  int mCurFishCount;
+  int mPreFishCount;
+  int mTestTime;
+  BACKENDTYPE mBackendType;
+  ContextFactory *mFactory;
+  std::vector<std::string> mSkyUrls;
+  std::queue<Behavior *> mFishBehavior;
 };
 
 #endif  // AQUARIUM_H

--- a/src/aquarium-optimized/Behavior.h
+++ b/src/aquarium-optimized/Behavior.h
@@ -14,19 +14,22 @@ enum UNIFORMNAME : short;
 
 class Behavior
 {
-  public:
-    Behavior() {}
-    Behavior(int frame, std::string &op, int count) : mFrame(frame), mOp(op), mCount(count) {}
+public:
+  Behavior() {}
+  Behavior(int frame, std::string &op, int count)
+      : mFrame(frame), mOp(op), mCount(count)
+  {
+  }
 
-    int getFrame() const { return mFrame; }
-    const std::string &getOp() const { return mOp; }
-    int getCount() const { return mCount; }
-    void setFrame(int frame) { mFrame = frame; }
+  int getFrame() const { return mFrame; }
+  const std::string &getOp() const { return mOp; }
+  int getCount() const { return mCount; }
+  void setFrame(int frame) { mFrame = frame; }
 
-  private:
-    int mFrame;
-    std::string mOp;
-    int mCount;
+private:
+  int mFrame;
+  std::string mOp;
+  int mCount;
 };
 
 #endif  // BEHAVIOR_H

--- a/src/aquarium-optimized/Buffer.h
+++ b/src/aquarium-optimized/Buffer.h
@@ -12,11 +12,15 @@
 
 class Buffer
 {
-  public:
-    Buffer() {}
-    Buffer(int numComponents, int numElements, const std::vector<float> &buffer) {}
-    Buffer(int numComponents, int numElements, const std::vector<short> &buffer) {}
-    virtual ~Buffer() {}
+public:
+  Buffer() {}
+  Buffer(int numComponents, int numElements, const std::vector<float> &buffer)
+  {
+  }
+  Buffer(int numComponents, int numElements, const std::vector<short> &buffer)
+  {
+  }
+  virtual ~Buffer() {}
 };
 
 #endif  // BUFFER_H

--- a/src/aquarium-optimized/BufferManager.cpp
+++ b/src/aquarium-optimized/BufferManager.cpp
@@ -8,76 +8,79 @@
 
 #include "common/AQUARIUM_ASSERT.h"
 
-BufferManager::BufferManager() : mBufferPoolSize(BUFFER_POOL_MAX_SIZE), mUsedSize(0), mCount(0) {}
+BufferManager::BufferManager()
+    : mBufferPoolSize(BUFFER_POOL_MAX_SIZE), mUsedSize(0), mCount(0)
+{
+}
 
 BufferManager::~BufferManager()
 {
-    destroyBufferPool();
+  destroyBufferPool();
 }
 
 bool BufferManager::resetBuffer(RingBuffer *ringBuffer, size_t size)
 {
-    size_t index = find(ringBuffer);
+  size_t index = find(ringBuffer);
 
-    if (index >= mEnqueuedBufferList.size())
-    {
-        return false;
-    }
+  if (index >= mEnqueuedBufferList.size())
+  {
+    return false;
+  }
 
-    size_t oldSize = ringBuffer->getSize();
+  size_t oldSize = ringBuffer->getSize();
 
-    bool result = ringBuffer->reset(size);
-    // If the size is larger than the ring buffer size, reset fails and the ring
-    // buffer retains.
-    // If the size is equal or smaller than the ring buffer size, reset success
-    // and the used size need to be updated.
-    if (!result)
-    {
-        return false;
-    }
-    else
-    {
-        mUsedSize = mUsedSize - oldSize + size;
-    }
+  bool result = ringBuffer->reset(size);
+  // If the size is larger than the ring buffer size, reset fails and the ring
+  // buffer retains.
+  // If the size is equal or smaller than the ring buffer size, reset success
+  // and the used size need to be updated.
+  if (!result)
+  {
+    return false;
+  }
+  else
+  {
+    mUsedSize = mUsedSize - oldSize + size;
+  }
 
-    return true;
+  return true;
 }
 
 bool BufferManager::destoryBuffer(RingBuffer *ringBuffer)
 {
-    size_t index = find(ringBuffer);
+  size_t index = find(ringBuffer);
 
-    if (index >= mEnqueuedBufferList.size())
-    {
-        return false;
-    }
+  if (index >= mEnqueuedBufferList.size())
+  {
+    return false;
+  }
 
-    mUsedSize -= ringBuffer->getSize();
-    ringBuffer->destory();
-    mEnqueuedBufferList.erase(mEnqueuedBufferList.begin() + index);
+  mUsedSize -= ringBuffer->getSize();
+  ringBuffer->destory();
+  mEnqueuedBufferList.erase(mEnqueuedBufferList.begin() + index);
 
-    return true;
+  return true;
 }
 
 size_t BufferManager::find(RingBuffer *ringBuffer)
 {
-    size_t index = 0;
-    for (auto buffer : mEnqueuedBufferList)
+  size_t index = 0;
+  for (auto buffer : mEnqueuedBufferList)
+  {
+    if (buffer == ringBuffer)
     {
-        if (buffer == ringBuffer)
-        {
-            break;
-        }
-        index++;
+      break;
     }
-    return index;
+    index++;
+  }
+  return index;
 }
 
 // Flush copy commands in buffer pool
 void BufferManager::flush()
 {
-    for (auto buffer : mEnqueuedBufferList)
-    {
-        buffer->flush();
-    }
+  for (auto buffer : mEnqueuedBufferList)
+  {
+    buffer->flush();
+  }
 }

--- a/src/aquarium-optimized/BufferManager.h
+++ b/src/aquarium-optimized/BufferManager.h
@@ -14,57 +14,58 @@
 
 #include "Context.h"
 
-constexpr size_t BUFFER_POOL_MAX_SIZE     = 409600000;
-constexpr size_t BUFFER_MAX_COUNT         = 10;
-constexpr size_t BUFFER_PER_ALLOCATE_SIZE = BUFFER_POOL_MAX_SIZE / BUFFER_MAX_COUNT;
+constexpr size_t BUFFER_POOL_MAX_SIZE = 409600000;
+constexpr size_t BUFFER_MAX_COUNT     = 10;
+constexpr size_t BUFFER_PER_ALLOCATE_SIZE =
+    BUFFER_POOL_MAX_SIZE / BUFFER_MAX_COUNT;
 
 class RingBuffer
 {
-  public:
-    RingBuffer(size_t size) : mHead(0), mTail(size), mSize(size) {}
-    virtual ~RingBuffer() {}
+public:
+  RingBuffer(size_t size) : mHead(0), mTail(size), mSize(size) {}
+  virtual ~RingBuffer() {}
 
-    size_t getSize() const { return mSize; }
-    size_t getAvailableSize() const { return mSize - mTail; }
+  size_t getSize() const { return mSize; }
+  size_t getAvailableSize() const { return mSize - mTail; }
 
-    virtual bool reset(size_t size) { return false; }
-    virtual void flush() {}
-    virtual void destory() {}
-    virtual size_t allocate(size_t size)
-    {
-        return 0;
-    }  // allocate size in a RingBuffer, return offset of the buffer
+  virtual bool reset(size_t size) { return false; }
+  virtual void flush() {}
+  virtual void destory() {}
+  virtual size_t allocate(size_t size)
+  {
+    return 0;
+  }  // allocate size in a RingBuffer, return offset of the buffer
 
-  protected:
-    size_t mHead;
-    size_t mTail;
-    size_t mSize;
+protected:
+  size_t mHead;
+  size_t mTail;
+  size_t mSize;
 };
 
 class BufferManager
 {
-  public:
-    BufferManager();
-    virtual ~BufferManager();
+public:
+  BufferManager();
+  virtual ~BufferManager();
 
-    size_t GetSize() const { return mBufferPoolSize; }
-    bool resetBuffer(RingBuffer *ringBuffer, size_t size);
-    bool destoryBuffer(RingBuffer *ringBuffer);
-    virtual void destroyBufferPool() {}
-    virtual void flush();
+  size_t GetSize() const { return mBufferPoolSize; }
+  bool resetBuffer(RingBuffer *ringBuffer, size_t size);
+  bool destoryBuffer(RingBuffer *ringBuffer);
+  virtual void destroyBufferPool() {}
+  virtual void flush();
 
-    virtual RingBuffer *allocate(size_t size, size_t *offset) { return nullptr; }
+  virtual RingBuffer *allocate(size_t size, size_t *offset) { return nullptr; }
 
-    std::queue<RingBuffer *> mMappedBufferList;
+  std::queue<RingBuffer *> mMappedBufferList;
 
-  protected:
-    std::vector<RingBuffer *> mEnqueuedBufferList;
-    size_t mBufferPoolSize;
-    size_t mUsedSize;
-    size_t mCount;
+protected:
+  std::vector<RingBuffer *> mEnqueuedBufferList;
+  size_t mBufferPoolSize;
+  size_t mUsedSize;
+  size_t mCount;
 
-  private:
-    size_t find(RingBuffer *ringBuffer);
+private:
+  size_t find(RingBuffer *ringBuffer);
 };
 
 #endif  // BUFFERMANAGER_H

--- a/src/aquarium-optimized/Context.cpp
+++ b/src/aquarium-optimized/Context.cpp
@@ -14,157 +14,165 @@
 
 #include "Aquarium.h"
 
-void Context::renderImgui(const FPSTimer &fpsTimer,
-                          int *fishCount,
-                          std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> *toggleBitset)
+void Context::renderImgui(
+    const FPSTimer &fpsTimer,
+    int *fishCount,
+    std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> *toggleBitset)
 {
-    ImGui_ImplGlfw_NewFrame();
-    ImGui::NewFrame();
+  ImGui_ImplGlfw_NewFrame();
+  ImGui::NewFrame();
 
-    if (show_option_window)
+  if (show_option_window)
+  {
+    ImGui::SetNextWindowPos(ImVec2(500, 30), ImGuiCond_Appearing);
+    ImGui::SetNextWindowSize(ImVec2(300, 500), ImGuiCond_Appearing);
+
+    ImGuiWindowFlags window_flags = 0;
+    ImGui::Begin("Option Window", &show_option_window, window_flags);
+
+    ImGui::Text("Number of Fish");
+    static int selected  = -1;
+    int fishSelection[6] = {1, 10000, 20000, 30000, 50000, 100000};
+    char buf[6][32];
+    for (int n = 0; n < 6; n++)
     {
-        ImGui::SetNextWindowPos(ImVec2(500, 30), ImGuiCond_Appearing);
-        ImGui::SetNextWindowSize(ImVec2(300, 500), ImGuiCond_Appearing);
-
-        ImGuiWindowFlags window_flags = 0;
-        ImGui::Begin("Option Window", &show_option_window, window_flags);
-
-        ImGui::Text("Number of Fish");
-        static int selected  = -1;
-        int fishSelection[6] = {1, 10000, 20000, 30000, 50000, 100000};
-        char buf[6][32];
-        for (int n = 0; n < 6; n++)
-        {
-            sprintf(buf[n], "%d", fishSelection[n]);
-            if (ImGui::Selectable(buf[n], selected == n))
-            {
-                selected   = n;
-                *fishCount = fishSelection[selected];
-                memset(fishCountInputBuffer, 0, 64);
-            }
-        }
-
-        char *pNext;
-        ImGui::InputText("Specify fish count", fishCountInputBuffer, 64,
-                         ImGuiInputTextFlags_CharsDecimal);
-        int inputFishCount = strtol(fishCountInputBuffer, &pNext, 10);
-
-        if (inputFishCount != 0)
-        {
-            *fishCount = inputFishCount;
-        }
-
-        ImGui::End();
+      sprintf(buf[n], "%d", fishSelection[n]);
+      if (ImGui::Selectable(buf[n], selected == n))
+      {
+        selected   = n;
+        *fishCount = fishSelection[selected];
+        memset(fishCountInputBuffer, 0, 64);
+      }
     }
 
+    char *pNext;
+    ImGui::InputText("Specify fish count", fishCountInputBuffer, 64,
+                     ImGuiInputTextFlags_CharsDecimal);
+    int inputFishCount = strtol(fishCountInputBuffer, &pNext, 10);
+
+    if (inputFishCount != 0)
     {
-        ImGui::Begin("Aquarium");
-
-        std::string rendererInfo = mResourceHelper->getRendererInfo();
-        ImGui::Text(rendererInfo.c_str());
-
-        std::ostringstream resolutionStream;
-        resolutionStream << "Resolution " << mClientWidth << "x" << mClientHeight;
-        std::string resolution = resolutionStream.str();
-        ImGui::Text(resolution.c_str());
-
-        ImGui::PlotLines("[0,100 FPS]", fpsTimer.getHistoryFps(), NUM_HISTORY_DATA, 0, NULL, 0.0f,
-                         100.0f, ImVec2(0, 40));
-
-        ImGui::PlotHistogram("[0,100 ms/frame]", fpsTimer.getHistoryFrameTime(), NUM_HISTORY_DATA,
-                             0, NULL, 0.0f, 100.0f, ImVec2(0, 40));
-
-        ImGui::Text("Application average %.3f ms/frame (%.1f FPS)",
-                    1000.0f / fpsTimer.getAverageFPS(), fpsTimer.getAverageFPS());
-
-        if (mMSAASampleCount > 1)
-        {
-            ImGui::Text("MSAA: ON, Sample Count: %d", mMSAASampleCount);
-        }
-        else
-        {
-            ImGui::Text("MSAA: OFF");
-        }
-
-        if (toggleBitset->test(static_cast<size_t>(TOGGLE::ENABLEALPHABLENDING)))
-        {
-            ImGui::Text("ALPHABLENDING: ON");
-        }
-        else
-        {
-            ImGui::Text("ALPHABLENDING: OFF");
-        }
-
-        if (toggleBitset->test(static_cast<size_t>(TOGGLE::ENABLEDYNAMICBUFFEROFFSET)))
-        {
-            ImGui::Text("DBO: ON");
-        }
-        else
-        {
-            ImGui::Text("DBO: OFF");
-        }
-
-        if (toggleBitset->test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS)))
-        {
-            ImGui::Text("INSTANCEDDRAWS: ON");
-        }
-        else
-        {
-            ImGui::Text("INSTANCEDDRAWS: OFF");
-        }
-
-        if (mResourceHelper->getBackendType() == BACKENDTYPE::BACKENDTYPEDAWND3D12 ||
-            mResourceHelper->getBackendType() == BACKENDTYPE::BACKENDTYPED3D12)
-        {
-            if (toggleBitset->test(static_cast<size_t>(TOGGLE::DISABLED3D12RENDERPASS)))
-            {
-                ImGui::Text("RENDERPASS: OFF");
-            }
-            else
-            {
-                ImGui::Text("RENDERPASS: ON");
-            }
-        }
-
-        if (mResourceHelper->getBackendType() == BACKENDTYPE::BACKENDTYPEDAWND3D12 ||
-            mResourceHelper->getBackendType() == BACKENDTYPE::BACKENDTYPEDAWNVULKAN ||
-            mResourceHelper->getBackendType() == BACKENDTYPE::BACKENDTYPEDAWNMETAL)
-        {
-            if (toggleBitset->test(static_cast<size_t>(TOGGLE::DISABLEDAWNVALIDATION)))
-            {
-                ImGui::Text("VALIDATION: OFF");
-            }
-            else
-            {
-                ImGui::Text("VALIDATION: ON");
-            }
-
-            if (toggleBitset->test(static_cast<size_t>(TOGGLE::BUFFERMAPPINGASYNC)))
-            {
-                ImGui::Text("BUFFERMAPPINGASNC: ON");
-            }
-            else
-            {
-                ImGui::Text("BUFFERMAPPINGASNC: OFF");
-            }
-        }
-
-        ImGui::Checkbox("Option Window", &show_option_window);
-
-        ImGui::End();
+      *fishCount = inputFishCount;
     }
 
-    ImGui::Render();
+    ImGui::End();
+  }
+
+  {
+    ImGui::Begin("Aquarium");
+
+    std::string rendererInfo = mResourceHelper->getRendererInfo();
+    ImGui::Text(rendererInfo.c_str());
+
+    std::ostringstream resolutionStream;
+    resolutionStream << "Resolution " << mClientWidth << "x" << mClientHeight;
+    std::string resolution = resolutionStream.str();
+    ImGui::Text(resolution.c_str());
+
+    ImGui::PlotLines("[0,100 FPS]", fpsTimer.getHistoryFps(), NUM_HISTORY_DATA,
+                     0, NULL, 0.0f, 100.0f, ImVec2(0, 40));
+
+    ImGui::PlotHistogram("[0,100 ms/frame]", fpsTimer.getHistoryFrameTime(),
+                         NUM_HISTORY_DATA, 0, NULL, 0.0f, 100.0f,
+                         ImVec2(0, 40));
+
+    ImGui::Text("Application average %.3f ms/frame (%.1f FPS)",
+                1000.0f / fpsTimer.getAverageFPS(), fpsTimer.getAverageFPS());
+
+    if (mMSAASampleCount > 1)
+    {
+      ImGui::Text("MSAA: ON, Sample Count: %d", mMSAASampleCount);
+    }
+    else
+    {
+      ImGui::Text("MSAA: OFF");
+    }
+
+    if (toggleBitset->test(static_cast<size_t>(TOGGLE::ENABLEALPHABLENDING)))
+    {
+      ImGui::Text("ALPHABLENDING: ON");
+    }
+    else
+    {
+      ImGui::Text("ALPHABLENDING: OFF");
+    }
+
+    if (toggleBitset->test(
+            static_cast<size_t>(TOGGLE::ENABLEDYNAMICBUFFEROFFSET)))
+    {
+      ImGui::Text("DBO: ON");
+    }
+    else
+    {
+      ImGui::Text("DBO: OFF");
+    }
+
+    if (toggleBitset->test(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS)))
+    {
+      ImGui::Text("INSTANCEDDRAWS: ON");
+    }
+    else
+    {
+      ImGui::Text("INSTANCEDDRAWS: OFF");
+    }
+
+    if (mResourceHelper->getBackendType() ==
+            BACKENDTYPE::BACKENDTYPEDAWND3D12 ||
+        mResourceHelper->getBackendType() == BACKENDTYPE::BACKENDTYPED3D12)
+    {
+      if (toggleBitset->test(
+              static_cast<size_t>(TOGGLE::DISABLED3D12RENDERPASS)))
+      {
+        ImGui::Text("RENDERPASS: OFF");
+      }
+      else
+      {
+        ImGui::Text("RENDERPASS: ON");
+      }
+    }
+
+    if (mResourceHelper->getBackendType() ==
+            BACKENDTYPE::BACKENDTYPEDAWND3D12 ||
+        mResourceHelper->getBackendType() ==
+            BACKENDTYPE::BACKENDTYPEDAWNVULKAN ||
+        mResourceHelper->getBackendType() == BACKENDTYPE::BACKENDTYPEDAWNMETAL)
+    {
+      if (toggleBitset->test(
+              static_cast<size_t>(TOGGLE::DISABLEDAWNVALIDATION)))
+      {
+        ImGui::Text("VALIDATION: OFF");
+      }
+      else
+      {
+        ImGui::Text("VALIDATION: ON");
+      }
+
+      if (toggleBitset->test(static_cast<size_t>(TOGGLE::BUFFERMAPPINGASYNC)))
+      {
+        ImGui::Text("BUFFERMAPPINGASNC: ON");
+      }
+      else
+      {
+        ImGui::Text("BUFFERMAPPINGASNC: OFF");
+      }
+    }
+
+    ImGui::Checkbox("Option Window", &show_option_window);
+
+    ImGui::End();
+  }
+
+  ImGui::Render();
 }
 
 void Context::setWindowSize(int windowWidth, int windowHeight)
 {
-    if (windowWidth != 0)
-    {
-        mClientWidth = windowWidth;
-    }
-    if (windowHeight != 0)
-    {
-        mClientHeight = windowHeight;
-    }
+  if (windowWidth != 0)
+  {
+    mClientWidth = windowWidth;
+  }
+  if (windowHeight != 0)
+  {
+    mClientHeight = windowHeight;
+  }
 }

--- a/src/aquarium-optimized/Context.h
+++ b/src/aquarium-optimized/Context.h
@@ -32,80 +32,98 @@ static char fishCountInputBuffer[64];
 
 class Context
 {
-  public:
-    Context() : mDisableControlPanel(false), mMSAASampleCount(1), show_option_window(false) {}
-    virtual ~Context() {}
-    virtual bool initialize(BACKENDTYPE backend,
-                            const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset,
-                            int windowWidth,
-                            int windowHeight)                                                 = 0;
-    virtual Texture *createTexture(const std::string &name, const std::string &url)           = 0;
-    virtual Texture *createTexture(const std::string &name,
-                                   const std::vector<std::string> &urls)                      = 0;
-    virtual Buffer *createBuffer(int numComponents, std::vector<float> *buffer, bool isIndex) = 0;
-    virtual Buffer *createBuffer(int numComponents,
-                                 std::vector<unsigned short> *buffer,
-                                 bool isIndex)                                                = 0;
-    virtual Program *createProgram(const std::string &mVId, const std::string &mFId)          = 0;
-    virtual void setWindowTitle(const std::string &text)                                      = 0;
-    virtual bool ShouldQuit()                                                                 = 0;
-    virtual void KeyBoardQuit()                                                               = 0;
-    virtual void DoFlush(
-        const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset) = 0;
-    virtual void Terminate()                                                     = 0;
-    virtual void Flush() {}
+public:
+  Context()
+      : mDisableControlPanel(false),
+        mMSAASampleCount(1),
+        show_option_window(false)
+  {
+  }
+  virtual ~Context() {}
+  virtual bool initialize(
+      BACKENDTYPE backend,
+      const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset,
+      int windowWidth,
+      int windowHeight)                                                = 0;
+  virtual Texture *createTexture(const std::string &name,
+                                 const std::string &url)               = 0;
+  virtual Texture *createTexture(const std::string &name,
+                                 const std::vector<std::string> &urls) = 0;
+  virtual Buffer *createBuffer(int numComponents,
+                               std::vector<float> *buffer,
+                               bool isIndex)                           = 0;
+  virtual Buffer *createBuffer(int numComponents,
+                               std::vector<unsigned short> *buffer,
+                               bool isIndex)                           = 0;
+  virtual Program *createProgram(const std::string &mVId,
+                                 const std::string &mFId)              = 0;
+  virtual void setWindowTitle(const std::string &text)                 = 0;
+  virtual bool ShouldQuit()                                            = 0;
+  virtual void KeyBoardQuit()                                          = 0;
+  virtual void DoFlush(const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)>
+                           &toggleBitset)                              = 0;
+  virtual void Terminate()                                             = 0;
+  virtual void Flush() {}
 
-    virtual void preFrame()                                                                   = 0;
-    virtual void showWindow()                                                                 = 0;
-    virtual void updateFPS(const FPSTimer &fpsTimer,
-                           int *fishCount,
-                           std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> *toggleBitset) = 0;
-    virtual void showFPS() {}
-    virtual void destoryImgUI() = 0;
-    virtual void reallocResource(int preTotalInstance,
-                                 int curTotalInstance,
-                                 bool enableDynamicBufferOffset)
-    {
-    }
-    virtual void updateAllFishData() = 0;
-    virtual void beginRenderPass() {}
+  virtual void preFrame()   = 0;
+  virtual void showWindow() = 0;
+  virtual void updateFPS(
+      const FPSTimer &fpsTimer,
+      int *fishCount,
+      std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> *toggleBitset) = 0;
+  virtual void showFPS() {}
+  virtual void destoryImgUI() = 0;
+  virtual void reallocResource(int preTotalInstance,
+                               int curTotalInstance,
+                               bool enableDynamicBufferOffset)
+  {
+  }
+  virtual void updateAllFishData() = 0;
+  virtual void beginRenderPass() {}
 
-    int getClientWidth() const { return mClientWidth; }
-    int getclientHeight() const { return mClientHeight; }
-    std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> getAvailableToggleBitset()
-    {
-        return mAvailableToggleBitset;
-    }
+  int getClientWidth() const { return mClientWidth; }
+  int getclientHeight() const { return mClientHeight; }
+  std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> getAvailableToggleBitset()
+  {
+    return mAvailableToggleBitset;
+  }
 
-    virtual Model *createModel(Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend) = 0;
+  virtual Model *createModel(Aquarium *aquarium,
+                             MODELGROUP type,
+                             MODELNAME name,
+                             bool blend) = 0;
 
-    virtual void initGeneralResources(Aquarium *aquarium) {}
-    virtual void updateWorldlUniforms(Aquarium *aquarium) {}
+  virtual void initGeneralResources(Aquarium *aquarium) {}
+  virtual void updateWorldlUniforms(Aquarium *aquarium) {}
 
-    ResourceHelper *getResourceHelper() { return mResourceHelper; }
-    void setMSAASampleCount(int MSAASampleCount) { mMSAASampleCount = MSAASampleCount; }
+  ResourceHelper *getResourceHelper() { return mResourceHelper; }
+  void setMSAASampleCount(int MSAASampleCount)
+  {
+    mMSAASampleCount = MSAASampleCount;
+  }
 
-  protected:
-    void renderImgui(const FPSTimer &fpsTimer,
-                     int *fishCount,
-                     std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> *toggleBitset);
-    void setWindowSize(int windowWidth, int windowHeight);
+protected:
+  void renderImgui(
+      const FPSTimer &fpsTimer,
+      int *fishCount,
+      std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> *toggleBitset);
+  void setWindowSize(int windowWidth, int windowHeight);
 
-    int mClientWidth;
-    int mClientHeight;
-    int mPreTotalInstance;
-    int mCurTotalInstance;
+  int mClientWidth;
+  int mClientHeight;
+  int mPreTotalInstance;
+  int mCurTotalInstance;
 
-    ResourceHelper *mResourceHelper;
+  ResourceHelper *mResourceHelper;
 
-    std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> mAvailableToggleBitset;
-    virtual void initAvailableToggleBitset(BACKENDTYPE backendType) = 0;
+  std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> mAvailableToggleBitset;
+  virtual void initAvailableToggleBitset(BACKENDTYPE backendType) = 0;
 
-    bool mDisableControlPanel;
-    int mMSAASampleCount;
+  bool mDisableControlPanel;
+  int mMSAASampleCount;
 
-  private:
-    bool show_option_window;
+private:
+  bool show_option_window;
 };
 
 #endif  // CONTEXT_H

--- a/src/aquarium-optimized/ContextFactory.cpp
+++ b/src/aquarium-optimized/ContextFactory.cpp
@@ -19,40 +19,40 @@ ContextFactory::ContextFactory() : mContext(nullptr) {}
 
 ContextFactory::~ContextFactory()
 {
-    delete mContext;
+  delete mContext;
 }
 
 Context *ContextFactory::createContext(BACKENDTYPE backendType)
 {
-    switch (backendType)
-    {
-        case BACKENDTYPE::BACKENDTYPEOPENGL:
-        case BACKENDTYPE::BACKENDTYPEANGLE:
-        {
+  switch (backendType)
+  {
+  case BACKENDTYPE::BACKENDTYPEOPENGL:
+  case BACKENDTYPE::BACKENDTYPEANGLE:
+  {
 #if defined(ENABLE_OPENGL_BACKEND) || defined(ENABLE_ANGLE_BACKEND)
-            mContext = new ContextGL(backendType);
+    mContext = new ContextGL(backendType);
 #endif
-            break;
-        }
-        case BACKENDTYPE::BACKENDTYPEDAWND3D12:
-        case BACKENDTYPE::BACKENDTYPEDAWNMETAL:
-        case BACKENDTYPE::BACKENDTYPEDAWNVULKAN:
-        {
+    break;
+  }
+  case BACKENDTYPE::BACKENDTYPEDAWND3D12:
+  case BACKENDTYPE::BACKENDTYPEDAWNMETAL:
+  case BACKENDTYPE::BACKENDTYPEDAWNVULKAN:
+  {
 #if defined(ENABLE_DAWN_BACKEND)
-            mContext = new ContextDawn(backendType);
+    mContext = new ContextDawn(backendType);
 #endif
-            break;
-        }
-        case BACKENDTYPE::BACKENDTYPED3D12:
-        {
+    break;
+  }
+  case BACKENDTYPE::BACKENDTYPED3D12:
+  {
 #if defined(ENABLE_D3D12_BACKEND)
-            mContext = new ContextD3D12(backendType);
+    mContext = new ContextD3D12(backendType);
 #endif
-            break;
-        }
-        default:
-            break;
-    }
+    break;
+  }
+  default:
+    break;
+  }
 
-    return mContext;
+  return mContext;
 }

--- a/src/aquarium-optimized/ContextFactory.h
+++ b/src/aquarium-optimized/ContextFactory.h
@@ -12,13 +12,13 @@ enum BACKENDTYPE : short;
 
 class ContextFactory
 {
-  public:
-    ContextFactory();
-    ~ContextFactory();
-    Context *createContext(BACKENDTYPE backendType);
+public:
+  ContextFactory();
+  ~ContextFactory();
+  Context *createContext(BACKENDTYPE backendType);
 
-  private:
-    Context *mContext;
+private:
+  Context *mContext;
 };
 
 #endif  // CONTEXTFACTORY_H

--- a/src/aquarium-optimized/FishModel.cpp
+++ b/src/aquarium-optimized/FishModel.cpp
@@ -9,13 +9,15 @@
 
 void FishModel::prepareForDraw()
 {
-    mFishPerOffset = 0;
-    for (int i = 0; i < mName - MODELNAME::MODELSMALLFISHA; i++)
-    {
-        const Fish &fishInfo = fishTable[i];
-        mFishPerOffset += mAquarium->fishCount[fishInfo.modelName - MODELNAME::MODELSMALLFISHA];
-    }
+  mFishPerOffset = 0;
+  for (int i = 0; i < mName - MODELNAME::MODELSMALLFISHA; i++)
+  {
+    const Fish &fishInfo = fishTable[i];
+    mFishPerOffset +=
+        mAquarium->fishCount[fishInfo.modelName - MODELNAME::MODELSMALLFISHA];
+  }
 
-    const Fish &fishInfo = fishTable[mName - MODELNAME::MODELSMALLFISHA];
-    mCurInstance         = mAquarium->fishCount[fishInfo.modelName - MODELNAME::MODELSMALLFISHA];
+  const Fish &fishInfo = fishTable[mName - MODELNAME::MODELSMALLFISHA];
+  mCurInstance =
+      mAquarium->fishCount[fishInfo.modelName - MODELNAME::MODELSMALLFISHA];
 }

--- a/src/aquarium-optimized/FishModel.h
+++ b/src/aquarium-optimized/FishModel.h
@@ -12,33 +12,33 @@
 
 class FishModel : public Model
 {
-  public:
-    FishModel(MODELGROUP type, MODELNAME name, bool blend, Aquarium *aquarium)
-        : Model(type, name, blend),
-          mPreInstance(0),
-          mCurInstance(0),
-          mFishPerOffset(0),
-          mAquarium(aquarium)
-    {
-    }
+public:
+  FishModel(MODELGROUP type, MODELNAME name, bool blend, Aquarium *aquarium)
+      : Model(type, name, blend),
+        mPreInstance(0),
+        mCurInstance(0),
+        mFishPerOffset(0),
+        mAquarium(aquarium)
+  {
+  }
 
-    virtual void updateFishPerUniforms(float x,
-                                       float y,
-                                       float z,
-                                       float nextX,
-                                       float nextY,
-                                       float nextZ,
-                                       float scale,
-                                       float time,
-                                       int index) = 0;
-    void prepareForDraw();
+  virtual void updateFishPerUniforms(float x,
+                                     float y,
+                                     float z,
+                                     float nextX,
+                                     float nextY,
+                                     float nextZ,
+                                     float scale,
+                                     float time,
+                                     int index) = 0;
+  void prepareForDraw();
 
-  protected:
-    int mPreInstance;
-    int mCurInstance;
-    int mFishPerOffset;
+protected:
+  int mPreInstance;
+  int mCurInstance;
+  int mFishPerOffset;
 
-    Aquarium *mAquarium;
+  Aquarium *mAquarium;
 };
 
 #endif  // FISHMODEL_H

--- a/src/aquarium-optimized/Main.cpp
+++ b/src/aquarium-optimized/Main.cpp
@@ -9,13 +9,13 @@
 
 int main(int argc, char **argv)
 {
-    Aquarium aquarium;
-    if (!aquarium.init(argc, argv))
-    {
-        return -1;
-    }
+  Aquarium aquarium;
+  if (!aquarium.init(argc, argv))
+  {
+    return -1;
+  }
 
-    aquarium.display();
+  aquarium.display();
 
-    return 0;
+  return 0;
 }

--- a/src/aquarium-optimized/Matrix.h
+++ b/src/aquarium-optimized/Matrix.h
@@ -18,366 +18,370 @@ static long long RANDOM_RANGE_ = 4294967296;
 template <typename T>
 void mulMatrixMatrix4(T *dst, const T *a, const T *b)
 {
-    T a00   = a[0];
-    T a01   = a[1];
-    T a02   = a[2];
-    T a03   = a[3];
-    T a10   = a[4 + 0];
-    T a11   = a[4 + 1];
-    T a12   = a[4 + 2];
-    T a13   = a[4 + 3];
-    T a20   = a[8 + 0];
-    T a21   = a[8 + 1];
-    T a22   = a[8 + 2];
-    T a23   = a[8 + 3];
-    T a30   = a[12 + 0];
-    T a31   = a[12 + 1];
-    T a32   = a[12 + 2];
-    T a33   = a[12 + 3];
-    T b00   = b[0];
-    T b01   = b[1];
-    T b02   = b[2];
-    T b03   = b[3];
-    T b10   = b[4 + 0];
-    T b11   = b[4 + 1];
-    T b12   = b[4 + 2];
-    T b13   = b[4 + 3];
-    T b20   = b[8 + 0];
-    T b21   = b[8 + 1];
-    T b22   = b[8 + 2];
-    T b23   = b[8 + 3];
-    T b30   = b[12 + 0];
-    T b31   = b[12 + 1];
-    T b32   = b[12 + 2];
-    T b33   = b[12 + 3];
-    dst[0]  = a00 * b00 + a01 * b10 + a02 * b20 + a03 * b30;
-    dst[1]  = a00 * b01 + a01 * b11 + a02 * b21 + a03 * b31;
-    dst[2]  = a00 * b02 + a01 * b12 + a02 * b22 + a03 * b32;
-    dst[3]  = a00 * b03 + a01 * b13 + a02 * b23 + a03 * b33;
-    dst[4]  = a10 * b00 + a11 * b10 + a12 * b20 + a13 * b30;
-    dst[5]  = a10 * b01 + a11 * b11 + a12 * b21 + a13 * b31;
-    dst[6]  = a10 * b02 + a11 * b12 + a12 * b22 + a13 * b32;
-    dst[7]  = a10 * b03 + a11 * b13 + a12 * b23 + a13 * b33;
-    dst[8]  = a20 * b00 + a21 * b10 + a22 * b20 + a23 * b30;
-    dst[9]  = a20 * b01 + a21 * b11 + a22 * b21 + a23 * b31;
-    dst[10] = a20 * b02 + a21 * b12 + a22 * b22 + a23 * b32;
-    dst[11] = a20 * b03 + a21 * b13 + a22 * b23 + a23 * b33;
-    dst[12] = a30 * b00 + a31 * b10 + a32 * b20 + a33 * b30;
-    dst[13] = a30 * b01 + a31 * b11 + a32 * b21 + a33 * b31;
-    dst[14] = a30 * b02 + a31 * b12 + a32 * b22 + a33 * b32;
-    dst[15] = a30 * b03 + a31 * b13 + a32 * b23 + a33 * b33;
+  T a00   = a[0];
+  T a01   = a[1];
+  T a02   = a[2];
+  T a03   = a[3];
+  T a10   = a[4 + 0];
+  T a11   = a[4 + 1];
+  T a12   = a[4 + 2];
+  T a13   = a[4 + 3];
+  T a20   = a[8 + 0];
+  T a21   = a[8 + 1];
+  T a22   = a[8 + 2];
+  T a23   = a[8 + 3];
+  T a30   = a[12 + 0];
+  T a31   = a[12 + 1];
+  T a32   = a[12 + 2];
+  T a33   = a[12 + 3];
+  T b00   = b[0];
+  T b01   = b[1];
+  T b02   = b[2];
+  T b03   = b[3];
+  T b10   = b[4 + 0];
+  T b11   = b[4 + 1];
+  T b12   = b[4 + 2];
+  T b13   = b[4 + 3];
+  T b20   = b[8 + 0];
+  T b21   = b[8 + 1];
+  T b22   = b[8 + 2];
+  T b23   = b[8 + 3];
+  T b30   = b[12 + 0];
+  T b31   = b[12 + 1];
+  T b32   = b[12 + 2];
+  T b33   = b[12 + 3];
+  dst[0]  = a00 * b00 + a01 * b10 + a02 * b20 + a03 * b30;
+  dst[1]  = a00 * b01 + a01 * b11 + a02 * b21 + a03 * b31;
+  dst[2]  = a00 * b02 + a01 * b12 + a02 * b22 + a03 * b32;
+  dst[3]  = a00 * b03 + a01 * b13 + a02 * b23 + a03 * b33;
+  dst[4]  = a10 * b00 + a11 * b10 + a12 * b20 + a13 * b30;
+  dst[5]  = a10 * b01 + a11 * b11 + a12 * b21 + a13 * b31;
+  dst[6]  = a10 * b02 + a11 * b12 + a12 * b22 + a13 * b32;
+  dst[7]  = a10 * b03 + a11 * b13 + a12 * b23 + a13 * b33;
+  dst[8]  = a20 * b00 + a21 * b10 + a22 * b20 + a23 * b30;
+  dst[9]  = a20 * b01 + a21 * b11 + a22 * b21 + a23 * b31;
+  dst[10] = a20 * b02 + a21 * b12 + a22 * b22 + a23 * b32;
+  dst[11] = a20 * b03 + a21 * b13 + a22 * b23 + a23 * b33;
+  dst[12] = a30 * b00 + a31 * b10 + a32 * b20 + a33 * b30;
+  dst[13] = a30 * b01 + a31 * b11 + a32 * b21 + a33 * b31;
+  dst[14] = a30 * b02 + a31 * b12 + a32 * b22 + a33 * b32;
+  dst[15] = a30 * b03 + a31 * b13 + a32 * b23 + a33 * b33;
 }
 
 template <typename T>
 void inverse4(T *dst, const T *m)
 {
-    T m00    = m[0 * 4 + 0];
-    T m01    = m[0 * 4 + 1];
-    T m02    = m[0 * 4 + 2];
-    T m03    = m[0 * 4 + 3];
-    T m10    = m[1 * 4 + 0];
-    T m11    = m[1 * 4 + 1];
-    T m12    = m[1 * 4 + 2];
-    T m13    = m[1 * 4 + 3];
-    T m20    = m[2 * 4 + 0];
-    T m21    = m[2 * 4 + 1];
-    T m22    = m[2 * 4 + 2];
-    T m23    = m[2 * 4 + 3];
-    T m30    = m[3 * 4 + 0];
-    T m31    = m[3 * 4 + 1];
-    T m32    = m[3 * 4 + 2];
-    T m33    = m[3 * 4 + 3];
-    T tmp_0  = m22 * m33;
-    T tmp_1  = m32 * m23;
-    T tmp_2  = m12 * m33;
-    T tmp_3  = m32 * m13;
-    T tmp_4  = m12 * m23;
-    T tmp_5  = m22 * m13;
-    T tmp_6  = m02 * m33;
-    T tmp_7  = m32 * m03;
-    T tmp_8  = m02 * m23;
-    T tmp_9  = m22 * m03;
-    T tmp_10 = m02 * m13;
-    T tmp_11 = m12 * m03;
-    T tmp_12 = m20 * m31;
-    T tmp_13 = m30 * m21;
-    T tmp_14 = m10 * m31;
-    T tmp_15 = m30 * m11;
-    T tmp_16 = m10 * m21;
-    T tmp_17 = m20 * m11;
-    T tmp_18 = m00 * m31;
-    T tmp_19 = m30 * m01;
-    T tmp_20 = m00 * m21;
-    T tmp_21 = m20 * m01;
-    T tmp_22 = m00 * m11;
-    T tmp_23 = m10 * m01;
+  T m00    = m[0 * 4 + 0];
+  T m01    = m[0 * 4 + 1];
+  T m02    = m[0 * 4 + 2];
+  T m03    = m[0 * 4 + 3];
+  T m10    = m[1 * 4 + 0];
+  T m11    = m[1 * 4 + 1];
+  T m12    = m[1 * 4 + 2];
+  T m13    = m[1 * 4 + 3];
+  T m20    = m[2 * 4 + 0];
+  T m21    = m[2 * 4 + 1];
+  T m22    = m[2 * 4 + 2];
+  T m23    = m[2 * 4 + 3];
+  T m30    = m[3 * 4 + 0];
+  T m31    = m[3 * 4 + 1];
+  T m32    = m[3 * 4 + 2];
+  T m33    = m[3 * 4 + 3];
+  T tmp_0  = m22 * m33;
+  T tmp_1  = m32 * m23;
+  T tmp_2  = m12 * m33;
+  T tmp_3  = m32 * m13;
+  T tmp_4  = m12 * m23;
+  T tmp_5  = m22 * m13;
+  T tmp_6  = m02 * m33;
+  T tmp_7  = m32 * m03;
+  T tmp_8  = m02 * m23;
+  T tmp_9  = m22 * m03;
+  T tmp_10 = m02 * m13;
+  T tmp_11 = m12 * m03;
+  T tmp_12 = m20 * m31;
+  T tmp_13 = m30 * m21;
+  T tmp_14 = m10 * m31;
+  T tmp_15 = m30 * m11;
+  T tmp_16 = m10 * m21;
+  T tmp_17 = m20 * m11;
+  T tmp_18 = m00 * m31;
+  T tmp_19 = m30 * m01;
+  T tmp_20 = m00 * m21;
+  T tmp_21 = m20 * m01;
+  T tmp_22 = m00 * m11;
+  T tmp_23 = m10 * m01;
 
-    T t0 = (tmp_0 * m11 + tmp_3 * m21 + tmp_4 * m31) - (tmp_1 * m11 + tmp_2 * m21 + tmp_5 * m31);
-    T t1 = (tmp_1 * m01 + tmp_6 * m21 + tmp_9 * m31) - (tmp_0 * m01 + tmp_7 * m21 + tmp_8 * m31);
-    T t2 = (tmp_2 * m01 + tmp_7 * m11 + tmp_10 * m31) - (tmp_3 * m01 + tmp_6 * m11 + tmp_11 * m31);
-    T t3 = (tmp_5 * m01 + tmp_8 * m11 + tmp_11 * m21) - (tmp_4 * m01 + tmp_9 * m11 + tmp_10 * m21);
+  T t0 = (tmp_0 * m11 + tmp_3 * m21 + tmp_4 * m31) -
+         (tmp_1 * m11 + tmp_2 * m21 + tmp_5 * m31);
+  T t1 = (tmp_1 * m01 + tmp_6 * m21 + tmp_9 * m31) -
+         (tmp_0 * m01 + tmp_7 * m21 + tmp_8 * m31);
+  T t2 = (tmp_2 * m01 + tmp_7 * m11 + tmp_10 * m31) -
+         (tmp_3 * m01 + tmp_6 * m11 + tmp_11 * m31);
+  T t3 = (tmp_5 * m01 + tmp_8 * m11 + tmp_11 * m21) -
+         (tmp_4 * m01 + tmp_9 * m11 + tmp_10 * m21);
 
-    T d = static_cast<T>(1.0) / (m00 * t0 + m10 * t1 + m20 * t2 + m30 * t3);
+  T d = static_cast<T>(1.0) / (m00 * t0 + m10 * t1 + m20 * t2 + m30 * t3);
 
-    dst[0] = d * t0;
-    dst[1] = d * t1;
-    dst[2] = d * t2;
-    dst[3] = d * t3;
-    dst[4] =
-        d * ((tmp_1 * m10 + tmp_2 * m20 + tmp_5 * m30) - (tmp_0 * m10 + tmp_3 * m20 + tmp_4 * m30));
-    dst[5] =
-        d * ((tmp_0 * m00 + tmp_7 * m20 + tmp_8 * m30) - (tmp_1 * m00 + tmp_6 * m20 + tmp_9 * m30));
-    dst[6]  = d * ((tmp_3 * m00 + tmp_6 * m10 + tmp_11 * m30) -
-                  (tmp_2 * m00 + tmp_7 * m10 + tmp_10 * m30));
-    dst[7]  = d * ((tmp_4 * m00 + tmp_9 * m10 + tmp_10 * m20) -
-                  (tmp_5 * m00 + tmp_8 * m10 + tmp_11 * m20));
-    dst[8]  = d * ((tmp_12 * m13 + tmp_15 * m23 + tmp_16 * m33) -
-                  (tmp_13 * m13 + tmp_14 * m23 + tmp_17 * m33));
-    dst[9]  = d * ((tmp_13 * m03 + tmp_18 * m23 + tmp_21 * m33) -
-                  (tmp_12 * m03 + tmp_19 * m23 + tmp_20 * m33));
-    dst[10] = d * ((tmp_14 * m03 + tmp_19 * m13 + tmp_22 * m33) -
-                   (tmp_15 * m03 + tmp_18 * m13 + tmp_23 * m33));
-    dst[11] = d * ((tmp_17 * m03 + tmp_20 * m13 + tmp_23 * m23) -
-                   (tmp_16 * m03 + tmp_21 * m13 + tmp_22 * m23));
-    dst[12] = d * ((tmp_14 * m22 + tmp_17 * m32 + tmp_13 * m12) -
-                   (tmp_16 * m32 + tmp_12 * m12 + tmp_15 * m22));
-    dst[13] = d * ((tmp_20 * m32 + tmp_12 * m02 + tmp_19 * m22) -
-                   (tmp_18 * m22 + tmp_21 * m32 + tmp_13 * m02));
-    dst[14] = d * ((tmp_18 * m12 + tmp_23 * m32 + tmp_15 * m02) -
-                   (tmp_22 * m32 + tmp_14 * m02 + tmp_19 * m12));
-    dst[15] = d * ((tmp_22 * m22 + tmp_16 * m02 + tmp_21 * m12) -
-                   (tmp_20 * m12 + tmp_23 * m22 + tmp_17 * m02));
+  dst[0]  = d * t0;
+  dst[1]  = d * t1;
+  dst[2]  = d * t2;
+  dst[3]  = d * t3;
+  dst[4]  = d * ((tmp_1 * m10 + tmp_2 * m20 + tmp_5 * m30) -
+                (tmp_0 * m10 + tmp_3 * m20 + tmp_4 * m30));
+  dst[5]  = d * ((tmp_0 * m00 + tmp_7 * m20 + tmp_8 * m30) -
+                (tmp_1 * m00 + tmp_6 * m20 + tmp_9 * m30));
+  dst[6]  = d * ((tmp_3 * m00 + tmp_6 * m10 + tmp_11 * m30) -
+                (tmp_2 * m00 + tmp_7 * m10 + tmp_10 * m30));
+  dst[7]  = d * ((tmp_4 * m00 + tmp_9 * m10 + tmp_10 * m20) -
+                (tmp_5 * m00 + tmp_8 * m10 + tmp_11 * m20));
+  dst[8]  = d * ((tmp_12 * m13 + tmp_15 * m23 + tmp_16 * m33) -
+                (tmp_13 * m13 + tmp_14 * m23 + tmp_17 * m33));
+  dst[9]  = d * ((tmp_13 * m03 + tmp_18 * m23 + tmp_21 * m33) -
+                (tmp_12 * m03 + tmp_19 * m23 + tmp_20 * m33));
+  dst[10] = d * ((tmp_14 * m03 + tmp_19 * m13 + tmp_22 * m33) -
+                 (tmp_15 * m03 + tmp_18 * m13 + tmp_23 * m33));
+  dst[11] = d * ((tmp_17 * m03 + tmp_20 * m13 + tmp_23 * m23) -
+                 (tmp_16 * m03 + tmp_21 * m13 + tmp_22 * m23));
+  dst[12] = d * ((tmp_14 * m22 + tmp_17 * m32 + tmp_13 * m12) -
+                 (tmp_16 * m32 + tmp_12 * m12 + tmp_15 * m22));
+  dst[13] = d * ((tmp_20 * m32 + tmp_12 * m02 + tmp_19 * m22) -
+                 (tmp_18 * m22 + tmp_21 * m32 + tmp_13 * m02));
+  dst[14] = d * ((tmp_18 * m12 + tmp_23 * m32 + tmp_15 * m02) -
+                 (tmp_22 * m32 + tmp_14 * m02 + tmp_19 * m12));
+  dst[15] = d * ((tmp_22 * m22 + tmp_16 * m02 + tmp_21 * m12) -
+                 (tmp_20 * m12 + tmp_23 * m22 + tmp_17 * m02));
 }
 
 template <typename T>
 void transpose4(T *dst, const T *m)
 {
-    T m00 = m[0 * 4 + 0];
-    T m01 = m[0 * 4 + 1];
-    T m02 = m[0 * 4 + 2];
-    T m03 = m[0 * 4 + 3];
-    T m10 = m[1 * 4 + 0];
-    T m11 = m[1 * 4 + 1];
-    T m12 = m[1 * 4 + 2];
-    T m13 = m[1 * 4 + 3];
-    T m20 = m[2 * 4 + 0];
-    T m21 = m[2 * 4 + 1];
-    T m22 = m[2 * 4 + 2];
-    T m23 = m[2 * 4 + 3];
-    T m30 = m[3 * 4 + 0];
-    T m31 = m[3 * 4 + 1];
-    T m32 = m[3 * 4 + 2];
-    T m33 = m[3 * 4 + 3];
+  T m00 = m[0 * 4 + 0];
+  T m01 = m[0 * 4 + 1];
+  T m02 = m[0 * 4 + 2];
+  T m03 = m[0 * 4 + 3];
+  T m10 = m[1 * 4 + 0];
+  T m11 = m[1 * 4 + 1];
+  T m12 = m[1 * 4 + 2];
+  T m13 = m[1 * 4 + 3];
+  T m20 = m[2 * 4 + 0];
+  T m21 = m[2 * 4 + 1];
+  T m22 = m[2 * 4 + 2];
+  T m23 = m[2 * 4 + 3];
+  T m30 = m[3 * 4 + 0];
+  T m31 = m[3 * 4 + 1];
+  T m32 = m[3 * 4 + 2];
+  T m33 = m[3 * 4 + 3];
 
-    dst[0]  = m00;
-    dst[1]  = m10;
-    dst[2]  = m20;
-    dst[3]  = m30;
-    dst[4]  = m01;
-    dst[5]  = m11;
-    dst[6]  = m21;
-    dst[7]  = m31;
-    dst[8]  = m02;
-    dst[9]  = m12;
-    dst[10] = m22;
-    dst[11] = m32;
-    dst[12] = m03;
-    dst[13] = m13;
-    dst[14] = m23;
-    dst[15] = m33;
+  dst[0]  = m00;
+  dst[1]  = m10;
+  dst[2]  = m20;
+  dst[3]  = m30;
+  dst[4]  = m01;
+  dst[5]  = m11;
+  dst[6]  = m21;
+  dst[7]  = m31;
+  dst[8]  = m02;
+  dst[9]  = m12;
+  dst[10] = m22;
+  dst[11] = m32;
+  dst[12] = m03;
+  dst[13] = m13;
+  dst[14] = m23;
+  dst[15] = m33;
 }
 
 template <typename T>
 void frustum(T *dst, T left, T right, T bottom, T top, T near_, T far_)
 {
-    T dx = right - left;
-    T dy = top - bottom;
-    T dz = near_ - far_;
+  T dx = right - left;
+  T dy = top - bottom;
+  T dz = near_ - far_;
 
-    dst[0]  = 2 * near_ / dx;
-    dst[1]  = 0;
-    dst[2]  = 0;
-    dst[3]  = 0;
-    dst[4]  = 0;
-    dst[5]  = 2 * near_ / dy;
-    dst[6]  = 0;
-    dst[7]  = 0;
-    dst[8]  = (left + right) / dx;
-    dst[9]  = (top + bottom) / dy;
-    dst[10] = far_ / dz;
-    dst[11] = -1;
-    dst[12] = 0;
-    dst[13] = 0;
-    dst[14] = near_ * far_ / dz;
-    dst[15] = 0;
+  dst[0]  = 2 * near_ / dx;
+  dst[1]  = 0;
+  dst[2]  = 0;
+  dst[3]  = 0;
+  dst[4]  = 0;
+  dst[5]  = 2 * near_ / dy;
+  dst[6]  = 0;
+  dst[7]  = 0;
+  dst[8]  = (left + right) / dx;
+  dst[9]  = (top + bottom) / dy;
+  dst[10] = far_ / dz;
+  dst[11] = -1;
+  dst[12] = 0;
+  dst[13] = 0;
+  dst[14] = near_ * far_ / dz;
+  dst[15] = 0;
 }
 
 template <typename T>
 void getAxis(T *dst, const T *m, int axis)
 {
-    int off = axis * 4;
-    dst[0]  = m[off + 0];
-    dst[1]  = m[off + 1];
-    dst[2]  = m[off + 2];
+  int off = axis * 4;
+  dst[0]  = m[off + 0];
+  dst[1]  = m[off + 1];
+  dst[2]  = m[off + 2];
 }
 
 template <typename T>
 void mulScalarVector(T k, T *v, size_t length)
 {
-    for (size_t i = 0; i < length; ++i)
-    {
-        v[i] = v[i] * k;
-    }
+  for (size_t i = 0; i < length; ++i)
+  {
+    v[i] = v[i] * k;
+  }
 }
 
 template <typename T>
 void addVector(T *dst, const T *a, const T *b, size_t length)
 {
-    for (size_t i = 0; i < length; ++i)
-    {
-        dst[i] = a[i] + b[i];
-    }
+  for (size_t i = 0; i < length; ++i)
+  {
+    dst[i] = a[i] + b[i];
+  }
 }
 
 template <typename T>
 void normalize(T *dst, const T *a, size_t length)
 {
-    T n = 0.0;
+  T n = 0.0;
 
+  for (size_t i = 0; i < length; ++i)
+    n += a[i] * a[i];
+  n = sqrt(n);
+  if (n > 0.00001)
+  {
     for (size_t i = 0; i < length; ++i)
-        n += a[i] * a[i];
-    n = sqrt(n);
-    if (n > 0.00001)
-    {
-        for (size_t i = 0; i < length; ++i)
-            dst[i] = a[i] / n;
-    }
-    else
-    {
-        for (size_t i = 0; i < length; ++i)
-            dst[i] = 0;
-    }
+      dst[i] = a[i] / n;
+  }
+  else
+  {
+    for (size_t i = 0; i < length; ++i)
+      dst[i] = 0;
+  }
 }
 
 template <typename T>
 void subVector(T *dst, const T *a, const T *b, size_t length)
 {
 
-    for (size_t i = 0; i < length; ++i)
-    {
-        dst[i] = a[i] - b[i];
-    }
+  for (size_t i = 0; i < length; ++i)
+  {
+    dst[i] = a[i] - b[i];
+  }
 }
 
 template <typename T>
 void cross(T *dst, const T *a, const T *b)
 {
-    dst[0] = a[1] * b[2] - a[2] * b[1];
-    dst[1] = a[2] * b[0] - a[0] * b[2];
-    dst[2] = a[0] * b[1] - a[1] * b[0];
+  dst[0] = a[1] * b[2] - a[2] * b[1];
+  dst[1] = a[2] * b[0] - a[0] * b[2];
+  dst[2] = a[0] * b[1] - a[1] * b[0];
 }
 
 template <typename T>
 T dot(T *a, T *b)
 {
-    return (a[0] * b[0]) + (a[1] * b[1]) + (a[2] * b[2]);
+  return (a[0] * b[0]) + (a[1] * b[1]) + (a[2] * b[2]);
 }
 
 template <typename T>
 void cameraLookAt(T *dst, const T *eye, const T *target, const T *up)
 {
-    T t0[3];
-    T t1[3];
-    T t2[3];
-    subVector(t0, eye, target, 3);
-    normalize(t0, t0, 3);
-    cross(t1, up, t0);
-    normalize(t1, t1, 3);
-    cross(t2, t0, t1);
+  T t0[3];
+  T t1[3];
+  T t2[3];
+  subVector(t0, eye, target, 3);
+  normalize(t0, t0, 3);
+  cross(t1, up, t0);
+  normalize(t1, t1, 3);
+  cross(t2, t0, t1);
 
-    dst[0]  = t1[0];
-    dst[1]  = t1[1];
-    dst[2]  = t1[2];
-    dst[3]  = 0;
-    dst[4]  = t2[0];
-    dst[5]  = t2[1];
-    dst[6]  = t2[2];
-    dst[7]  = 0;
-    dst[8]  = t0[0];
-    dst[9]  = t0[1];
-    dst[10] = t0[2];
-    dst[11] = 0;
-    dst[12] = eye[0];
-    dst[13] = eye[1];
-    dst[14] = eye[2];
-    dst[15] = 1;
+  dst[0]  = t1[0];
+  dst[1]  = t1[1];
+  dst[2]  = t1[2];
+  dst[3]  = 0;
+  dst[4]  = t2[0];
+  dst[5]  = t2[1];
+  dst[6]  = t2[2];
+  dst[7]  = 0;
+  dst[8]  = t0[0];
+  dst[9]  = t0[1];
+  dst[10] = t0[2];
+  dst[11] = 0;
+  dst[12] = eye[0];
+  dst[13] = eye[1];
+  dst[14] = eye[2];
+  dst[15] = 1;
 }
 
 static long long randomSeed_;
 void resetPseudoRandom()
 {
-    randomSeed_ = 0;
+  randomSeed_ = 0;
 }
 
 static double pseudoRandom()
 {
-    randomSeed_ = (134775813 * randomSeed_ + 1) % RANDOM_RANGE_;
-    return static_cast<double>(randomSeed_) / static_cast<double>(RANDOM_RANGE_);
+  randomSeed_ = (134775813 * randomSeed_ + 1) % RANDOM_RANGE_;
+  return static_cast<double>(randomSeed_) / static_cast<double>(RANDOM_RANGE_);
 }
 
 template <typename T>
 void translation(T *dst, const T *v)
 {
-    dst[0]  = 1;
-    dst[1]  = 0;
-    dst[2]  = 0;
-    dst[3]  = 0;
-    dst[4]  = 0;
-    dst[5]  = 1;
-    dst[6]  = 0;
-    dst[7]  = 0;
-    dst[8]  = 0;
-    dst[9]  = 0;
-    dst[10] = 1;
-    dst[11] = 0;
-    dst[12] = v[0];
-    dst[13] = v[1];
-    dst[14] = v[2];
-    dst[15] = 1;
+  dst[0]  = 1;
+  dst[1]  = 0;
+  dst[2]  = 0;
+  dst[3]  = 0;
+  dst[4]  = 0;
+  dst[5]  = 1;
+  dst[6]  = 0;
+  dst[7]  = 0;
+  dst[8]  = 0;
+  dst[9]  = 0;
+  dst[10] = 1;
+  dst[11] = 0;
+  dst[12] = v[0];
+  dst[13] = v[1];
+  dst[14] = v[2];
+  dst[15] = 1;
 }
 
 template <typename T>
 void translate(float *m, const float *v)
 {
-    T v0  = v[0];
-    T v1  = v[1];
-    T v2  = v[2];
-    T m00 = m[0];
-    T m01 = m[1];
-    T m02 = m[2];
-    T m03 = m[3];
-    T m10 = m[1 * 4 + 0];
-    T m11 = m[1 * 4 + 1];
-    T m12 = m[1 * 4 + 2];
-    T m13 = m[1 * 4 + 3];
-    T m20 = m[2 * 4 + 0];
-    T m21 = m[2 * 4 + 1];
-    T m22 = m[2 * 4 + 2];
-    T m23 = m[2 * 4 + 3];
-    T m30 = m[3 * 4 + 0];
-    T m31 = m[3 * 4 + 1];
-    T m32 = m[3 * 4 + 2];
-    T m33 = m[3 * 4 + 3];
+  T v0  = v[0];
+  T v1  = v[1];
+  T v2  = v[2];
+  T m00 = m[0];
+  T m01 = m[1];
+  T m02 = m[2];
+  T m03 = m[3];
+  T m10 = m[1 * 4 + 0];
+  T m11 = m[1 * 4 + 1];
+  T m12 = m[1 * 4 + 2];
+  T m13 = m[1 * 4 + 3];
+  T m20 = m[2 * 4 + 0];
+  T m21 = m[2 * 4 + 1];
+  T m22 = m[2 * 4 + 2];
+  T m23 = m[2 * 4 + 3];
+  T m30 = m[3 * 4 + 0];
+  T m31 = m[3 * 4 + 1];
+  T m32 = m[3 * 4 + 2];
+  T m33 = m[3 * 4 + 3];
 
-    m[12] = m00 * v0 + m10 * v1 + m20 * v2 + m30;
-    m[13] = m01 * v0 + m11 * v1 + m21 * v2 + m31;
-    m[14] = m02 * v0 + m12 * v1 + m22 * v2 + m32;
-    m[15] = m03 * v0 + m13 * v1 + m23 * v2 + m33;
+  m[12] = m00 * v0 + m10 * v1 + m20 * v2 + m30;
+  m[13] = m01 * v0 + m11 * v1 + m21 * v2 + m31;
+  m[14] = m02 * v0 + m12 * v1 + m22 * v2 + m32;
+  m[15] = m03 * v0 + m13 * v1 + m23 * v2 + m33;
 }
 
 float degToRad(float degrees)
 {
-    return static_cast<float>(degrees * M_PI / 180.0);
+  return static_cast<float>(degrees * M_PI / 180.0);
 }
 }  // namespace matrix
 

--- a/src/aquarium-optimized/Model.cpp
+++ b/src/aquarium-optimized/Model.cpp
@@ -14,17 +14,17 @@ Model::Model() : mProgram(nullptr), mBlend(false), mName(MODELMAX) {}
 
 Model::~Model()
 {
-    for (auto &buf : bufferMap)
+  for (auto &buf : bufferMap)
+  {
+    if (buf.second != nullptr)
     {
-        if (buf.second != nullptr)
-        {
-            delete buf.second;
-            buf.second = nullptr;
-        }
+      delete buf.second;
+      buf.second = nullptr;
     }
+  }
 }
 
 void Model::setProgram(Program *prgm)
 {
-    mProgram = prgm;
+  mProgram = prgm;
 }

--- a/src/aquarium-optimized/Model.h
+++ b/src/aquarium-optimized/Model.h
@@ -27,28 +27,29 @@ struct WorldUniforms;
 
 class Model
 {
-  public:
-    Model();
-    Model(MODELGROUP type, MODELNAME name, bool blend)
-        : mProgram(nullptr), mBlend(blend), mName(name)
-    {
-    }
-    virtual ~Model();
-    virtual void prepareForDraw()                                              = 0;
-    virtual void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) = 0;
-    virtual void draw()                                                        = 0;
+public:
+  Model();
+  Model(MODELGROUP type, MODELNAME name, bool blend)
+      : mProgram(nullptr), mBlend(blend), mName(name)
+  {
+  }
+  virtual ~Model();
+  virtual void prepareForDraw() = 0;
+  virtual void updatePerInstanceUniforms(
+      const WorldUniforms &worldUniforms) = 0;
+  virtual void draw()                     = 0;
 
-    void setProgram(Program *program);
-    virtual void init() = 0;
+  void setProgram(Program *program);
+  virtual void init() = 0;
 
-    std::vector<std::vector<float>> worldmatrices;
-    std::unordered_map<std::string, Texture *> textureMap;
-    std::unordered_map<std::string, Buffer *> bufferMap;
+  std::vector<std::vector<float>> worldmatrices;
+  std::unordered_map<std::string, Texture *> textureMap;
+  std::unordered_map<std::string, Buffer *> bufferMap;
 
-  protected:
-    Program *mProgram;
-    bool mBlend;
-    MODELNAME mName;
+protected:
+  Program *mProgram;
+  bool mBlend;
+  MODELNAME mName;
 };
 
 #endif  // MODEL_H

--- a/src/aquarium-optimized/Program.cpp
+++ b/src/aquarium-optimized/Program.cpp
@@ -11,14 +11,16 @@
 
 void Program::loadProgram()
 {
-    std::ifstream VertexShaderStream(mVId, std::ios::in);
-    VertexShaderCode = std::string((std::istreambuf_iterator<char>(VertexShaderStream)),
-                                   std::istreambuf_iterator<char>());
-    VertexShaderStream.close();
+  std::ifstream VertexShaderStream(mVId, std::ios::in);
+  VertexShaderCode =
+      std::string((std::istreambuf_iterator<char>(VertexShaderStream)),
+                  std::istreambuf_iterator<char>());
+  VertexShaderStream.close();
 
-    // Read the Fragment Shader code from the file
-    std::ifstream FragmentShaderStream(mFId, std::ios::in);
-    FragmentShaderCode = std::string((std::istreambuf_iterator<char>(FragmentShaderStream)),
-                                     std::istreambuf_iterator<char>());
-    FragmentShaderStream.close();
+  // Read the Fragment Shader code from the file
+  std::ifstream FragmentShaderStream(mFId, std::ios::in);
+  FragmentShaderCode =
+      std::string((std::istreambuf_iterator<char>(FragmentShaderStream)),
+                  std::istreambuf_iterator<char>());
+  FragmentShaderStream.close();
 }

--- a/src/aquarium-optimized/Program.h
+++ b/src/aquarium-optimized/Program.h
@@ -14,24 +14,25 @@ enum UNIFORMNAME : short;
 
 class Program
 {
-  public:
-    Program() {}
-    Program(const std::string &mVertexShader, const std::string &fragmentShader)
-        : mVId(mVertexShader), mFId(fragmentShader)
-    {
-    }
-    virtual ~Program() {}
-    virtual void setProgram() {}
-    virtual void compileProgram(bool enableAlphaBlending, const std::string &alpha) = 0;
+public:
+  Program() {}
+  Program(const std::string &mVertexShader, const std::string &fragmentShader)
+      : mVId(mVertexShader), mFId(fragmentShader)
+  {
+  }
+  virtual ~Program() {}
+  virtual void setProgram() {}
+  virtual void compileProgram(bool enableAlphaBlending,
+                              const std::string &alpha) = 0;
 
-  protected:
-    void loadProgram();
+protected:
+  void loadProgram();
 
-    std::string mVId;
-    std::string mFId;
+  std::string mVId;
+  std::string mFId;
 
-    std::string VertexShaderCode;
-    std::string FragmentShaderCode;
+  std::string VertexShaderCode;
+  std::string FragmentShaderCode;
 };
 
 #endif  // PROGRAM_H

--- a/src/aquarium-optimized/ResourceHelper.cpp
+++ b/src/aquarium-optimized/ResourceHelper.cpp
@@ -25,129 +25,134 @@ static const char *shaderFolder   = "shaders";
 static const char *resourceFolder = "assets";
 
 const std::vector<std::string> skyBoxUrls = {
-    "GlobeOuter_EM_positive_x.jpg", "GlobeOuter_EM_negative_x.jpg", "GlobeOuter_EM_positive_y.jpg",
-    "GlobeOuter_EM_negative_y.jpg", "GlobeOuter_EM_positive_z.jpg", "GlobeOuter_EM_negative_z.jpg"};
+    "GlobeOuter_EM_positive_x.jpg", "GlobeOuter_EM_negative_x.jpg",
+    "GlobeOuter_EM_positive_y.jpg", "GlobeOuter_EM_negative_y.jpg",
+    "GlobeOuter_EM_positive_z.jpg", "GlobeOuter_EM_negative_z.jpg"};
 
 ResourceHelper::ResourceHelper(const std::string &mBackendName,
                                const std::string &mShaderVersion,
                                BACKENDTYPE backendType)
-    : mBackendName(mBackendName), mBackendType(backendType), mShaderVersion(mShaderVersion)
+    : mBackendName(mBackendName),
+      mBackendType(backendType),
+      mShaderVersion(mShaderVersion)
 {
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32)
-    TCHAR temp[200];
-    GetModuleFileName(nullptr, temp, MAX_PATH);
-    std::wstring ws(temp);
-    mPath = std::string(ws.begin(), ws.end());
+  TCHAR temp[200];
+  GetModuleFileName(nullptr, temp, MAX_PATH);
+  std::wstring ws(temp);
+  mPath = std::string(ws.begin(), ws.end());
 #elif __APPLE__
-    char temp[200];
-    uint32_t size = sizeof(temp);
-    _NSGetExecutablePath(temp, &size);
-    mPath = std::string(temp);
+  char temp[200];
+  uint32_t size = sizeof(temp);
+  _NSGetExecutablePath(temp, &size);
+  mPath = std::string(temp);
 #else
-    char temp[200];
-    readlink("/proc/self/exe", temp, sizeof(temp));
-    mPath = std::string(temp);
+  char temp[200];
+  readlink("/proc/self/exe", temp, sizeof(temp));
+  mPath = std::string(temp);
 #endif
 
-    size_t nPos = mPath.find_last_of(slash);
-    std::ostringstream pathStream;
-    pathStream << mPath.substr(0, nPos) << slash << ".." << slash << ".." << slash;
-    mPath = pathStream.str();
+  size_t nPos = mPath.find_last_of(slash);
+  std::ostringstream pathStream;
+  pathStream << mPath.substr(0, nPos) << slash << ".." << slash << ".."
+             << slash;
+  mPath = pathStream.str();
 
-    std::ostringstream placementStream;
-    placementStream << mPath << resourceFolder << slash << "PropPlacement.js";
-    mPropPlacementPath = placementStream.str();
+  std::ostringstream placementStream;
+  placementStream << mPath << resourceFolder << slash << "PropPlacement.js";
+  mPropPlacementPath = placementStream.str();
 
-    std::ostringstream imageStream;
-    imageStream << mPath << resourceFolder << slash;
-    mImagePath = imageStream.str();
+  std::ostringstream imageStream;
+  imageStream << mPath << resourceFolder << slash;
+  mImagePath = imageStream.str();
 
-    std::ostringstream programStream;
-    programStream << mPath << shaderFolder << slash << mBackendName << slash << mShaderVersion
-                  << slash;
-    mProgramPath = programStream.str();
+  std::ostringstream programStream;
+  programStream << mPath << shaderFolder << slash << mBackendName << slash
+                << mShaderVersion << slash;
+  mProgramPath = programStream.str();
 
-    std::ostringstream fishBehaviorStream;
-    fishBehaviorStream << mPath << "FishBehavior.json";
-    mFishBehaviorPath = fishBehaviorStream.str();
+  std::ostringstream fishBehaviorStream;
+  fishBehaviorStream << mPath << "FishBehavior.json";
+  mFishBehaviorPath = fishBehaviorStream.str();
 
-    switch (mBackendType)
-    {
-        case BACKENDTYPE::BACKENDTYPEDAWND3D12:
-        {
-            mBackendTypeStr = "Dawn D3D12";
-            break;
-        }
-        case BACKENDTYPE::BACKENDTYPEDAWNVULKAN:
-        {
-            mBackendTypeStr = "Dawn Vulkan";
-            break;
-        }
-        case BACKENDTYPE::BACKENDTYPEDAWNMETAL:
-        {
-            mBackendTypeStr = "Dawn Metal";
-            break;
-        }
-        case BACKENDTYPE::BACKENDTYPEANGLE:
-        {
-            mBackendTypeStr = "ANGLE";
-            break;
-        }
-        case BACKENDTYPE::BACKENDTYPEOPENGL:
-        {
-            mBackendTypeStr = "OPENGL";
-            break;
-        }
-        case BACKENDTYPE::BACKENDTYPED3D12:
-        {
-            mBackendTypeStr = "D3D12";
-            break;
-        }
-        default:
-        {
-            std::cerr << "Backend type can not reached." << std::endl;
-        }
-    }
+  switch (mBackendType)
+  {
+  case BACKENDTYPE::BACKENDTYPEDAWND3D12:
+  {
+    mBackendTypeStr = "Dawn D3D12";
+    break;
+  }
+  case BACKENDTYPE::BACKENDTYPEDAWNVULKAN:
+  {
+    mBackendTypeStr = "Dawn Vulkan";
+    break;
+  }
+  case BACKENDTYPE::BACKENDTYPEDAWNMETAL:
+  {
+    mBackendTypeStr = "Dawn Metal";
+    break;
+  }
+  case BACKENDTYPE::BACKENDTYPEANGLE:
+  {
+    mBackendTypeStr = "ANGLE";
+    break;
+  }
+  case BACKENDTYPE::BACKENDTYPEOPENGL:
+  {
+    mBackendTypeStr = "OPENGL";
+    break;
+  }
+  case BACKENDTYPE::BACKENDTYPED3D12:
+  {
+    mBackendTypeStr = "D3D12";
+    break;
+  }
+  default:
+  {
+    std::cerr << "Backend type can not reached." << std::endl;
+  }
+  }
 }
 
 void ResourceHelper::getSkyBoxUrls(std::vector<std::string> *skyUrls) const
 {
-    for (auto &str : skyBoxUrls)
-    {
-        std::ostringstream url;
-        url << mPath << resourceFolder << slash << str;
+  for (auto &str : skyBoxUrls)
+  {
+    std::ostringstream url;
+    url << mPath << resourceFolder << slash << str;
 
-        skyUrls->emplace_back(url.str());
-    }
+    skyUrls->emplace_back(url.str());
+  }
 }
 
 std::string ResourceHelper::getModelPath(const std::string &modelName) const
 {
-    std::ostringstream modelStream;
-    modelStream << mImagePath << modelName << ".js";
-    return modelStream.str();
+  std::ostringstream modelStream;
+  modelStream << mImagePath << modelName << ".js";
+  return modelStream.str();
 }
 
 const std::string &ResourceHelper::getProgramPath() const
 {
-    return mProgramPath;
+  return mProgramPath;
 }
 
 const std::string &ResourceHelper::getRendererInfo() const
 {
-    return mRendererInfo;
+  return mRendererInfo;
 }
 
 void ResourceHelper::setRenderer(const std::string &renderer)
 {
-    mRenderer = renderer;
+  mRenderer = renderer;
 
-    std::ostringstream rendererInfoStream;
+  std::ostringstream rendererInfoStream;
 #ifdef EGL_EGL_PROTOTYPES
-    rendererInfoStream << mRenderer;
+  rendererInfoStream << mRenderer;
 #else
-    rendererInfoStream << mRenderer << " " << mBackendTypeStr << " " << mShaderVersion;
+  rendererInfoStream << mRenderer << " " << mBackendTypeStr << " "
+                     << mShaderVersion;
 #endif
 
-    mRendererInfo = rendererInfoStream.str();
+  mRendererInfo = rendererInfoStream.str();
 }

--- a/src/aquarium-optimized/ResourceHelper.h
+++ b/src/aquarium-optimized/ResourceHelper.h
@@ -14,39 +14,39 @@
 
 class ResourceHelper
 {
-  public:
-    ResourceHelper() {}
-    ResourceHelper(const std::string &mBackendName,
-                   const std::string &mShaderVersion,
-                   BACKENDTYPE backendType);
-    void getSkyBoxUrls(std::vector<std::string> *skyUrls) const;
-    const std::string &getPropPlacementPath() const { return mPropPlacementPath; }
-    const std::string &getImagePath() const { return mImagePath; }
-    std::string getModelPath(const std::string &modelName) const;
-    const std::string &getProgramPath() const;
-    const std::string &getFishBehaviorPath() const { return mFishBehaviorPath; }
-    const std::string &getBackendName() const { return mBackendName; }
-    BACKENDTYPE getBackendType() const { return mBackendType; }
-    const std::string &getShaderVersion() const { return mShaderVersion; }
-    const std::string &getRendererInfo() const;
-    void setRenderer(const std::string &renderer);
+public:
+  ResourceHelper() {}
+  ResourceHelper(const std::string &mBackendName,
+                 const std::string &mShaderVersion,
+                 BACKENDTYPE backendType);
+  void getSkyBoxUrls(std::vector<std::string> *skyUrls) const;
+  const std::string &getPropPlacementPath() const { return mPropPlacementPath; }
+  const std::string &getImagePath() const { return mImagePath; }
+  std::string getModelPath(const std::string &modelName) const;
+  const std::string &getProgramPath() const;
+  const std::string &getFishBehaviorPath() const { return mFishBehaviorPath; }
+  const std::string &getBackendName() const { return mBackendName; }
+  BACKENDTYPE getBackendType() const { return mBackendType; }
+  const std::string &getShaderVersion() const { return mShaderVersion; }
+  const std::string &getRendererInfo() const;
+  void setRenderer(const std::string &renderer);
 
-  private:
-    std::string mPath;
-    std::string mImagePath;
-    std::string mProgramPath;
-    std::string mPropPlacementPath;
-    std::string mModelPath;
-    std::string mFishBehaviorPath;
+private:
+  std::string mPath;
+  std::string mImagePath;
+  std::string mProgramPath;
+  std::string mPropPlacementPath;
+  std::string mModelPath;
+  std::string mFishBehaviorPath;
 
-    std::string mBackendName;
-    BACKENDTYPE mBackendType;
-    std::string mBackendTypeStr;
+  std::string mBackendName;
+  BACKENDTYPE mBackendType;
+  std::string mBackendTypeStr;
 
-    std::string mShaderVersion;
+  std::string mShaderVersion;
 
-    std::string mRenderer;
-    std::string mRendererInfo;
+  std::string mRenderer;
+  std::string mRendererInfo;
 };
 
 #endif  // RESOURCEHELPER_H

--- a/src/aquarium-optimized/SeaweedModel.h
+++ b/src/aquarium-optimized/SeaweedModel.h
@@ -12,10 +12,13 @@
 
 class SeaweedModel : public Model
 {
-  public:
-    SeaweedModel(MODELGROUP type, MODELNAME name, bool blend) : Model(type, name, blend) {}
+public:
+  SeaweedModel(MODELGROUP type, MODELNAME name, bool blend)
+      : Model(type, name, blend)
+  {
+  }
 
-    virtual void updateSeaweedModelTime(float time) = 0;
+  virtual void updateSeaweedModelTime(float time) = 0;
 };
 
 #endif  // SEAWEEDMODEL_H

--- a/src/aquarium-optimized/Texture.cpp
+++ b/src/aquarium-optimized/Texture.cpp
@@ -21,42 +21,45 @@
 Texture::Texture(const std::string &name, const std::string &url, bool flip)
     : mUrls(), mWidth(0), mHeight(0), mFlip(flip), mName(name)
 {
-    std::string urlpath = url;
-    mUrls.push_back(urlpath);
+  std::string urlpath = url;
+  mUrls.push_back(urlpath);
 }
 
-// Force loading 3 channel images to 4 channel by stb becasue Dawn doesn't support 3 channel
-// formats currently. The group is discussing on whether webgpu shoud support 3 channel format.
+// Force loading 3 channel images to 4 channel by stb becasue Dawn doesn't
+// support 3 channel formats currently. The group is discussing on whether
+// webgpu shoud support 3 channel format.
 // https://github.com/gpuweb/gpuweb/issues/66#issuecomment-410021505
-bool Texture::loadImage(const std::vector<std::string> &urls, std::vector<uint8_t *> *pixels)
+bool Texture::loadImage(const std::vector<std::string> &urls,
+                        std::vector<uint8_t *> *pixels)
 {
-    stbi_set_flip_vertically_on_load(mFlip);
-    for (auto filename : urls)
+  stbi_set_flip_vertically_on_load(mFlip);
+  for (auto filename : urls)
+  {
+    uint8_t *pixel = stbi_load(filename.c_str(), &mWidth, &mHeight, 0, 4);
+    if (pixel == 0)
     {
-        uint8_t *pixel = stbi_load(filename.c_str(), &mWidth, &mHeight, 0, 4);
-        if (pixel == 0)
-        {
-            std::cout << stderr << "Couldn't open input file" << filename << std::endl;
-            return false;
-        }
-        pixels->push_back(pixel);
+      std::cout << stderr << "Couldn't open input file" << filename
+                << std::endl;
+      return false;
     }
-    return true;
+    pixels->push_back(pixel);
+  }
+  return true;
 }
 
 bool Texture::isPowerOf2(int value)
 {
-    return (value & (value - 1)) == 0;
+  return (value & (value - 1)) == 0;
 }
 
 // Free image data after upload to gpu
 void Texture::DestoryImageData(std::vector<uint8_t *> &pixelVec)
 {
-    for (auto &pixels : pixelVec)
-    {
-        free(pixels);
-        pixels = nullptr;
-    }
+  for (auto &pixels : pixelVec)
+  {
+    free(pixels);
+    pixels = nullptr;
+  }
 }
 
 void Texture::copyPaddingBuffer(unsigned char *dst,
@@ -65,14 +68,14 @@ void Texture::copyPaddingBuffer(unsigned char *dst,
                                 int height,
                                 int kPadding)
 {
-    unsigned char *s = src;
-    unsigned char *d = dst;
-    for (int i = 0; i < height; ++i)
-    {
-        memcpy(d, s, width * 4);
-        s += width * 4;
-        d += kPadding * 4;
-    }
+  unsigned char *s = src;
+  unsigned char *d = dst;
+  for (int i = 0; i < height; ++i)
+  {
+    memcpy(d, s, width * 4);
+    s += width * 4;
+    d += kPadding * 4;
+  }
 }
 
 void Texture::generateMipmap(uint8_t *input_pixels,
@@ -86,46 +89,51 @@ void Texture::generateMipmap(uint8_t *input_pixels,
                              int num_channels,
                              bool is256padding)
 {
-    int mipmapLevel = static_cast<uint32_t>(floor(log2(std::max(output_w, output_h)))) + 1;
-    output_pixels.resize(mipmapLevel);
-    int height = output_h;
-    int width  = output_w;
+  int mipmapLevel =
+      static_cast<uint32_t>(floor(log2(std::max(output_w, output_h)))) + 1;
+  output_pixels.resize(mipmapLevel);
+  int height = output_h;
+  int width  = output_w;
 
-    if (!is256padding)
+  if (!is256padding)
+  {
+    for (int i = 0; i < mipmapLevel; ++i)
     {
-        for (int i = 0; i < mipmapLevel; ++i)
-        {
-            output_pixels[i] = (unsigned char *)malloc(output_w * height * 4 * sizeof(char));
-            stbir_resize_uint8(input_pixels, input_w, input_h, input_stride_in_bytes,
-                               output_pixels[i], width, height, output_stride_in_bytes,
-                               num_channels);
+      output_pixels[i] =
+          (unsigned char *)malloc(output_w * height * 4 * sizeof(char));
+      stbir_resize_uint8(input_pixels, input_w, input_h, input_stride_in_bytes,
+                         output_pixels[i], width, height,
+                         output_stride_in_bytes, num_channels);
 
-            height >>= 1;
-            width >>= 1;
-            if (height == 0)
-            {
-                height = 1;
-            }
-        }
+      height >>= 1;
+      width >>= 1;
+      if (height == 0)
+      {
+        height = 1;
+      }
     }
-    else
+  }
+  else
+  {
+    uint8_t *pixels =
+        (unsigned char *)malloc(output_w * height * 4 * sizeof(char));
+
+    for (int i = 0; i < mipmapLevel; ++i)
     {
-        uint8_t *pixels = (unsigned char *)malloc(output_w * height * 4 * sizeof(char));
+      output_pixels[i] =
+          (unsigned char *)malloc(output_w * height * 4 * sizeof(char));
+      stbir_resize_uint8(input_pixels, input_w, input_h, input_stride_in_bytes,
+                         pixels, width, height, output_stride_in_bytes,
+                         num_channels);
+      copyPaddingBuffer(output_pixels[i], pixels, width, height, output_w);
 
-        for (int i = 0; i < mipmapLevel; ++i)
-        {
-            output_pixels[i] = (unsigned char *)malloc(output_w * height * 4 * sizeof(char));
-            stbir_resize_uint8(input_pixels, input_w, input_h, input_stride_in_bytes, pixels, width,
-                               height, output_stride_in_bytes, num_channels);
-            copyPaddingBuffer(output_pixels[i], pixels, width, height, output_w);
-
-            height >>= 1;
-            width >>= 1;
-            if (height == 0)
-            {
-                height = 1;
-            }
-        }
-        free(pixels);
+      height >>= 1;
+      width >>= 1;
+      if (height == 0)
+      {
+        height = 1;
+      }
     }
+    free(pixels);
+  }
 }

--- a/src/aquarium-optimized/Texture.h
+++ b/src/aquarium-optimized/Texture.h
@@ -13,43 +13,46 @@
 
 class Texture
 {
-  public:
-    virtual ~Texture() {}
-    Texture() {}
-    Texture(const std::string &name, const std::vector<std::string> &urls, bool flip)
-        : mUrls(urls), mFlip(flip), mName(name)
-    {
-    }
-    Texture(const std::string &name, const std::string &url, bool flip);
-    std::string getName() { return mName; }
-    virtual void loadTexture() = 0;
-    void generateMipmap(uint8_t *input_pixels,
-                        int input_w,
-                        int input_h,
-                        int input_stride_in_bytes,
-                        std::vector<uint8_t *> &output_pixels,
-                        int output_w,
-                        int output_h,
-                        int output_stride_in_bytes,
-                        int num_channels,
-                        bool is256padding);
+public:
+  virtual ~Texture() {}
+  Texture() {}
+  Texture(const std::string &name,
+          const std::vector<std::string> &urls,
+          bool flip)
+      : mUrls(urls), mFlip(flip), mName(name)
+  {
+  }
+  Texture(const std::string &name, const std::string &url, bool flip);
+  std::string getName() { return mName; }
+  virtual void loadTexture() = 0;
+  void generateMipmap(uint8_t *input_pixels,
+                      int input_w,
+                      int input_h,
+                      int input_stride_in_bytes,
+                      std::vector<uint8_t *> &output_pixels,
+                      int output_w,
+                      int output_h,
+                      int output_stride_in_bytes,
+                      int num_channels,
+                      bool is256padding);
 
-  protected:
-    bool isPowerOf2(int);
-    bool loadImage(const std::vector<std::string> &urls, std::vector<uint8_t *> *pixels);
-    void DestoryImageData(std::vector<uint8_t *> &pixelVec);
-    void copyPaddingBuffer(unsigned char *dst,
-                           unsigned char *src,
-                           int width,
-                           int height,
-                           int kPadding);
+protected:
+  bool isPowerOf2(int);
+  bool loadImage(const std::vector<std::string> &urls,
+                 std::vector<uint8_t *> *pixels);
+  void DestoryImageData(std::vector<uint8_t *> &pixelVec);
+  void copyPaddingBuffer(unsigned char *dst,
+                         unsigned char *src,
+                         int width,
+                         int height,
+                         int kPadding);
 
-    std::vector<std::string> mUrls;
-    int mWidth;
-    int mHeight;
-    bool mFlip;
+  std::vector<std::string> mUrls;
+  int mWidth;
+  int mHeight;
+  bool mFlip;
 
-    std::string mName;
+  std::string mName;
 };
 
 #endif  // TEXTURE_H

--- a/src/aquarium-optimized/d3d12/BufferD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/BufferD3D12.cpp
@@ -13,15 +13,19 @@ BufferD3D12::BufferD3D12(ContextD3D12 *context,
                          int numComponents,
                          const std::vector<float> &buffer,
                          bool isIndex)
-    : mIsIndex(isIndex), mTotoalComponents(totalCmoponents), mStride(0), mOffset(nullptr)
+    : mIsIndex(isIndex),
+      mTotoalComponents(totalCmoponents),
+      mStride(0),
+      mOffset(nullptr)
 {
-    mSize   = totalCmoponents * sizeof(float);
-    mBuffer = context->createDefaultBuffer(buffer.data(), mSize, mSize, mUploadBuffer);
+  mSize = totalCmoponents * sizeof(float);
+  mBuffer =
+      context->createDefaultBuffer(buffer.data(), mSize, mSize, mUploadBuffer);
 
-    // Initialize the vertex buffer view.
-    mVertexBufferView.BufferLocation = mBuffer->GetGPUVirtualAddress();
-    mVertexBufferView.StrideInBytes  = numComponents * sizeof(float);
-    mVertexBufferView.SizeInBytes    = mSize;
+  // Initialize the vertex buffer view.
+  mVertexBufferView.BufferLocation = mBuffer->GetGPUVirtualAddress();
+  mVertexBufferView.StrideInBytes  = numComponents * sizeof(float);
+  mVertexBufferView.SizeInBytes    = mSize;
 }
 
 BufferD3D12::BufferD3D12(ContextD3D12 *context,
@@ -29,13 +33,17 @@ BufferD3D12::BufferD3D12(ContextD3D12 *context,
                          int numComponents,
                          const std::vector<unsigned short> &buffer,
                          bool isIndex)
-    : mIsIndex(isIndex), mTotoalComponents(totalCmoponents), mStride(0), mOffset(nullptr)
+    : mIsIndex(isIndex),
+      mTotoalComponents(totalCmoponents),
+      mStride(0),
+      mOffset(nullptr)
 {
-    mSize   = totalCmoponents * sizeof(unsigned short);
-    mBuffer = context->createDefaultBuffer(buffer.data(), mSize, mSize, mUploadBuffer);
+  mSize = totalCmoponents * sizeof(unsigned short);
+  mBuffer =
+      context->createDefaultBuffer(buffer.data(), mSize, mSize, mUploadBuffer);
 
-    // Initialize the vertex buffer view.
-    mIndexBufferView.BufferLocation = mBuffer->GetGPUVirtualAddress();
-    mIndexBufferView.SizeInBytes    = mSize;
-    mIndexBufferView.Format         = DXGI_FORMAT_R16_UINT;
+  // Initialize the vertex buffer view.
+  mIndexBufferView.BufferLocation = mBuffer->GetGPUVirtualAddress();
+  mIndexBufferView.SizeInBytes    = mSize;
+  mIndexBufferView.Format         = DXGI_FORMAT_R16_UINT;
 }

--- a/src/aquarium-optimized/d3d12/BufferD3D12.h
+++ b/src/aquarium-optimized/d3d12/BufferD3D12.h
@@ -3,8 +3,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 //
-// BufferD3D12.h: Defines the buffer wrapper of D3D12, abstracting the vetex and index buffer
-// binding.
+// BufferD3D12.h: Defines the buffer wrapper of D3D12, abstracting the vetex and
+// index buffer binding.
 
 #ifndef BUFFERD3D12_H
 #define BUFFERD3D12_H
@@ -20,38 +20,38 @@ class ContextD3D12;
 
 class BufferD3D12 : public Buffer
 {
-  public:
-    BufferD3D12(ContextD3D12 *context,
-                int totalCmoponents,
-                int numComponents,
-                const std::vector<float> &buffer,
-                bool isIndex);
-    BufferD3D12(ContextD3D12 *context,
-                int totalCmoponents,
-                int numComponents,
-                const std::vector<unsigned short> &buffer,
-                bool isIndex);
+public:
+  BufferD3D12(ContextD3D12 *context,
+              int totalCmoponents,
+              int numComponents,
+              const std::vector<float> &buffer,
+              bool isIndex);
+  BufferD3D12(ContextD3D12 *context,
+              int totalCmoponents,
+              int numComponents,
+              const std::vector<unsigned short> &buffer,
+              bool isIndex);
 
-    ComPtr<ID3D12Resource> getBuffer() const { return mBuffer; }
+  ComPtr<ID3D12Resource> getBuffer() const { return mBuffer; }
 
-    int getTotalComponents() const { return mTotoalComponents; }
+  int getTotalComponents() const { return mTotoalComponents; }
 
-    uint32_t getStride() const { return mStride; }
-    void *getOffset() const { return mOffset; }
-    bool getIsIndex() const { return mIsIndex; }
-    int getDataSize() { return mSize; }
+  uint32_t getStride() const { return mStride; }
+  void *getOffset() const { return mOffset; }
+  bool getIsIndex() const { return mIsIndex; }
+  int getDataSize() { return mSize; }
 
-    D3D12_VERTEX_BUFFER_VIEW mVertexBufferView;
-    D3D12_INDEX_BUFFER_VIEW mIndexBufferView;
+  D3D12_VERTEX_BUFFER_VIEW mVertexBufferView;
+  D3D12_INDEX_BUFFER_VIEW mIndexBufferView;
 
-  private:
-    ComPtr<ID3D12Resource> mBuffer;
-    ComPtr<ID3D12Resource> mUploadBuffer;
-    bool mIsIndex;
-    int mTotoalComponents;
-    uint32_t mStride;
-    void *mOffset;
-    int mSize;
+private:
+  ComPtr<ID3D12Resource> mBuffer;
+  ComPtr<ID3D12Resource> mUploadBuffer;
+  bool mIsIndex;
+  int mTotoalComponents;
+  uint32_t mStride;
+  void *mOffset;
+  int mSize;
 };
 
 #endif  // BUFFERD3D12_H

--- a/src/aquarium-optimized/d3d12/ContextD3D12.h
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.h
@@ -22,180 +22,196 @@ constexpr int cbvsrvCount = 88;
 
 class ContextD3D12 : public Context
 {
-  public:
-    ContextD3D12(BACKENDTYPE backendType);
-    ~ContextD3D12();
-    bool initialize(BACKENDTYPE backend,
-                    const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset,
-                    int windowWidth,
-                    int windowHeight) override;
-    void setWindowTitle(const std::string &text) override;
-    bool ShouldQuit() override;
-    void KeyBoardQuit() override;
-    void DoFlush(const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset) override;
-    void Terminate() override;
-    void showWindow() override;
-    void updateFPS(const FPSTimer &fpsTimer,
-                   int *fishCount,
-                   std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> *toggleBitset) override;
-    void showFPS() override;
-    void destoryImgUI() override;
+public:
+  ContextD3D12(BACKENDTYPE backendType);
+  ~ContextD3D12();
+  bool initialize(
+      BACKENDTYPE backend,
+      const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset,
+      int windowWidth,
+      int windowHeight) override;
+  void setWindowTitle(const std::string &text) override;
+  bool ShouldQuit() override;
+  void KeyBoardQuit() override;
+  void DoFlush(const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)>
+                   &toggleBitset) override;
+  void Terminate() override;
+  void showWindow() override;
+  void updateFPS(const FPSTimer &fpsTimer,
+                 int *fishCount,
+                 std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)>
+                     *toggleBitset) override;
+  void showFPS() override;
+  void destoryImgUI() override;
 
-    void Flush() override;
-    void preFrame() override;
+  void Flush() override;
+  void preFrame() override;
 
-    Model *createModel(Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend) override;
-    Buffer *createBuffer(int numComponents, std::vector<float> *buffer, bool isIndex) override;
-    Buffer *createBuffer(int numComponents,
-                         std::vector<unsigned short> *buffer,
-                         bool isIndex) override;
+  Model *createModel(Aquarium *aquarium,
+                     MODELGROUP type,
+                     MODELNAME name,
+                     bool blend) override;
+  Buffer *createBuffer(int numComponents,
+                       std::vector<float> *buffer,
+                       bool isIndex) override;
+  Buffer *createBuffer(int numComponents,
+                       std::vector<unsigned short> *buffer,
+                       bool isIndex) override;
 
-    Program *createProgram(const std::string &mVId, const std::string &mFId) override;
+  Program *createProgram(const std::string &mVId,
+                         const std::string &mFId) override;
 
-    Texture *createTexture(const std::string &name, const std::string &url) override;
-    Texture *createTexture(const std::string &name, const std::vector<std::string> &urls) override;
+  Texture *createTexture(const std::string &name,
+                         const std::string &url) override;
+  Texture *createTexture(const std::string &name,
+                         const std::vector<std::string> &urls) override;
 
-    void initGeneralResources(Aquarium *aquarium) override;
-    void updateWorldlUniforms(Aquarium *aquarium) override;
+  void initGeneralResources(Aquarium *aquarium) override;
+  void updateWorldlUniforms(Aquarium *aquarium) override;
 
-    ComPtr<ID3DBlob> createShaderModule(const std::string &type, const std::string &shader);
-    void createCommittedResource(const D3D12_HEAP_PROPERTIES &properties,
-                                 const D3D12_RESOURCE_DESC &desc,
-                                 D3D12_RESOURCE_STATES state,
-                                 ComPtr<ID3D12Resource> &resource);
-    void updateSubresources(ID3D12GraphicsCommandList *pCmdList,
-                            ID3D12Resource *pDestinationResource,
-                            ID3D12Resource *pIntermediate,
-                            UINT64 IntermediateOffset,
-                            UINT FirstSubresource,
-                            UINT NumSubresources,
-                            D3D12_SUBRESOURCE_DATA *pSrcData);
-    void executeCommandLists(UINT NumCommandLists, ID3D12CommandList *const *ppCommandLists);
+  ComPtr<ID3DBlob> createShaderModule(const std::string &type,
+                                      const std::string &shader);
+  void createCommittedResource(const D3D12_HEAP_PROPERTIES &properties,
+                               const D3D12_RESOURCE_DESC &desc,
+                               D3D12_RESOURCE_STATES state,
+                               ComPtr<ID3D12Resource> &resource);
+  void updateSubresources(ID3D12GraphicsCommandList *pCmdList,
+                          ID3D12Resource *pDestinationResource,
+                          ID3D12Resource *pIntermediate,
+                          UINT64 IntermediateOffset,
+                          UINT FirstSubresource,
+                          UINT NumSubresources,
+                          D3D12_SUBRESOURCE_DATA *pSrcData);
+  void executeCommandLists(UINT NumCommandLists,
+                           ID3D12CommandList *const *ppCommandLists);
 
-    void createCommandList(ID3D12PipelineState *pInitialState,
-                           ComPtr<ID3D12GraphicsCommandList4> &commandList);
+  void createCommandList(ID3D12PipelineState *pInitialState,
+                         ComPtr<ID3D12GraphicsCommandList4> &commandList);
 
-    ComPtr<ID3D12Resource> createDefaultBuffer(const void *initData,
-                                               UINT64 initDataSize,
-                                               UINT64 bufferSize,
-                                               ComPtr<ID3D12Resource> &uploadBuffer) const;
-    void createRootSignature(const D3D12_VERSIONED_ROOT_SIGNATURE_DESC &pRootSignatureDesc,
-                             ComPtr<ID3D12RootSignature> &rootSignature) const;
-    void createGraphicsPipelineState(
-        const std::vector<D3D12_INPUT_ELEMENT_DESC> &mInputElementDescs,
-        const ComPtr<ID3D12RootSignature> &rootSignature,
-        const ComPtr<ID3DBlob> &mVertexShader,
-        const ComPtr<ID3DBlob> &mPixelShader,
-        ComPtr<ID3D12PipelineState> &mPipelineState,
-        bool enableBlend) const;
-    void buildSrvDescriptor(const ComPtr<ID3D12Resource> resource,
-                            const D3D12_SHADER_RESOURCE_VIEW_DESC &mSrvDesc,
-                            D3D12_GPU_DESCRIPTOR_HANDLE *hGpuDescriptor);
-    void buildCbvDescriptor(const D3D12_CONSTANT_BUFFER_VIEW_DESC &cbvDesc,
-                            D3D12_GPU_DESCRIPTOR_HANDLE *hGpuDescriptor);
-    UINT CalcConstantBufferByteSize(UINT byteSize);
-    void createTexture(const D3D12_RESOURCE_DESC &textureDesc,
-                       const std::vector<UINT8 *> &texture,
-                       ComPtr<ID3D12Resource> &m_texture,
-                       ComPtr<ID3D12Resource> &textureUploadHeap,
-                       int TextureWidth,
-                       int TextureHeight,
-                       int TexturePixelSize,
-                       int mipLevels,
-                       int arraySize);
-    void FlushPreviousFrames();
-    void reallocResource(int preTotalInstance,
-                         int curTotalInstance,
-                         bool enableDynamicBufferOffset) override;
-    void updateAllFishData() override;
-    void updateConstantBufferSync(ComPtr<ID3D12Resource> defaultBuffer,
-                                  const ComPtr<ID3D12Resource> uploadBuffer,
-                                  const void *initData,
-                                  UINT64 byteSize);
-    void checkRootSignatureSupport();
-    bool getRenderPassesTier(ID3D12Device *device);
-    void beginRenderPass() override;
+  ComPtr<ID3D12Resource> createDefaultBuffer(
+      const void *initData,
+      UINT64 initDataSize,
+      UINT64 bufferSize,
+      ComPtr<ID3D12Resource> &uploadBuffer) const;
+  void createRootSignature(
+      const D3D12_VERSIONED_ROOT_SIGNATURE_DESC &pRootSignatureDesc,
+      ComPtr<ID3D12RootSignature> &rootSignature) const;
+  void createGraphicsPipelineState(
+      const std::vector<D3D12_INPUT_ELEMENT_DESC> &mInputElementDescs,
+      const ComPtr<ID3D12RootSignature> &rootSignature,
+      const ComPtr<ID3DBlob> &mVertexShader,
+      const ComPtr<ID3DBlob> &mPixelShader,
+      ComPtr<ID3D12PipelineState> &mPipelineState,
+      bool enableBlend) const;
+  void buildSrvDescriptor(const ComPtr<ID3D12Resource> resource,
+                          const D3D12_SHADER_RESOURCE_VIEW_DESC &mSrvDesc,
+                          D3D12_GPU_DESCRIPTOR_HANDLE *hGpuDescriptor);
+  void buildCbvDescriptor(const D3D12_CONSTANT_BUFFER_VIEW_DESC &cbvDesc,
+                          D3D12_GPU_DESCRIPTOR_HANDLE *hGpuDescriptor);
+  UINT CalcConstantBufferByteSize(UINT byteSize);
+  void createTexture(const D3D12_RESOURCE_DESC &textureDesc,
+                     const std::vector<UINT8 *> &texture,
+                     ComPtr<ID3D12Resource> &m_texture,
+                     ComPtr<ID3D12Resource> &textureUploadHeap,
+                     int TextureWidth,
+                     int TextureHeight,
+                     int TexturePixelSize,
+                     int mipLevels,
+                     int arraySize);
+  void FlushPreviousFrames();
+  void reallocResource(int preTotalInstance,
+                       int curTotalInstance,
+                       bool enableDynamicBufferOffset) override;
+  void updateAllFishData() override;
+  void updateConstantBufferSync(ComPtr<ID3D12Resource> defaultBuffer,
+                                const ComPtr<ID3D12Resource> uploadBuffer,
+                                const void *initData,
+                                UINT64 byteSize);
+  void checkRootSignatureSupport();
+  bool getRenderPassesTier(ID3D12Device *device);
+  void beginRenderPass() override;
 
-    Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList4> mCommandList;
+  Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList4> mCommandList;
 
-    CD3DX12_DESCRIPTOR_RANGE1 rangeGeneral[2];
-    CD3DX12_ROOT_PARAMETER1 rootParameterGeneral;
-    CD3DX12_DESCRIPTOR_RANGE1 rangeLightWorldPosition;
-    CD3DX12_ROOT_PARAMETER1 rootParameterWorld;
-    D3D12_GPU_DESCRIPTOR_HANDLE fogGPUHandle;
-    D3D12_GPU_DESCRIPTOR_HANDLE lightGPUHandle;
-    D3D12_CONSTANT_BUFFER_VIEW_DESC lightWorldPositionView;
-    D3D12_GPU_DESCRIPTOR_HANDLE lightWorldPositionGPUHandle;
-    CD3DX12_CPU_DESCRIPTOR_HANDLE cbvsrvCPUHandle;
-    CD3DX12_GPU_DESCRIPTOR_HANDLE cbvsrvGPUHandle;
+  CD3DX12_DESCRIPTOR_RANGE1 rangeGeneral[2];
+  CD3DX12_ROOT_PARAMETER1 rootParameterGeneral;
+  CD3DX12_DESCRIPTOR_RANGE1 rangeLightWorldPosition;
+  CD3DX12_ROOT_PARAMETER1 rootParameterWorld;
+  D3D12_GPU_DESCRIPTOR_HANDLE fogGPUHandle;
+  D3D12_GPU_DESCRIPTOR_HANDLE lightGPUHandle;
+  D3D12_CONSTANT_BUFFER_VIEW_DESC lightWorldPositionView;
+  D3D12_GPU_DESCRIPTOR_HANDLE lightWorldPositionGPUHandle;
+  CD3DX12_CPU_DESCRIPTOR_HANDLE cbvsrvCPUHandle;
+  CD3DX12_GPU_DESCRIPTOR_HANDLE cbvsrvGPUHandle;
 
-    std::vector<CD3DX12_STATIC_SAMPLER_DESC> staticSamplers;
+  std::vector<CD3DX12_STATIC_SAMPLER_DESC> staticSamplers;
 
-    D3D12_CONSTANT_BUFFER_VIEW_DESC mFishPersBufferView;
-    ComPtr<ID3D12Resource> mFishPersBuffer;
-    ComPtr<ID3D12Resource> stagingBuffer;
-    FishPer *fishPers;
+  D3D12_CONSTANT_BUFFER_VIEW_DESC mFishPersBufferView;
+  ComPtr<ID3D12Resource> mFishPersBuffer;
+  ComPtr<ID3D12Resource> stagingBuffer;
+  FishPer *fishPers;
 
-  private:
-    bool GetHardwareAdapter(
-        IDXGIFactory2 *pFactory,
-        IDXGIAdapter1 **ppAdapter,
-        const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset);
-    void WaitForPreviousFrame();
-    void createDepthStencilView();
-    void stateTransition(ComPtr<ID3D12Resource> resource,
-                         D3D12_RESOURCE_STATES preState,
-                         D3D12_RESOURCE_STATES transferState) const;
-    void initAvailableToggleBitset(BACKENDTYPE backendType) override;
-    void destoryFishResource();
+private:
+  bool GetHardwareAdapter(
+      IDXGIFactory2 *pFactory,
+      IDXGIAdapter1 **ppAdapter,
+      const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset);
+  void WaitForPreviousFrame();
+  void createDepthStencilView();
+  void stateTransition(ComPtr<ID3D12Resource> resource,
+                       D3D12_RESOURCE_STATES preState,
+                       D3D12_RESOURCE_STATES transferState) const;
+  void initAvailableToggleBitset(BACKENDTYPE backendType) override;
+  void destoryFishResource();
 
-    GLFWwindow *mWindow;
-    ComPtr<ID3D12Device> mDevice;
-    ComPtr<ID3D12CommandQueue> mCommandQueue;
-    ComPtr<IDXGISwapChain3> mSwapChain;
-    DXGI_FORMAT mPreferredSwapChainFormat;
-    UINT mCompileFlags;
+  GLFWwindow *mWindow;
+  ComPtr<ID3D12Device> mDevice;
+  ComPtr<ID3D12CommandQueue> mCommandQueue;
+  ComPtr<IDXGISwapChain3> mSwapChain;
+  DXGI_FORMAT mPreferredSwapChainFormat;
+  UINT mCompileFlags;
 
-    static const UINT mFrameCount = 3;
-    UINT m_frameIndex;
-    UINT mBufferSerias[mFrameCount];
-    ComPtr<ID3D12CommandAllocator> mCommandAllocators[mFrameCount];
+  static const UINT mFrameCount = 3;
+  UINT m_frameIndex;
+  UINT mBufferSerias[mFrameCount];
+  ComPtr<ID3D12CommandAllocator> mCommandAllocators[mFrameCount];
 
-    ComPtr<ID3D12DescriptorHeap> mRtvHeap;
-    ComPtr<ID3D12DescriptorHeap> mDsvHeap;
-    ComPtr<ID3D12DescriptorHeap> mCbvsrvHeap;
-    UINT mRtvDescriptorSize;
-    UINT mCbvmSrvDescriptorSize;
-    ComPtr<ID3D12Resource> mRenderTargets[mFrameCount];
-    ComPtr<ID3D12Resource> mDepthStencil;
+  ComPtr<ID3D12DescriptorHeap> mRtvHeap;
+  ComPtr<ID3D12DescriptorHeap> mDsvHeap;
+  ComPtr<ID3D12DescriptorHeap> mCbvsrvHeap;
+  UINT mRtvDescriptorSize;
+  UINT mCbvmSrvDescriptorSize;
+  ComPtr<ID3D12Resource> mRenderTargets[mFrameCount];
+  ComPtr<ID3D12Resource> mDepthStencil;
 
-    ComPtr<ID3D12Fence> mFence;
-    UINT64 mFenceValue;
-    HANDLE mFenceEvent;
+  ComPtr<ID3D12Fence> mFence;
+  UINT64 mFenceValue;
+  HANDLE mFenceEvent;
 
-    D3D12_FEATURE_DATA_ROOT_SIGNATURE mRootSignature;
-    D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_SUBRESOURCE_PARAMETERS subresourceParameters;
+  D3D12_FEATURE_DATA_ROOT_SIGNATURE mRootSignature;
+  D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_SUBRESOURCE_PARAMETERS
+  subresourceParameters;
 
-    CD3DX12_VIEWPORT mViewport;
-    CD3DX12_RECT mScissorRect;
+  CD3DX12_VIEWPORT mViewport;
+  CD3DX12_RECT mScissorRect;
 
-    // General Resources
-    ComPtr<ID3D12Resource> mLightWorldPositionBuffer;
-    ComPtr<ID3D12Resource> mLightWorldPositionUploadBuffer;
+  // General Resources
+  ComPtr<ID3D12Resource> mLightWorldPositionBuffer;
+  ComPtr<ID3D12Resource> mLightWorldPositionUploadBuffer;
 
-    D3D12_CONSTANT_BUFFER_VIEW_DESC mLightView;
-    ComPtr<ID3D12Resource> mLightBuffer;
-    ComPtr<ID3D12Resource> mLightUploadBuffer;
+  D3D12_CONSTANT_BUFFER_VIEW_DESC mLightView;
+  ComPtr<ID3D12Resource> mLightBuffer;
+  ComPtr<ID3D12Resource> mLightUploadBuffer;
 
-    D3D12_CONSTANT_BUFFER_VIEW_DESC mFogView;
-    ComPtr<ID3D12Resource> mFogBuffer;
-    ComPtr<ID3D12Resource> mFogUploadBuffer;
+  D3D12_CONSTANT_BUFFER_VIEW_DESC mFogView;
+  ComPtr<ID3D12Resource> mFogBuffer;
+  ComPtr<ID3D12Resource> mFogUploadBuffer;
 
-    ComPtr<ID3D12Resource> mSceneRenderTargetTexture;
-    D3D12_RENDER_TARGET_VIEW_DESC mSceneRenderTargetView;
+  ComPtr<ID3D12Resource> mSceneRenderTargetTexture;
+  D3D12_RENDER_TARGET_VIEW_DESC mSceneRenderTargetView;
 
-    UINT mVsync;
-    bool mDisableD3D12RenderPass;
+  UINT mVsync;
+  bool mDisableD3D12RenderPass;
 };
 
 #endif  // CONTEXTD3D12_H

--- a/src/aquarium-optimized/d3d12/FishModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/FishModelD3D12.cpp
@@ -16,154 +16,171 @@ FishModelD3D12::FishModelD3D12(Context *context,
                                bool blend)
     : FishModel(type, name, blend, aquarium)
 {
-    mContextD3D12 = static_cast<ContextD3D12 *>(context);
+  mContextD3D12 = static_cast<ContextD3D12 *>(context);
 
-    const Fish &fishInfo               = fishTable[name - MODELNAME::MODELSMALLFISHA];
-    mFishVertexUniforms.fishLength     = fishInfo.fishLength;
-    mFishVertexUniforms.fishBendAmount = fishInfo.fishBendAmount;
-    mFishVertexUniforms.fishWaveLength = fishInfo.fishWaveLength;
+  const Fish &fishInfo           = fishTable[name - MODELNAME::MODELSMALLFISHA];
+  mFishVertexUniforms.fishLength = fishInfo.fishLength;
+  mFishVertexUniforms.fishBendAmount = fishInfo.fishBendAmount;
+  mFishVertexUniforms.fishWaveLength = fishInfo.fishWaveLength;
 
-    mLightFactorUniforms.shininess      = 5.0f;
-    mLightFactorUniforms.specularFactor = 0.3f;
+  mLightFactorUniforms.shininess      = 5.0f;
+  mLightFactorUniforms.specularFactor = 0.3f;
 
-    mCurInstance = aquarium->fishCount[fishInfo.modelName - MODELNAME::MODELSMALLFISHA];
-    mPreInstance = mCurInstance;
+  mCurInstance =
+      aquarium->fishCount[fishInfo.modelName - MODELNAME::MODELSMALLFISHA];
+  mPreInstance = mCurInstance;
 }
 
 FishModelD3D12::~FishModelD3D12() {}
 
 void FishModelD3D12::init()
 {
-    mProgramD3D12 = static_cast<ProgramD3D12 *>(mProgram);
+  mProgramD3D12 = static_cast<ProgramD3D12 *>(mProgram);
 
-    mDiffuseTexture    = static_cast<TextureD3D12 *>(textureMap["diffuse"]);
-    mNormalTexture     = static_cast<TextureD3D12 *>(textureMap["normalMap"]);
-    mReflectionTexture = static_cast<TextureD3D12 *>(textureMap["reflectionMap"]);
-    mSkyboxTexture     = static_cast<TextureD3D12 *>(textureMap["skybox"]);
+  mDiffuseTexture    = static_cast<TextureD3D12 *>(textureMap["diffuse"]);
+  mNormalTexture     = static_cast<TextureD3D12 *>(textureMap["normalMap"]);
+  mReflectionTexture = static_cast<TextureD3D12 *>(textureMap["reflectionMap"]);
+  mSkyboxTexture     = static_cast<TextureD3D12 *>(textureMap["skybox"]);
 
-    mPositionBuffer = static_cast<BufferD3D12 *>(bufferMap["position"]);
-    mNormalBuffer   = static_cast<BufferD3D12 *>(bufferMap["normal"]);
-    mTexCoordBuffer = static_cast<BufferD3D12 *>(bufferMap["texCoord"]);
-    mTangentBuffer  = static_cast<BufferD3D12 *>(bufferMap["tangent"]);
-    mBiNormalBuffer = static_cast<BufferD3D12 *>(bufferMap["binormal"]);
-    mIndicesBuffer  = static_cast<BufferD3D12 *>(bufferMap["indices"]);
+  mPositionBuffer = static_cast<BufferD3D12 *>(bufferMap["position"]);
+  mNormalBuffer   = static_cast<BufferD3D12 *>(bufferMap["normal"]);
+  mTexCoordBuffer = static_cast<BufferD3D12 *>(bufferMap["texCoord"]);
+  mTangentBuffer  = static_cast<BufferD3D12 *>(bufferMap["tangent"]);
+  mBiNormalBuffer = static_cast<BufferD3D12 *>(bufferMap["binormal"]);
+  mIndicesBuffer  = static_cast<BufferD3D12 *>(bufferMap["indices"]);
 
-    mVertexBufferView[0] = mPositionBuffer->mVertexBufferView;
-    mVertexBufferView[1] = mNormalBuffer->mVertexBufferView;
-    mVertexBufferView[2] = mTexCoordBuffer->mVertexBufferView;
-    mVertexBufferView[3] = mTangentBuffer->mVertexBufferView;
-    mVertexBufferView[4] = mBiNormalBuffer->mVertexBufferView;
+  mVertexBufferView[0] = mPositionBuffer->mVertexBufferView;
+  mVertexBufferView[1] = mNormalBuffer->mVertexBufferView;
+  mVertexBufferView[2] = mTexCoordBuffer->mVertexBufferView;
+  mVertexBufferView[3] = mTangentBuffer->mVertexBufferView;
+  mVertexBufferView[4] = mBiNormalBuffer->mVertexBufferView;
 
-    mInputElementDescs = {
-        {"TEXCOORD", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,
-         D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
-        {"TEXCOORD", 1, DXGI_FORMAT_R32G32B32_FLOAT, 1, 0,
-         D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
-        {"TEXCOORD", 2, DXGI_FORMAT_R32G32_FLOAT, 2, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA,
-         0},
-        {"TEXCOORD", 3, DXGI_FORMAT_R32G32B32_FLOAT, 3, 0,
-         D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
-        {"TEXCOORD", 4, DXGI_FORMAT_R32G32B32_FLOAT, 4, 0,
-         D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
-    };
+  mInputElementDescs = {
+      {"TEXCOORD", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,
+       D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+      {"TEXCOORD", 1, DXGI_FORMAT_R32G32B32_FLOAT, 1, 0,
+       D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+      {"TEXCOORD", 2, DXGI_FORMAT_R32G32_FLOAT, 2, 0,
+       D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+      {"TEXCOORD", 3, DXGI_FORMAT_R32G32B32_FLOAT, 3, 0,
+       D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+      {"TEXCOORD", 4, DXGI_FORMAT_R32G32B32_FLOAT, 4, 0,
+       D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+  };
 
-    // create constant buffer, desc.
-    mFishVertexBuffer = mContextD3D12->createDefaultBuffer(
-        &mFishVertexUniforms, sizeof(FishVertexUniforms),
-        mContextD3D12->CalcConstantBufferByteSize(sizeof(FishVertexUniforms)),
-        mFishVertexUploadBuffer);
-    mFishVertexView.BufferLocation = mFishVertexBuffer->GetGPUVirtualAddress();
-    mFishVertexView.SizeInBytes    = mContextD3D12->CalcConstantBufferByteSize(
-        sizeof(mFishVertexUniforms));  // CB size is required to be 256-byte aligned.
-    mContextD3D12->buildCbvDescriptor(mFishVertexView, &mFishVertexGPUHandle);
-    mLightFactorBuffer = mContextD3D12->createDefaultBuffer(
-        &mLightFactorUniforms, sizeof(LightFactorUniforms),
-        mContextD3D12->CalcConstantBufferByteSize(sizeof(LightFactorUniforms)),
-        mLightFactorUploadBuffer);
-    mLightFactorView.BufferLocation = mLightFactorBuffer->GetGPUVirtualAddress();
-    mLightFactorView.SizeInBytes    = mContextD3D12->CalcConstantBufferByteSize(
-        sizeof(LightFactorUniforms));  // CB size is required to be 256-byte aligned.
-    mContextD3D12->buildCbvDescriptor(mLightFactorView, &mLightFactorGPUHandle);
+  // create constant buffer, desc.
+  mFishVertexBuffer = mContextD3D12->createDefaultBuffer(
+      &mFishVertexUniforms, sizeof(FishVertexUniforms),
+      mContextD3D12->CalcConstantBufferByteSize(sizeof(FishVertexUniforms)),
+      mFishVertexUploadBuffer);
+  mFishVertexView.BufferLocation = mFishVertexBuffer->GetGPUVirtualAddress();
+  mFishVertexView.SizeInBytes =
+      mContextD3D12->CalcConstantBufferByteSize(sizeof(
+          mFishVertexUniforms));  // CB size is required to be 256-byte aligned.
+  mContextD3D12->buildCbvDescriptor(mFishVertexView, &mFishVertexGPUHandle);
+  mLightFactorBuffer = mContextD3D12->createDefaultBuffer(
+      &mLightFactorUniforms, sizeof(LightFactorUniforms),
+      mContextD3D12->CalcConstantBufferByteSize(sizeof(LightFactorUniforms)),
+      mLightFactorUploadBuffer);
+  mLightFactorView.BufferLocation = mLightFactorBuffer->GetGPUVirtualAddress();
+  mLightFactorView.SizeInBytes =
+      mContextD3D12->CalcConstantBufferByteSize(sizeof(
+          LightFactorUniforms));  // CB size is required to be 256-byte aligned.
+  mContextD3D12->buildCbvDescriptor(mLightFactorView, &mLightFactorGPUHandle);
 
-    // Create root signature to bind resources.
-    // Bind textures, samplers and immutable constant buffers in a descriptor table.
-    // Bind frequently updated constant buffers by root descriptors.
-    CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-    CD3DX12_ROOT_PARAMETER1 rootParameters[5];
-    CD3DX12_DESCRIPTOR_RANGE1 ranges[2];
-    rootParameters[0] = mContextD3D12->rootParameterGeneral;
-    rootParameters[1] = mContextD3D12->rootParameterWorld;
+  // Create root signature to bind resources.
+  // Bind textures, samplers and immutable constant buffers in a descriptor
+  // table. Bind frequently updated constant buffers by root descriptors.
+  CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+  CD3DX12_ROOT_PARAMETER1 rootParameters[5];
+  CD3DX12_DESCRIPTOR_RANGE1 ranges[2];
+  rootParameters[0] = mContextD3D12->rootParameterGeneral;
+  rootParameters[1] = mContextD3D12->rootParameterWorld;
 
-    if (mSkyboxTexture && mReflectionTexture)
-    {
-        mDiffuseTexture->createSrvDescriptor();
-        mNormalTexture->createSrvDescriptor();
-        mReflectionTexture->createSrvDescriptor();
+  if (mSkyboxTexture && mReflectionTexture)
+  {
+    mDiffuseTexture->createSrvDescriptor();
+    mNormalTexture->createSrvDescriptor();
+    mReflectionTexture->createSrvDescriptor();
 
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 2, 0, 2,
-                       D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-        ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 3, 0, 2,
-                       D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-        rootParameters[2].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_ALL);
-        rootParameters[3].InitAsDescriptorTable(1, &ranges[1], D3D12_SHADER_VISIBILITY_PIXEL);
-    }
-    else
-    {
-        mDiffuseTexture->createSrvDescriptor();
-        mNormalTexture->createSrvDescriptor();
+    ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 2, 0, 2,
+                   D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+    ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 3, 0, 2,
+                   D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+    rootParameters[2].InitAsDescriptorTable(1, &ranges[0],
+                                            D3D12_SHADER_VISIBILITY_ALL);
+    rootParameters[3].InitAsDescriptorTable(1, &ranges[1],
+                                            D3D12_SHADER_VISIBILITY_PIXEL);
+  }
+  else
+  {
+    mDiffuseTexture->createSrvDescriptor();
+    mNormalTexture->createSrvDescriptor();
 
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 2, 0, 2,
-                       D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-        ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 2, 0, 2,
-                       D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-        rootParameters[2].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_ALL);
-        rootParameters[3].InitAsDescriptorTable(1, &ranges[1], D3D12_SHADER_VISIBILITY_PIXEL);
-    }
+    ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 2, 0, 2,
+                   D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+    ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 2, 0, 2,
+                   D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+    rootParameters[2].InitAsDescriptorTable(1, &ranges[0],
+                                            D3D12_SHADER_VISIBILITY_ALL);
+    rootParameters[3].InitAsDescriptorTable(1, &ranges[1],
+                                            D3D12_SHADER_VISIBILITY_PIXEL);
+  }
 
-    rootParameters[4].InitAsConstantBufferView(0, 3, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_VOLATILE,
-                                               D3D12_SHADER_VISIBILITY_VERTEX);
+  rootParameters[4].InitAsConstantBufferView(
+      0, 3, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_VOLATILE,
+      D3D12_SHADER_VISIBILITY_VERTEX);
 
-    rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 2u,
-                               mContextD3D12->staticSamplers.data(),
-                               D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+  rootSignatureDesc.Init_1_1(
+      _countof(rootParameters), rootParameters, 2u,
+      mContextD3D12->staticSamplers.data(),
+      D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-    mContextD3D12->createRootSignature(rootSignatureDesc, mRootSignature);
+  mContextD3D12->createRootSignature(rootSignatureDesc, mRootSignature);
 
-    mContextD3D12->createGraphicsPipelineState(
-        mInputElementDescs, mRootSignature, mProgramD3D12->getVSModule(),
-        mProgramD3D12->getFSModule(), mPipelineState, mBlend);
+  mContextD3D12->createGraphicsPipelineState(
+      mInputElementDescs, mRootSignature, mProgramD3D12->getVSModule(),
+      mProgramD3D12->getFSModule(), mPipelineState, mBlend);
 }
 
 void FishModelD3D12::draw()
 {
-    if (mCurInstance == 0)
-        return;
+  if (mCurInstance == 0)
+    return;
 
-    mContextD3D12->mCommandList->SetPipelineState(mPipelineState.Get());
-    mContextD3D12->mCommandList->SetGraphicsRootSignature(mRootSignature.Get());
+  mContextD3D12->mCommandList->SetPipelineState(mPipelineState.Get());
+  mContextD3D12->mCommandList->SetGraphicsRootSignature(mRootSignature.Get());
 
-    mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(0, mContextD3D12->lightGPUHandle);
-    mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
-        1, mContextD3D12->lightWorldPositionGPUHandle);
-    mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(2, mFishVertexGPUHandle);
-    mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
-        3, mDiffuseTexture->getTextureGPUHandle());
+  mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
+      0, mContextD3D12->lightGPUHandle);
+  mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
+      1, mContextD3D12->lightWorldPositionGPUHandle);
+  mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
+      2, mFishVertexGPUHandle);
+  mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
+      3, mDiffuseTexture->getTextureGPUHandle());
 
-    mContextD3D12->mCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    mContextD3D12->mCommandList->IASetVertexBuffers(0, 5, mVertexBufferView);
-    mContextD3D12->mCommandList->IASetIndexBuffer(&mIndicesBuffer->mIndexBufferView);
+  mContextD3D12->mCommandList->IASetPrimitiveTopology(
+      D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+  mContextD3D12->mCommandList->IASetVertexBuffers(0, 5, mVertexBufferView);
+  mContextD3D12->mCommandList->IASetIndexBuffer(
+      &mIndicesBuffer->mIndexBufferView);
 
-    for (int i = 0; i < mCurInstance; i++)
-    {
-        mContextD3D12->mCommandList->SetGraphicsRootConstantBufferView(
-            4, mContextD3D12->mFishPersBufferView.BufferLocation +
-                   (mFishPerOffset + i) * mContextD3D12->mFishPersBufferView.SizeInBytes);
-        mContextD3D12->mCommandList->DrawIndexedInstanced(mIndicesBuffer->getTotalComponents(), 1,
-                                                          0, 0, 0);
-    }
+  for (int i = 0; i < mCurInstance; i++)
+  {
+    mContextD3D12->mCommandList->SetGraphicsRootConstantBufferView(
+        4, mContextD3D12->mFishPersBufferView.BufferLocation +
+               (mFishPerOffset + i) *
+                   mContextD3D12->mFishPersBufferView.SizeInBytes);
+    mContextD3D12->mCommandList->DrawIndexedInstanced(
+        mIndicesBuffer->getTotalComponents(), 1, 0, 0, 0);
+  }
 }
 
-void FishModelD3D12::updatePerInstanceUniforms(const WorldUniforms &worldUniforms) {}
+void FishModelD3D12::updatePerInstanceUniforms(
+    const WorldUniforms &worldUniforms)
+{
+}
 
 void FishModelD3D12::updateFishPerUniforms(float x,
                                            float y,
@@ -175,13 +192,13 @@ void FishModelD3D12::updateFishPerUniforms(float x,
                                            float time,
                                            int index)
 {
-    index += mFishPerOffset;
-    mContextD3D12->fishPers[index].worldPosition[0] = x;
-    mContextD3D12->fishPers[index].worldPosition[1] = y;
-    mContextD3D12->fishPers[index].worldPosition[2] = z;
-    mContextD3D12->fishPers[index].nextPosition[0]  = nextX;
-    mContextD3D12->fishPers[index].nextPosition[1]  = nextY;
-    mContextD3D12->fishPers[index].nextPosition[2]  = nextZ;
-    mContextD3D12->fishPers[index].scale            = scale;
-    mContextD3D12->fishPers[index].time             = time;
+  index += mFishPerOffset;
+  mContextD3D12->fishPers[index].worldPosition[0] = x;
+  mContextD3D12->fishPers[index].worldPosition[1] = y;
+  mContextD3D12->fishPers[index].worldPosition[2] = z;
+  mContextD3D12->fishPers[index].nextPosition[0]  = nextX;
+  mContextD3D12->fishPers[index].nextPosition[1]  = nextY;
+  mContextD3D12->fishPers[index].nextPosition[2]  = nextZ;
+  mContextD3D12->fishPers[index].scale            = scale;
+  mContextD3D12->fishPers[index].time             = time;
 }

--- a/src/aquarium-optimized/d3d12/FishModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/FishModelD3D12.h
@@ -18,75 +18,75 @@
 
 class FishModelD3D12 : public FishModel
 {
-  public:
-    FishModelD3D12(Context *context,
-                   Aquarium *aquarium,
-                   MODELGROUP type,
-                   MODELNAME name,
-                   bool blend);
-    ~FishModelD3D12();
+public:
+  FishModelD3D12(Context *context,
+                 Aquarium *aquarium,
+                 MODELGROUP type,
+                 MODELNAME name,
+                 bool blend);
+  ~FishModelD3D12();
 
-    void init() override;
-    void draw() override;
+  void init() override;
+  void draw() override;
 
-    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
-    void updateFishPerUniforms(float x,
-                               float y,
-                               float z,
-                               float nextX,
-                               float nextY,
-                               float nextZ,
-                               float scale,
-                               float time,
-                               int index) override;
+  void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
+  void updateFishPerUniforms(float x,
+                             float y,
+                             float z,
+                             float nextX,
+                             float nextY,
+                             float nextZ,
+                             float scale,
+                             float time,
+                             int index) override;
 
-    struct FishVertexUniforms
-    {
-        float fishLength;
-        float fishWaveLength;
-        float fishBendAmount;
-    } mFishVertexUniforms;
+  struct FishVertexUniforms
+  {
+    float fishLength;
+    float fishWaveLength;
+    float fishBendAmount;
+  } mFishVertexUniforms;
 
-    struct LightFactorUniforms
-    {
-        float shininess;
-        float specularFactor;
-    } mLightFactorUniforms;
+  struct LightFactorUniforms
+  {
+    float shininess;
+    float specularFactor;
+  } mLightFactorUniforms;
 
-    TextureD3D12 *mDiffuseTexture;
-    TextureD3D12 *mNormalTexture;
-    TextureD3D12 *mReflectionTexture;
-    TextureD3D12 *mSkyboxTexture;
+  TextureD3D12 *mDiffuseTexture;
+  TextureD3D12 *mNormalTexture;
+  TextureD3D12 *mReflectionTexture;
+  TextureD3D12 *mSkyboxTexture;
 
-    BufferD3D12 *mPositionBuffer;
-    BufferD3D12 *mNormalBuffer;
-    BufferD3D12 *mTexCoordBuffer;
-    BufferD3D12 *mTangentBuffer;
-    BufferD3D12 *mBiNormalBuffer;
+  BufferD3D12 *mPositionBuffer;
+  BufferD3D12 *mNormalBuffer;
+  BufferD3D12 *mTexCoordBuffer;
+  BufferD3D12 *mTangentBuffer;
+  BufferD3D12 *mBiNormalBuffer;
 
-    BufferD3D12 *mIndicesBuffer;
+  BufferD3D12 *mIndicesBuffer;
 
-  private:
-    D3D12_CONSTANT_BUFFER_VIEW_DESC mLightFactorView;
-    D3D12_GPU_DESCRIPTOR_HANDLE mLightFactorGPUHandle;
-    ComPtr<ID3D12Resource> mLightFactorBuffer;
-    ComPtr<ID3D12Resource> mLightFactorUploadBuffer;
+private:
+  D3D12_CONSTANT_BUFFER_VIEW_DESC mLightFactorView;
+  D3D12_GPU_DESCRIPTOR_HANDLE mLightFactorGPUHandle;
+  ComPtr<ID3D12Resource> mLightFactorBuffer;
+  ComPtr<ID3D12Resource> mLightFactorUploadBuffer;
 
-    D3D12_CONSTANT_BUFFER_VIEW_DESC mFishVertexView;
-    D3D12_GPU_DESCRIPTOR_HANDLE mFishVertexGPUHandle;
-    ComPtr<ID3D12Resource> mFishVertexBuffer;
-    ComPtr<ID3D12Resource> mFishVertexUploadBuffer;
+  D3D12_CONSTANT_BUFFER_VIEW_DESC mFishVertexView;
+  D3D12_GPU_DESCRIPTOR_HANDLE mFishVertexGPUHandle;
+  ComPtr<ID3D12Resource> mFishVertexBuffer;
+  ComPtr<ID3D12Resource> mFishVertexUploadBuffer;
 
-    std::vector<D3D12_INPUT_ELEMENT_DESC> mInputElementDescs;
+  std::vector<D3D12_INPUT_ELEMENT_DESC> mInputElementDescs;
 
-    D3D12_VERTEX_BUFFER_VIEW mVertexBufferView[5];
+  D3D12_VERTEX_BUFFER_VIEW mVertexBufferView[5];
 
-    ComPtr<ID3D12RootSignature> mRootSignature;
+  ComPtr<ID3D12RootSignature> mRootSignature;
 
-    ComPtr<ID3D12PipelineState> mPipelineState;
+  ComPtr<ID3D12PipelineState> mPipelineState;
 
-    ProgramD3D12 *mProgramD3D12;
-    ContextD3D12 *mContextD3D12;
+  ProgramD3D12 *mProgramD3D12;
+  ContextD3D12 *mContextD3D12;
 };
 
 #endif  // FISHMODELD3D12_H

--- a/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.cpp
@@ -16,176 +16,193 @@ FishModelInstancedDrawD3D12::FishModelInstancedDrawD3D12(Context *context,
                                                          bool blend)
     : FishModel(type, name, blend, aquarium), instance(0)
 {
-    mContextD3D12 = static_cast<ContextD3D12 *>(context);
+  mContextD3D12 = static_cast<ContextD3D12 *>(context);
 
-    const Fish &fishInfo               = fishTable[name - MODELNAME::MODELSMALLFISHAINSTANCEDDRAWS];
-    mFishVertexUniforms.fishLength     = fishInfo.fishLength;
-    mFishVertexUniforms.fishBendAmount = fishInfo.fishBendAmount;
-    mFishVertexUniforms.fishWaveLength = fishInfo.fishWaveLength;
+  const Fish &fishInfo =
+      fishTable[name - MODELNAME::MODELSMALLFISHAINSTANCEDDRAWS];
+  mFishVertexUniforms.fishLength     = fishInfo.fishLength;
+  mFishVertexUniforms.fishBendAmount = fishInfo.fishBendAmount;
+  mFishVertexUniforms.fishWaveLength = fishInfo.fishWaveLength;
 
-    mLightFactorUniforms.shininess      = 5.0f;
-    mLightFactorUniforms.specularFactor = 0.3f;
+  mLightFactorUniforms.shininess      = 5.0f;
+  mLightFactorUniforms.specularFactor = 0.3f;
 
-    instance  = aquarium->fishCount[fishInfo.modelName - MODELNAME::MODELSMALLFISHA];
-    mFishPers = new FishPer[instance];
+  instance =
+      aquarium->fishCount[fishInfo.modelName - MODELNAME::MODELSMALLFISHA];
+  mFishPers = new FishPer[instance];
 }
 
 FishModelInstancedDrawD3D12::~FishModelInstancedDrawD3D12()
 {
-    delete mFishPers;
+  delete mFishPers;
 }
 
 void FishModelInstancedDrawD3D12::init()
 {
-    if (instance == 0)
-        return;
+  if (instance == 0)
+    return;
 
-    mProgramD3D12 = static_cast<ProgramD3D12 *>(mProgram);
+  mProgramD3D12 = static_cast<ProgramD3D12 *>(mProgram);
 
-    mDiffuseTexture    = static_cast<TextureD3D12 *>(textureMap["diffuse"]);
-    mNormalTexture     = static_cast<TextureD3D12 *>(textureMap["normalMap"]);
-    mReflectionTexture = static_cast<TextureD3D12 *>(textureMap["reflectionMap"]);
-    mSkyboxTexture     = static_cast<TextureD3D12 *>(textureMap["skybox"]);
+  mDiffuseTexture    = static_cast<TextureD3D12 *>(textureMap["diffuse"]);
+  mNormalTexture     = static_cast<TextureD3D12 *>(textureMap["normalMap"]);
+  mReflectionTexture = static_cast<TextureD3D12 *>(textureMap["reflectionMap"]);
+  mSkyboxTexture     = static_cast<TextureD3D12 *>(textureMap["skybox"]);
 
-    mPositionBuffer = static_cast<BufferD3D12 *>(bufferMap["position"]);
-    mNormalBuffer   = static_cast<BufferD3D12 *>(bufferMap["normal"]);
-    mTexCoordBuffer = static_cast<BufferD3D12 *>(bufferMap["texCoord"]);
-    mTangentBuffer  = static_cast<BufferD3D12 *>(bufferMap["tangent"]);
-    mBiNormalBuffer = static_cast<BufferD3D12 *>(bufferMap["binormal"]);
-    mIndicesBuffer  = static_cast<BufferD3D12 *>(bufferMap["indices"]);
+  mPositionBuffer = static_cast<BufferD3D12 *>(bufferMap["position"]);
+  mNormalBuffer   = static_cast<BufferD3D12 *>(bufferMap["normal"]);
+  mTexCoordBuffer = static_cast<BufferD3D12 *>(bufferMap["texCoord"]);
+  mTangentBuffer  = static_cast<BufferD3D12 *>(bufferMap["tangent"]);
+  mBiNormalBuffer = static_cast<BufferD3D12 *>(bufferMap["binormal"]);
+  mIndicesBuffer  = static_cast<BufferD3D12 *>(bufferMap["indices"]);
 
-    mVertexBufferView[0] = mPositionBuffer->mVertexBufferView;
-    mVertexBufferView[1] = mNormalBuffer->mVertexBufferView;
-    mVertexBufferView[2] = mTexCoordBuffer->mVertexBufferView;
-    mVertexBufferView[3] = mTangentBuffer->mVertexBufferView;
-    mVertexBufferView[4] = mBiNormalBuffer->mVertexBufferView;
+  mVertexBufferView[0] = mPositionBuffer->mVertexBufferView;
+  mVertexBufferView[1] = mNormalBuffer->mVertexBufferView;
+  mVertexBufferView[2] = mTexCoordBuffer->mVertexBufferView;
+  mVertexBufferView[3] = mTangentBuffer->mVertexBufferView;
+  mVertexBufferView[4] = mBiNormalBuffer->mVertexBufferView;
 
-    mFishPersBuffer = mContextD3D12->createDefaultBuffer(
-        mFishPers, sizeof(FishPer) * instance,
-        mContextD3D12->CalcConstantBufferByteSize(sizeof(FishPer) * instance),
-        mFishPersUploadBuffer);
-    mFishPersBufferView.BufferLocation = mFishPersBuffer->GetGPUVirtualAddress();
-    mFishPersBufferView.SizeInBytes =
-        mContextD3D12->CalcConstantBufferByteSize(sizeof(FishPer) * instance);
-    mFishPersBufferView.StrideInBytes = sizeof(FishPer);
+  mFishPersBuffer = mContextD3D12->createDefaultBuffer(
+      mFishPers, sizeof(FishPer) * instance,
+      mContextD3D12->CalcConstantBufferByteSize(sizeof(FishPer) * instance),
+      mFishPersUploadBuffer);
+  mFishPersBufferView.BufferLocation = mFishPersBuffer->GetGPUVirtualAddress();
+  mFishPersBufferView.SizeInBytes =
+      mContextD3D12->CalcConstantBufferByteSize(sizeof(FishPer) * instance);
+  mFishPersBufferView.StrideInBytes = sizeof(FishPer);
 
-    mVertexBufferView[5] = mFishPersBufferView;
+  mVertexBufferView[5] = mFishPersBufferView;
 
-    mInputElementDescs = {
-        {"TEXCOORD", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,
-         D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
-        {"TEXCOORD", 1, DXGI_FORMAT_R32G32B32_FLOAT, 1, 0,
-         D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
-        {"TEXCOORD", 2, DXGI_FORMAT_R32G32_FLOAT, 2, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA,
-         0},
-        {"TEXCOORD", 3, DXGI_FORMAT_R32G32B32_FLOAT, 3, 0,
-         D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
-        {"TEXCOORD", 4, DXGI_FORMAT_R32G32B32_FLOAT, 4, 0,
-         D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
-        {"TEXCOORD", 5, DXGI_FORMAT_R32G32B32_FLOAT, 5, 0,
-         D3D12_INPUT_CLASSIFICATION_PER_INSTANCE_DATA, 1},
-        {"TEXCOORD", 6, DXGI_FORMAT_R32_FLOAT, 5, 3 * sizeof(float),
-         D3D12_INPUT_CLASSIFICATION_PER_INSTANCE_DATA, 1},
-        {"TEXCOORD", 7, DXGI_FORMAT_R32G32B32_FLOAT, 5, 4 * sizeof(float),
-         D3D12_INPUT_CLASSIFICATION_PER_INSTANCE_DATA, 1},
-        {"TEXCOORD", 8, DXGI_FORMAT_R32_FLOAT, 5, 5 * sizeof(float),
-         D3D12_INPUT_CLASSIFICATION_PER_INSTANCE_DATA, 1},
-    };
+  mInputElementDescs = {
+      {"TEXCOORD", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,
+       D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+      {"TEXCOORD", 1, DXGI_FORMAT_R32G32B32_FLOAT, 1, 0,
+       D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+      {"TEXCOORD", 2, DXGI_FORMAT_R32G32_FLOAT, 2, 0,
+       D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+      {"TEXCOORD", 3, DXGI_FORMAT_R32G32B32_FLOAT, 3, 0,
+       D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+      {"TEXCOORD", 4, DXGI_FORMAT_R32G32B32_FLOAT, 4, 0,
+       D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+      {"TEXCOORD", 5, DXGI_FORMAT_R32G32B32_FLOAT, 5, 0,
+       D3D12_INPUT_CLASSIFICATION_PER_INSTANCE_DATA, 1},
+      {"TEXCOORD", 6, DXGI_FORMAT_R32_FLOAT, 5, 3 * sizeof(float),
+       D3D12_INPUT_CLASSIFICATION_PER_INSTANCE_DATA, 1},
+      {"TEXCOORD", 7, DXGI_FORMAT_R32G32B32_FLOAT, 5, 4 * sizeof(float),
+       D3D12_INPUT_CLASSIFICATION_PER_INSTANCE_DATA, 1},
+      {"TEXCOORD", 8, DXGI_FORMAT_R32_FLOAT, 5, 5 * sizeof(float),
+       D3D12_INPUT_CLASSIFICATION_PER_INSTANCE_DATA, 1},
+  };
 
-    // create constant buffer, desc.
-    mFishVertexBuffer = mContextD3D12->createDefaultBuffer(
-        &mFishVertexUniforms, sizeof(FishVertexUniforms),
-        mContextD3D12->CalcConstantBufferByteSize(sizeof(FishVertexUniforms)),
-        mFishVertexUploadBuffer);
-    mFishVertexView.BufferLocation = mFishVertexBuffer->GetGPUVirtualAddress();
-    mFishVertexView.SizeInBytes    = mContextD3D12->CalcConstantBufferByteSize(
-        sizeof(mFishVertexUniforms));  // CB size is required to be 256-byte aligned.
-    mContextD3D12->buildCbvDescriptor(mFishVertexView, &mFishVertexGPUHandle);
-    mLightFactorBuffer = mContextD3D12->createDefaultBuffer(
-        &mLightFactorUniforms, sizeof(LightFactorUniforms),
-        mContextD3D12->CalcConstantBufferByteSize(sizeof(LightFactorUniforms)),
-        mLightFactorUploadBuffer);
-    mLightFactorView.BufferLocation = mLightFactorBuffer->GetGPUVirtualAddress();
-    mLightFactorView.SizeInBytes    = mContextD3D12->CalcConstantBufferByteSize(
-        sizeof(LightFactorUniforms));  // CB size is required to be 256-byte aligned.
-    mContextD3D12->buildCbvDescriptor(mLightFactorView, &mLightFactorGPUHandle);
+  // create constant buffer, desc.
+  mFishVertexBuffer = mContextD3D12->createDefaultBuffer(
+      &mFishVertexUniforms, sizeof(FishVertexUniforms),
+      mContextD3D12->CalcConstantBufferByteSize(sizeof(FishVertexUniforms)),
+      mFishVertexUploadBuffer);
+  mFishVertexView.BufferLocation = mFishVertexBuffer->GetGPUVirtualAddress();
+  mFishVertexView.SizeInBytes =
+      mContextD3D12->CalcConstantBufferByteSize(sizeof(
+          mFishVertexUniforms));  // CB size is required to be 256-byte aligned.
+  mContextD3D12->buildCbvDescriptor(mFishVertexView, &mFishVertexGPUHandle);
+  mLightFactorBuffer = mContextD3D12->createDefaultBuffer(
+      &mLightFactorUniforms, sizeof(LightFactorUniforms),
+      mContextD3D12->CalcConstantBufferByteSize(sizeof(LightFactorUniforms)),
+      mLightFactorUploadBuffer);
+  mLightFactorView.BufferLocation = mLightFactorBuffer->GetGPUVirtualAddress();
+  mLightFactorView.SizeInBytes =
+      mContextD3D12->CalcConstantBufferByteSize(sizeof(
+          LightFactorUniforms));  // CB size is required to be 256-byte aligned.
+  mContextD3D12->buildCbvDescriptor(mLightFactorView, &mLightFactorGPUHandle);
 
-    // Create root signature to bind resources.
-    // Bind textures, samplers and immutable constant buffers in a descriptor table.
-    // Bind frequently updated constant buffers by root descriptors.
-    CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-    CD3DX12_ROOT_PARAMETER1 rootParameters[4];
-    CD3DX12_DESCRIPTOR_RANGE1 ranges[2];
-    rootParameters[0] = mContextD3D12->rootParameterGeneral;
-    rootParameters[1] = mContextD3D12->rootParameterWorld;
+  // Create root signature to bind resources.
+  // Bind textures, samplers and immutable constant buffers in a descriptor
+  // table. Bind frequently updated constant buffers by root descriptors.
+  CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+  CD3DX12_ROOT_PARAMETER1 rootParameters[4];
+  CD3DX12_DESCRIPTOR_RANGE1 ranges[2];
+  rootParameters[0] = mContextD3D12->rootParameterGeneral;
+  rootParameters[1] = mContextD3D12->rootParameterWorld;
 
-    if (mSkyboxTexture && mReflectionTexture)
-    {
-        mDiffuseTexture->createSrvDescriptor();
-        mNormalTexture->createSrvDescriptor();
-        mReflectionTexture->createSrvDescriptor();
+  if (mSkyboxTexture && mReflectionTexture)
+  {
+    mDiffuseTexture->createSrvDescriptor();
+    mNormalTexture->createSrvDescriptor();
+    mReflectionTexture->createSrvDescriptor();
 
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 2, 0, 2,
-                       D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-        ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 3, 0, 2,
-                       D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-        rootParameters[2].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_ALL);
-        rootParameters[3].InitAsDescriptorTable(1, &ranges[1], D3D12_SHADER_VISIBILITY_PIXEL);
-    }
-    else
-    {
-        mDiffuseTexture->createSrvDescriptor();
-        mNormalTexture->createSrvDescriptor();
+    ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 2, 0, 2,
+                   D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+    ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 3, 0, 2,
+                   D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+    rootParameters[2].InitAsDescriptorTable(1, &ranges[0],
+                                            D3D12_SHADER_VISIBILITY_ALL);
+    rootParameters[3].InitAsDescriptorTable(1, &ranges[1],
+                                            D3D12_SHADER_VISIBILITY_PIXEL);
+  }
+  else
+  {
+    mDiffuseTexture->createSrvDescriptor();
+    mNormalTexture->createSrvDescriptor();
 
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 2, 0, 2,
-                       D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-        ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 2, 0, 2,
-                       D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-        rootParameters[2].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_ALL);
-        rootParameters[3].InitAsDescriptorTable(1, &ranges[1], D3D12_SHADER_VISIBILITY_PIXEL);
-    }
+    ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 2, 0, 2,
+                   D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+    ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 2, 0, 2,
+                   D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+    rootParameters[2].InitAsDescriptorTable(1, &ranges[0],
+                                            D3D12_SHADER_VISIBILITY_ALL);
+    rootParameters[3].InitAsDescriptorTable(1, &ranges[1],
+                                            D3D12_SHADER_VISIBILITY_PIXEL);
+  }
 
-    rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 2u,
-                               mContextD3D12->staticSamplers.data(),
-                               D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+  rootSignatureDesc.Init_1_1(
+      _countof(rootParameters), rootParameters, 2u,
+      mContextD3D12->staticSamplers.data(),
+      D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-    mContextD3D12->createRootSignature(rootSignatureDesc, mRootSignature);
+  mContextD3D12->createRootSignature(rootSignatureDesc, mRootSignature);
 
-    mContextD3D12->createGraphicsPipelineState(
-        mInputElementDescs, mRootSignature, mProgramD3D12->getVSModule(),
-        mProgramD3D12->getFSModule(), mPipelineState, mBlend);
+  mContextD3D12->createGraphicsPipelineState(
+      mInputElementDescs, mRootSignature, mProgramD3D12->getVSModule(),
+      mProgramD3D12->getFSModule(), mPipelineState, mBlend);
 }
 
 void FishModelInstancedDrawD3D12::prepareForDraw()
 {
-    mContextD3D12->updateConstantBufferSync(mFishPersBuffer, mFishPersUploadBuffer, mFishPers,
-                                            sizeof(FishPer) * instance);
+  mContextD3D12->updateConstantBufferSync(mFishPersBuffer,
+                                          mFishPersUploadBuffer, mFishPers,
+                                          sizeof(FishPer) * instance);
 }
 
 void FishModelInstancedDrawD3D12::draw()
 {
-    if (instance == 0)
-        return;
+  if (instance == 0)
+    return;
 
-    mContextD3D12->mCommandList->SetPipelineState(mPipelineState.Get());
-    mContextD3D12->mCommandList->SetGraphicsRootSignature(mRootSignature.Get());
+  mContextD3D12->mCommandList->SetPipelineState(mPipelineState.Get());
+  mContextD3D12->mCommandList->SetGraphicsRootSignature(mRootSignature.Get());
 
-    mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(0, mContextD3D12->lightGPUHandle);
-    mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
-        1, mContextD3D12->lightWorldPositionGPUHandle);
-    mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(2, mFishVertexGPUHandle);
-    mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
-        3, mDiffuseTexture->getTextureGPUHandle());
+  mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
+      0, mContextD3D12->lightGPUHandle);
+  mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
+      1, mContextD3D12->lightWorldPositionGPUHandle);
+  mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
+      2, mFishVertexGPUHandle);
+  mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
+      3, mDiffuseTexture->getTextureGPUHandle());
 
-    mContextD3D12->mCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    mContextD3D12->mCommandList->IASetVertexBuffers(0, 6, mVertexBufferView);
-    mContextD3D12->mCommandList->IASetIndexBuffer(&mIndicesBuffer->mIndexBufferView);
+  mContextD3D12->mCommandList->IASetPrimitiveTopology(
+      D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+  mContextD3D12->mCommandList->IASetVertexBuffers(0, 6, mVertexBufferView);
+  mContextD3D12->mCommandList->IASetIndexBuffer(
+      &mIndicesBuffer->mIndexBufferView);
 
-    mContextD3D12->mCommandList->DrawIndexedInstanced(mIndicesBuffer->getTotalComponents(),
-                                                      instance, 0, 0, 0);
+  mContextD3D12->mCommandList->DrawIndexedInstanced(
+      mIndicesBuffer->getTotalComponents(), instance, 0, 0, 0);
 }
 
-void FishModelInstancedDrawD3D12::updatePerInstanceUniforms(const WorldUniforms &worldUniforms) {}
+void FishModelInstancedDrawD3D12::updatePerInstanceUniforms(
+    const WorldUniforms &worldUniforms)
+{
+}
 
 void FishModelInstancedDrawD3D12::updateFishPerUniforms(float x,
                                                         float y,
@@ -197,12 +214,12 @@ void FishModelInstancedDrawD3D12::updateFishPerUniforms(float x,
                                                         float time,
                                                         int index)
 {
-    mFishPers[index].worldPosition[0] = x;
-    mFishPers[index].worldPosition[1] = y;
-    mFishPers[index].worldPosition[2] = z;
-    mFishPers[index].nextPosition[0]  = nextX;
-    mFishPers[index].nextPosition[1]  = nextY;
-    mFishPers[index].nextPosition[2]  = nextZ;
-    mFishPers[index].scale            = scale;
-    mFishPers[index].time             = time;
+  mFishPers[index].worldPosition[0] = x;
+  mFishPers[index].worldPosition[1] = y;
+  mFishPers[index].worldPosition[2] = z;
+  mFishPers[index].nextPosition[0]  = nextX;
+  mFishPers[index].nextPosition[1]  = nextY;
+  mFishPers[index].nextPosition[2]  = nextZ;
+  mFishPers[index].scale            = scale;
+  mFishPers[index].time             = time;
 }

--- a/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.h
+++ b/src/aquarium-optimized/d3d12/FishModelInstancedDrawD3D12.h
@@ -18,89 +18,89 @@
 
 class FishModelInstancedDrawD3D12 : public FishModel
 {
-  public:
-    FishModelInstancedDrawD3D12(Context *context,
-                                Aquarium *aquarium,
-                                MODELGROUP type,
-                                MODELNAME name,
-                                bool blend);
-    ~FishModelInstancedDrawD3D12();
+public:
+  FishModelInstancedDrawD3D12(Context *context,
+                              Aquarium *aquarium,
+                              MODELGROUP type,
+                              MODELNAME name,
+                              bool blend);
+  ~FishModelInstancedDrawD3D12();
 
-    void init() override;
-    void prepareForDraw() override;
-    void draw() override;
+  void init() override;
+  void prepareForDraw() override;
+  void draw() override;
 
-    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
-    void updateFishPerUniforms(float x,
-                               float y,
-                               float z,
-                               float nextX,
-                               float nextY,
-                               float nextZ,
-                               float scale,
-                               float time,
-                               int index) override;
+  void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
+  void updateFishPerUniforms(float x,
+                             float y,
+                             float z,
+                             float nextX,
+                             float nextY,
+                             float nextZ,
+                             float scale,
+                             float time,
+                             int index) override;
 
-    struct FishVertexUniforms
-    {
-        float fishLength;
-        float fishWaveLength;
-        float fishBendAmount;
-    } mFishVertexUniforms;
+  struct FishVertexUniforms
+  {
+    float fishLength;
+    float fishWaveLength;
+    float fishBendAmount;
+  } mFishVertexUniforms;
 
-    struct LightFactorUniforms
-    {
-        float shininess;
-        float specularFactor;
-    } mLightFactorUniforms;
+  struct LightFactorUniforms
+  {
+    float shininess;
+    float specularFactor;
+  } mLightFactorUniforms;
 
-    struct FishPer
-    {
-        float worldPosition[3];
-        float scale;
-        float nextPosition[3];
-        float time;
-    };
-    FishPer *mFishPers;
+  struct FishPer
+  {
+    float worldPosition[3];
+    float scale;
+    float nextPosition[3];
+    float time;
+  };
+  FishPer *mFishPers;
 
-    TextureD3D12 *mDiffuseTexture;
-    TextureD3D12 *mNormalTexture;
-    TextureD3D12 *mReflectionTexture;
-    TextureD3D12 *mSkyboxTexture;
+  TextureD3D12 *mDiffuseTexture;
+  TextureD3D12 *mNormalTexture;
+  TextureD3D12 *mReflectionTexture;
+  TextureD3D12 *mSkyboxTexture;
 
-    BufferD3D12 *mPositionBuffer;
-    BufferD3D12 *mNormalBuffer;
-    BufferD3D12 *mTexCoordBuffer;
-    BufferD3D12 *mTangentBuffer;
-    BufferD3D12 *mBiNormalBuffer;
+  BufferD3D12 *mPositionBuffer;
+  BufferD3D12 *mNormalBuffer;
+  BufferD3D12 *mTexCoordBuffer;
+  BufferD3D12 *mTangentBuffer;
+  BufferD3D12 *mBiNormalBuffer;
 
-    BufferD3D12 *mIndicesBuffer;
+  BufferD3D12 *mIndicesBuffer;
 
-  private:
-    D3D12_VERTEX_BUFFER_VIEW mFishPersBufferView;
-    ComPtr<ID3D12Resource> mFishPersBuffer;
-    ComPtr<ID3D12Resource> mFishPersUploadBuffer;
+private:
+  D3D12_VERTEX_BUFFER_VIEW mFishPersBufferView;
+  ComPtr<ID3D12Resource> mFishPersBuffer;
+  ComPtr<ID3D12Resource> mFishPersUploadBuffer;
 
-    D3D12_CONSTANT_BUFFER_VIEW_DESC mLightFactorView;
-    D3D12_GPU_DESCRIPTOR_HANDLE mLightFactorGPUHandle;
-    ComPtr<ID3D12Resource> mLightFactorBuffer;
-    ComPtr<ID3D12Resource> mLightFactorUploadBuffer;
+  D3D12_CONSTANT_BUFFER_VIEW_DESC mLightFactorView;
+  D3D12_GPU_DESCRIPTOR_HANDLE mLightFactorGPUHandle;
+  ComPtr<ID3D12Resource> mLightFactorBuffer;
+  ComPtr<ID3D12Resource> mLightFactorUploadBuffer;
 
-    D3D12_CONSTANT_BUFFER_VIEW_DESC mFishVertexView;
-    D3D12_GPU_DESCRIPTOR_HANDLE mFishVertexGPUHandle;
-    ComPtr<ID3D12Resource> mFishVertexBuffer;
-    ComPtr<ID3D12Resource> mFishVertexUploadBuffer;
+  D3D12_CONSTANT_BUFFER_VIEW_DESC mFishVertexView;
+  D3D12_GPU_DESCRIPTOR_HANDLE mFishVertexGPUHandle;
+  ComPtr<ID3D12Resource> mFishVertexBuffer;
+  ComPtr<ID3D12Resource> mFishVertexUploadBuffer;
 
-    std::vector<D3D12_INPUT_ELEMENT_DESC> mInputElementDescs;
-    D3D12_VERTEX_BUFFER_VIEW mVertexBufferView[6];
+  std::vector<D3D12_INPUT_ELEMENT_DESC> mInputElementDescs;
+  D3D12_VERTEX_BUFFER_VIEW mVertexBufferView[6];
 
-    ComPtr<ID3D12RootSignature> mRootSignature;
-    ComPtr<ID3D12PipelineState> mPipelineState;
+  ComPtr<ID3D12RootSignature> mRootSignature;
+  ComPtr<ID3D12PipelineState> mPipelineState;
 
-    int instance;
+  int instance;
 
-    ProgramD3D12 *mProgramD3D12;
-    ContextD3D12 *mContextD3D12;
+  ProgramD3D12 *mProgramD3D12;
+  ContextD3D12 *mContextD3D12;
 };
 
 #endif  // FISHMODELINSTANCEDDRAWD3D12_H

--- a/src/aquarium-optimized/d3d12/GenericModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/GenericModelD3D12.cpp
@@ -13,184 +13,201 @@ GenericModelD3D12::GenericModelD3D12(Context *context,
                                      bool blend)
     : Model(type, name, blend), mInstance(0)
 {
-    mContextD3D12 = static_cast<ContextD3D12 *>(context);
+  mContextD3D12 = static_cast<ContextD3D12 *>(context);
 
-    mLightFactorUniforms.shininess      = 50.0f;
-    mLightFactorUniforms.specularFactor = 1.0f;
+  mLightFactorUniforms.shininess      = 50.0f;
+  mLightFactorUniforms.specularFactor = 1.0f;
 }
 
 void GenericModelD3D12::init()
 {
-    mProgramD3D12 = static_cast<ProgramD3D12 *>(mProgram);
+  mProgramD3D12 = static_cast<ProgramD3D12 *>(mProgram);
 
-    mDiffuseTexture    = static_cast<TextureD3D12 *>(textureMap["diffuse"]);
-    mNormalTexture     = static_cast<TextureD3D12 *>(textureMap["normalMap"]);
-    mReflectionTexture = static_cast<TextureD3D12 *>(textureMap["reflectionMap"]);
-    mSkyboxTexture     = static_cast<TextureD3D12 *>(textureMap["skybox"]);
+  mDiffuseTexture    = static_cast<TextureD3D12 *>(textureMap["diffuse"]);
+  mNormalTexture     = static_cast<TextureD3D12 *>(textureMap["normalMap"]);
+  mReflectionTexture = static_cast<TextureD3D12 *>(textureMap["reflectionMap"]);
+  mSkyboxTexture     = static_cast<TextureD3D12 *>(textureMap["skybox"]);
 
-    mPositionBuffer = static_cast<BufferD3D12 *>(bufferMap["position"]);
-    mNormalBuffer   = static_cast<BufferD3D12 *>(bufferMap["normal"]);
-    mTexCoordBuffer = static_cast<BufferD3D12 *>(bufferMap["texCoord"]);
-    mTangentBuffer  = static_cast<BufferD3D12 *>(bufferMap["tangent"]);
-    mBiNormalBuffer = static_cast<BufferD3D12 *>(bufferMap["binormal"]);
-    mIndicesBuffer  = static_cast<BufferD3D12 *>(bufferMap["indices"]);
+  mPositionBuffer = static_cast<BufferD3D12 *>(bufferMap["position"]);
+  mNormalBuffer   = static_cast<BufferD3D12 *>(bufferMap["normal"]);
+  mTexCoordBuffer = static_cast<BufferD3D12 *>(bufferMap["texCoord"]);
+  mTangentBuffer  = static_cast<BufferD3D12 *>(bufferMap["tangent"]);
+  mBiNormalBuffer = static_cast<BufferD3D12 *>(bufferMap["binormal"]);
+  mIndicesBuffer  = static_cast<BufferD3D12 *>(bufferMap["indices"]);
 
-    mVertexBufferView[0] = mPositionBuffer->mVertexBufferView;
-    mVertexBufferView[1] = mNormalBuffer->mVertexBufferView;
-    mVertexBufferView[2] = mTexCoordBuffer->mVertexBufferView;
-    mVertexBufferView[3] = mTangentBuffer->mVertexBufferView;
-    mVertexBufferView[4] = mBiNormalBuffer->mVertexBufferView;
+  mVertexBufferView[0] = mPositionBuffer->mVertexBufferView;
+  mVertexBufferView[1] = mNormalBuffer->mVertexBufferView;
+  mVertexBufferView[2] = mTexCoordBuffer->mVertexBufferView;
+  mVertexBufferView[3] = mTangentBuffer->mVertexBufferView;
+  mVertexBufferView[4] = mBiNormalBuffer->mVertexBufferView;
 
-    // create input layout
-    // Generic models use reflection, normal or diffuse shaders, of which groupLayouts are
-    // different in texture binding.  MODELGLOBEBASE use diffuse shader though it contains
-    // normal and reflection textures.
-    if (mNormalTexture && mName != MODELNAME::MODELGLOBEBASE)
-    {
-        mInputElementDescs = {
-            {"TEXCOORD", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,
-             D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
-            {"TEXCOORD", 1, DXGI_FORMAT_R32G32B32_FLOAT, 1, 0,
-             D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
-            {"TEXCOORD", 2, DXGI_FORMAT_R32G32_FLOAT, 2, 0,
-             D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
-            {"TEXCOORD", 3, DXGI_FORMAT_R32G32B32_FLOAT, 3, 0,
-             D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
-            {"TEXCOORD", 4, DXGI_FORMAT_R32G32B32_FLOAT, 4, 0,
-             D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
-        };
-    }
-    else
-    {
-        mInputElementDescs = {
-            {"TEXCOORD", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,
-             D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
-            {"TEXCOORD", 1, DXGI_FORMAT_R32G32B32_FLOAT, 1, 0,
-             D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
-            {"TEXCOORD", 2, DXGI_FORMAT_R32G32_FLOAT, 2, 0,
-             D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
-        };
-    }
+  // create input layout
+  // Generic models use reflection, normal or diffuse shaders, of which
+  // groupLayouts are different in texture binding.  MODELGLOBEBASE use diffuse
+  // shader though it contains normal and reflection textures.
+  if (mNormalTexture && mName != MODELNAME::MODELGLOBEBASE)
+  {
+    mInputElementDescs = {
+        {"TEXCOORD", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,
+         D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+        {"TEXCOORD", 1, DXGI_FORMAT_R32G32B32_FLOAT, 1, 0,
+         D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+        {"TEXCOORD", 2, DXGI_FORMAT_R32G32_FLOAT, 2, 0,
+         D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+        {"TEXCOORD", 3, DXGI_FORMAT_R32G32B32_FLOAT, 3, 0,
+         D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+        {"TEXCOORD", 4, DXGI_FORMAT_R32G32B32_FLOAT, 4, 0,
+         D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+    };
+  }
+  else
+  {
+    mInputElementDescs = {
+        {"TEXCOORD", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,
+         D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+        {"TEXCOORD", 1, DXGI_FORMAT_R32G32B32_FLOAT, 1, 0,
+         D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+        {"TEXCOORD", 2, DXGI_FORMAT_R32G32_FLOAT, 2, 0,
+         D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+    };
+  }
 
-    // create constant buffer, desc.
-    mLightFactorBuffer = mContextD3D12->createDefaultBuffer(
-        &mLightFactorUniforms, sizeof(LightFactorUniforms),
-        mContextD3D12->CalcConstantBufferByteSize(sizeof(LightFactorUniforms)),
-        mLightFactorUploadBuffer);
-    mLightFactorView.BufferLocation = mLightFactorBuffer->GetGPUVirtualAddress();
-    mLightFactorView.SizeInBytes    = mContextD3D12->CalcConstantBufferByteSize(
-        sizeof(LightFactorUniforms));  // CB size is required to be 256-byte aligned.
-    mContextD3D12->buildCbvDescriptor(mLightFactorView, &mLightFactorGPUHandle);
-    mWorldBuffer = mContextD3D12->createDefaultBuffer(
-        &mWorldUniformPer, sizeof(WorldUniformPer),
-        mContextD3D12->CalcConstantBufferByteSize(sizeof(WorldUniformPer)), mWorldUploadBuffer);
-    mWorldBufferView.BufferLocation = mWorldBuffer->GetGPUVirtualAddress();
-    mWorldBufferView.SizeInBytes =
-        mContextD3D12->CalcConstantBufferByteSize(sizeof(WorldUniformPer));
+  // create constant buffer, desc.
+  mLightFactorBuffer = mContextD3D12->createDefaultBuffer(
+      &mLightFactorUniforms, sizeof(LightFactorUniforms),
+      mContextD3D12->CalcConstantBufferByteSize(sizeof(LightFactorUniforms)),
+      mLightFactorUploadBuffer);
+  mLightFactorView.BufferLocation = mLightFactorBuffer->GetGPUVirtualAddress();
+  mLightFactorView.SizeInBytes =
+      mContextD3D12->CalcConstantBufferByteSize(sizeof(
+          LightFactorUniforms));  // CB size is required to be 256-byte aligned.
+  mContextD3D12->buildCbvDescriptor(mLightFactorView, &mLightFactorGPUHandle);
+  mWorldBuffer = mContextD3D12->createDefaultBuffer(
+      &mWorldUniformPer, sizeof(WorldUniformPer),
+      mContextD3D12->CalcConstantBufferByteSize(sizeof(WorldUniformPer)),
+      mWorldUploadBuffer);
+  mWorldBufferView.BufferLocation = mWorldBuffer->GetGPUVirtualAddress();
+  mWorldBufferView.SizeInBytes =
+      mContextD3D12->CalcConstantBufferByteSize(sizeof(WorldUniformPer));
 
-    // Create root signature to bind resources.
-    // Bind textures, samplers and immutable constant buffers in a descriptor table.
-    // Bind frequently updated constant buffers by root descriptors.
-    CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-    CD3DX12_ROOT_PARAMETER1 rootParameters[5];
-    CD3DX12_DESCRIPTOR_RANGE1 ranges[2];
-    rootParameters[0] = mContextD3D12->rootParameterGeneral;
-    rootParameters[1] = mContextD3D12->rootParameterWorld;
+  // Create root signature to bind resources.
+  // Bind textures, samplers and immutable constant buffers in a descriptor
+  // table. Bind frequently updated constant buffers by root descriptors.
+  CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+  CD3DX12_ROOT_PARAMETER1 rootParameters[5];
+  CD3DX12_DESCRIPTOR_RANGE1 ranges[2];
+  rootParameters[0] = mContextD3D12->rootParameterGeneral;
+  rootParameters[1] = mContextD3D12->rootParameterWorld;
 
-    if (mSkyboxTexture && mReflectionTexture && mName != MODELNAME::MODELGLOBEBASE)
-    {
-        mDiffuseTexture->createSrvDescriptor();
-        mNormalTexture->createSrvDescriptor();
-        mReflectionTexture->createSrvDescriptor();
+  if (mSkyboxTexture && mReflectionTexture &&
+      mName != MODELNAME::MODELGLOBEBASE)
+  {
+    mDiffuseTexture->createSrvDescriptor();
+    mNormalTexture->createSrvDescriptor();
+    mReflectionTexture->createSrvDescriptor();
 
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 2,
-                       D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-        ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 3, 0, 2,
-                       D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-        rootParameters[2].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
-        rootParameters[3].InitAsDescriptorTable(1, &ranges[1], D3D12_SHADER_VISIBILITY_PIXEL);
-    }
-    else if (mNormalTexture && mName != MODELNAME::MODELGLOBEBASE)
-    {
-        mDiffuseTexture->createSrvDescriptor();
-        mNormalTexture->createSrvDescriptor();
+    ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 2,
+                   D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+    ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 3, 0, 2,
+                   D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+    rootParameters[2].InitAsDescriptorTable(1, &ranges[0],
+                                            D3D12_SHADER_VISIBILITY_PIXEL);
+    rootParameters[3].InitAsDescriptorTable(1, &ranges[1],
+                                            D3D12_SHADER_VISIBILITY_PIXEL);
+  }
+  else if (mNormalTexture && mName != MODELNAME::MODELGLOBEBASE)
+  {
+    mDiffuseTexture->createSrvDescriptor();
+    mNormalTexture->createSrvDescriptor();
 
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 2,
-                       D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-        ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 2, 0, 2,
-                       D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-        rootParameters[2].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
-        rootParameters[3].InitAsDescriptorTable(1, &ranges[1], D3D12_SHADER_VISIBILITY_PIXEL);
-    }
-    else
-    {
-        mDiffuseTexture->createSrvDescriptor();
+    ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 2,
+                   D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+    ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 2, 0, 2,
+                   D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+    rootParameters[2].InitAsDescriptorTable(1, &ranges[0],
+                                            D3D12_SHADER_VISIBILITY_PIXEL);
+    rootParameters[3].InitAsDescriptorTable(1, &ranges[1],
+                                            D3D12_SHADER_VISIBILITY_PIXEL);
+  }
+  else
+  {
+    mDiffuseTexture->createSrvDescriptor();
 
-        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 2,
-                       D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-        ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 2,
-                       D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-        rootParameters[2].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
-        rootParameters[3].InitAsDescriptorTable(1, &ranges[1], D3D12_SHADER_VISIBILITY_PIXEL);
-    }
+    ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 2,
+                   D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+    ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 2,
+                   D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+    rootParameters[2].InitAsDescriptorTable(1, &ranges[0],
+                                            D3D12_SHADER_VISIBILITY_PIXEL);
+    rootParameters[3].InitAsDescriptorTable(1, &ranges[1],
+                                            D3D12_SHADER_VISIBILITY_PIXEL);
+  }
 
-    rootParameters[4].InitAsConstantBufferView(0, 3, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_VOLATILE,
-                                               D3D12_SHADER_VISIBILITY_VERTEX);
+  rootParameters[4].InitAsConstantBufferView(
+      0, 3, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_VOLATILE,
+      D3D12_SHADER_VISIBILITY_VERTEX);
 
-    rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 2u,
-                               mContextD3D12->staticSamplers.data(),
-                               D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+  rootSignatureDesc.Init_1_1(
+      _countof(rootParameters), rootParameters, 2u,
+      mContextD3D12->staticSamplers.data(),
+      D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-    mContextD3D12->createRootSignature(rootSignatureDesc, mRootSignature);
+  mContextD3D12->createRootSignature(rootSignatureDesc, mRootSignature);
 
-    mContextD3D12->createGraphicsPipelineState(
-        mInputElementDescs, mRootSignature, mProgramD3D12->getVSModule(),
-        mProgramD3D12->getFSModule(), mPipelineState, mBlend);
+  mContextD3D12->createGraphicsPipelineState(
+      mInputElementDescs, mRootSignature, mProgramD3D12->getVSModule(),
+      mProgramD3D12->getFSModule(), mPipelineState, mBlend);
 }
 
 // Update constant buffer per frame
 void GenericModelD3D12::prepareForDraw()
 {
-    mContextD3D12->updateConstantBufferSync(mWorldBuffer, mWorldUploadBuffer, &mWorldUniformPer,
-                                            sizeof(WorldUniformPer));
+  mContextD3D12->updateConstantBufferSync(mWorldBuffer, mWorldUploadBuffer,
+                                          &mWorldUniformPer,
+                                          sizeof(WorldUniformPer));
 }
 
 void GenericModelD3D12::draw()
 {
-    mContextD3D12->mCommandList->SetPipelineState(mPipelineState.Get());
-    mContextD3D12->mCommandList->SetGraphicsRootSignature(mRootSignature.Get());
+  mContextD3D12->mCommandList->SetPipelineState(mPipelineState.Get());
+  mContextD3D12->mCommandList->SetGraphicsRootSignature(mRootSignature.Get());
 
-    mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(0, mContextD3D12->lightGPUHandle);
-    mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
-        1, mContextD3D12->lightWorldPositionGPUHandle);
-    mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(2, mLightFactorGPUHandle);
-    mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
-        3, mDiffuseTexture->getTextureGPUHandle());
-    mContextD3D12->mCommandList->SetGraphicsRootConstantBufferView(4,
-                                                                   mWorldBufferView.BufferLocation);
+  mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
+      0, mContextD3D12->lightGPUHandle);
+  mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
+      1, mContextD3D12->lightWorldPositionGPUHandle);
+  mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
+      2, mLightFactorGPUHandle);
+  mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
+      3, mDiffuseTexture->getTextureGPUHandle());
+  mContextD3D12->mCommandList->SetGraphicsRootConstantBufferView(
+      4, mWorldBufferView.BufferLocation);
 
-    mContextD3D12->mCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+  mContextD3D12->mCommandList->IASetPrimitiveTopology(
+      D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
 
-    // diffuseShader doesn't have to input tangent buffer or binormal buffer.
-    if (mTangentBuffer && mBiNormalBuffer && mName != MODELNAME::MODELGLOBEBASE)
-    {
-        mContextD3D12->mCommandList->IASetVertexBuffers(0, 5, mVertexBufferView);
-    }
-    else
-    {
-        mContextD3D12->mCommandList->IASetVertexBuffers(0, 3, mVertexBufferView);
-    }
-    mContextD3D12->mCommandList->IASetIndexBuffer(&mIndicesBuffer->mIndexBufferView);
+  // diffuseShader doesn't have to input tangent buffer or binormal buffer.
+  if (mTangentBuffer && mBiNormalBuffer && mName != MODELNAME::MODELGLOBEBASE)
+  {
+    mContextD3D12->mCommandList->IASetVertexBuffers(0, 5, mVertexBufferView);
+  }
+  else
+  {
+    mContextD3D12->mCommandList->IASetVertexBuffers(0, 3, mVertexBufferView);
+  }
+  mContextD3D12->mCommandList->IASetIndexBuffer(
+      &mIndicesBuffer->mIndexBufferView);
 
-    mContextD3D12->mCommandList->DrawIndexedInstanced(mIndicesBuffer->getTotalComponents(),
-                                                      mInstance, 0, 0, 0);
+  mContextD3D12->mCommandList->DrawIndexedInstanced(
+      mIndicesBuffer->getTotalComponents(), mInstance, 0, 0, 0);
 
-    mInstance = 0;
+  mInstance = 0;
 }
 
-void GenericModelD3D12::updatePerInstanceUniforms(const WorldUniforms &worldUniforms)
+void GenericModelD3D12::updatePerInstanceUniforms(
+    const WorldUniforms &worldUniforms)
 {
-    mWorldUniformPer.WorldUniforms[mInstance] = worldUniforms;
+  mWorldUniformPer.WorldUniforms[mInstance] = worldUniforms;
 
-    mInstance++;
+  mInstance++;
 }

--- a/src/aquarium-optimized/d3d12/GenericModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/GenericModelD3D12.h
@@ -19,64 +19,64 @@
 
 class GenericModelD3D12 : public Model
 {
-  public:
-    GenericModelD3D12(Context *context,
-                      Aquarium *aquarium,
-                      MODELGROUP type,
-                      MODELNAME name,
-                      bool blend);
+public:
+  GenericModelD3D12(Context *context,
+                    Aquarium *aquarium,
+                    MODELGROUP type,
+                    MODELNAME name,
+                    bool blend);
 
-    void init() override;
-    void prepareForDraw() override;
-    void draw() override;
+  void init() override;
+  void prepareForDraw() override;
+  void draw() override;
 
-    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
+  void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
 
-    TextureD3D12 *mDiffuseTexture;
-    TextureD3D12 *mNormalTexture;
-    TextureD3D12 *mReflectionTexture;
-    TextureD3D12 *mSkyboxTexture;
+  TextureD3D12 *mDiffuseTexture;
+  TextureD3D12 *mNormalTexture;
+  TextureD3D12 *mReflectionTexture;
+  TextureD3D12 *mSkyboxTexture;
 
-    BufferD3D12 *mPositionBuffer;
-    BufferD3D12 *mNormalBuffer;
-    BufferD3D12 *mTexCoordBuffer;
-    BufferD3D12 *mTangentBuffer;
-    BufferD3D12 *mBiNormalBuffer;
+  BufferD3D12 *mPositionBuffer;
+  BufferD3D12 *mNormalBuffer;
+  BufferD3D12 *mTexCoordBuffer;
+  BufferD3D12 *mTangentBuffer;
+  BufferD3D12 *mBiNormalBuffer;
 
-    BufferD3D12 *mIndicesBuffer;
+  BufferD3D12 *mIndicesBuffer;
 
-    struct LightFactorUniforms
-    {
-        float shininess;
-        float specularFactor;
-    } mLightFactorUniforms;
+  struct LightFactorUniforms
+  {
+    float shininess;
+    float specularFactor;
+  } mLightFactorUniforms;
 
-    struct WorldUniformPer
-    {
-        WorldUniforms WorldUniforms[20];
-    };
-    WorldUniformPer mWorldUniformPer;
+  struct WorldUniformPer
+  {
+    WorldUniforms WorldUniforms[20];
+  };
+  WorldUniformPer mWorldUniformPer;
 
-  private:
-    D3D12_CONSTANT_BUFFER_VIEW_DESC mWorldBufferView;
-    ComPtr<ID3D12Resource> mWorldBuffer;
-    ComPtr<ID3D12Resource> mWorldUploadBuffer;
+private:
+  D3D12_CONSTANT_BUFFER_VIEW_DESC mWorldBufferView;
+  ComPtr<ID3D12Resource> mWorldBuffer;
+  ComPtr<ID3D12Resource> mWorldUploadBuffer;
 
-    D3D12_CONSTANT_BUFFER_VIEW_DESC mLightFactorView;
-    D3D12_GPU_DESCRIPTOR_HANDLE mLightFactorGPUHandle;
-    ComPtr<ID3D12Resource> mLightFactorBuffer;
-    ComPtr<ID3D12Resource> mLightFactorUploadBuffer;
+  D3D12_CONSTANT_BUFFER_VIEW_DESC mLightFactorView;
+  D3D12_GPU_DESCRIPTOR_HANDLE mLightFactorGPUHandle;
+  ComPtr<ID3D12Resource> mLightFactorBuffer;
+  ComPtr<ID3D12Resource> mLightFactorUploadBuffer;
 
-    std::vector<D3D12_INPUT_ELEMENT_DESC> mInputElementDescs;
-    D3D12_VERTEX_BUFFER_VIEW mVertexBufferView[5];
+  std::vector<D3D12_INPUT_ELEMENT_DESC> mInputElementDescs;
+  D3D12_VERTEX_BUFFER_VIEW mVertexBufferView[5];
 
-    ComPtr<ID3D12RootSignature> mRootSignature;
-    ComPtr<ID3D12PipelineState> mPipelineState;
+  ComPtr<ID3D12RootSignature> mRootSignature;
+  ComPtr<ID3D12PipelineState> mPipelineState;
 
-    ContextD3D12 *mContextD3D12;
-    ProgramD3D12 *mProgramD3D12;
+  ContextD3D12 *mContextD3D12;
+  ProgramD3D12 *mProgramD3D12;
 
-    int mInstance;
+  int mInstance;
 };
 
 #endif  // GENERICMODELD3D12_H

--- a/src/aquarium-optimized/d3d12/InnerModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/InnerModelD3D12.cpp
@@ -14,124 +14,137 @@ InnerModelD3D12::InnerModelD3D12(Context *context,
                                  bool blend)
     : Model(type, name, blend)
 {
-    mContextD3D12 = static_cast<ContextD3D12 *>(context);
+  mContextD3D12 = static_cast<ContextD3D12 *>(context);
 
-    mInnerUniforms.eta             = 1.0f;
-    mInnerUniforms.tankColorFudge  = 0.796f;
-    mInnerUniforms.refractionFudge = 3.0f;
+  mInnerUniforms.eta             = 1.0f;
+  mInnerUniforms.tankColorFudge  = 0.796f;
+  mInnerUniforms.refractionFudge = 3.0f;
 }
 
 void InnerModelD3D12::init()
 {
-    mProgramD3D12 = static_cast<ProgramD3D12 *>(mProgram);
+  mProgramD3D12 = static_cast<ProgramD3D12 *>(mProgram);
 
-    mDiffuseTexture    = static_cast<TextureD3D12 *>(textureMap["diffuse"]);
-    mNormalTexture     = static_cast<TextureD3D12 *>(textureMap["normalMap"]);
-    mReflectionTexture = static_cast<TextureD3D12 *>(textureMap["reflectionMap"]);
-    mSkyboxTexture     = static_cast<TextureD3D12 *>(textureMap["skybox"]);
+  mDiffuseTexture    = static_cast<TextureD3D12 *>(textureMap["diffuse"]);
+  mNormalTexture     = static_cast<TextureD3D12 *>(textureMap["normalMap"]);
+  mReflectionTexture = static_cast<TextureD3D12 *>(textureMap["reflectionMap"]);
+  mSkyboxTexture     = static_cast<TextureD3D12 *>(textureMap["skybox"]);
 
-    mPositionBuffer = static_cast<BufferD3D12 *>(bufferMap["position"]);
-    mNormalBuffer   = static_cast<BufferD3D12 *>(bufferMap["normal"]);
-    mTexCoordBuffer = static_cast<BufferD3D12 *>(bufferMap["texCoord"]);
-    mTangentBuffer  = static_cast<BufferD3D12 *>(bufferMap["tangent"]);
-    mBiNormalBuffer = static_cast<BufferD3D12 *>(bufferMap["binormal"]);
-    mIndicesBuffer  = static_cast<BufferD3D12 *>(bufferMap["indices"]);
+  mPositionBuffer = static_cast<BufferD3D12 *>(bufferMap["position"]);
+  mNormalBuffer   = static_cast<BufferD3D12 *>(bufferMap["normal"]);
+  mTexCoordBuffer = static_cast<BufferD3D12 *>(bufferMap["texCoord"]);
+  mTangentBuffer  = static_cast<BufferD3D12 *>(bufferMap["tangent"]);
+  mBiNormalBuffer = static_cast<BufferD3D12 *>(bufferMap["binormal"]);
+  mIndicesBuffer  = static_cast<BufferD3D12 *>(bufferMap["indices"]);
 
-    mVertexBufferView[0] = mPositionBuffer->mVertexBufferView;
-    mVertexBufferView[1] = mNormalBuffer->mVertexBufferView;
-    mVertexBufferView[2] = mTexCoordBuffer->mVertexBufferView;
-    mVertexBufferView[3] = mTangentBuffer->mVertexBufferView;
-    mVertexBufferView[4] = mBiNormalBuffer->mVertexBufferView;
+  mVertexBufferView[0] = mPositionBuffer->mVertexBufferView;
+  mVertexBufferView[1] = mNormalBuffer->mVertexBufferView;
+  mVertexBufferView[2] = mTexCoordBuffer->mVertexBufferView;
+  mVertexBufferView[3] = mTangentBuffer->mVertexBufferView;
+  mVertexBufferView[4] = mBiNormalBuffer->mVertexBufferView;
 
-    mInputElementDescs = {{"TEXCOORD", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,
-                           D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
-                          {"TEXCOORD", 1, DXGI_FORMAT_R32G32B32_FLOAT, 1, 0,
-                           D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
-                          {"TEXCOORD", 2, DXGI_FORMAT_R32G32_FLOAT, 2, 0,
-                           D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
-                          {"TEXCOORD", 3, DXGI_FORMAT_R32G32B32_FLOAT, 3, 0,
-                           D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
-                          {"TEXCOORD", 4, DXGI_FORMAT_R32G32B32_FLOAT, 4, 0,
-                           D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0}};
+  mInputElementDescs = {{"TEXCOORD", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,
+                         D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+                        {"TEXCOORD", 1, DXGI_FORMAT_R32G32B32_FLOAT, 1, 0,
+                         D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+                        {"TEXCOORD", 2, DXGI_FORMAT_R32G32_FLOAT, 2, 0,
+                         D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+                        {"TEXCOORD", 3, DXGI_FORMAT_R32G32B32_FLOAT, 3, 0,
+                         D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+                        {"TEXCOORD", 4, DXGI_FORMAT_R32G32B32_FLOAT, 4, 0,
+                         D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0}};
 
-    // create constant buffer, desc.
-    mInnerBuffer = mContextD3D12->createDefaultBuffer(
-        &mInnerUniforms, sizeof(InnerUniforms),
-        mContextD3D12->CalcConstantBufferByteSize(sizeof(InnerUniforms)), mInnerUploadBuffer);
-    mInnerView.BufferLocation = mInnerBuffer->GetGPUVirtualAddress();
-    mInnerView.SizeInBytes    = mContextD3D12->CalcConstantBufferByteSize(
-        sizeof(InnerUniforms));  // CB size is required to be 256-byte aligned.
-    mContextD3D12->buildCbvDescriptor(mInnerView, &mInnerGPUHandle);
-    mWorldBuffer = mContextD3D12->createDefaultBuffer(
-        &mWorldUniformPer, sizeof(WorldUniforms),
-        mContextD3D12->CalcConstantBufferByteSize(sizeof(WorldUniforms)), mWorldUploadBuffer);
-    mWorldBufferView.BufferLocation = mWorldBuffer->GetGPUVirtualAddress();
-    mWorldBufferView.SizeInBytes = mContextD3D12->CalcConstantBufferByteSize(sizeof(WorldUniforms));
+  // create constant buffer, desc.
+  mInnerBuffer = mContextD3D12->createDefaultBuffer(
+      &mInnerUniforms, sizeof(InnerUniforms),
+      mContextD3D12->CalcConstantBufferByteSize(sizeof(InnerUniforms)),
+      mInnerUploadBuffer);
+  mInnerView.BufferLocation = mInnerBuffer->GetGPUVirtualAddress();
+  mInnerView.SizeInBytes    = mContextD3D12->CalcConstantBufferByteSize(
+      sizeof(InnerUniforms));  // CB size is required to be 256-byte aligned.
+  mContextD3D12->buildCbvDescriptor(mInnerView, &mInnerGPUHandle);
+  mWorldBuffer = mContextD3D12->createDefaultBuffer(
+      &mWorldUniformPer, sizeof(WorldUniforms),
+      mContextD3D12->CalcConstantBufferByteSize(sizeof(WorldUniforms)),
+      mWorldUploadBuffer);
+  mWorldBufferView.BufferLocation = mWorldBuffer->GetGPUVirtualAddress();
+  mWorldBufferView.SizeInBytes =
+      mContextD3D12->CalcConstantBufferByteSize(sizeof(WorldUniforms));
 
-    // Create root signature to bind resources.
-    // Bind textures, samplers and immutable constant buffers in a descriptor table.
-    // Bind frequently updated constant buffers by root descriptors.
-    CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-    CD3DX12_ROOT_PARAMETER1 rootParameters[5];
-    CD3DX12_DESCRIPTOR_RANGE1 ranges[2];
-    rootParameters[0] = mContextD3D12->rootParameterGeneral;
-    rootParameters[1] = mContextD3D12->rootParameterWorld;
+  // Create root signature to bind resources.
+  // Bind textures, samplers and immutable constant buffers in a descriptor
+  // table. Bind frequently updated constant buffers by root descriptors.
+  CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+  CD3DX12_ROOT_PARAMETER1 rootParameters[5];
+  CD3DX12_DESCRIPTOR_RANGE1 ranges[2];
+  rootParameters[0] = mContextD3D12->rootParameterGeneral;
+  rootParameters[1] = mContextD3D12->rootParameterWorld;
 
-    mDiffuseTexture->createSrvDescriptor();
-    mNormalTexture->createSrvDescriptor();
-    mReflectionTexture->createSrvDescriptor();
+  mDiffuseTexture->createSrvDescriptor();
+  mNormalTexture->createSrvDescriptor();
+  mReflectionTexture->createSrvDescriptor();
 
-    ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 2,
-                   D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-    ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 3, 0, 2,
-                   D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-    rootParameters[2].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
-    rootParameters[3].InitAsDescriptorTable(1, &ranges[1], D3D12_SHADER_VISIBILITY_PIXEL);
+  ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 2,
+                 D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+  ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 3, 0, 2,
+                 D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+  rootParameters[2].InitAsDescriptorTable(1, &ranges[0],
+                                          D3D12_SHADER_VISIBILITY_PIXEL);
+  rootParameters[3].InitAsDescriptorTable(1, &ranges[1],
+                                          D3D12_SHADER_VISIBILITY_PIXEL);
 
-    rootParameters[4].InitAsConstantBufferView(0, 3, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_VOLATILE,
-                                               D3D12_SHADER_VISIBILITY_VERTEX);
+  rootParameters[4].InitAsConstantBufferView(
+      0, 3, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_VOLATILE,
+      D3D12_SHADER_VISIBILITY_VERTEX);
 
-    rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 2u,
-                               mContextD3D12->staticSamplers.data(),
-                               D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+  rootSignatureDesc.Init_1_1(
+      _countof(rootParameters), rootParameters, 2u,
+      mContextD3D12->staticSamplers.data(),
+      D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-    mContextD3D12->createRootSignature(rootSignatureDesc, mRootSignature);
+  mContextD3D12->createRootSignature(rootSignatureDesc, mRootSignature);
 
-    mContextD3D12->createGraphicsPipelineState(
-        mInputElementDescs, mRootSignature, mProgramD3D12->getVSModule(),
-        mProgramD3D12->getFSModule(), mPipelineState, mBlend);
+  mContextD3D12->createGraphicsPipelineState(
+      mInputElementDescs, mRootSignature, mProgramD3D12->getVSModule(),
+      mProgramD3D12->getFSModule(), mPipelineState, mBlend);
 }
 
 void InnerModelD3D12::prepareForDraw()
 {
-    mContextD3D12->updateConstantBufferSync(mWorldBuffer, mWorldUploadBuffer, &mWorldUniformPer,
-                                            sizeof(WorldUniforms));
+  mContextD3D12->updateConstantBufferSync(mWorldBuffer, mWorldUploadBuffer,
+                                          &mWorldUniformPer,
+                                          sizeof(WorldUniforms));
 }
 
 void InnerModelD3D12::draw()
 {
-    mContextD3D12->mCommandList->SetPipelineState(mPipelineState.Get());
-    mContextD3D12->mCommandList->SetGraphicsRootSignature(mRootSignature.Get());
+  mContextD3D12->mCommandList->SetPipelineState(mPipelineState.Get());
+  mContextD3D12->mCommandList->SetGraphicsRootSignature(mRootSignature.Get());
 
-    mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(0, mContextD3D12->lightGPUHandle);
-    mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
-        1, mContextD3D12->lightWorldPositionGPUHandle);
-    mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(2, mInnerGPUHandle);
-    mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
-        3, mDiffuseTexture->getTextureGPUHandle());
-    mContextD3D12->mCommandList->SetGraphicsRootConstantBufferView(4,
-                                                                   mWorldBufferView.BufferLocation);
+  mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
+      0, mContextD3D12->lightGPUHandle);
+  mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
+      1, mContextD3D12->lightWorldPositionGPUHandle);
+  mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(2,
+                                                              mInnerGPUHandle);
+  mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
+      3, mDiffuseTexture->getTextureGPUHandle());
+  mContextD3D12->mCommandList->SetGraphicsRootConstantBufferView(
+      4, mWorldBufferView.BufferLocation);
 
-    mContextD3D12->mCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    mContextD3D12->mCommandList->IASetVertexBuffers(0, 5, mVertexBufferView);
+  mContextD3D12->mCommandList->IASetPrimitiveTopology(
+      D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+  mContextD3D12->mCommandList->IASetVertexBuffers(0, 5, mVertexBufferView);
 
-    mContextD3D12->mCommandList->IASetIndexBuffer(&mIndicesBuffer->mIndexBufferView);
+  mContextD3D12->mCommandList->IASetIndexBuffer(
+      &mIndicesBuffer->mIndexBufferView);
 
-    mContextD3D12->mCommandList->DrawIndexedInstanced(mIndicesBuffer->getTotalComponents(), 1, 0, 0,
-                                                      0);
+  mContextD3D12->mCommandList->DrawIndexedInstanced(
+      mIndicesBuffer->getTotalComponents(), 1, 0, 0, 0);
 }
 
-void InnerModelD3D12::updatePerInstanceUniforms(const WorldUniforms &worldUniforms)
+void InnerModelD3D12::updatePerInstanceUniforms(
+    const WorldUniforms &worldUniforms)
 {
-    memcpy(&mWorldUniformPer, &worldUniforms, sizeof(WorldUniforms));
+  memcpy(&mWorldUniformPer, &worldUniforms, sizeof(WorldUniforms));
 }

--- a/src/aquarium-optimized/d3d12/InnerModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/InnerModelD3D12.h
@@ -16,59 +16,59 @@
 
 class InnerModelD3D12 : public Model
 {
-  public:
-    InnerModelD3D12(Context *context,
-                    Aquarium *aquarium,
-                    MODELGROUP type,
-                    MODELNAME name,
-                    bool blend);
+public:
+  InnerModelD3D12(Context *context,
+                  Aquarium *aquarium,
+                  MODELGROUP type,
+                  MODELNAME name,
+                  bool blend);
 
-    void init() override;
-    void prepareForDraw() override;
-    void draw() override;
-    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
+  void init() override;
+  void prepareForDraw() override;
+  void draw() override;
+  void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
 
-    struct InnerUniforms
-    {
-        float eta;
-        float tankColorFudge;
-        float refractionFudge;
-        float padding;
-    } mInnerUniforms;
+  struct InnerUniforms
+  {
+    float eta;
+    float tankColorFudge;
+    float refractionFudge;
+    float padding;
+  } mInnerUniforms;
 
-    WorldUniforms mWorldUniformPer;
+  WorldUniforms mWorldUniformPer;
 
-    TextureD3D12 *mDiffuseTexture;
-    TextureD3D12 *mNormalTexture;
-    TextureD3D12 *mReflectionTexture;
-    TextureD3D12 *mSkyboxTexture;
+  TextureD3D12 *mDiffuseTexture;
+  TextureD3D12 *mNormalTexture;
+  TextureD3D12 *mReflectionTexture;
+  TextureD3D12 *mSkyboxTexture;
 
-    BufferD3D12 *mPositionBuffer;
-    BufferD3D12 *mNormalBuffer;
-    BufferD3D12 *mTexCoordBuffer;
-    BufferD3D12 *mTangentBuffer;
-    BufferD3D12 *mBiNormalBuffer;
+  BufferD3D12 *mPositionBuffer;
+  BufferD3D12 *mNormalBuffer;
+  BufferD3D12 *mTexCoordBuffer;
+  BufferD3D12 *mTangentBuffer;
+  BufferD3D12 *mBiNormalBuffer;
 
-    BufferD3D12 *mIndicesBuffer;
+  BufferD3D12 *mIndicesBuffer;
 
-  private:
-    D3D12_CONSTANT_BUFFER_VIEW_DESC mWorldBufferView;
-    ComPtr<ID3D12Resource> mWorldBuffer;
-    ComPtr<ID3D12Resource> mWorldUploadBuffer;
+private:
+  D3D12_CONSTANT_BUFFER_VIEW_DESC mWorldBufferView;
+  ComPtr<ID3D12Resource> mWorldBuffer;
+  ComPtr<ID3D12Resource> mWorldUploadBuffer;
 
-    D3D12_CONSTANT_BUFFER_VIEW_DESC mInnerView;
-    D3D12_GPU_DESCRIPTOR_HANDLE mInnerGPUHandle;
-    ComPtr<ID3D12Resource> mInnerBuffer;
-    ComPtr<ID3D12Resource> mInnerUploadBuffer;
+  D3D12_CONSTANT_BUFFER_VIEW_DESC mInnerView;
+  D3D12_GPU_DESCRIPTOR_HANDLE mInnerGPUHandle;
+  ComPtr<ID3D12Resource> mInnerBuffer;
+  ComPtr<ID3D12Resource> mInnerUploadBuffer;
 
-    std::vector<D3D12_INPUT_ELEMENT_DESC> mInputElementDescs;
-    D3D12_VERTEX_BUFFER_VIEW mVertexBufferView[5];
+  std::vector<D3D12_INPUT_ELEMENT_DESC> mInputElementDescs;
+  D3D12_VERTEX_BUFFER_VIEW mVertexBufferView[5];
 
-    ComPtr<ID3D12RootSignature> mRootSignature;
-    ComPtr<ID3D12PipelineState> mPipelineState;
+  ComPtr<ID3D12RootSignature> mRootSignature;
+  ComPtr<ID3D12PipelineState> mPipelineState;
 
-    ContextD3D12 *mContextD3D12;
-    ProgramD3D12 *mProgramD3D12;
+  ContextD3D12 *mContextD3D12;
+  ProgramD3D12 *mProgramD3D12;
 };
 
 #endif  // INNERMODELD3D12_H

--- a/src/aquarium-optimized/d3d12/OutsideModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/OutsideModelD3D12.cpp
@@ -13,117 +13,129 @@ OutsideModelD3D12::OutsideModelD3D12(Context *context,
                                      bool blend)
     : Model(type, name, blend)
 {
-    mContextD3D12 = static_cast<ContextD3D12 *>(context);
+  mContextD3D12 = static_cast<ContextD3D12 *>(context);
 
-    mLightFactorUniforms.shininess      = 50.0f;
-    mLightFactorUniforms.specularFactor = 0.0f;
+  mLightFactorUniforms.shininess      = 50.0f;
+  mLightFactorUniforms.specularFactor = 0.0f;
 }
 
 void OutsideModelD3D12::init()
 {
-    mProgramD3D12 = static_cast<ProgramD3D12 *>(mProgram);
+  mProgramD3D12 = static_cast<ProgramD3D12 *>(mProgram);
 
-    mDiffuseTexture    = static_cast<TextureD3D12 *>(textureMap["diffuse"]);
-    mNormalTexture     = static_cast<TextureD3D12 *>(textureMap["normalMap"]);
-    mReflectionTexture = static_cast<TextureD3D12 *>(textureMap["reflectionMap"]);
-    mSkyboxTexture     = static_cast<TextureD3D12 *>(textureMap["skybox"]);
+  mDiffuseTexture    = static_cast<TextureD3D12 *>(textureMap["diffuse"]);
+  mNormalTexture     = static_cast<TextureD3D12 *>(textureMap["normalMap"]);
+  mReflectionTexture = static_cast<TextureD3D12 *>(textureMap["reflectionMap"]);
+  mSkyboxTexture     = static_cast<TextureD3D12 *>(textureMap["skybox"]);
 
-    mPositionBuffer = static_cast<BufferD3D12 *>(bufferMap["position"]);
-    mNormalBuffer   = static_cast<BufferD3D12 *>(bufferMap["normal"]);
-    mTexCoordBuffer = static_cast<BufferD3D12 *>(bufferMap["texCoord"]);
-    mTangentBuffer  = static_cast<BufferD3D12 *>(bufferMap["tangent"]);
-    mBiNormalBuffer = static_cast<BufferD3D12 *>(bufferMap["binormal"]);
-    mIndicesBuffer  = static_cast<BufferD3D12 *>(bufferMap["indices"]);
+  mPositionBuffer = static_cast<BufferD3D12 *>(bufferMap["position"]);
+  mNormalBuffer   = static_cast<BufferD3D12 *>(bufferMap["normal"]);
+  mTexCoordBuffer = static_cast<BufferD3D12 *>(bufferMap["texCoord"]);
+  mTangentBuffer  = static_cast<BufferD3D12 *>(bufferMap["tangent"]);
+  mBiNormalBuffer = static_cast<BufferD3D12 *>(bufferMap["binormal"]);
+  mIndicesBuffer  = static_cast<BufferD3D12 *>(bufferMap["indices"]);
 
-    mVertexBufferView[0] = mPositionBuffer->mVertexBufferView;
-    mVertexBufferView[1] = mNormalBuffer->mVertexBufferView;
-    mVertexBufferView[2] = mTexCoordBuffer->mVertexBufferView;
+  mVertexBufferView[0] = mPositionBuffer->mVertexBufferView;
+  mVertexBufferView[1] = mNormalBuffer->mVertexBufferView;
+  mVertexBufferView[2] = mTexCoordBuffer->mVertexBufferView;
 
-    mInputElementDescs = {
-        {"TEXCOORD", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,
-         D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
-        {"TEXCOORD", 1, DXGI_FORMAT_R32G32B32_FLOAT, 1, 0,
-         D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
-        {"TEXCOORD", 2, DXGI_FORMAT_R32G32_FLOAT, 2, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA,
-         0},
-    };
+  mInputElementDescs = {
+      {"TEXCOORD", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,
+       D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+      {"TEXCOORD", 1, DXGI_FORMAT_R32G32B32_FLOAT, 1, 0,
+       D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+      {"TEXCOORD", 2, DXGI_FORMAT_R32G32_FLOAT, 2, 0,
+       D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+  };
 
-    // create constant buffer, desc.
-    mLightFactorBuffer = mContextD3D12->createDefaultBuffer(
-        &mLightFactorUniforms, sizeof(LightFactorUniforms),
-        mContextD3D12->CalcConstantBufferByteSize(sizeof(LightFactorUniforms)),
-        mLightFactorUploadBuffer);
-    mLightFactorView.BufferLocation = mLightFactorBuffer->GetGPUVirtualAddress();
-    mLightFactorView.SizeInBytes    = mContextD3D12->CalcConstantBufferByteSize(
-        sizeof(LightFactorUniforms));  // CB size is required to be 256-byte aligned.
-    mContextD3D12->buildCbvDescriptor(mLightFactorView, &mLightFactorGPUHandle);
-    mWorldBuffer = mContextD3D12->createDefaultBuffer(
-        &mWorldUniformPer, sizeof(WorldUniforms) * 20,
-        mContextD3D12->CalcConstantBufferByteSize(sizeof(WorldUniforms) * 20), mWorldUploadBuffer);
-    mWorldBufferView.BufferLocation = mWorldBuffer->GetGPUVirtualAddress();
-    mWorldBufferView.SizeInBytes =
-        mContextD3D12->CalcConstantBufferByteSize(sizeof(WorldUniforms) * 20);
+  // create constant buffer, desc.
+  mLightFactorBuffer = mContextD3D12->createDefaultBuffer(
+      &mLightFactorUniforms, sizeof(LightFactorUniforms),
+      mContextD3D12->CalcConstantBufferByteSize(sizeof(LightFactorUniforms)),
+      mLightFactorUploadBuffer);
+  mLightFactorView.BufferLocation = mLightFactorBuffer->GetGPUVirtualAddress();
+  mLightFactorView.SizeInBytes =
+      mContextD3D12->CalcConstantBufferByteSize(sizeof(
+          LightFactorUniforms));  // CB size is required to be 256-byte aligned.
+  mContextD3D12->buildCbvDescriptor(mLightFactorView, &mLightFactorGPUHandle);
+  mWorldBuffer = mContextD3D12->createDefaultBuffer(
+      &mWorldUniformPer, sizeof(WorldUniforms) * 20,
+      mContextD3D12->CalcConstantBufferByteSize(sizeof(WorldUniforms) * 20),
+      mWorldUploadBuffer);
+  mWorldBufferView.BufferLocation = mWorldBuffer->GetGPUVirtualAddress();
+  mWorldBufferView.SizeInBytes =
+      mContextD3D12->CalcConstantBufferByteSize(sizeof(WorldUniforms) * 20);
 
-    // Create root signature to bind resources.
-    // Bind textures, samplers and immutable constant buffers in a descriptor table.
-    // Bind frequently updated constant buffers by root descriptors.
-    CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-    CD3DX12_ROOT_PARAMETER1 rootParameters[5];
-    CD3DX12_DESCRIPTOR_RANGE1 ranges[2];
-    rootParameters[0] = mContextD3D12->rootParameterGeneral;
-    rootParameters[1] = mContextD3D12->rootParameterWorld;
+  // Create root signature to bind resources.
+  // Bind textures, samplers and immutable constant buffers in a descriptor
+  // table. Bind frequently updated constant buffers by root descriptors.
+  CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+  CD3DX12_ROOT_PARAMETER1 rootParameters[5];
+  CD3DX12_DESCRIPTOR_RANGE1 ranges[2];
+  rootParameters[0] = mContextD3D12->rootParameterGeneral;
+  rootParameters[1] = mContextD3D12->rootParameterWorld;
 
-    mDiffuseTexture->createSrvDescriptor();
+  mDiffuseTexture->createSrvDescriptor();
 
-    ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 2,
-                   D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-    ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 2,
-                   D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-    rootParameters[2].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
-    rootParameters[3].InitAsDescriptorTable(1, &ranges[1], D3D12_SHADER_VISIBILITY_PIXEL);
+  ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 2,
+                 D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+  ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 2,
+                 D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+  rootParameters[2].InitAsDescriptorTable(1, &ranges[0],
+                                          D3D12_SHADER_VISIBILITY_PIXEL);
+  rootParameters[3].InitAsDescriptorTable(1, &ranges[1],
+                                          D3D12_SHADER_VISIBILITY_PIXEL);
 
-    rootParameters[4].InitAsConstantBufferView(0, 3, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_VOLATILE,
-                                               D3D12_SHADER_VISIBILITY_VERTEX);
+  rootParameters[4].InitAsConstantBufferView(
+      0, 3, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_VOLATILE,
+      D3D12_SHADER_VISIBILITY_VERTEX);
 
-    rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 2u,
-                               mContextD3D12->staticSamplers.data(),
-                               D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+  rootSignatureDesc.Init_1_1(
+      _countof(rootParameters), rootParameters, 2u,
+      mContextD3D12->staticSamplers.data(),
+      D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-    mContextD3D12->createRootSignature(rootSignatureDesc, mRootSignature);
+  mContextD3D12->createRootSignature(rootSignatureDesc, mRootSignature);
 
-    mContextD3D12->createGraphicsPipelineState(
-        mInputElementDescs, mRootSignature, mProgramD3D12->getVSModule(),
-        mProgramD3D12->getFSModule(), mPipelineState, mBlend);
+  mContextD3D12->createGraphicsPipelineState(
+      mInputElementDescs, mRootSignature, mProgramD3D12->getVSModule(),
+      mProgramD3D12->getFSModule(), mPipelineState, mBlend);
 }
 
 void OutsideModelD3D12::prepareForDraw()
 {
-    mContextD3D12->updateConstantBufferSync(mWorldBuffer, mWorldUploadBuffer, &mWorldUniformPer,
-                                            sizeof(WorldUniforms) * 20);
+  mContextD3D12->updateConstantBufferSync(mWorldBuffer, mWorldUploadBuffer,
+                                          &mWorldUniformPer,
+                                          sizeof(WorldUniforms) * 20);
 }
 
 void OutsideModelD3D12::draw()
 {
-    auto &commandList = mContextD3D12->mCommandList;
+  auto &commandList = mContextD3D12->mCommandList;
 
-    commandList->SetPipelineState(mPipelineState.Get());
-    commandList->SetGraphicsRootSignature(mRootSignature.Get());
+  commandList->SetPipelineState(mPipelineState.Get());
+  commandList->SetGraphicsRootSignature(mRootSignature.Get());
 
-    commandList->SetGraphicsRootDescriptorTable(0, mContextD3D12->lightGPUHandle);
-    commandList->SetGraphicsRootDescriptorTable(1, mContextD3D12->lightWorldPositionGPUHandle);
-    commandList->SetGraphicsRootDescriptorTable(2, mLightFactorGPUHandle);
-    commandList->SetGraphicsRootDescriptorTable(3, mDiffuseTexture->getTextureGPUHandle());
-    commandList->SetGraphicsRootConstantBufferView(4, mWorldBufferView.BufferLocation);
+  commandList->SetGraphicsRootDescriptorTable(0, mContextD3D12->lightGPUHandle);
+  commandList->SetGraphicsRootDescriptorTable(
+      1, mContextD3D12->lightWorldPositionGPUHandle);
+  commandList->SetGraphicsRootDescriptorTable(2, mLightFactorGPUHandle);
+  commandList->SetGraphicsRootDescriptorTable(
+      3, mDiffuseTexture->getTextureGPUHandle());
+  commandList->SetGraphicsRootConstantBufferView(
+      4, mWorldBufferView.BufferLocation);
 
-    commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    commandList->IASetVertexBuffers(0, 3, mVertexBufferView);
+  commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+  commandList->IASetVertexBuffers(0, 3, mVertexBufferView);
 
-    commandList->IASetIndexBuffer(&mIndicesBuffer->mIndexBufferView);
+  commandList->IASetIndexBuffer(&mIndicesBuffer->mIndexBufferView);
 
-    commandList->DrawIndexedInstanced(mIndicesBuffer->getTotalComponents(), 1, 0, 0, 0);
+  commandList->DrawIndexedInstanced(mIndicesBuffer->getTotalComponents(), 1, 0,
+                                    0, 0);
 }
 
-void OutsideModelD3D12::updatePerInstanceUniforms(const WorldUniforms &worldUniforms)
+void OutsideModelD3D12::updatePerInstanceUniforms(
+    const WorldUniforms &worldUniforms)
 {
-    memcpy(&mWorldUniformPer, &worldUniforms, sizeof(WorldUniforms));
+  memcpy(&mWorldUniformPer, &worldUniforms, sizeof(WorldUniforms));
 }

--- a/src/aquarium-optimized/d3d12/OutsideModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/OutsideModelD3D12.h
@@ -18,58 +18,58 @@
 
 class OutsideModelD3D12 : public Model
 {
-  public:
-    OutsideModelD3D12(Context *context,
-                      Aquarium *aquarium,
-                      MODELGROUP type,
-                      MODELNAME name,
-                      bool blend);
+public:
+  OutsideModelD3D12(Context *context,
+                    Aquarium *aquarium,
+                    MODELGROUP type,
+                    MODELNAME name,
+                    bool blend);
 
-    void init() override;
-    void prepareForDraw() override;
-    void draw() override;
+  void init() override;
+  void prepareForDraw() override;
+  void draw() override;
 
-    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
+  void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
 
-    TextureD3D12 *mDiffuseTexture;
-    TextureD3D12 *mNormalTexture;
-    TextureD3D12 *mReflectionTexture;
-    TextureD3D12 *mSkyboxTexture;
+  TextureD3D12 *mDiffuseTexture;
+  TextureD3D12 *mNormalTexture;
+  TextureD3D12 *mReflectionTexture;
+  TextureD3D12 *mSkyboxTexture;
 
-    BufferD3D12 *mPositionBuffer;
-    BufferD3D12 *mNormalBuffer;
-    BufferD3D12 *mTexCoordBuffer;
-    BufferD3D12 *mTangentBuffer;
-    BufferD3D12 *mBiNormalBuffer;
+  BufferD3D12 *mPositionBuffer;
+  BufferD3D12 *mNormalBuffer;
+  BufferD3D12 *mTexCoordBuffer;
+  BufferD3D12 *mTangentBuffer;
+  BufferD3D12 *mBiNormalBuffer;
 
-    BufferD3D12 *mIndicesBuffer;
+  BufferD3D12 *mIndicesBuffer;
 
-    struct LightFactorUniforms
-    {
-        float shininess;
-        float specularFactor;
-    } mLightFactorUniforms;
+  struct LightFactorUniforms
+  {
+    float shininess;
+    float specularFactor;
+  } mLightFactorUniforms;
 
-    WorldUniforms mWorldUniformPer[20];
+  WorldUniforms mWorldUniformPer[20];
 
-  private:
-    D3D12_CONSTANT_BUFFER_VIEW_DESC mWorldBufferView;
-    ComPtr<ID3D12Resource> mWorldBuffer;
-    ComPtr<ID3D12Resource> mWorldUploadBuffer;
+private:
+  D3D12_CONSTANT_BUFFER_VIEW_DESC mWorldBufferView;
+  ComPtr<ID3D12Resource> mWorldBuffer;
+  ComPtr<ID3D12Resource> mWorldUploadBuffer;
 
-    D3D12_CONSTANT_BUFFER_VIEW_DESC mLightFactorView;
-    D3D12_GPU_DESCRIPTOR_HANDLE mLightFactorGPUHandle;
-    ComPtr<ID3D12Resource> mLightFactorBuffer;
-    ComPtr<ID3D12Resource> mLightFactorUploadBuffer;
+  D3D12_CONSTANT_BUFFER_VIEW_DESC mLightFactorView;
+  D3D12_GPU_DESCRIPTOR_HANDLE mLightFactorGPUHandle;
+  ComPtr<ID3D12Resource> mLightFactorBuffer;
+  ComPtr<ID3D12Resource> mLightFactorUploadBuffer;
 
-    std::vector<D3D12_INPUT_ELEMENT_DESC> mInputElementDescs;
-    D3D12_VERTEX_BUFFER_VIEW mVertexBufferView[3];
+  std::vector<D3D12_INPUT_ELEMENT_DESC> mInputElementDescs;
+  D3D12_VERTEX_BUFFER_VIEW mVertexBufferView[3];
 
-    ComPtr<ID3D12RootSignature> mRootSignature;
-    ComPtr<ID3D12PipelineState> mPipelineState;
+  ComPtr<ID3D12RootSignature> mRootSignature;
+  ComPtr<ID3D12PipelineState> mPipelineState;
 
-    ContextD3D12 *mContextD3D12;
-    ProgramD3D12 *mProgramD3D12;
+  ContextD3D12 *mContextD3D12;
+  ProgramD3D12 *mProgramD3D12;
 };
 
 #endif  // OUTSIDEMODELD3D12_H

--- a/src/aquarium-optimized/d3d12/ProgramD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/ProgramD3D12.cpp
@@ -11,8 +11,13 @@
 
 #include "ContextD3D12.h"
 
-ProgramD3D12::ProgramD3D12(ContextD3D12 *context, const std::string &mVId, const std::string &mFId)
-    : Program(mVId, mFId), mVertexShader(nullptr), mPixelShader(nullptr), context(context)
+ProgramD3D12::ProgramD3D12(ContextD3D12 *context,
+                           const std::string &mVId,
+                           const std::string &mFId)
+    : Program(mVId, mFId),
+      mVertexShader(nullptr),
+      mPixelShader(nullptr),
+      context(context)
 {
 }
 
@@ -20,14 +25,14 @@ ProgramD3D12::~ProgramD3D12() {}
 
 void ProgramD3D12::compileProgram(bool enableBlending, const std::string &alpha)
 {
-    loadProgram();
+  loadProgram();
 
-    if (enableBlending)
-    {
-        FragmentShaderCode =
-            std::regex_replace(FragmentShaderCode, std::regex(R"(diffuseColor.w)"), alpha);
-    }
+  if (enableBlending)
+  {
+    FragmentShaderCode = std::regex_replace(
+        FragmentShaderCode, std::regex(R"(diffuseColor.w)"), alpha);
+  }
 
-    mVertexShader = context->createShaderModule("VS", VertexShaderCode);
-    mPixelShader  = context->createShaderModule("PS", FragmentShaderCode);
+  mVertexShader = context->createShaderModule("VS", VertexShaderCode);
+  mPixelShader  = context->createShaderModule("PS", FragmentShaderCode);
 }

--- a/src/aquarium-optimized/d3d12/ProgramD3D12.h
+++ b/src/aquarium-optimized/d3d12/ProgramD3D12.h
@@ -23,20 +23,23 @@ class ContextD3D12;
 
 class ProgramD3D12 : public Program
 {
-  public:
-    ProgramD3D12() {}
-    ProgramD3D12(ContextD3D12 *context, const std::string &mVId, const std::string &mFId);
-    ~ProgramD3D12() override;
+public:
+  ProgramD3D12() {}
+  ProgramD3D12(ContextD3D12 *context,
+               const std::string &mVId,
+               const std::string &mFId);
+  ~ProgramD3D12() override;
 
-    void compileProgram(bool enableAlphaBlending, const std::string &alpha) override;
-    ComPtr<ID3DBlob> getVSModule() { return mVertexShader; }
-    ComPtr<ID3DBlob> getFSModule() { return mPixelShader; }
+  void compileProgram(bool enableAlphaBlending,
+                      const std::string &alpha) override;
+  ComPtr<ID3DBlob> getVSModule() { return mVertexShader; }
+  ComPtr<ID3DBlob> getFSModule() { return mPixelShader; }
 
-  private:
-    ComPtr<ID3DBlob> mVertexShader;
-    ComPtr<ID3DBlob> mPixelShader;
+private:
+  ComPtr<ID3DBlob> mVertexShader;
+  ComPtr<ID3DBlob> mPixelShader;
 
-    ContextD3D12 *context;
+  ContextD3D12 *context;
 };
 
 #endif  // PROGRAMD3D12_H

--- a/src/aquarium-optimized/d3d12/SeaweedModelD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/SeaweedModelD3D12.cpp
@@ -14,138 +14,153 @@ SeaweedModelD3D12::SeaweedModelD3D12(Context *context,
                                      bool blend)
     : SeaweedModel(type, name, blend), instance(0)
 {
-    mContextD3D12 = static_cast<ContextD3D12 *>(context);
-    mAquarium     = aquarium;
+  mContextD3D12 = static_cast<ContextD3D12 *>(context);
+  mAquarium     = aquarium;
 
-    mLightFactorUniforms.shininess      = 50.0f;
-    mLightFactorUniforms.specularFactor = 1.0f;
+  mLightFactorUniforms.shininess      = 50.0f;
+  mLightFactorUniforms.specularFactor = 1.0f;
 }
 
 void SeaweedModelD3D12::init()
 {
-    mProgramD3D12 = static_cast<ProgramD3D12 *>(mProgram);
+  mProgramD3D12 = static_cast<ProgramD3D12 *>(mProgram);
 
-    mDiffuseTexture    = static_cast<TextureD3D12 *>(textureMap["diffuse"]);
-    mNormalTexture     = static_cast<TextureD3D12 *>(textureMap["normalMap"]);
-    mReflectionTexture = static_cast<TextureD3D12 *>(textureMap["reflectionMap"]);
-    mSkyboxTexture     = static_cast<TextureD3D12 *>(textureMap["skybox"]);
+  mDiffuseTexture    = static_cast<TextureD3D12 *>(textureMap["diffuse"]);
+  mNormalTexture     = static_cast<TextureD3D12 *>(textureMap["normalMap"]);
+  mReflectionTexture = static_cast<TextureD3D12 *>(textureMap["reflectionMap"]);
+  mSkyboxTexture     = static_cast<TextureD3D12 *>(textureMap["skybox"]);
 
-    mPositionBuffer = static_cast<BufferD3D12 *>(bufferMap["position"]);
-    mNormalBuffer   = static_cast<BufferD3D12 *>(bufferMap["normal"]);
-    mTexCoordBuffer = static_cast<BufferD3D12 *>(bufferMap["texCoord"]);
-    mIndicesBuffer  = static_cast<BufferD3D12 *>(bufferMap["indices"]);
+  mPositionBuffer = static_cast<BufferD3D12 *>(bufferMap["position"]);
+  mNormalBuffer   = static_cast<BufferD3D12 *>(bufferMap["normal"]);
+  mTexCoordBuffer = static_cast<BufferD3D12 *>(bufferMap["texCoord"]);
+  mIndicesBuffer  = static_cast<BufferD3D12 *>(bufferMap["indices"]);
 
-    mVertexBufferView[0] = mPositionBuffer->mVertexBufferView;
-    mVertexBufferView[1] = mNormalBuffer->mVertexBufferView;
-    mVertexBufferView[2] = mTexCoordBuffer->mVertexBufferView;
+  mVertexBufferView[0] = mPositionBuffer->mVertexBufferView;
+  mVertexBufferView[1] = mNormalBuffer->mVertexBufferView;
+  mVertexBufferView[2] = mTexCoordBuffer->mVertexBufferView;
 
-    // create input layout
-    mInputElementDescs = {
-        {"TEXCOORD", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,
-         D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
-        {"TEXCOORD", 1, DXGI_FORMAT_R32G32B32_FLOAT, 1, 0,
-         D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
-        {"TEXCOORD", 2, DXGI_FORMAT_R32G32_FLOAT, 2, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA,
-         0},
-    };
+  // create input layout
+  mInputElementDescs = {
+      {"TEXCOORD", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,
+       D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+      {"TEXCOORD", 1, DXGI_FORMAT_R32G32B32_FLOAT, 1, 0,
+       D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+      {"TEXCOORD", 2, DXGI_FORMAT_R32G32_FLOAT, 2, 0,
+       D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+  };
 
-    // create constant buffer, desc.
-    mLightFactorBuffer = mContextD3D12->createDefaultBuffer(
-        &mLightFactorUniforms, sizeof(LightFactorUniforms),
-        mContextD3D12->CalcConstantBufferByteSize(sizeof(LightFactorUniforms)),
-        mLightFactorUploadBuffer);
-    mLightFactorView.BufferLocation = mLightFactorBuffer->GetGPUVirtualAddress();
-    mLightFactorView.SizeInBytes    = mContextD3D12->CalcConstantBufferByteSize(
-        sizeof(LightFactorUniforms));  // CB size is required to be 256-byte aligned.
-    mContextD3D12->buildCbvDescriptor(mLightFactorView, &mLightFactorGPUHandle);
-    mWorldBuffer = mContextD3D12->createDefaultBuffer(
-        &mWorldUniformPer, sizeof(WorldUniformPer),
-        mContextD3D12->CalcConstantBufferByteSize(sizeof(WorldUniformPer)), mWorldUploadBuffer);
-    mWorldBufferView.BufferLocation = mWorldBuffer->GetGPUVirtualAddress();
-    mWorldBufferView.SizeInBytes =
-        mContextD3D12->CalcConstantBufferByteSize(sizeof(WorldUniformPer));
-    mSeaweedBuffer = mContextD3D12->createDefaultBuffer(
-        &mSeaweedPer, sizeof(SeaweedPer),
-        mContextD3D12->CalcConstantBufferByteSize(sizeof(SeaweedPer)), mSeaweedUploadBuffer);
-    mSeaweedBufferView.BufferLocation = mSeaweedBuffer->GetGPUVirtualAddress();
-    mSeaweedBufferView.SizeInBytes = mContextD3D12->CalcConstantBufferByteSize(sizeof(SeaweedPer));
+  // create constant buffer, desc.
+  mLightFactorBuffer = mContextD3D12->createDefaultBuffer(
+      &mLightFactorUniforms, sizeof(LightFactorUniforms),
+      mContextD3D12->CalcConstantBufferByteSize(sizeof(LightFactorUniforms)),
+      mLightFactorUploadBuffer);
+  mLightFactorView.BufferLocation = mLightFactorBuffer->GetGPUVirtualAddress();
+  mLightFactorView.SizeInBytes =
+      mContextD3D12->CalcConstantBufferByteSize(sizeof(
+          LightFactorUniforms));  // CB size is required to be 256-byte aligned.
+  mContextD3D12->buildCbvDescriptor(mLightFactorView, &mLightFactorGPUHandle);
+  mWorldBuffer = mContextD3D12->createDefaultBuffer(
+      &mWorldUniformPer, sizeof(WorldUniformPer),
+      mContextD3D12->CalcConstantBufferByteSize(sizeof(WorldUniformPer)),
+      mWorldUploadBuffer);
+  mWorldBufferView.BufferLocation = mWorldBuffer->GetGPUVirtualAddress();
+  mWorldBufferView.SizeInBytes =
+      mContextD3D12->CalcConstantBufferByteSize(sizeof(WorldUniformPer));
+  mSeaweedBuffer = mContextD3D12->createDefaultBuffer(
+      &mSeaweedPer, sizeof(SeaweedPer),
+      mContextD3D12->CalcConstantBufferByteSize(sizeof(SeaweedPer)),
+      mSeaweedUploadBuffer);
+  mSeaweedBufferView.BufferLocation = mSeaweedBuffer->GetGPUVirtualAddress();
+  mSeaweedBufferView.SizeInBytes =
+      mContextD3D12->CalcConstantBufferByteSize(sizeof(SeaweedPer));
 
-    // Create root signature to bind resources.
-    // Bind textures, samplers and immutable constant buffers in a descriptor table.
-    // Bind frequently updated constant buffers by root descriptors.
-    CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
-    CD3DX12_ROOT_PARAMETER1 rootParameters[6];
-    CD3DX12_DESCRIPTOR_RANGE1 ranges[2];
-    rootParameters[0] = mContextD3D12->rootParameterGeneral;
-    rootParameters[1] = mContextD3D12->rootParameterWorld;
+  // Create root signature to bind resources.
+  // Bind textures, samplers and immutable constant buffers in a descriptor
+  // table. Bind frequently updated constant buffers by root descriptors.
+  CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+  CD3DX12_ROOT_PARAMETER1 rootParameters[6];
+  CD3DX12_DESCRIPTOR_RANGE1 ranges[2];
+  rootParameters[0] = mContextD3D12->rootParameterGeneral;
+  rootParameters[1] = mContextD3D12->rootParameterWorld;
 
-    mDiffuseTexture->createSrvDescriptor();
+  mDiffuseTexture->createSrvDescriptor();
 
-    ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 2,
-                   D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-    ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 2,
-                   D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-    rootParameters[2].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
-    rootParameters[3].InitAsDescriptorTable(1, &ranges[1], D3D12_SHADER_VISIBILITY_PIXEL);
+  ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 1, 0, 2,
+                 D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+  ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 2,
+                 D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
+  rootParameters[2].InitAsDescriptorTable(1, &ranges[0],
+                                          D3D12_SHADER_VISIBILITY_PIXEL);
+  rootParameters[3].InitAsDescriptorTable(1, &ranges[1],
+                                          D3D12_SHADER_VISIBILITY_PIXEL);
 
-    rootParameters[4].InitAsConstantBufferView(0, 3, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_VOLATILE,
-                                               D3D12_SHADER_VISIBILITY_VERTEX);
-    rootParameters[5].InitAsConstantBufferView(1, 3, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_VOLATILE,
-                                               D3D12_SHADER_VISIBILITY_VERTEX);
+  rootParameters[4].InitAsConstantBufferView(
+      0, 3, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_VOLATILE,
+      D3D12_SHADER_VISIBILITY_VERTEX);
+  rootParameters[5].InitAsConstantBufferView(
+      1, 3, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_VOLATILE,
+      D3D12_SHADER_VISIBILITY_VERTEX);
 
-    rootSignatureDesc.Init_1_1(_countof(rootParameters), rootParameters, 2u,
-                               mContextD3D12->staticSamplers.data(),
-                               D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+  rootSignatureDesc.Init_1_1(
+      _countof(rootParameters), rootParameters, 2u,
+      mContextD3D12->staticSamplers.data(),
+      D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
-    mContextD3D12->createRootSignature(rootSignatureDesc, mRootSignature);
+  mContextD3D12->createRootSignature(rootSignatureDesc, mRootSignature);
 
-    mContextD3D12->createGraphicsPipelineState(
-        mInputElementDescs, mRootSignature, mProgramD3D12->getVSModule(),
-        mProgramD3D12->getFSModule(), mPipelineState, mBlend);
+  mContextD3D12->createGraphicsPipelineState(
+      mInputElementDescs, mRootSignature, mProgramD3D12->getVSModule(),
+      mProgramD3D12->getFSModule(), mPipelineState, mBlend);
 }
 
 void SeaweedModelD3D12::prepareForDraw()
 {
-    mContextD3D12->updateConstantBufferSync(mWorldBuffer, mWorldUploadBuffer, &mWorldUniformPer,
-                                            sizeof(WorldUniformPer));
+  mContextD3D12->updateConstantBufferSync(mWorldBuffer, mWorldUploadBuffer,
+                                          &mWorldUniformPer,
+                                          sizeof(WorldUniformPer));
 
-    mContextD3D12->updateConstantBufferSync(mSeaweedBuffer, mSeaweedUploadBuffer, &mSeaweedPer,
-                                            sizeof(SeaweedPer));
+  mContextD3D12->updateConstantBufferSync(mSeaweedBuffer, mSeaweedUploadBuffer,
+                                          &mSeaweedPer, sizeof(SeaweedPer));
 }
 
 void SeaweedModelD3D12::draw()
 {
-    mContextD3D12->mCommandList->SetPipelineState(mPipelineState.Get());
-    mContextD3D12->mCommandList->SetGraphicsRootSignature(mRootSignature.Get());
+  mContextD3D12->mCommandList->SetPipelineState(mPipelineState.Get());
+  mContextD3D12->mCommandList->SetGraphicsRootSignature(mRootSignature.Get());
 
-    mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(0, mContextD3D12->lightGPUHandle);
-    mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
-        1, mContextD3D12->lightWorldPositionGPUHandle);
-    mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(2, mLightFactorGPUHandle);
-    mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
-        3, mDiffuseTexture->getTextureGPUHandle());
-    mContextD3D12->mCommandList->SetGraphicsRootConstantBufferView(4,
-                                                                   mWorldBufferView.BufferLocation);
-    mContextD3D12->mCommandList->SetGraphicsRootConstantBufferView(
-        5, mSeaweedBufferView.BufferLocation);
+  mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
+      0, mContextD3D12->lightGPUHandle);
+  mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
+      1, mContextD3D12->lightWorldPositionGPUHandle);
+  mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
+      2, mLightFactorGPUHandle);
+  mContextD3D12->mCommandList->SetGraphicsRootDescriptorTable(
+      3, mDiffuseTexture->getTextureGPUHandle());
+  mContextD3D12->mCommandList->SetGraphicsRootConstantBufferView(
+      4, mWorldBufferView.BufferLocation);
+  mContextD3D12->mCommandList->SetGraphicsRootConstantBufferView(
+      5, mSeaweedBufferView.BufferLocation);
 
-    mContextD3D12->mCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    mContextD3D12->mCommandList->IASetVertexBuffers(0, 3, mVertexBufferView);
+  mContextD3D12->mCommandList->IASetPrimitiveTopology(
+      D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+  mContextD3D12->mCommandList->IASetVertexBuffers(0, 3, mVertexBufferView);
 
-    mContextD3D12->mCommandList->IASetIndexBuffer(&mIndicesBuffer->mIndexBufferView);
+  mContextD3D12->mCommandList->IASetIndexBuffer(
+      &mIndicesBuffer->mIndexBufferView);
 
-    mContextD3D12->mCommandList->DrawIndexedInstanced(mIndicesBuffer->getTotalComponents(),
-                                                      instance, 0, 0, 0);
+  mContextD3D12->mCommandList->DrawIndexedInstanced(
+      mIndicesBuffer->getTotalComponents(), instance, 0, 0, 0);
 
-    instance = 0;
+  instance = 0;
 }
 
-void SeaweedModelD3D12::updatePerInstanceUniforms(const WorldUniforms &worldUniforms)
+void SeaweedModelD3D12::updatePerInstanceUniforms(
+    const WorldUniforms &worldUniforms)
 {
-    mWorldUniformPer.worldUniforms[instance] = worldUniforms;
-    mSeaweedPer.seaweed[instance].time       = mAquarium->g.mclock + instance;
+  mWorldUniformPer.worldUniforms[instance] = worldUniforms;
+  mSeaweedPer.seaweed[instance].time       = mAquarium->g.mclock + instance;
 
-    instance++;
+  instance++;
 }
 
 void SeaweedModelD3D12::updateSeaweedModelTime(float time) {}

--- a/src/aquarium-optimized/d3d12/SeaweedModelD3D12.h
+++ b/src/aquarium-optimized/d3d12/SeaweedModelD3D12.h
@@ -16,77 +16,77 @@
 
 class SeaweedModelD3D12 : public SeaweedModel
 {
-  public:
-    SeaweedModelD3D12(Context *context,
-                      Aquarium *aquarium,
-                      MODELGROUP type,
-                      MODELNAME name,
-                      bool blend);
+public:
+  SeaweedModelD3D12(Context *context,
+                    Aquarium *aquarium,
+                    MODELGROUP type,
+                    MODELNAME name,
+                    bool blend);
 
-    void init() override;
-    void prepareForDraw() override;
-    void draw() override;
+  void init() override;
+  void prepareForDraw() override;
+  void draw() override;
 
-    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
+  void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
 
-    TextureD3D12 *mDiffuseTexture;
-    TextureD3D12 *mNormalTexture;
-    TextureD3D12 *mReflectionTexture;
-    TextureD3D12 *mSkyboxTexture;
+  TextureD3D12 *mDiffuseTexture;
+  TextureD3D12 *mNormalTexture;
+  TextureD3D12 *mReflectionTexture;
+  TextureD3D12 *mSkyboxTexture;
 
-    BufferD3D12 *mPositionBuffer;
-    BufferD3D12 *mNormalBuffer;
-    BufferD3D12 *mTexCoordBuffer;
+  BufferD3D12 *mPositionBuffer;
+  BufferD3D12 *mNormalBuffer;
+  BufferD3D12 *mTexCoordBuffer;
 
-    BufferD3D12 *mIndicesBuffer;
-    void updateSeaweedModelTime(float time) override;
+  BufferD3D12 *mIndicesBuffer;
+  void updateSeaweedModelTime(float time) override;
 
-    struct LightFactorUniforms
-    {
-        float shininess;
-        float specularFactor;
-    } mLightFactorUniforms;
+  struct LightFactorUniforms
+  {
+    float shininess;
+    float specularFactor;
+  } mLightFactorUniforms;
 
-    struct Seaweed
-    {
-        float time;
-        float padding[3];
-    };
-    struct SeaweedPer
-    {
-        Seaweed seaweed[20];
-    } mSeaweedPer;
+  struct Seaweed
+  {
+    float time;
+    float padding[3];
+  };
+  struct SeaweedPer
+  {
+    Seaweed seaweed[20];
+  } mSeaweedPer;
 
-    struct WorldUniformPer
-    {
-        WorldUniforms worldUniforms[20];
-    };
-    WorldUniformPer mWorldUniformPer;
+  struct WorldUniformPer
+  {
+    WorldUniforms worldUniforms[20];
+  };
+  WorldUniformPer mWorldUniformPer;
 
-  private:
-    D3D12_CONSTANT_BUFFER_VIEW_DESC mWorldBufferView;
-    ComPtr<ID3D12Resource> mWorldBuffer;
-    ComPtr<ID3D12Resource> mWorldUploadBuffer;
-    D3D12_CONSTANT_BUFFER_VIEW_DESC mSeaweedBufferView;
-    ComPtr<ID3D12Resource> mSeaweedBuffer;
-    ComPtr<ID3D12Resource> mSeaweedUploadBuffer;
+private:
+  D3D12_CONSTANT_BUFFER_VIEW_DESC mWorldBufferView;
+  ComPtr<ID3D12Resource> mWorldBuffer;
+  ComPtr<ID3D12Resource> mWorldUploadBuffer;
+  D3D12_CONSTANT_BUFFER_VIEW_DESC mSeaweedBufferView;
+  ComPtr<ID3D12Resource> mSeaweedBuffer;
+  ComPtr<ID3D12Resource> mSeaweedUploadBuffer;
 
-    D3D12_CONSTANT_BUFFER_VIEW_DESC mLightFactorView;
-    D3D12_GPU_DESCRIPTOR_HANDLE mLightFactorGPUHandle;
-    ComPtr<ID3D12Resource> mLightFactorBuffer;
-    ComPtr<ID3D12Resource> mLightFactorUploadBuffer;
+  D3D12_CONSTANT_BUFFER_VIEW_DESC mLightFactorView;
+  D3D12_GPU_DESCRIPTOR_HANDLE mLightFactorGPUHandle;
+  ComPtr<ID3D12Resource> mLightFactorBuffer;
+  ComPtr<ID3D12Resource> mLightFactorUploadBuffer;
 
-    std::vector<D3D12_INPUT_ELEMENT_DESC> mInputElementDescs;
-    D3D12_VERTEX_BUFFER_VIEW mVertexBufferView[3];
+  std::vector<D3D12_INPUT_ELEMENT_DESC> mInputElementDescs;
+  D3D12_VERTEX_BUFFER_VIEW mVertexBufferView[3];
 
-    ComPtr<ID3D12RootSignature> mRootSignature;
-    ComPtr<ID3D12PipelineState> mPipelineState;
+  ComPtr<ID3D12RootSignature> mRootSignature;
+  ComPtr<ID3D12PipelineState> mPipelineState;
 
-    ContextD3D12 *mContextD3D12;
-    ProgramD3D12 *mProgramD3D12;
-    Aquarium *mAquarium;
+  ContextD3D12 *mContextD3D12;
+  ProgramD3D12 *mProgramD3D12;
+  Aquarium *mAquarium;
 
-    int instance;
+  int instance;
 };
 
 #endif  // SEAWEEDMODELD3D12_H

--- a/src/aquarium-optimized/d3d12/TextureD3D12.h
+++ b/src/aquarium-optimized/d3d12/TextureD3D12.h
@@ -20,31 +20,39 @@ class ContextD3D12;
 
 class TextureD3D12 : public Texture
 {
-  public:
-    ~TextureD3D12() override;
-    TextureD3D12(ContextD3D12 *context, const std::string &name, const std::string &url);
-    TextureD3D12(ContextD3D12 *context,
-                 const std::string &name,
-                 const std::vector<std::string> &urls);
+public:
+  ~TextureD3D12() override;
+  TextureD3D12(ContextD3D12 *context,
+               const std::string &name,
+               const std::string &url);
+  TextureD3D12(ContextD3D12 *context,
+               const std::string &name,
+               const std::vector<std::string> &urls);
 
-    D3D12_RESOURCE_DIMENSION getTextureDimension() { return mTextureDimension; }
-    D3D12_SRV_DIMENSION getTextureViewDimension() { return mTextureViewDimension; }
-    D3D12_GPU_DESCRIPTOR_HANDLE getTextureGPUHandle() { return mTextureGPUHandle; }
-    void loadTexture() override;
-    void createSrvDescriptor();
+  D3D12_RESOURCE_DIMENSION getTextureDimension() { return mTextureDimension; }
+  D3D12_SRV_DIMENSION getTextureViewDimension()
+  {
+    return mTextureViewDimension;
+  }
+  D3D12_GPU_DESCRIPTOR_HANDLE getTextureGPUHandle()
+  {
+    return mTextureGPUHandle;
+  }
+  void loadTexture() override;
+  void createSrvDescriptor();
 
-  private:
-    D3D12_RESOURCE_DIMENSION mTextureDimension;
-    D3D12_SRV_DIMENSION mTextureViewDimension;
-    DXGI_FORMAT mFormat;
-    ComPtr<ID3D12Resource> mTexture;
-    ComPtr<ID3D12Resource> mTextureUploadHeap;
-    D3D12_SHADER_RESOURCE_VIEW_DESC mSrvDesc;
-    D3D12_GPU_DESCRIPTOR_HANDLE mTextureGPUHandle;
+private:
+  D3D12_RESOURCE_DIMENSION mTextureDimension;
+  D3D12_SRV_DIMENSION mTextureViewDimension;
+  DXGI_FORMAT mFormat;
+  ComPtr<ID3D12Resource> mTexture;
+  ComPtr<ID3D12Resource> mTextureUploadHeap;
+  D3D12_SHADER_RESOURCE_VIEW_DESC mSrvDesc;
+  D3D12_GPU_DESCRIPTOR_HANDLE mTextureGPUHandle;
 
-    std::vector<unsigned char *> mPixelVec;
-    std::vector<unsigned char *> mResizedVec;
-    ContextD3D12 *mContext;
+  std::vector<unsigned char *> mPixelVec;
+  std::vector<unsigned char *> mResizedVec;
+  ContextD3D12 *mContext;
 };
 
 #endif  // TEXTURED3D12_H

--- a/src/aquarium-optimized/dawn/BufferDawn.cpp
+++ b/src/aquarium-optimized/dawn/BufferDawn.cpp
@@ -3,7 +3,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 //
-// BufferDawn.cpp: Implements the index or vertex buffers wrappers and resource bindings of dawn.
+// BufferDawn.cpp: Implements the index or vertex buffers wrappers and resource
+// bindings of dawn.
 
 #include "BufferDawn.h"
 
@@ -20,13 +21,13 @@ BufferDawn::BufferDawn(ContextDawn *context,
       mStride(0),
       mOffset(nullptr)
 {
-    mSize = numComponents * sizeof(float);
-    // Create buffer for vertex buffer. Because float is multiple of 4 bytes, dummy padding isnt'
-    // needed.
-    int bufferSize = sizeof(float) * static_cast<int>(buffer->size());
-    mBuf           = context->createBuffer(bufferSize, mUsage | wgpu::BufferUsage::CopyDst);
+  mSize = numComponents * sizeof(float);
+  // Create buffer for vertex buffer. Because float is multiple of 4 bytes,
+  // dummy padding isnt' needed.
+  int bufferSize = sizeof(float) * static_cast<int>(buffer->size());
+  mBuf = context->createBuffer(bufferSize, mUsage | wgpu::BufferUsage::CopyDst);
 
-    context->setBufferData(mBuf, bufferSize, buffer->data(), bufferSize);
+  context->setBufferData(mBuf, bufferSize, buffer->data(), bufferSize);
 }
 
 BufferDawn::BufferDawn(ContextDawn *context,
@@ -39,21 +40,22 @@ BufferDawn::BufferDawn(ContextDawn *context,
       mStride(0),
       mOffset(nullptr)
 {
-    mSize = numComponents * sizeof(unsigned short);
-    // Create buffer for index buffer. Because unsigned short is multiple of 2 bytes, in order to
-    // align with 4 bytes of dawn metal, dummy padding need to be added.
-    if (mTotoalComponents % 2 != 0)
-    {
-        buffer->push_back(0.0f);
-    }
+  mSize = numComponents * sizeof(unsigned short);
+  // Create buffer for index buffer. Because unsigned short is multiple of 2
+  // bytes, in order to align with 4 bytes of dawn metal, dummy padding need to
+  // be added.
+  if (mTotoalComponents % 2 != 0)
+  {
+    buffer->push_back(0.0f);
+  }
 
-    int bufferSize = sizeof(unsigned short) * static_cast<int>(buffer->size());
-    mBuf           = context->createBuffer(bufferSize, mUsage | wgpu::BufferUsage::CopyDst);
+  int bufferSize = sizeof(unsigned short) * static_cast<int>(buffer->size());
+  mBuf = context->createBuffer(bufferSize, mUsage | wgpu::BufferUsage::CopyDst);
 
-    context->setBufferData(mBuf, bufferSize, buffer->data(), bufferSize);
+  context->setBufferData(mBuf, bufferSize, buffer->data(), bufferSize);
 }
 
 BufferDawn::~BufferDawn()
 {
-    mBuf = nullptr;
+  mBuf = nullptr;
 }

--- a/src/aquarium-optimized/dawn/BufferDawn.h
+++ b/src/aquarium-optimized/dawn/BufferDawn.h
@@ -3,7 +3,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 //
-// BufferDawn.h: Defines the buffer wrapper of dawn, abstracting the vetex and index buffer binding.
+// BufferDawn.h: Defines the buffer wrapper of dawn, abstracting the vetex and
+// index buffer binding.
 
 #ifndef BUFFERDAWN_H
 #define BUFFERDAWN_H
@@ -18,34 +19,34 @@ class ContextDawn;
 
 class BufferDawn : public Buffer
 {
-  public:
-    BufferDawn(ContextDawn *context,
-               int totalCmoponents,
-               int numComponents,
-               std::vector<float> *buffer,
-               bool isIndex);
-    BufferDawn(ContextDawn *context,
-               int totalCmoponents,
-               int numComponents,
-               std::vector<unsigned short> *buffer,
-               bool isIndex);
-    ~BufferDawn() override;
+public:
+  BufferDawn(ContextDawn *context,
+             int totalCmoponents,
+             int numComponents,
+             std::vector<float> *buffer,
+             bool isIndex);
+  BufferDawn(ContextDawn *context,
+             int totalCmoponents,
+             int numComponents,
+             std::vector<unsigned short> *buffer,
+             bool isIndex);
+  ~BufferDawn() override;
 
-    const wgpu::Buffer &getBuffer() const { return mBuf; }
-    int getTotalComponents() const { return mTotoalComponents; }
+  const wgpu::Buffer &getBuffer() const { return mBuf; }
+  int getTotalComponents() const { return mTotoalComponents; }
 
-    uint32_t getStride() const { return mStride; }
-    const void *getOffset() const { return mOffset; }
-    wgpu::BufferUsage getUsageBit() const { return mUsage; }
-    int getDataSize() { return mSize; }
+  uint32_t getStride() const { return mStride; }
+  const void *getOffset() const { return mOffset; }
+  wgpu::BufferUsage getUsageBit() const { return mUsage; }
+  int getDataSize() { return mSize; }
 
-  private:
-    wgpu::Buffer mBuf;
-    wgpu::BufferUsage mUsage;
-    int mTotoalComponents;
-    uint32_t mStride;
-    void *mOffset;
-    int mSize;
+private:
+  wgpu::Buffer mBuf;
+  wgpu::BufferUsage mUsage;
+  int mTotoalComponents;
+  uint32_t mStride;
+  void *mOffset;
+  int mSize;
 };
 
 #endif  // BUFFERDAWN_H

--- a/src/aquarium-optimized/dawn/BufferManagerDawn.cpp
+++ b/src/aquarium-optimized/dawn/BufferManagerDawn.cpp
@@ -12,9 +12,12 @@
 #include "common/AQUARIUM_ASSERT.h"
 
 RingBufferDawn::RingBufferDawn(BufferManagerDawn *bufferManager, size_t size)
-    : RingBuffer(size), mBufferManager(bufferManager), mappedData(nullptr), mPixels(nullptr)
+    : RingBuffer(size),
+      mBufferManager(bufferManager),
+      mappedData(nullptr),
+      mPixels(nullptr)
 {
-    reset(size);
+  reset(size);
 }
 
 bool RingBufferDawn::push(const wgpu::CommandEncoder &encoder,
@@ -24,26 +27,26 @@ bool RingBufferDawn::push(const wgpu::CommandEncoder &encoder,
                           void *pixels,
                           size_t size)
 {
-    memcpy(static_cast<unsigned char *>(mPixels) + src_offset, pixels, size);
-    encoder.CopyBufferToBuffer(mBufferMappedResult.buffer, src_offset, destBuffer, dest_offset,
-                               size);
-    return true;
+  memcpy(static_cast<unsigned char *>(mPixels) + src_offset, pixels, size);
+  encoder.CopyBufferToBuffer(mBufferMappedResult.buffer, src_offset, destBuffer,
+                             dest_offset, size);
+  return true;
 }
 
 // Reset current buffer and reuse the buffer.
 bool RingBufferDawn::reset(size_t size)
 {
-    if (size > mSize)
-        return false;
+  if (size > mSize)
+    return false;
 
-    mHead = 0;
-    mTail = 0;
+  mHead = 0;
+  mTail = 0;
 
-    mBufferMappedResult = mBufferManager->mContext->CreateBufferMapped(
-        wgpu::BufferUsage::MapWrite | wgpu::BufferUsage::CopySrc, mSize);
-    mPixels = mBufferMappedResult.data;
+  mBufferMappedResult = mBufferManager->mContext->CreateBufferMapped(
+      wgpu::BufferUsage::MapWrite | wgpu::BufferUsage::CopySrc, mSize);
+  mPixels = mBufferMappedResult.data;
 
-    return true;
+  return true;
 }
 
 void RingBufferDawn::MapWriteCallback(WGPUBufferMapAsyncStatus status,
@@ -51,186 +54,189 @@ void RingBufferDawn::MapWriteCallback(WGPUBufferMapAsyncStatus status,
                                       uint64_t,
                                       void *userdata)
 {
-    ASSERT(status == WGPUBufferMapAsyncStatus_Success);
-    ASSERT(data != nullptr);
+  ASSERT(status == WGPUBufferMapAsyncStatus_Success);
+  ASSERT(data != nullptr);
 
-    RingBufferDawn *ringBuffer = static_cast<RingBufferDawn *>(userdata);
-    ringBuffer->mappedData     = data;
+  RingBufferDawn *ringBuffer = static_cast<RingBufferDawn *>(userdata);
+  ringBuffer->mappedData     = data;
 
-    ringBuffer->mBufferManager->mMappedBufferList.push(ringBuffer);
+  ringBuffer->mBufferManager->mMappedBufferList.push(ringBuffer);
 }
 
 void RingBufferDawn::flush()
 {
-    mHead = 0;
-    mTail = 0;
+  mHead = 0;
+  mTail = 0;
 
-    mBufferMappedResult.buffer.Unmap();
+  mBufferMappedResult.buffer.Unmap();
 }
 
 void RingBufferDawn::destory()
 {
-    mBufferMappedResult.buffer = nullptr;
+  mBufferMappedResult.buffer = nullptr;
 }
 
 void RingBufferDawn::reMap()
 {
-    mBufferMappedResult.buffer.MapWriteAsync(MapWriteCallback, this);
+  mBufferMappedResult.buffer.MapWriteAsync(MapWriteCallback, this);
 }
 
 size_t RingBufferDawn::allocate(size_t size)
 {
-    mTail += size;
-    ASSERT(mTail < mSize);
+  mTail += size;
+  ASSERT(mTail < mSize);
 
-    return mTail - size;
+  return mTail - size;
 }
 
 BufferManagerDawn::BufferManagerDawn(ContextDawn *context, bool sync)
     : mContext(context), mSync(sync)
 {
-    mEncoder = context->createCommandEncoder();
+  mEncoder = context->createCommandEncoder();
 }
 
 BufferManagerDawn::~BufferManagerDawn()
 {
-    mEncoder = nullptr;
+  mEncoder = nullptr;
 }
 
 // Allocate new buffer from buffer pool.
 RingBufferDawn *BufferManagerDawn::allocate(size_t size, size_t *offset)
 {
-    // If update data by sync method, create new buffer to upload every frame.
-    // If updaye data by async method, get new buffer from pool if available. If no available
-    // buffer and size is enough in the buffer pool, create a new buffer. If size reach the
-    // limit of the buffer pool, force wait for the buffer on mapping.
-    // Get the last one and check if the ring buffer is full. If the buffer can hold extra
-    // size space, use the last one directly.
-    // TODO(yizhou): Return nullptr if size reach the limit or no available buffer, this means
-    // small bubbles in some of the ring buffers and we haven't deal with the problem now.
+  // If update data by sync method, create new buffer to upload every frame.
+  // If updaye data by async method, get new buffer from pool if available. If
+  // no available buffer and size is enough in the buffer pool, create a new
+  // buffer. If size reach the limit of the buffer pool, force wait for the
+  // buffer on mapping. Get the last one and check if the ring buffer is full.
+  // If the buffer can hold extra size space, use the last one directly.
+  // TODO(yizhou): Return nullptr if size reach the limit or no available
+  // buffer, this means small bubbles in some of the ring buffers and we haven't
+  // deal with the problem now.
 
-    RingBufferDawn *ringBuffer = nullptr;
-    size_t cur_offset          = 0;
-    if (mSync)
+  RingBufferDawn *ringBuffer = nullptr;
+  size_t cur_offset          = 0;
+  if (mSync)
+  {
+    // Upper limit
+    if (mUsedSize + size > mBufferPoolSize)
     {
-        // Upper limit
-        if (mUsedSize + size > mBufferPoolSize)
-        {
-            return nullptr;
-        }
-
-        ringBuffer = new RingBufferDawn(this, size);
-        mEnqueuedBufferList.emplace_back(ringBuffer);
-    }
-    else  // Buffer mapping async
-    {
-        while (!mMappedBufferList.empty())
-        {
-            ringBuffer = static_cast<RingBufferDawn *>(mMappedBufferList.front());
-            if (ringBuffer->getAvailableSize() < size)
-            {
-                mMappedBufferList.pop();
-                ringBuffer = nullptr;
-            }
-            else
-            {
-                break;
-            }
-        }
-
-        if (ringBuffer == nullptr)
-        {
-            if (mCount < BUFFER_MAX_COUNT)
-            {
-                mUsedSize += size;
-                ringBuffer = new RingBufferDawn(this, BUFFER_PER_ALLOCATE_SIZE);
-                mMappedBufferList.push(ringBuffer);
-                mCount++;
-            }
-            else if (mMappedBufferList.size() + mEnqueuedBufferList.size() < mCount)
-            {
-                // Force wait for the buffer remapping
-                while (mMappedBufferList.empty())
-                {
-                    mContext->WaitABit();
-                }
-
-                ringBuffer = static_cast<RingBufferDawn *>(mMappedBufferList.front());
-                if (ringBuffer->getAvailableSize() < size)
-                {
-                    mMappedBufferList.pop();
-                    ringBuffer = nullptr;
-                }
-            }
-            else  // Upper limit
-            {
-                return nullptr;
-            }
-        }
-
-        if (mEnqueuedBufferList.empty() || mEnqueuedBufferList.back() != ringBuffer)
-        {
-            mEnqueuedBufferList.emplace_back(ringBuffer);
-        }
-
-        // allocate size in the ring buffer
-        cur_offset = ringBuffer->allocate(size);
-        *offset    = cur_offset;
+      return nullptr;
     }
 
-    return ringBuffer;
+    ringBuffer = new RingBufferDawn(this, size);
+    mEnqueuedBufferList.emplace_back(ringBuffer);
+  }
+  else  // Buffer mapping async
+  {
+    while (!mMappedBufferList.empty())
+    {
+      ringBuffer = static_cast<RingBufferDawn *>(mMappedBufferList.front());
+      if (ringBuffer->getAvailableSize() < size)
+      {
+        mMappedBufferList.pop();
+        ringBuffer = nullptr;
+      }
+      else
+      {
+        break;
+      }
+    }
+
+    if (ringBuffer == nullptr)
+    {
+      if (mCount < BUFFER_MAX_COUNT)
+      {
+        mUsedSize += size;
+        ringBuffer = new RingBufferDawn(this, BUFFER_PER_ALLOCATE_SIZE);
+        mMappedBufferList.push(ringBuffer);
+        mCount++;
+      }
+      else if (mMappedBufferList.size() + mEnqueuedBufferList.size() < mCount)
+      {
+        // Force wait for the buffer remapping
+        while (mMappedBufferList.empty())
+        {
+          mContext->WaitABit();
+        }
+
+        ringBuffer = static_cast<RingBufferDawn *>(mMappedBufferList.front());
+        if (ringBuffer->getAvailableSize() < size)
+        {
+          mMappedBufferList.pop();
+          ringBuffer = nullptr;
+        }
+      }
+      else  // Upper limit
+      {
+        return nullptr;
+      }
+    }
+
+    if (mEnqueuedBufferList.empty() || mEnqueuedBufferList.back() != ringBuffer)
+    {
+      mEnqueuedBufferList.emplace_back(ringBuffer);
+    }
+
+    // allocate size in the ring buffer
+    cur_offset = ringBuffer->allocate(size);
+    *offset    = cur_offset;
+  }
+
+  return ringBuffer;
 }
 
 void BufferManagerDawn::flush()
 {
-    // The front buffer in MappedBufferList will be remap after submit, pop the buffer from
-    // MappedBufferList.
-    if (!mMappedBufferList.empty() && mEnqueuedBufferList.back() == mMappedBufferList.front())
-    {
-        mMappedBufferList.pop();
-    }
+  // The front buffer in MappedBufferList will be remap after submit, pop the
+  // buffer from MappedBufferList.
+  if (!mMappedBufferList.empty() &&
+      mEnqueuedBufferList.back() == mMappedBufferList.front())
+  {
+    mMappedBufferList.pop();
+  }
 
-    for (auto buffer : mEnqueuedBufferList)
-    {
-        buffer->flush();
-    }
+  for (auto buffer : mEnqueuedBufferList)
+  {
+    buffer->flush();
+  }
 
-    wgpu::CommandBuffer copy = mEncoder.Finish();
-    mContext->queue.Submit(1, &copy);
+  wgpu::CommandBuffer copy = mEncoder.Finish();
+  mContext->queue.Submit(1, &copy);
 
-    // Async function
-    if (!mSync)
+  // Async function
+  if (!mSync)
+  {
+    for (size_t index = 0; index < mEnqueuedBufferList.size(); index++)
     {
-        for (size_t index = 0; index < mEnqueuedBufferList.size(); index++)
-        {
-            RingBufferDawn *ringBuffer = static_cast<RingBufferDawn *>(mEnqueuedBufferList[index]);
-            ringBuffer->reMap();
-        }
+      RingBufferDawn *ringBuffer =
+          static_cast<RingBufferDawn *>(mEnqueuedBufferList[index]);
+      ringBuffer->reMap();
     }
-    else
+  }
+  else
+  {
+    // All buffers are used once in buffer sync mode.
+    for (size_t index = 0; index < mEnqueuedBufferList.size(); index++)
     {
-        // All buffers are used once in buffer sync mode.
-        for (size_t index = 0; index < mEnqueuedBufferList.size(); index++)
-        {
-            delete mEnqueuedBufferList[index];
-        }
-        mUsedSize = 0;
+      delete mEnqueuedBufferList[index];
     }
+    mUsedSize = 0;
+  }
 
-    mEnqueuedBufferList.clear();
-    mEncoder = mContext->createCommandEncoder();
+  mEnqueuedBufferList.clear();
+  mEncoder = mContext->createCommandEncoder();
 }
 
 void BufferManagerDawn::destroyBufferPool()
 {
-    if (!mSync)
-    {
-        return;
-    }
+  if (!mSync)
+  {
+    return;
+  }
 
-    for (auto ringBuffer : mEnqueuedBufferList)
-    {
-        ringBuffer->destory();
-    }
-    mEnqueuedBufferList.clear();
+  for (auto ringBuffer : mEnqueuedBufferList)
+  {
+    ringBuffer->destory();
+  }
+  mEnqueuedBufferList.clear();
 }

--- a/src/aquarium-optimized/dawn/BufferManagerDawn.h
+++ b/src/aquarium-optimized/dawn/BufferManagerDawn.h
@@ -21,48 +21,48 @@ class ContextDawn;
 
 class RingBufferDawn : public RingBuffer
 {
-  public:
-    RingBufferDawn(BufferManagerDawn *bufferManager, size_t size);
-    ~RingBufferDawn() override {}
+public:
+  RingBufferDawn(BufferManagerDawn *bufferManager, size_t size);
+  ~RingBufferDawn() override {}
 
-    bool push(const wgpu::CommandEncoder &encoder,
-              const wgpu::Buffer &destBuffer,
-              size_t src_offset,
-              size_t dest_offset,
-              void *pixels,
-              size_t size);
-    bool reset(size_t size) override;
-    void flush() override;
-    void destory() override;
-    void reMap();
-    size_t allocate(size_t size) override;
+  bool push(const wgpu::CommandEncoder &encoder,
+            const wgpu::Buffer &destBuffer,
+            size_t src_offset,
+            size_t dest_offset,
+            void *pixels,
+            size_t size);
+  bool reset(size_t size) override;
+  void flush() override;
+  void destory() override;
+  void reMap();
+  size_t allocate(size_t size) override;
 
-  private:
-    static void MapWriteCallback(WGPUBufferMapAsyncStatus status,
-                                 void *data,
-                                 uint64_t,
-                                 void *userdata);
+private:
+  static void MapWriteCallback(WGPUBufferMapAsyncStatus status,
+                               void *data,
+                               uint64_t,
+                               void *userdata);
 
-    wgpu::CreateBufferMappedResult mBufferMappedResult;
+  wgpu::CreateBufferMappedResult mBufferMappedResult;
 
-    BufferManagerDawn *mBufferManager;
-    void *mappedData;
-    void *mPixels;
+  BufferManagerDawn *mBufferManager;
+  void *mappedData;
+  void *mPixels;
 };
 
 class BufferManagerDawn : public BufferManager
 {
-  public:
-    BufferManagerDawn(ContextDawn *context, bool sync);
-    ~BufferManagerDawn();
+public:
+  BufferManagerDawn(ContextDawn *context, bool sync);
+  ~BufferManagerDawn();
 
-    RingBufferDawn *allocate(size_t size, size_t *offset) override;
-    void flush() override;
-    void destroyBufferPool() override;
+  RingBufferDawn *allocate(size_t size, size_t *offset) override;
+  void flush() override;
+  void destroyBufferPool() override;
 
-    wgpu::CommandEncoder mEncoder;
-    ContextDawn *mContext;
-    bool mSync;
+  wgpu::CommandEncoder mEncoder;
+  ContextDawn *mContext;
+  bool mSync;
 };
 
 #endif  // BUFFERMANAGERDAWN_H

--- a/src/aquarium-optimized/dawn/ContextDawn.cpp
+++ b/src/aquarium-optimized/dawn/ContextDawn.cpp
@@ -62,42 +62,42 @@ ContextDawn::ContextDawn(BACKENDTYPE backendType)
       mPreferredSwapChainFormat(wgpu::TextureFormat::RGBA8Unorm),
       bufferManager(nullptr)
 {
-    mResourceHelper = new ResourceHelper("dawn", "", backendType);
-    initAvailableToggleBitset(backendType);
+  mResourceHelper = new ResourceHelper("dawn", "", backendType);
+  initAvailableToggleBitset(backendType);
 }
 
 ContextDawn::~ContextDawn()
 {
-    delete mResourceHelper;
-    if (mWindow != nullptr && !mDisableControlPanel)
-    {
-        destoryImgUI();
-    }
+  delete mResourceHelper;
+  if (mWindow != nullptr && !mDisableControlPanel)
+  {
+    destoryImgUI();
+  }
 
-    mSceneRenderTargetView    = nullptr;
-    mSceneDepthStencilView    = nullptr;
-    mBackbufferView           = nullptr;
-    mPipeline                 = nullptr;
-    mBindGroup                = nullptr;
-    mLightWorldPositionBuffer = nullptr;
-    mLightBuffer              = nullptr;
-    mFogBuffer                = nullptr;
-    mCommandEncoder           = nullptr;
-    mCommandBuffers.clear();
-    mRenderPass           = nullptr;
-    mRenderPassDescriptor = {};
-    groupLayoutGeneral    = nullptr;
-    bindGroupGeneral      = nullptr;
-    groupLayoutWorld      = nullptr;
-    bindGroupWorld        = nullptr;
+  mSceneRenderTargetView    = nullptr;
+  mSceneDepthStencilView    = nullptr;
+  mBackbufferView           = nullptr;
+  mPipeline                 = nullptr;
+  mBindGroup                = nullptr;
+  mLightWorldPositionBuffer = nullptr;
+  mLightBuffer              = nullptr;
+  mFogBuffer                = nullptr;
+  mCommandEncoder           = nullptr;
+  mCommandBuffers.clear();
+  mRenderPass           = nullptr;
+  mRenderPassDescriptor = {};
+  groupLayoutGeneral    = nullptr;
+  bindGroupGeneral      = nullptr;
+  groupLayoutWorld      = nullptr;
+  bindGroupWorld        = nullptr;
 
-    groupLayoutFishPer = nullptr;
-    destoryFishResource();
-    delete bufferManager;
+  groupLayoutFishPer = nullptr;
+  destoryFishResource();
+  delete bufferManager;
 
-    mSwapchain = nullptr;
-    queue      = nullptr;
-    mDevice    = nullptr;
+  mSwapchain = nullptr;
+  queue      = nullptr;
+  mDevice    = nullptr;
 }
 
 bool ContextDawn::initialize(
@@ -106,179 +106,189 @@ bool ContextDawn::initialize(
     int windowWidth,
     int windowHeight)
 {
-    wgpu::BackendType backendType = wgpu::BackendType::Null;
+  wgpu::BackendType backendType = wgpu::BackendType::Null;
 
-    switch (backend)
-    {
-        case BACKENDTYPE::BACKENDTYPEDAWND3D12:
-        {
-            backendType = wgpu::BackendType::D3D12;
-            break;
-        }
-        case BACKENDTYPE::BACKENDTYPEDAWNVULKAN:
-        {
-            backendType = wgpu::BackendType::Vulkan;
-            break;
-        }
-        case BACKENDTYPE::BACKENDTYPEDAWNMETAL:
-        {
-            backendType = wgpu::BackendType::Metal;
-            break;
-        }
-        case BACKENDTYPE::BACKENDTYPEOPENGL:
-        {
-            backendType = wgpu::BackendType::OpenGL;
-            break;
-        }
-        default:
-        {
-            std::cerr << "Backend type can not reached." << std::endl;
-            return false;
-        }
-    }
+  switch (backend)
+  {
+  case BACKENDTYPE::BACKENDTYPEDAWND3D12:
+  {
+    backendType = wgpu::BackendType::D3D12;
+    break;
+  }
+  case BACKENDTYPE::BACKENDTYPEDAWNVULKAN:
+  {
+    backendType = wgpu::BackendType::Vulkan;
+    break;
+  }
+  case BACKENDTYPE::BACKENDTYPEDAWNMETAL:
+  {
+    backendType = wgpu::BackendType::Metal;
+    break;
+  }
+  case BACKENDTYPE::BACKENDTYPEOPENGL:
+  {
+    backendType = wgpu::BackendType::OpenGL;
+    break;
+  }
+  default:
+  {
+    std::cerr << "Backend type can not reached." << std::endl;
+    return false;
+  }
+  }
 
-    mDisableControlPanel = toggleBitset.test(static_cast<TOGGLE>(TOGGLE::DISABLECONTROLPANEL));
+  mDisableControlPanel =
+      toggleBitset.test(static_cast<TOGGLE>(TOGGLE::DISABLECONTROLPANEL));
 
-    // initialise GLFW
-    if (!glfwInit())
-    {
-        std::cout << "Failed to initialise GLFW" << std::endl;
-        return false;
-    }
+  // initialise GLFW
+  if (!glfwInit())
+  {
+    std::cout << "Failed to initialise GLFW" << std::endl;
+    return false;
+  }
 
-    utils::SetupGLFWWindowHintsForBackend(backendType);
-    // set full screen
-    glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+  utils::SetupGLFWWindowHintsForBackend(backendType);
+  // set full screen
+  glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
 
-    GLFWmonitor *pMonitor   = glfwGetPrimaryMonitor();
-    const GLFWvidmode *mode = glfwGetVideoMode(pMonitor);
-    mClientWidth            = mode->width;
-    mClientHeight           = mode->height;
+  GLFWmonitor *pMonitor   = glfwGetPrimaryMonitor();
+  const GLFWvidmode *mode = glfwGetVideoMode(pMonitor);
+  mClientWidth            = mode->width;
+  mClientHeight           = mode->height;
 
-    setWindowSize(windowWidth, windowHeight);
+  setWindowSize(windowWidth, windowHeight);
 
-    if (toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEFULLSCREENMODE)))
-    {
-        mWindow = glfwCreateWindow(mClientWidth, mClientHeight, "Aquarium", pMonitor, nullptr);
-    }
-    else
-    {
-        mWindow = glfwCreateWindow(mClientWidth, mClientHeight, "Aquarium", nullptr, nullptr);
-    }
+  if (toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEFULLSCREENMODE)))
+  {
+    mWindow = glfwCreateWindow(mClientWidth, mClientHeight, "Aquarium",
+                               pMonitor, nullptr);
+  }
+  else
+  {
+    mWindow = glfwCreateWindow(mClientWidth, mClientHeight, "Aquarium", nullptr,
+                               nullptr);
+  }
 
-    if (mWindow == nullptr)
-    {
-        std::cout << "Failed to open GLFW window." << std::endl;
-        glfwTerminate();
-        return false;
-    }
+  if (mWindow == nullptr)
+  {
+    std::cout << "Failed to open GLFW window." << std::endl;
+    glfwTerminate();
+    return false;
+  }
 
-    // Get the resolution of screen
-    glfwGetFramebufferSize(mWindow, &mClientWidth, &mClientHeight);
+  // Get the resolution of screen
+  glfwGetFramebufferSize(mWindow, &mClientWidth, &mClientHeight);
 
-    mInstance = std::make_unique<dawn_native::Instance>();
+  mInstance = std::make_unique<dawn_native::Instance>();
 
-    // Enable debug layer in Debug mode
+  // Enable debug layer in Debug mode
 #if defined(_DEBUG)
-    mInstance->EnableBackendValidation(true);
+  mInstance->EnableBackendValidation(true);
 #endif
 
-    utils::DiscoverAdapter(mInstance.get(), mWindow, backendType);
+  utils::DiscoverAdapter(mInstance.get(), mWindow, backendType);
 
-    dawn_native::Adapter backendAdapter;
-    if (!GetHardwareAdapter(mInstance, &backendAdapter, backendType, toggleBitset))
-    {
-        return false;
-    }
+  dawn_native::Adapter backendAdapter;
+  if (!GetHardwareAdapter(mInstance, &backendAdapter, backendType,
+                          toggleBitset))
+  {
+    return false;
+  }
 
-    WGPUDevice backendDevice;
-    dawn_native::DeviceDescriptor descriptor;
-    if (toggleBitset.test(static_cast<size_t>(TOGGLE::TURNOFFVSYNC)))
-    {
-        const char *turnOffVsync = "turn_off_vsync";
-        descriptor.forceEnabledToggles.push_back(turnOffVsync);
-    }
-    if (toggleBitset.test(static_cast<size_t>(TOGGLE::DISABLED3D12RENDERPASS)))
-    {
-        const char *useD3D12RenderPass = "use_d3d12_render_pass";
-        descriptor.forceDisabledToggles.push_back(useD3D12RenderPass);
-    }
-    if (toggleBitset.test(static_cast<size_t>(TOGGLE::DISABLEDAWNVALIDATION)))
-    {
-        const char *skipValidation = "skip_validation";
-        descriptor.forceEnabledToggles.push_back(skipValidation);
-    }
-    backendDevice = backendAdapter.CreateDevice(&descriptor);
+  WGPUDevice backendDevice;
+  dawn_native::DeviceDescriptor descriptor;
+  if (toggleBitset.test(static_cast<size_t>(TOGGLE::TURNOFFVSYNC)))
+  {
+    const char *turnOffVsync = "turn_off_vsync";
+    descriptor.forceEnabledToggles.push_back(turnOffVsync);
+  }
+  if (toggleBitset.test(static_cast<size_t>(TOGGLE::DISABLED3D12RENDERPASS)))
+  {
+    const char *useD3D12RenderPass = "use_d3d12_render_pass";
+    descriptor.forceDisabledToggles.push_back(useD3D12RenderPass);
+  }
+  if (toggleBitset.test(static_cast<size_t>(TOGGLE::DISABLEDAWNVALIDATION)))
+  {
+    const char *skipValidation = "skip_validation";
+    descriptor.forceEnabledToggles.push_back(skipValidation);
+  }
+  backendDevice = backendAdapter.CreateDevice(&descriptor);
 
-    DawnProcTable backendProcs = dawn_native::GetProcs();
+  DawnProcTable backendProcs = dawn_native::GetProcs();
 
-    utils::BackendBinding *binding = utils::CreateBinding(backendType, mWindow, backendDevice);
-    if (binding == nullptr)
-    {
-        return false;
-    }
+  utils::BackendBinding *binding =
+      utils::CreateBinding(backendType, mWindow, backendDevice);
+  if (binding == nullptr)
+  {
+    return false;
+  }
 
-    dawnProcSetProcs(&backendProcs);
-    mDevice = wgpu::Device::Acquire(backendDevice);
+  dawnProcSetProcs(&backendProcs);
+  mDevice = wgpu::Device::Acquire(backendDevice);
 
-    queue = mDevice.GetDefaultQueue();
-    wgpu::SwapChainDescriptor swapChainDesc;
-    swapChainDesc.implementation = binding->GetSwapChainImplementation();
+  queue = mDevice.GetDefaultQueue();
+  wgpu::SwapChainDescriptor swapChainDesc;
+  swapChainDesc.implementation = binding->GetSwapChainImplementation();
 
-    mSwapchain = mDevice.CreateSwapChain(nullptr, &swapChainDesc);
+  mSwapchain = mDevice.CreateSwapChain(nullptr, &swapChainDesc);
 
-    mPreferredSwapChainFormat =
-        static_cast<wgpu::TextureFormat>(binding->GetPreferredSwapChainTextureFormat());
-    mSwapchain.Configure(mPreferredSwapChainFormat, kSwapchainBackBufferUsage, mClientWidth,
-                         mClientHeight);
+  mPreferredSwapChainFormat = static_cast<wgpu::TextureFormat>(
+      binding->GetPreferredSwapChainTextureFormat());
+  mSwapchain.Configure(mPreferredSwapChainFormat, kSwapchainBackBufferUsage,
+                       mClientWidth, mClientHeight);
 
-    dawn_native::PCIInfo info = backendAdapter.GetPCIInfo();
-    std::string renderer      = info.name;
-    std::cout << renderer << std::endl;
-    mResourceHelper->setRenderer(renderer);
+  dawn_native::PCIInfo info = backendAdapter.GetPCIInfo();
+  std::string renderer      = info.name;
+  std::cout << renderer << std::endl;
+  mResourceHelper->setRenderer(renderer);
 
-    // When MSAA is enabled, we create an intermediate multisampled texture to render the scene to.
-    if (mMSAASampleCount > 1)
-    {
-        mSceneRenderTargetView = createMultisampledRenderTargetView();
-    }
+  // When MSAA is enabled, we create an intermediate multisampled texture to
+  // render the scene to.
+  if (mMSAASampleCount > 1)
+  {
+    mSceneRenderTargetView = createMultisampledRenderTargetView();
+  }
 
-    mSceneDepthStencilView = createDepthStencilView();
+  mSceneDepthStencilView = createDepthStencilView();
 
-    // TODO(jiawei.shao@intel.com): support recreating swapchain when window is resized on all
-    // backends
-    if (backend == BACKENDTYPE::BACKENDTYPEDAWNVULKAN)
-    {
-        glfwSetFramebufferSizeCallback(mWindow, framebufferResizeCallback);
-        glfwSetWindowUserPointer(mWindow, this);
-    }
+  // TODO(jiawei.shao@intel.com): support recreating swapchain when window is
+  // resized on all backends
+  if (backend == BACKENDTYPE::BACKENDTYPEDAWNVULKAN)
+  {
+    glfwSetFramebufferSizeCallback(mWindow, framebufferResizeCallback);
+    glfwSetWindowUserPointer(mWindow, this);
+  }
 
-    if (!mDisableControlPanel)
-    {
-        // Setup Dear ImGui context
-        IMGUI_CHECKVERSION();
-        ImGui::CreateContext();
+  if (!mDisableControlPanel)
+  {
+    // Setup Dear ImGui context
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
 
-        // Setup Dear ImGui style
-        ImGui::StyleColorsDark();
+    // Setup Dear ImGui style
+    ImGui::StyleColorsDark();
 
-        // Setup Platform/Renderer bindings
-        // We use glfw to create window for dawn backend as well.
-        // Because imgui doesn't have dawn backend, we rewrite the functions by dawn API in
-        // imgui_impl_dawn.cpp and imgui_impl_dawn.h
-        ImGui_ImplGlfw_InitForOpenGL(mWindow, true);
-        ImGui_ImplDawn_Init(this, mPreferredSwapChainFormat);
-    }
-    bufferManager = new BufferManagerDawn(
-        this, !toggleBitset.test(static_cast<TOGGLE>(TOGGLE::BUFFERMAPPINGASYNC)));
+    // Setup Platform/Renderer bindings
+    // We use glfw to create window for dawn backend as well.
+    // Because imgui doesn't have dawn backend, we rewrite the functions by dawn
+    // API in imgui_impl_dawn.cpp and imgui_impl_dawn.h
+    ImGui_ImplGlfw_InitForOpenGL(mWindow, true);
+    ImGui_ImplDawn_Init(this, mPreferredSwapChainFormat);
+  }
+  bufferManager = new BufferManagerDawn(
+      this,
+      !toggleBitset.test(static_cast<TOGGLE>(TOGGLE::BUFFERMAPPINGASYNC)));
 
-    return true;
+  return true;
 }
 
-void ContextDawn::framebufferResizeCallback(GLFWwindow *window, int width, int height)
+void ContextDawn::framebufferResizeCallback(GLFWwindow *window,
+                                            int width,
+                                            int height)
 {
-    ContextDawn *contextDawn = reinterpret_cast<ContextDawn *>(glfwGetWindowUserPointer(window));
-    contextDawn->mIsSwapchainOutOfDate = true;
+  ContextDawn *contextDawn =
+      reinterpret_cast<ContextDawn *>(glfwGetWindowUserPointer(window));
+  contextDawn->mIsSwapchainOutOfDate = true;
 }
 
 bool ContextDawn::GetHardwareAdapter(
@@ -287,76 +297,87 @@ bool ContextDawn::GetHardwareAdapter(
     wgpu::BackendType backendType,
     const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset)
 {
-    bool enableIntegratedGpu = toggleBitset.test(static_cast<size_t>(TOGGLE::INTEGRATEDGPU));
-    bool enableDiscreteGpu   = toggleBitset.test(static_cast<size_t>(TOGGLE::DISCRETEGPU));
-    bool useDefaultGpu       = (enableDiscreteGpu | enableIntegratedGpu) == false ? true : false;
-    bool result              = false;
+  bool enableIntegratedGpu =
+      toggleBitset.test(static_cast<size_t>(TOGGLE::INTEGRATEDGPU));
+  bool enableDiscreteGpu =
+      toggleBitset.test(static_cast<size_t>(TOGGLE::DISCRETEGPU));
+  bool useDefaultGpu =
+      (enableDiscreteGpu | enableIntegratedGpu) == false ? true : false;
+  bool result = false;
 
-    // Get an adapter for the backend to use, and create the Device.
-    for (auto &adapter : instance->GetAdapters())
+  // Get an adapter for the backend to use, and create the Device.
+  for (auto &adapter : instance->GetAdapters())
+  {
+    wgpu::AdapterProperties properties;
+    adapter.GetProperties(&properties);
+    if (properties.backendType == backendType)
     {
-        wgpu::AdapterProperties properties;
-        adapter.GetProperties(&properties);
-        if (properties.backendType == backendType)
-        {
-            if (useDefaultGpu ||
-                (enableDiscreteGpu &&
-                 adapter.GetDeviceType() == dawn_native::DeviceType::DiscreteGPU) ||
-                (enableIntegratedGpu &&
-                 adapter.GetDeviceType() == dawn_native::DeviceType::IntegratedGPU))
-            {
-                *backendAdapter = adapter;
-                result          = true;
-                break;
-            }
-        }
+      if (useDefaultGpu ||
+          (enableDiscreteGpu &&
+           adapter.GetDeviceType() == dawn_native::DeviceType::DiscreteGPU) ||
+          (enableIntegratedGpu &&
+           adapter.GetDeviceType() == dawn_native::DeviceType::IntegratedGPU))
+      {
+        *backendAdapter = adapter;
+        result          = true;
+        break;
+      }
     }
+  }
 
-    if (!result)
-    {
-        std::cerr << "Failed to create adapter." << std::endl;
-        return false;
-    }
+  if (!result)
+  {
+    std::cerr << "Failed to create adapter." << std::endl;
+    return false;
+  }
 
-    return true;
+  return true;
 }
 
 void ContextDawn::initAvailableToggleBitset(BACKENDTYPE backendType)
 {
-    mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS));
-    mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEDYNAMICBUFFEROFFSET));
-    mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::DISCRETEGPU));
-    mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::INTEGRATEDGPU));
-    mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEFULLSCREENMODE));
-    mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::BUFFERMAPPINGASYNC));
-    mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::TURNOFFVSYNC));
-    mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::DISABLED3D12RENDERPASS));
-    mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::DISABLEDAWNVALIDATION));
-    mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::SIMULATINGFISHCOMEANDGO));
+  mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEINSTANCEDDRAWS));
+  mAvailableToggleBitset.set(
+      static_cast<size_t>(TOGGLE::ENABLEDYNAMICBUFFEROFFSET));
+  mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::DISCRETEGPU));
+  mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::INTEGRATEDGPU));
+  mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEFULLSCREENMODE));
+  mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::BUFFERMAPPINGASYNC));
+  mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::TURNOFFVSYNC));
+  mAvailableToggleBitset.set(
+      static_cast<size_t>(TOGGLE::DISABLED3D12RENDERPASS));
+  mAvailableToggleBitset.set(
+      static_cast<size_t>(TOGGLE::DISABLEDAWNVALIDATION));
+  mAvailableToggleBitset.set(
+      static_cast<size_t>(TOGGLE::SIMULATINGFISHCOMEANDGO));
 }
 
-Texture *ContextDawn::createTexture(const std::string &name, const std::string &url)
+Texture *ContextDawn::createTexture(const std::string &name,
+                                    const std::string &url)
 {
-    Texture *texture = new TextureDawn(this, name, url);
-    texture->loadTexture();
-    return texture;
+  Texture *texture = new TextureDawn(this, name, url);
+  texture->loadTexture();
+  return texture;
 }
 
-Texture *ContextDawn::createTexture(const std::string &name, const std::vector<std::string> &urls)
+Texture *ContextDawn::createTexture(const std::string &name,
+                                    const std::vector<std::string> &urls)
 {
-    Texture *texture = new TextureDawn(this, name, urls);
-    texture->loadTexture();
-    return texture;
+  Texture *texture = new TextureDawn(this, name, urls);
+  texture->loadTexture();
+  return texture;
 }
 
-wgpu::Texture ContextDawn::createTexture(const wgpu::TextureDescriptor &descriptor) const
+wgpu::Texture ContextDawn::createTexture(
+    const wgpu::TextureDescriptor &descriptor) const
 {
-    return mDevice.CreateTexture(&descriptor);
+  return mDevice.CreateTexture(&descriptor);
 }
 
-wgpu::Sampler ContextDawn::createSampler(const wgpu::SamplerDescriptor &descriptor) const
+wgpu::Sampler ContextDawn::createSampler(
+    const wgpu::SamplerDescriptor &descriptor) const
 {
-    return mDevice.CreateSampler(&descriptor);
+  return mDevice.CreateSampler(&descriptor);
 }
 
 wgpu::Buffer ContextDawn::createBufferFromData(const void *data,
@@ -364,19 +385,21 @@ wgpu::Buffer ContextDawn::createBufferFromData(const void *data,
                                                uint32_t maxSize,
                                                wgpu::BufferUsage usage)
 {
-    wgpu::Buffer buffer = createBuffer(maxSize, usage | wgpu::BufferUsage::CopyDst);
+  wgpu::Buffer buffer =
+      createBuffer(maxSize, usage | wgpu::BufferUsage::CopyDst);
 
-    setBufferData(buffer, maxSize, data, size);
-    return buffer;
+  setBufferData(buffer, maxSize, data, size);
+  return buffer;
 }
 
-wgpu::BufferCopyView ContextDawn::createBufferCopyView(const wgpu::Buffer &buffer,
-                                                       uint32_t offset,
-                                                       uint32_t bytesPerRow,
-                                                       uint32_t rowsPerImage) const
+wgpu::BufferCopyView ContextDawn::createBufferCopyView(
+    const wgpu::Buffer &buffer,
+    uint32_t offset,
+    uint32_t bytesPerRow,
+    uint32_t rowsPerImage) const
 {
 
-    return utils::CreateBufferCopyView(buffer, offset, bytesPerRow, rowsPerImage);
+  return utils::CreateBufferCopyView(buffer, offset, bytesPerRow, rowsPerImage);
 }
 
 wgpu::TextureCopyView ContextDawn::createTextureCopyView(wgpu::Texture texture,
@@ -384,54 +407,59 @@ wgpu::TextureCopyView ContextDawn::createTextureCopyView(wgpu::Texture texture,
                                                          wgpu::Origin3D origin)
 {
 
-    return utils::CreateTextureCopyView(texture, level, origin);
+  return utils::CreateTextureCopyView(texture, level, origin);
 }
 
-wgpu::CommandBuffer ContextDawn::copyBufferToTexture(const wgpu::BufferCopyView &bufferCopyView,
-                                                     const wgpu::TextureCopyView &textureCopyView,
-                                                     const wgpu::Extent3D &ext3D) const
+wgpu::CommandBuffer ContextDawn::copyBufferToTexture(
+    const wgpu::BufferCopyView &bufferCopyView,
+    const wgpu::TextureCopyView &textureCopyView,
+    const wgpu::Extent3D &ext3D) const
 {
-    wgpu::CommandEncoder encoder = mDevice.CreateCommandEncoder();
-    encoder.CopyBufferToTexture(&bufferCopyView, &textureCopyView, &ext3D);
-    wgpu::CommandBuffer copy = encoder.Finish();
-    return copy;
+  wgpu::CommandEncoder encoder = mDevice.CreateCommandEncoder();
+  encoder.CopyBufferToTexture(&bufferCopyView, &textureCopyView, &ext3D);
+  wgpu::CommandBuffer copy = encoder.Finish();
+  return copy;
 }
 
-wgpu::CommandBuffer ContextDawn::copyBufferToBuffer(wgpu::Buffer const &srcBuffer,
-                                                    uint64_t srcOffset,
-                                                    wgpu::Buffer const &destBuffer,
-                                                    uint64_t destOffset,
-                                                    uint64_t size) const
+wgpu::CommandBuffer ContextDawn::copyBufferToBuffer(
+    wgpu::Buffer const &srcBuffer,
+    uint64_t srcOffset,
+    wgpu::Buffer const &destBuffer,
+    uint64_t destOffset,
+    uint64_t size) const
 {
-    wgpu::CommandEncoder encoder = mDevice.CreateCommandEncoder();
-    encoder.CopyBufferToBuffer(srcBuffer, srcOffset, destBuffer, destOffset, size);
-    wgpu::CommandBuffer copy = encoder.Finish();
+  wgpu::CommandEncoder encoder = mDevice.CreateCommandEncoder();
+  encoder.CopyBufferToBuffer(srcBuffer, srcOffset, destBuffer, destOffset,
+                             size);
+  wgpu::CommandBuffer copy = encoder.Finish();
 
-    return copy;
+  return copy;
 }
 
-wgpu::ShaderModule ContextDawn::createShaderModule(utils::SingleShaderStage stage,
-                                                   const std::string &str) const
+wgpu::ShaderModule ContextDawn::createShaderModule(
+    utils::SingleShaderStage stage,
+    const std::string &str) const
 {
-    return utils::CreateShaderModule(mDevice, stage, str.c_str());
+  return utils::CreateShaderModule(mDevice, stage, str.c_str());
 }
 
 wgpu::BindGroupLayout ContextDawn::MakeBindGroupLayout(
     std::initializer_list<wgpu::BindGroupLayoutEntry> bindingsInitializer) const
 {
 
-    return utils::MakeBindGroupLayout(mDevice, bindingsInitializer);
+  return utils::MakeBindGroupLayout(mDevice, bindingsInitializer);
 }
 
 wgpu::PipelineLayout ContextDawn::MakeBasicPipelineLayout(
     std::vector<wgpu::BindGroupLayout> bindingsInitializer) const
 {
-    wgpu::PipelineLayoutDescriptor descriptor;
+  wgpu::PipelineLayoutDescriptor descriptor;
 
-    descriptor.bindGroupLayoutCount = static_cast<uint32_t>(bindingsInitializer.size());
-    descriptor.bindGroupLayouts     = bindingsInitializer.data();
+  descriptor.bindGroupLayoutCount =
+      static_cast<uint32_t>(bindingsInitializer.size());
+  descriptor.bindGroupLayouts = bindingsInitializer.data();
 
-    return mDevice.CreatePipelineLayout(&descriptor);
+  return mDevice.CreatePipelineLayout(&descriptor);
 }
 
 wgpu::RenderPipeline ContextDawn::createRenderPipeline(
@@ -440,95 +468,97 @@ wgpu::RenderPipeline ContextDawn::createRenderPipeline(
     const wgpu::VertexStateDescriptor &mVertexStateDescriptor,
     bool enableBlend) const
 {
-    const wgpu::ShaderModule &mVsModule = mProgramDawn->getVSModule();
-    const wgpu::ShaderModule &mFsModule = mProgramDawn->getFSModule();
+  const wgpu::ShaderModule &mVsModule = mProgramDawn->getVSModule();
+  const wgpu::ShaderModule &mFsModule = mProgramDawn->getFSModule();
 
-    wgpu::BlendDescriptor blendDescriptor;
-    blendDescriptor.operation = wgpu::BlendOperation::Add;
-    if (enableBlend)
-    {
-        blendDescriptor.srcFactor = wgpu::BlendFactor::SrcAlpha;
-        blendDescriptor.dstFactor = wgpu::BlendFactor::OneMinusSrcAlpha;
-    }
-    else
-    {
-        blendDescriptor.srcFactor = wgpu::BlendFactor::One;
-        blendDescriptor.dstFactor = wgpu::BlendFactor::Zero;
-    }
+  wgpu::BlendDescriptor blendDescriptor;
+  blendDescriptor.operation = wgpu::BlendOperation::Add;
+  if (enableBlend)
+  {
+    blendDescriptor.srcFactor = wgpu::BlendFactor::SrcAlpha;
+    blendDescriptor.dstFactor = wgpu::BlendFactor::OneMinusSrcAlpha;
+  }
+  else
+  {
+    blendDescriptor.srcFactor = wgpu::BlendFactor::One;
+    blendDescriptor.dstFactor = wgpu::BlendFactor::Zero;
+  }
 
-    wgpu::ColorStateDescriptor ColorStateDescriptor;
-    ColorStateDescriptor.colorBlend = blendDescriptor;
-    ColorStateDescriptor.alphaBlend = blendDescriptor;
-    ColorStateDescriptor.writeMask  = wgpu::ColorWriteMask::All;
+  wgpu::ColorStateDescriptor ColorStateDescriptor;
+  ColorStateDescriptor.colorBlend = blendDescriptor;
+  ColorStateDescriptor.alphaBlend = blendDescriptor;
+  ColorStateDescriptor.writeMask  = wgpu::ColorWriteMask::All;
 
-    wgpu::RasterizationStateDescriptor rasterizationState;
-    rasterizationState.nextInChain         = nullptr;
-    rasterizationState.frontFace           = wgpu::FrontFace::CCW;
-    rasterizationState.cullMode            = wgpu::CullMode::Back;
-    rasterizationState.depthBias           = 0;
-    rasterizationState.depthBiasSlopeScale = 0.0;
-    rasterizationState.depthBiasClamp      = 0.0;
+  wgpu::RasterizationStateDescriptor rasterizationState;
+  rasterizationState.nextInChain         = nullptr;
+  rasterizationState.frontFace           = wgpu::FrontFace::CCW;
+  rasterizationState.cullMode            = wgpu::CullMode::Back;
+  rasterizationState.depthBias           = 0;
+  rasterizationState.depthBiasSlopeScale = 0.0;
+  rasterizationState.depthBiasClamp      = 0.0;
 
-    // test
-    utils::ComboRenderPipelineDescriptor descriptor(mDevice);
-    descriptor.layout                               = mPipelineLayout;
-    descriptor.vertexStage.module                   = mVsModule;
-    descriptor.cFragmentStage.module                = mFsModule;
-    descriptor.vertexState                          = &mVertexStateDescriptor;
-    descriptor.depthStencilState                    = &descriptor.cDepthStencilState;
-    descriptor.cDepthStencilState.format            = wgpu::TextureFormat::Depth24PlusStencil8;
-    descriptor.colorStateCount                      = 1;
-    descriptor.cColorStates[0]                      = ColorStateDescriptor;
-    descriptor.cColorStates[0].format               = mPreferredSwapChainFormat;
-    descriptor.cDepthStencilState.depthWriteEnabled = true;
-    descriptor.cDepthStencilState.depthCompare      = wgpu::CompareFunction::Less;
-    descriptor.primitiveTopology                    = wgpu::PrimitiveTopology::TriangleList;
-    descriptor.sampleCount                          = mMSAASampleCount;
-    descriptor.rasterizationState                   = &rasterizationState;
+  // test
+  utils::ComboRenderPipelineDescriptor descriptor(mDevice);
+  descriptor.layout                = mPipelineLayout;
+  descriptor.vertexStage.module    = mVsModule;
+  descriptor.cFragmentStage.module = mFsModule;
+  descriptor.vertexState           = &mVertexStateDescriptor;
+  descriptor.depthStencilState     = &descriptor.cDepthStencilState;
+  descriptor.cDepthStencilState.format =
+      wgpu::TextureFormat::Depth24PlusStencil8;
+  descriptor.colorStateCount                      = 1;
+  descriptor.cColorStates[0]                      = ColorStateDescriptor;
+  descriptor.cColorStates[0].format               = mPreferredSwapChainFormat;
+  descriptor.cDepthStencilState.depthWriteEnabled = true;
+  descriptor.cDepthStencilState.depthCompare      = wgpu::CompareFunction::Less;
+  descriptor.primitiveTopology  = wgpu::PrimitiveTopology::TriangleList;
+  descriptor.sampleCount        = mMSAASampleCount;
+  descriptor.rasterizationState = &rasterizationState;
 
-    wgpu::RenderPipeline mPipeline = mDevice.CreateRenderPipeline(&descriptor);
+  wgpu::RenderPipeline mPipeline = mDevice.CreateRenderPipeline(&descriptor);
 
-    return mPipeline;
+  return mPipeline;
 }
 
 wgpu::TextureView ContextDawn::createMultisampledRenderTargetView() const
 {
-    wgpu::TextureDescriptor descriptor;
-    descriptor.dimension     = wgpu::TextureDimension::e2D;
-    descriptor.size.width    = mClientWidth;
-    descriptor.size.height   = mClientHeight;
-    descriptor.size.depth    = 1;
-    descriptor.sampleCount   = mMSAASampleCount;
-    descriptor.format        = mPreferredSwapChainFormat;
-    descriptor.mipLevelCount = 1;
-    descriptor.usage         = wgpu::TextureUsage::OutputAttachment;
+  wgpu::TextureDescriptor descriptor;
+  descriptor.dimension     = wgpu::TextureDimension::e2D;
+  descriptor.size.width    = mClientWidth;
+  descriptor.size.height   = mClientHeight;
+  descriptor.size.depth    = 1;
+  descriptor.sampleCount   = mMSAASampleCount;
+  descriptor.format        = mPreferredSwapChainFormat;
+  descriptor.mipLevelCount = 1;
+  descriptor.usage         = wgpu::TextureUsage::OutputAttachment;
 
-    return mDevice.CreateTexture(&descriptor).CreateView();
+  return mDevice.CreateTexture(&descriptor).CreateView();
 }
 
 wgpu::TextureView ContextDawn::createDepthStencilView() const
 {
-    wgpu::TextureDescriptor descriptor;
-    descriptor.dimension     = wgpu::TextureDimension::e2D;
-    descriptor.size.width    = mClientWidth;
-    descriptor.size.height   = mClientHeight;
-    descriptor.size.depth    = 1;
-    descriptor.sampleCount   = mMSAASampleCount;
-    descriptor.format        = wgpu::TextureFormat::Depth24PlusStencil8;
-    descriptor.mipLevelCount = 1;
-    descriptor.usage         = wgpu::TextureUsage::OutputAttachment;
-    auto depthStencilTexture = mDevice.CreateTexture(&descriptor);
-    return depthStencilTexture.CreateView();
+  wgpu::TextureDescriptor descriptor;
+  descriptor.dimension     = wgpu::TextureDimension::e2D;
+  descriptor.size.width    = mClientWidth;
+  descriptor.size.height   = mClientHeight;
+  descriptor.size.depth    = 1;
+  descriptor.sampleCount   = mMSAASampleCount;
+  descriptor.format        = wgpu::TextureFormat::Depth24PlusStencil8;
+  descriptor.mipLevelCount = 1;
+  descriptor.usage         = wgpu::TextureUsage::OutputAttachment;
+  auto depthStencilTexture = mDevice.CreateTexture(&descriptor);
+  return depthStencilTexture.CreateView();
 }
 
-wgpu::Buffer ContextDawn::createBuffer(uint32_t size, wgpu::BufferUsage bit) const
+wgpu::Buffer ContextDawn::createBuffer(uint32_t size,
+                                       wgpu::BufferUsage bit) const
 {
-    wgpu::BufferDescriptor descriptor;
-    descriptor.size  = size;
-    descriptor.usage = bit;
+  wgpu::BufferDescriptor descriptor;
+  descriptor.size  = size;
+  descriptor.usage = bit;
 
-    wgpu::Buffer buffer = mDevice.CreateBuffer(&descriptor);
-    return buffer;
+  wgpu::Buffer buffer = mDevice.CreateBuffer(&descriptor);
+  return buffer;
 }
 
 void ContextDawn::setBufferData(const wgpu::Buffer &buffer,
@@ -536,347 +566,372 @@ void ContextDawn::setBufferData(const wgpu::Buffer &buffer,
                                 const void *data,
                                 uint32_t dataSize)
 {
-    wgpu::CreateBufferMappedResult result =
-        CreateBufferMapped(wgpu::BufferUsage::MapWrite | wgpu::BufferUsage::CopySrc, bufferSize);
-    memcpy(result.data, data, dataSize);
-    result.buffer.Unmap();
+  wgpu::CreateBufferMappedResult result = CreateBufferMapped(
+      wgpu::BufferUsage::MapWrite | wgpu::BufferUsage::CopySrc, bufferSize);
+  memcpy(result.data, data, dataSize);
+  result.buffer.Unmap();
 
-    wgpu::CommandBuffer command = copyBufferToBuffer(result.buffer, 0, buffer, 0, bufferSize);
-    mCommandBuffers.emplace_back(command);
+  wgpu::CommandBuffer command =
+      copyBufferToBuffer(result.buffer, 0, buffer, 0, bufferSize);
+  mCommandBuffers.emplace_back(command);
 }
 
 wgpu::BindGroup ContextDawn::makeBindGroup(
     const wgpu::BindGroupLayout &layout,
-    std::initializer_list<utils::BindingInitializationHelper> bindingsInitializer) const
+    std::initializer_list<utils::BindingInitializationHelper>
+        bindingsInitializer) const
 {
-    return utils::MakeBindGroup(mDevice, layout, bindingsInitializer);
+  return utils::MakeBindGroup(mDevice, layout, bindingsInitializer);
 }
 
 void ContextDawn::initGeneralResources(Aquarium *aquarium)
 {
-    // initilize general uniform buffers
-    groupLayoutGeneral = MakeBindGroupLayout({
-        {0, wgpu::ShaderStage::Fragment, wgpu::BindingType::UniformBuffer},
-        {1, wgpu::ShaderStage::Fragment, wgpu::BindingType::UniformBuffer},
+  // initilize general uniform buffers
+  groupLayoutGeneral = MakeBindGroupLayout({
+      {0, wgpu::ShaderStage::Fragment, wgpu::BindingType::UniformBuffer},
+      {1, wgpu::ShaderStage::Fragment, wgpu::BindingType::UniformBuffer},
+  });
+
+  mLightBuffer = createBufferFromData(
+      &aquarium->lightUniforms, sizeof(aquarium->lightUniforms),
+      sizeof(aquarium->lightUniforms),
+      wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
+  mFogBuffer = createBufferFromData(
+      &aquarium->fogUniforms, sizeof(aquarium->fogUniforms),
+      sizeof(aquarium->fogUniforms),
+      wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
+
+  bindGroupGeneral =
+      makeBindGroup(groupLayoutGeneral,
+                    {{0, mLightBuffer, 0, sizeof(aquarium->lightUniforms)},
+                     {1, mFogBuffer, 0, sizeof(aquarium->fogUniforms)}});
+
+  setBufferData(mLightBuffer, sizeof(LightUniforms), &aquarium->lightUniforms,
+                sizeof(LightUniforms));
+  setBufferData(mFogBuffer, sizeof(FogUniforms), &aquarium->fogUniforms,
+                sizeof(FogUniforms));
+
+  // initilize world uniform buffers
+  groupLayoutWorld = MakeBindGroupLayout({
+      {0, wgpu::ShaderStage::Vertex, wgpu::BindingType::UniformBuffer},
+  });
+
+  mLightWorldPositionBuffer = createBufferFromData(
+      &aquarium->lightWorldPositionUniform,
+      sizeof(aquarium->lightWorldPositionUniform),
+      CalcConstantBufferByteSize(sizeof(aquarium->lightWorldPositionUniform)),
+      wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
+
+  bindGroupWorld = makeBindGroup(
+      groupLayoutWorld, {
+                            {0, mLightWorldPositionBuffer, 0,
+                             CalcConstantBufferByteSize(
+                                 sizeof(aquarium->lightWorldPositionUniform))},
+                        });
+
+  bool enableDynamicBufferOffset = aquarium->toggleBitset.test(
+      static_cast<size_t>(TOGGLE::ENABLEDYNAMICBUFFEROFFSET));
+  if (enableDynamicBufferOffset)
+  {
+    groupLayoutFishPer = MakeBindGroupLayout({
+        {0, wgpu::ShaderStage::Vertex, wgpu::BindingType::UniformBuffer, true},
     });
-
-    mLightBuffer = createBufferFromData(&aquarium->lightUniforms, sizeof(aquarium->lightUniforms),
-                                        sizeof(aquarium->lightUniforms),
-                                        wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
-    mFogBuffer   = createBufferFromData(&aquarium->fogUniforms, sizeof(aquarium->fogUniforms),
-                                      sizeof(aquarium->fogUniforms),
-                                      wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
-
-    bindGroupGeneral =
-        makeBindGroup(groupLayoutGeneral, {{0, mLightBuffer, 0, sizeof(aquarium->lightUniforms)},
-                                           {1, mFogBuffer, 0, sizeof(aquarium->fogUniforms)}});
-
-    setBufferData(mLightBuffer, sizeof(LightUniforms), &aquarium->lightUniforms,
-                  sizeof(LightUniforms));
-    setBufferData(mFogBuffer, sizeof(FogUniforms), &aquarium->fogUniforms, sizeof(FogUniforms));
-
-    // initilize world uniform buffers
-    groupLayoutWorld = MakeBindGroupLayout({
+  }
+  else
+  {
+    groupLayoutFishPer = MakeBindGroupLayout({
         {0, wgpu::ShaderStage::Vertex, wgpu::BindingType::UniformBuffer},
     });
+  }
 
-    mLightWorldPositionBuffer = createBufferFromData(
-        &aquarium->lightWorldPositionUniform, sizeof(aquarium->lightWorldPositionUniform),
-        CalcConstantBufferByteSize(sizeof(aquarium->lightWorldPositionUniform)),
-        wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
-
-    bindGroupWorld =
-        makeBindGroup(groupLayoutWorld,
-                      {
-                          {0, mLightWorldPositionBuffer, 0,
-                           CalcConstantBufferByteSize(sizeof(aquarium->lightWorldPositionUniform))},
-                      });
-
-    bool enableDynamicBufferOffset =
-        aquarium->toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEDYNAMICBUFFEROFFSET));
-    if (enableDynamicBufferOffset)
-    {
-        groupLayoutFishPer = MakeBindGroupLayout({
-            {0, wgpu::ShaderStage::Vertex, wgpu::BindingType::UniformBuffer, true},
-        });
-    }
-    else
-    {
-        groupLayoutFishPer = MakeBindGroupLayout({
-            {0, wgpu::ShaderStage::Vertex, wgpu::BindingType::UniformBuffer},
-        });
-    }
-
-    reallocResource(aquarium->getPreFishCount(), aquarium->getCurFishCount(),
-                    enableDynamicBufferOffset);
+  reallocResource(aquarium->getPreFishCount(), aquarium->getCurFishCount(),
+                  enableDynamicBufferOffset);
 }
 
 void ContextDawn::updateWorldlUniforms(Aquarium *aquarium)
 {
-    updateBufferData(mLightWorldPositionBuffer,
-                     CalcConstantBufferByteSize(sizeof(LightWorldPositionUniform)),
-                     &aquarium->lightWorldPositionUniform, sizeof(LightWorldPositionUniform));
+  updateBufferData(
+      mLightWorldPositionBuffer,
+      CalcConstantBufferByteSize(sizeof(LightWorldPositionUniform)),
+      &aquarium->lightWorldPositionUniform, sizeof(LightWorldPositionUniform));
 }
 
-Buffer *ContextDawn::createBuffer(int numComponents, std::vector<float> *buf, bool isIndex)
+Buffer *ContextDawn::createBuffer(int numComponents,
+                                  std::vector<float> *buf,
+                                  bool isIndex)
 {
-    Buffer *buffer =
-        new BufferDawn(this, static_cast<int>(buf->size()), numComponents, buf, isIndex);
-    return buffer;
+  Buffer *buffer = new BufferDawn(this, static_cast<int>(buf->size()),
+                                  numComponents, buf, isIndex);
+  return buffer;
 }
 
-Buffer *ContextDawn::createBuffer(int numComponents, std::vector<unsigned short> *buf, bool isIndex)
+Buffer *ContextDawn::createBuffer(int numComponents,
+                                  std::vector<unsigned short> *buf,
+                                  bool isIndex)
 {
-    Buffer *buffer =
-        new BufferDawn(this, static_cast<int>(buf->size()), numComponents, buf, isIndex);
-    return buffer;
+  Buffer *buffer = new BufferDawn(this, static_cast<int>(buf->size()),
+                                  numComponents, buf, isIndex);
+  return buffer;
 }
 
-Program *ContextDawn::createProgram(const std::string &mVId, const std::string &mFId)
+Program *ContextDawn::createProgram(const std::string &mVId,
+                                    const std::string &mFId)
 {
-    ProgramDawn *program = new ProgramDawn(this, mVId, mFId);
+  ProgramDawn *program = new ProgramDawn(this, mVId, mFId);
 
-    return program;
+  return program;
 }
 
 void ContextDawn::setWindowTitle(const std::string &text)
 {
-    glfwSetWindowTitle(mWindow, text.c_str());
+  glfwSetWindowTitle(mWindow, text.c_str());
 }
 
 bool ContextDawn::ShouldQuit()
 {
-    return glfwWindowShouldClose(mWindow);
+  return glfwWindowShouldClose(mWindow);
 }
 
 void ContextDawn::KeyBoardQuit()
 {
-    if (glfwGetKey(mWindow, GLFW_KEY_ESCAPE) == GLFW_PRESS)
-        glfwSetWindowShouldClose(mWindow, GLFW_TRUE);
+  if (glfwGetKey(mWindow, GLFW_KEY_ESCAPE) == GLFW_PRESS)
+    glfwSetWindowShouldClose(mWindow, GLFW_TRUE);
 }
 
 // Submit commands of the frame
-void ContextDawn::DoFlush(const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset)
+void ContextDawn::DoFlush(
+    const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset)
 {
-    mRenderPass.EndPass();
+  mRenderPass.EndPass();
 
-    bufferManager->flush();
+  bufferManager->flush();
 
-    wgpu::CommandBuffer cmd = mCommandEncoder.Finish();
-    mCommandBuffers.emplace_back(cmd);
+  wgpu::CommandBuffer cmd = mCommandEncoder.Finish();
+  mCommandBuffers.emplace_back(cmd);
 
-    Flush();
+  Flush();
 
-    mSwapchain.Present();
+  mSwapchain.Present();
 
-    glfwPollEvents();
+  glfwPollEvents();
 }
 
 void ContextDawn::Flush()
 {
-    queue.Submit(mCommandBuffers.size(), mCommandBuffers.data());
-    mCommandBuffers.clear();
+  queue.Submit(mCommandBuffers.size(), mCommandBuffers.data());
+  mCommandBuffers.clear();
 }
 
 void ContextDawn::Terminate()
 {
-    glfwTerminate();
+  glfwTerminate();
 }
 
 void ContextDawn::showWindow()
 {
-    glfwShowWindow(mWindow);
+  glfwShowWindow(mWindow);
 }
 
-void ContextDawn::updateFPS(const FPSTimer &fpsTimer,
-                            int *fishCount,
-                            std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> *toggleBitset)
+void ContextDawn::updateFPS(
+    const FPSTimer &fpsTimer,
+    int *fishCount,
+    std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> *toggleBitset)
 {
-    if (mDisableControlPanel)
-    {
-        return;
-    }
+  if (mDisableControlPanel)
+  {
+    return;
+  }
 
-    // Start the Dear ImGui frame
-    ImGui_ImplDawn_NewFrame(mMSAASampleCount,
-                            toggleBitset->test(static_cast<TOGGLE>(TOGGLE::ENABLEALPHABLENDING)));
-    renderImgui(fpsTimer, fishCount, toggleBitset);
-    ImGui_ImplDawn_RenderDrawData(ImGui::GetDrawData());
+  // Start the Dear ImGui frame
+  ImGui_ImplDawn_NewFrame(
+      mMSAASampleCount,
+      toggleBitset->test(static_cast<TOGGLE>(TOGGLE::ENABLEALPHABLENDING)));
+  renderImgui(fpsTimer, fishCount, toggleBitset);
+  ImGui_ImplDawn_RenderDrawData(ImGui::GetDrawData());
 }
 
 void ContextDawn::showFPS()
 {
-    if (mDisableControlPanel)
-    {
-        return;
-    }
+  if (mDisableControlPanel)
+  {
+    return;
+  }
 
-    ImGui_ImplDawn_Draw(ImGui::GetDrawData());
+  ImGui_ImplDawn_Draw(ImGui::GetDrawData());
 }
 
 void ContextDawn::destoryImgUI()
 {
-    ImGui_ImplDawn_Shutdown();
-    ImGui_ImplGlfw_Shutdown();
-    ImGui::DestroyContext();
+  ImGui_ImplDawn_Shutdown();
+  ImGui_ImplGlfw_Shutdown();
+  ImGui::DestroyContext();
 }
 
 void ContextDawn::preFrame()
 {
-    if (mIsSwapchainOutOfDate)
-    {
-        glfwGetFramebufferSize(mWindow, &mClientWidth, &mClientHeight);
-        if (mMSAASampleCount > 1)
-        {
-            mSceneRenderTargetView = createMultisampledRenderTargetView();
-        }
-        mSceneDepthStencilView = createDepthStencilView();
-        mSwapchain.Configure(mPreferredSwapChainFormat, kSwapchainBackBufferUsage, mClientWidth,
-                             mClientHeight);
-
-        mIsSwapchainOutOfDate = false;
-    }
-
-    mCommandEncoder = mDevice.CreateCommandEncoder();
-    mBackbufferView = mSwapchain.GetCurrentTextureView();
-
+  if (mIsSwapchainOutOfDate)
+  {
+    glfwGetFramebufferSize(mWindow, &mClientWidth, &mClientHeight);
     if (mMSAASampleCount > 1)
     {
-        // If MSAA is enabled, we render to a multisampled texture and then resolve to the
-        // backbuffer
-        mRenderPassDescriptor =
-            utils::ComboRenderPassDescriptor({mSceneRenderTargetView}, mSceneDepthStencilView);
-        mRenderPassDescriptor.cColorAttachments[0].resolveTarget = mBackbufferView;
-        mRenderPassDescriptor.cColorAttachments[0].loadOp        = wgpu::LoadOp::Clear;
-        mRenderPassDescriptor.cColorAttachments[0].storeOp       = wgpu::StoreOp::Clear;
-        mRenderPassDescriptor.cColorAttachments[0].clearColor    = {0.f, 0.8f, 1.f, 0.f};
+      mSceneRenderTargetView = createMultisampledRenderTargetView();
     }
-    else
-    {
-        // When MSAA is off, we render directly to the backbuffer
-        mRenderPassDescriptor =
-            utils::ComboRenderPassDescriptor({mBackbufferView}, mSceneDepthStencilView);
-        mRenderPassDescriptor.cColorAttachments[0].loadOp     = wgpu::LoadOp::Clear;
-        mRenderPassDescriptor.cColorAttachments[0].storeOp    = wgpu::StoreOp::Store;
-        mRenderPassDescriptor.cColorAttachments[0].clearColor = {0.f, 0.8f, 1.f, 0.f};
-    }
+    mSceneDepthStencilView = createDepthStencilView();
+    mSwapchain.Configure(mPreferredSwapChainFormat, kSwapchainBackBufferUsage,
+                         mClientWidth, mClientHeight);
 
-    mRenderPass = mCommandEncoder.BeginRenderPass(&mRenderPassDescriptor);
+    mIsSwapchainOutOfDate = false;
+  }
+
+  mCommandEncoder = mDevice.CreateCommandEncoder();
+  mBackbufferView = mSwapchain.GetCurrentTextureView();
+
+  if (mMSAASampleCount > 1)
+  {
+    // If MSAA is enabled, we render to a multisampled texture and then resolve
+    // to the backbuffer
+    mRenderPassDescriptor = utils::ComboRenderPassDescriptor(
+        {mSceneRenderTargetView}, mSceneDepthStencilView);
+    mRenderPassDescriptor.cColorAttachments[0].resolveTarget = mBackbufferView;
+    mRenderPassDescriptor.cColorAttachments[0].loadOp  = wgpu::LoadOp::Clear;
+    mRenderPassDescriptor.cColorAttachments[0].storeOp = wgpu::StoreOp::Clear;
+    mRenderPassDescriptor.cColorAttachments[0].clearColor = {0.f, 0.8f, 1.f,
+                                                             0.f};
+  }
+  else
+  {
+    // When MSAA is off, we render directly to the backbuffer
+    mRenderPassDescriptor = utils::ComboRenderPassDescriptor(
+        {mBackbufferView}, mSceneDepthStencilView);
+    mRenderPassDescriptor.cColorAttachments[0].loadOp  = wgpu::LoadOp::Clear;
+    mRenderPassDescriptor.cColorAttachments[0].storeOp = wgpu::StoreOp::Store;
+    mRenderPassDescriptor.cColorAttachments[0].clearColor = {0.f, 0.8f, 1.f,
+                                                             0.f};
+  }
+
+  mRenderPass = mCommandEncoder.BeginRenderPass(&mRenderPassDescriptor);
 }
 
-Model *ContextDawn::createModel(Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend)
+Model *ContextDawn::createModel(Aquarium *aquarium,
+                                MODELGROUP type,
+                                MODELNAME name,
+                                bool blend)
 {
-    Model *model;
-    switch (type)
-    {
-        case MODELGROUP::FISH:
-            model = new FishModelDawn(this, aquarium, type, name, blend);
-            break;
-        case MODELGROUP::FISHINSTANCEDDRAW:
-            model = new FishModelInstancedDrawDawn(this, aquarium, type, name, blend);
-            break;
-        case MODELGROUP::GENERIC:
-            model = new GenericModelDawn(this, aquarium, type, name, blend);
-            break;
-        case MODELGROUP::INNER:
-            model = new InnerModelDawn(this, aquarium, type, name, blend);
-            break;
-        case MODELGROUP::SEAWEED:
-            model = new SeaweedModelDawn(this, aquarium, type, name, blend);
-            break;
-        case MODELGROUP::OUTSIDE:
-            model = new OutsideModelDawn(this, aquarium, type, name, blend);
-            break;
-        default:
-            model = nullptr;
-            std::cout << "can not create model type" << std::endl;
-    }
+  Model *model;
+  switch (type)
+  {
+  case MODELGROUP::FISH:
+    model = new FishModelDawn(this, aquarium, type, name, blend);
+    break;
+  case MODELGROUP::FISHINSTANCEDDRAW:
+    model = new FishModelInstancedDrawDawn(this, aquarium, type, name, blend);
+    break;
+  case MODELGROUP::GENERIC:
+    model = new GenericModelDawn(this, aquarium, type, name, blend);
+    break;
+  case MODELGROUP::INNER:
+    model = new InnerModelDawn(this, aquarium, type, name, blend);
+    break;
+  case MODELGROUP::SEAWEED:
+    model = new SeaweedModelDawn(this, aquarium, type, name, blend);
+    break;
+  case MODELGROUP::OUTSIDE:
+    model = new OutsideModelDawn(this, aquarium, type, name, blend);
+    break;
+  default:
+    model = nullptr;
+    std::cout << "can not create model type" << std::endl;
+  }
 
-    return model;
+  return model;
 }
 
 void ContextDawn::reallocResource(int preTotalInstance,
                                   int curTotalInstance,
                                   bool enableDynamicBufferOffset)
 {
-    mPreTotalInstance          = preTotalInstance;
-    mCurTotalInstance          = curTotalInstance;
-    mEnableDynamicBufferOffset = enableDynamicBufferOffset;
+  mPreTotalInstance          = preTotalInstance;
+  mCurTotalInstance          = curTotalInstance;
+  mEnableDynamicBufferOffset = enableDynamicBufferOffset;
 
-    if (curTotalInstance == 0)
-        return;
+  if (curTotalInstance == 0)
+    return;
 
-    // If current fish number > pre fish number, allocate a new bigger buffer.
-    // If current fish number <= prefish number, do not allocate a new one.
-    // TODO(yizhou) : optimize the buffer allocation strategy.
-    if (preTotalInstance >= curTotalInstance)
+  // If current fish number > pre fish number, allocate a new bigger buffer.
+  // If current fish number <= prefish number, do not allocate a new one.
+  // TODO(yizhou) : optimize the buffer allocation strategy.
+  if (preTotalInstance >= curTotalInstance)
+  {
+    return;
+  }
+
+  destoryFishResource();
+
+  fishPers = new FishPer[curTotalInstance];
+
+  if (enableDynamicBufferOffset)
+  {
+    bindGroupFishPers = new wgpu::BindGroup[1];
+  }
+  else
+  {
+    bindGroupFishPers = new wgpu::BindGroup[curTotalInstance];
+  }
+
+  size_t size = CalcConstantBufferByteSize(sizeof(FishPer) * curTotalInstance);
+  fishPersBuffer = createBuffer(
+      size, wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
+
+  if (enableDynamicBufferOffset)
+  {
+    bindGroupFishPers[0] = makeBindGroup(
+        groupLayoutFishPer,
+        {{0, fishPersBuffer, 0, CalcConstantBufferByteSize(sizeof(FishPer))}});
+  }
+  else
+  {
+    for (int i = 0; i < curTotalInstance; i++)
     {
-        return;
+      bindGroupFishPers[i] = makeBindGroup(
+          groupLayoutFishPer,
+          {{0, fishPersBuffer, CalcConstantBufferByteSize(sizeof(FishPer) * i),
+            CalcConstantBufferByteSize(sizeof(FishPer))}});
     }
-
-    destoryFishResource();
-
-    fishPers = new FishPer[curTotalInstance];
-
-    if (enableDynamicBufferOffset)
-    {
-        bindGroupFishPers = new wgpu::BindGroup[1];
-    }
-    else
-    {
-        bindGroupFishPers = new wgpu::BindGroup[curTotalInstance];
-    }
-
-    size_t size    = CalcConstantBufferByteSize(sizeof(FishPer) * curTotalInstance);
-    fishPersBuffer = createBuffer(size, wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
-
-    if (enableDynamicBufferOffset)
-    {
-        bindGroupFishPers[0] =
-            makeBindGroup(groupLayoutFishPer,
-                          {{0, fishPersBuffer, 0, CalcConstantBufferByteSize(sizeof(FishPer))}});
-    }
-    else
-    {
-        for (int i = 0; i < curTotalInstance; i++)
-        {
-            bindGroupFishPers[i] =
-                makeBindGroup(groupLayoutFishPer,
-                              {{0, fishPersBuffer, CalcConstantBufferByteSize(sizeof(FishPer) * i),
-                                CalcConstantBufferByteSize(sizeof(FishPer))}});
-        }
-    }
+  }
 }
 
-wgpu::CreateBufferMappedResult ContextDawn::CreateBufferMapped(wgpu::BufferUsage usage,
-                                                               uint64_t size) const
+wgpu::CreateBufferMappedResult ContextDawn::CreateBufferMapped(
+    wgpu::BufferUsage usage,
+    uint64_t size) const
 {
-    wgpu::BufferDescriptor descriptor;
-    descriptor.nextInChain = nullptr;
-    descriptor.size        = size;
-    descriptor.usage       = usage;
+  wgpu::BufferDescriptor descriptor;
+  descriptor.nextInChain = nullptr;
+  descriptor.size        = size;
+  descriptor.usage       = usage;
 
-    wgpu::CreateBufferMappedResult result = mDevice.CreateBufferMapped(&descriptor);
-    ASSERT(result.dataLength == size);
-    return result;
+  wgpu::CreateBufferMappedResult result =
+      mDevice.CreateBufferMapped(&descriptor);
+  ASSERT(result.dataLength == size);
+  return result;
 }
 
 void ContextDawn::WaitABit()
 {
-    mDevice.Tick();
+  mDevice.Tick();
 
-    utils::USleep(100);
+  utils::USleep(100);
 }
 
 wgpu::CommandEncoder ContextDawn::createCommandEncoder() const
 {
-    return mDevice.CreateCommandEncoder();
+  return mDevice.CreateCommandEncoder();
 }
 
 void ContextDawn::updateAllFishData()
 {
-    size_t size = CalcConstantBufferByteSize(sizeof(FishPer) * mCurTotalInstance);
-    updateBufferData(fishPersBuffer, size, fishPers, sizeof(FishPer) * mCurTotalInstance);
+  size_t size = CalcConstantBufferByteSize(sizeof(FishPer) * mCurTotalInstance);
+  updateBufferData(fishPersBuffer, size, fishPers,
+                   sizeof(FishPer) * mCurTotalInstance);
 }
 
 void ContextDawn::updateBufferData(const wgpu::Buffer &buffer,
@@ -884,57 +939,57 @@ void ContextDawn::updateBufferData(const wgpu::Buffer &buffer,
                                    void *data,
                                    size_t dataSize) const
 {
-    size_t offset              = 0;
-    RingBufferDawn *ringBuffer = bufferManager->allocate(bufferSize, &offset);
+  size_t offset              = 0;
+  RingBufferDawn *ringBuffer = bufferManager->allocate(bufferSize, &offset);
 
-    if (ringBuffer == nullptr)
-    {
-        std::cout << "Memory upper limit." << std::endl;
-        return;
-    }
+  if (ringBuffer == nullptr)
+  {
+    std::cout << "Memory upper limit." << std::endl;
+    return;
+  }
 
-    ringBuffer->push(bufferManager->mEncoder, buffer, offset, 0, data, dataSize);
+  ringBuffer->push(bufferManager->mEncoder, buffer, offset, 0, data, dataSize);
 }
 
 void ContextDawn::destoryFishResource()
 {
-    fishPersBuffer = nullptr;
+  fishPersBuffer = nullptr;
 
-    if (fishPers != nullptr)
+  if (fishPers != nullptr)
+  {
+    delete fishPers;
+    fishPers = nullptr;
+  }
+  if (mEnableDynamicBufferOffset)
+  {
+    if (bindGroupFishPers != nullptr)
     {
-        delete fishPers;
-        fishPers = nullptr;
+      if (bindGroupFishPers[0].Get() != nullptr)
+      {
+        bindGroupFishPers[0] = nullptr;
+      }
     }
-    if (mEnableDynamicBufferOffset)
+  }
+  else
+  {
+    if (bindGroupFishPers != nullptr)
     {
-        if (bindGroupFishPers != nullptr)
+      for (int i = 0; i < mPreTotalInstance; i++)
+      {
+        if (bindGroupFishPers[i].Get() != nullptr)
         {
-            if (bindGroupFishPers[0].Get() != nullptr)
-            {
-                bindGroupFishPers[0] = nullptr;
-            }
+          bindGroupFishPers[i] = nullptr;
         }
+      }
     }
-    else
-    {
-        if (bindGroupFishPers != nullptr)
-        {
-            for (int i = 0; i < mPreTotalInstance; i++)
-            {
-                if (bindGroupFishPers[i].Get() != nullptr)
-                {
-                    bindGroupFishPers[i] = nullptr;
-                }
-            }
-        }
-    }
+  }
 
-    bindGroupFishPers = nullptr;
+  bindGroupFishPers = nullptr;
 
-    bufferManager->destroyBufferPool();
+  bufferManager->destroyBufferPool();
 }
 
 size_t ContextDawn::CalcConstantBufferByteSize(size_t byteSize) const
 {
-    return (byteSize + 255) & ~255;
+  return (byteSize + 255) & ~255;
 }

--- a/src/aquarium-optimized/dawn/ContextDawn.h
+++ b/src/aquarium-optimized/dawn/ContextDawn.h
@@ -9,8 +9,8 @@
 #define CONTEXTDAWN_H
 
 #ifdef DAWN_ENABLE_VULKAN_BACKEND
-// The Vulkan header is included by VulkanBackend.h, so this should be placed before the GLFW
-// header.
+// The Vulkan header is included by VulkanBackend.h, so this should be placed
+// before the GLFW header.
 #include "dawn_native/VulkanBackend.h"
 #endif
 #define GLFW_INCLUDE_NONE
@@ -32,155 +32,172 @@ enum BACKENDTYPE : short;
 
 class ContextDawn : public Context
 {
-  public:
-    ContextDawn(BACKENDTYPE backendType);
-    ~ContextDawn();
-    bool initialize(BACKENDTYPE backend,
-                    const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset,
-                    int windowWidth,
-                    int windowHeight) override;
-    void setWindowTitle(const std::string &text) override;
-    bool ShouldQuit() override;
-    void KeyBoardQuit() override;
-    void DoFlush(const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset) override;
-    void Flush() override;
-    void Terminate() override;
-    void showWindow() override;
-    void updateFPS(const FPSTimer &fpsTimer,
-                   int *fishCount,
-                   std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> *toggleBitset) override;
-    void showFPS() override;
-    void destoryImgUI() override;
+public:
+  ContextDawn(BACKENDTYPE backendType);
+  ~ContextDawn();
+  bool initialize(
+      BACKENDTYPE backend,
+      const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset,
+      int windowWidth,
+      int windowHeight) override;
+  void setWindowTitle(const std::string &text) override;
+  bool ShouldQuit() override;
+  void KeyBoardQuit() override;
+  void DoFlush(const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)>
+                   &toggleBitset) override;
+  void Flush() override;
+  void Terminate() override;
+  void showWindow() override;
+  void updateFPS(const FPSTimer &fpsTimer,
+                 int *fishCount,
+                 std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)>
+                     *toggleBitset) override;
+  void showFPS() override;
+  void destoryImgUI() override;
 
-    void preFrame() override;
+  void preFrame() override;
 
-    Model *createModel(Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend) override;
-    Buffer *createBuffer(int numComponents, std::vector<float> *buffer, bool isIndex) override;
-    Buffer *createBuffer(int numComponents,
-                         std::vector<unsigned short> *buffer,
-                         bool isIndex) override;
+  Model *createModel(Aquarium *aquarium,
+                     MODELGROUP type,
+                     MODELNAME name,
+                     bool blend) override;
+  Buffer *createBuffer(int numComponents,
+                       std::vector<float> *buffer,
+                       bool isIndex) override;
+  Buffer *createBuffer(int numComponents,
+                       std::vector<unsigned short> *buffer,
+                       bool isIndex) override;
 
-    Program *createProgram(const std::string &mVId, const std::string &mFId) override;
+  Program *createProgram(const std::string &mVId,
+                         const std::string &mFId) override;
 
-    Texture *createTexture(const std::string &name, const std::string &url) override;
-    Texture *createTexture(const std::string &name, const std::vector<std::string> &urls) override;
-    wgpu::Texture createTexture(const wgpu::TextureDescriptor &descriptor) const;
-    wgpu::Sampler createSampler(const wgpu::SamplerDescriptor &descriptor) const;
-    wgpu::Buffer createBufferFromData(const void *data,
-                                      uint32_t size,
-                                      uint32_t maxSize,
-                                      wgpu::BufferUsage usage);
-    wgpu::BufferCopyView createBufferCopyView(const wgpu::Buffer &buffer,
-                                              uint32_t offset,
-                                              uint32_t bytesPerRow,
-                                              uint32_t rowsPerImage) const;
-    wgpu::CommandBuffer copyBufferToTexture(const wgpu::BufferCopyView &bufferCopyView,
-                                            const wgpu::TextureCopyView &textureCopyView,
-                                            const wgpu::Extent3D &ext3D) const;
-    wgpu::CommandBuffer copyBufferToBuffer(wgpu::Buffer const &srcBuffer,
-                                           uint64_t srcOffset,
-                                           wgpu::Buffer const &destBuffer,
-                                           uint64_t destOffset,
-                                           uint64_t size) const;
+  Texture *createTexture(const std::string &name,
+                         const std::string &url) override;
+  Texture *createTexture(const std::string &name,
+                         const std::vector<std::string> &urls) override;
+  wgpu::Texture createTexture(const wgpu::TextureDescriptor &descriptor) const;
+  wgpu::Sampler createSampler(const wgpu::SamplerDescriptor &descriptor) const;
+  wgpu::Buffer createBufferFromData(const void *data,
+                                    uint32_t size,
+                                    uint32_t maxSize,
+                                    wgpu::BufferUsage usage);
+  wgpu::BufferCopyView createBufferCopyView(const wgpu::Buffer &buffer,
+                                            uint32_t offset,
+                                            uint32_t bytesPerRow,
+                                            uint32_t rowsPerImage) const;
+  wgpu::CommandBuffer copyBufferToTexture(
+      const wgpu::BufferCopyView &bufferCopyView,
+      const wgpu::TextureCopyView &textureCopyView,
+      const wgpu::Extent3D &ext3D) const;
+  wgpu::CommandBuffer copyBufferToBuffer(wgpu::Buffer const &srcBuffer,
+                                         uint64_t srcOffset,
+                                         wgpu::Buffer const &destBuffer,
+                                         uint64_t destOffset,
+                                         uint64_t size) const;
 
-    wgpu::TextureCopyView createTextureCopyView(wgpu::Texture texture,
-                                                uint32_t level,
-                                                wgpu::Origin3D origin);
-    wgpu::ShaderModule createShaderModule(utils::SingleShaderStage stage,
-                                          const std::string &str) const;
-    wgpu::BindGroupLayout MakeBindGroupLayout(
-        std::initializer_list<wgpu::BindGroupLayoutEntry> bindingsInitializer) const;
-    wgpu::PipelineLayout MakeBasicPipelineLayout(
-        std::vector<wgpu::BindGroupLayout> bindingsInitializer) const;
-    wgpu::RenderPipeline createRenderPipeline(
-        wgpu::PipelineLayout mPipelineLayout,
-        ProgramDawn *mProgramDawn,
-        const wgpu::VertexStateDescriptor &mVertexInputDescriptor,
-        bool enableBlend) const;
-    wgpu::TextureView createMultisampledRenderTargetView() const;
-    wgpu::TextureView createDepthStencilView() const;
-    wgpu::Buffer createBuffer(uint32_t size, wgpu::BufferUsage bit) const;
-    void setBufferData(const wgpu::Buffer &buffer,
-                       uint32_t bufferSize,
-                       const void *data,
-                       uint32_t dataSize);
-    wgpu::BindGroup makeBindGroup(
-        const wgpu::BindGroupLayout &layout,
-        std::initializer_list<utils::BindingInitializationHelper> bindingsInitializer) const;
+  wgpu::TextureCopyView createTextureCopyView(wgpu::Texture texture,
+                                              uint32_t level,
+                                              wgpu::Origin3D origin);
+  wgpu::ShaderModule createShaderModule(utils::SingleShaderStage stage,
+                                        const std::string &str) const;
+  wgpu::BindGroupLayout MakeBindGroupLayout(
+      std::initializer_list<wgpu::BindGroupLayoutEntry> bindingsInitializer)
+      const;
+  wgpu::PipelineLayout MakeBasicPipelineLayout(
+      std::vector<wgpu::BindGroupLayout> bindingsInitializer) const;
+  wgpu::RenderPipeline createRenderPipeline(
+      wgpu::PipelineLayout mPipelineLayout,
+      ProgramDawn *mProgramDawn,
+      const wgpu::VertexStateDescriptor &mVertexInputDescriptor,
+      bool enableBlend) const;
+  wgpu::TextureView createMultisampledRenderTargetView() const;
+  wgpu::TextureView createDepthStencilView() const;
+  wgpu::Buffer createBuffer(uint32_t size, wgpu::BufferUsage bit) const;
+  void setBufferData(const wgpu::Buffer &buffer,
+                     uint32_t bufferSize,
+                     const void *data,
+                     uint32_t dataSize);
+  wgpu::BindGroup makeBindGroup(
+      const wgpu::BindGroupLayout &layout,
+      std::initializer_list<utils::BindingInitializationHelper>
+          bindingsInitializer) const;
 
-    void initGeneralResources(Aquarium *aquarium) override;
-    void updateWorldlUniforms(Aquarium *aquarium) override;
-    const wgpu::Device &getDevice() const { return mDevice; }
-    const wgpu::RenderPassEncoder &getRenderPass() const { return mRenderPass; }
+  void initGeneralResources(Aquarium *aquarium) override;
+  void updateWorldlUniforms(Aquarium *aquarium) override;
+  const wgpu::Device &getDevice() const { return mDevice; }
+  const wgpu::RenderPassEncoder &getRenderPass() const { return mRenderPass; }
 
-    void reallocResource(int preTotalInstance,
-                         int curTotalInstance,
-                         bool enableDynamicBufferOffset) override;
-    void updateAllFishData() override;
-    void updateBufferData(const wgpu::Buffer &buffer,
-                          size_t bufferSize,
-                          void *data,
-                          size_t dataSize) const;
-    wgpu::CreateBufferMappedResult CreateBufferMapped(wgpu::BufferUsage usage, uint64_t size) const;
-    void WaitABit();
-    wgpu::CommandEncoder createCommandEncoder() const;
-    size_t CalcConstantBufferByteSize(size_t byteSize) const;
+  void reallocResource(int preTotalInstance,
+                       int curTotalInstance,
+                       bool enableDynamicBufferOffset) override;
+  void updateAllFishData() override;
+  void updateBufferData(const wgpu::Buffer &buffer,
+                        size_t bufferSize,
+                        void *data,
+                        size_t dataSize) const;
+  wgpu::CreateBufferMappedResult CreateBufferMapped(wgpu::BufferUsage usage,
+                                                    uint64_t size) const;
+  void WaitABit();
+  wgpu::CommandEncoder createCommandEncoder() const;
+  size_t CalcConstantBufferByteSize(size_t byteSize) const;
 
-    std::vector<wgpu::CommandBuffer> mCommandBuffers;
-    wgpu::Queue queue;
+  std::vector<wgpu::CommandBuffer> mCommandBuffers;
+  wgpu::Queue queue;
 
-    wgpu::BindGroupLayout groupLayoutGeneral;
-    wgpu::BindGroup bindGroupGeneral;
-    wgpu::BindGroupLayout groupLayoutWorld;
-    wgpu::BindGroup bindGroupWorld;
+  wgpu::BindGroupLayout groupLayoutGeneral;
+  wgpu::BindGroup bindGroupGeneral;
+  wgpu::BindGroupLayout groupLayoutWorld;
+  wgpu::BindGroup bindGroupWorld;
 
-    wgpu::BindGroupLayout groupLayoutFishPer;
-    wgpu::Buffer fishPersBuffer;
-    wgpu::BindGroup *bindGroupFishPers;
+  wgpu::BindGroupLayout groupLayoutFishPer;
+  wgpu::Buffer fishPersBuffer;
+  wgpu::BindGroup *bindGroupFishPers;
 
-    FishPer *fishPers;
+  FishPer *fishPers;
 
-    wgpu::Device mDevice;
+  wgpu::Device mDevice;
 
-  private:
-    bool GetHardwareAdapter(
-        std::unique_ptr<dawn_native::Instance> &instance,
-        dawn_native::Adapter *backendAdapter,
-        wgpu::BackendType backendType,
-        const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset);
+private:
+  bool GetHardwareAdapter(
+      std::unique_ptr<dawn_native::Instance> &instance,
+      dawn_native::Adapter *backendAdapter,
+      wgpu::BackendType backendType,
+      const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset);
 
-    void initAvailableToggleBitset(BACKENDTYPE backendType) override;
-    static void framebufferResizeCallback(GLFWwindow *window, int width, int height);
-    void destoryFishResource();
+  void initAvailableToggleBitset(BACKENDTYPE backendType) override;
+  static void framebufferResizeCallback(GLFWwindow *window,
+                                        int width,
+                                        int height);
+  void destoryFishResource();
 
-    // TODO(jiawei.shao@intel.com): remove wgpu::TextureUsageBit::CopyDst when the bug in Dawn is
-    // fixed.
-    static constexpr wgpu::TextureUsage kSwapchainBackBufferUsage =
-        wgpu::TextureUsage::OutputAttachment | wgpu::TextureUsage::CopyDst;
+  // TODO(jiawei.shao@intel.com): remove wgpu::TextureUsageBit::CopyDst when the
+  // bug in Dawn is fixed.
+  static constexpr wgpu::TextureUsage kSwapchainBackBufferUsage =
+      wgpu::TextureUsage::OutputAttachment | wgpu::TextureUsage::CopyDst;
 
-    bool mIsSwapchainOutOfDate = false;
-    GLFWwindow *mWindow;
-    std::unique_ptr<dawn_native::Instance> mInstance;
+  bool mIsSwapchainOutOfDate = false;
+  GLFWwindow *mWindow;
+  std::unique_ptr<dawn_native::Instance> mInstance;
 
-    wgpu::SwapChain mSwapchain;
-    wgpu::CommandEncoder mCommandEncoder;
-    wgpu::RenderPassEncoder mRenderPass;
-    utils::ComboRenderPassDescriptor mRenderPassDescriptor;
+  wgpu::SwapChain mSwapchain;
+  wgpu::CommandEncoder mCommandEncoder;
+  wgpu::RenderPassEncoder mRenderPass;
+  utils::ComboRenderPassDescriptor mRenderPassDescriptor;
 
-    wgpu::TextureView mBackbufferView;
-    wgpu::TextureView mSceneRenderTargetView;
-    wgpu::TextureView mSceneDepthStencilView;
-    wgpu::RenderPipeline mPipeline;
-    wgpu::BindGroup mBindGroup;
-    wgpu::TextureFormat mPreferredSwapChainFormat;
+  wgpu::TextureView mBackbufferView;
+  wgpu::TextureView mSceneRenderTargetView;
+  wgpu::TextureView mSceneDepthStencilView;
+  wgpu::RenderPipeline mPipeline;
+  wgpu::BindGroup mBindGroup;
+  wgpu::TextureFormat mPreferredSwapChainFormat;
 
-    wgpu::Buffer mLightWorldPositionBuffer;
-    wgpu::Buffer mLightBuffer;
-    wgpu::Buffer mFogBuffer;
+  wgpu::Buffer mLightWorldPositionBuffer;
+  wgpu::Buffer mLightBuffer;
+  wgpu::Buffer mFogBuffer;
 
-    bool mEnableDynamicBufferOffset;
+  bool mEnableDynamicBufferOffset;
 
-    BufferManagerDawn *bufferManager;
+  BufferManagerDawn *bufferManager;
 };
 
 #endif  // CONTEXTDAWN_H

--- a/src/aquarium-optimized/dawn/FishModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/FishModelDawn.cpp
@@ -18,186 +18,213 @@ FishModelDawn::FishModelDawn(Context *context,
                              bool blend)
     : FishModel(type, name, blend, aquarium)
 {
-    mContextDawn = static_cast<ContextDawn *>(context);
+  mContextDawn = static_cast<ContextDawn *>(context);
 
-    mEnableDynamicBufferOffset =
-        aquarium->toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEDYNAMICBUFFEROFFSET));
+  mEnableDynamicBufferOffset = aquarium->toggleBitset.test(
+      static_cast<size_t>(TOGGLE::ENABLEDYNAMICBUFFEROFFSET));
 
-    mLightFactorUniforms.shininess      = 5.0f;
-    mLightFactorUniforms.specularFactor = 0.3f;
+  mLightFactorUniforms.shininess      = 5.0f;
+  mLightFactorUniforms.specularFactor = 0.3f;
 
-    const Fish &fishInfo               = fishTable[name - MODELNAME::MODELSMALLFISHA];
-    mFishVertexUniforms.fishLength     = fishInfo.fishLength;
-    mFishVertexUniforms.fishBendAmount = fishInfo.fishBendAmount;
-    mFishVertexUniforms.fishWaveLength = fishInfo.fishWaveLength;
+  const Fish &fishInfo           = fishTable[name - MODELNAME::MODELSMALLFISHA];
+  mFishVertexUniforms.fishLength = fishInfo.fishLength;
+  mFishVertexUniforms.fishBendAmount = fishInfo.fishBendAmount;
+  mFishVertexUniforms.fishWaveLength = fishInfo.fishWaveLength;
 
-    mCurInstance = mAquarium->fishCount[fishInfo.modelName - MODELNAME::MODELSMALLFISHA];
-    mPreInstance = mCurInstance;
+  mCurInstance =
+      mAquarium->fishCount[fishInfo.modelName - MODELNAME::MODELSMALLFISHA];
+  mPreInstance = mCurInstance;
 }
 
 void FishModelDawn::init()
 {
-    mProgramDawn = static_cast<ProgramDawn *>(mProgram);
+  mProgramDawn = static_cast<ProgramDawn *>(mProgram);
 
-    mDiffuseTexture    = static_cast<TextureDawn *>(textureMap["diffuse"]);
-    mNormalTexture     = static_cast<TextureDawn *>(textureMap["normalMap"]);
-    mReflectionTexture = static_cast<TextureDawn *>(textureMap["reflectionMap"]);
-    mSkyboxTexture     = static_cast<TextureDawn *>(textureMap["skybox"]);
+  mDiffuseTexture    = static_cast<TextureDawn *>(textureMap["diffuse"]);
+  mNormalTexture     = static_cast<TextureDawn *>(textureMap["normalMap"]);
+  mReflectionTexture = static_cast<TextureDawn *>(textureMap["reflectionMap"]);
+  mSkyboxTexture     = static_cast<TextureDawn *>(textureMap["skybox"]);
 
-    mPositionBuffer = static_cast<BufferDawn *>(bufferMap["position"]);
-    mNormalBuffer   = static_cast<BufferDawn *>(bufferMap["normal"]);
-    mTexCoordBuffer = static_cast<BufferDawn *>(bufferMap["texCoord"]);
-    mTangentBuffer  = static_cast<BufferDawn *>(bufferMap["tangent"]);
-    mBiNormalBuffer = static_cast<BufferDawn *>(bufferMap["binormal"]);
-    mIndicesBuffer  = static_cast<BufferDawn *>(bufferMap["indices"]);
+  mPositionBuffer = static_cast<BufferDawn *>(bufferMap["position"]);
+  mNormalBuffer   = static_cast<BufferDawn *>(bufferMap["normal"]);
+  mTexCoordBuffer = static_cast<BufferDawn *>(bufferMap["texCoord"]);
+  mTangentBuffer  = static_cast<BufferDawn *>(bufferMap["tangent"]);
+  mBiNormalBuffer = static_cast<BufferDawn *>(bufferMap["binormal"]);
+  mIndicesBuffer  = static_cast<BufferDawn *>(bufferMap["indices"]);
 
-    mVertexStateDescriptor.cVertexBuffers[0].attributeCount = 1;
-    mVertexStateDescriptor.cVertexBuffers[0].arrayStride    = mPositionBuffer->getDataSize();
-    mVertexStateDescriptor.cAttributes[0].format            = wgpu::VertexFormat::Float3;
-    mVertexStateDescriptor.cAttributes[0].shaderLocation    = 0;
-    mVertexStateDescriptor.cAttributes[0].offset            = 0;
-    mVertexStateDescriptor.cVertexBuffers[0].attributes = &mVertexStateDescriptor.cAttributes[0];
-    mVertexStateDescriptor.cVertexBuffers[1].attributeCount = 1;
-    mVertexStateDescriptor.cVertexBuffers[1].arrayStride    = mNormalBuffer->getDataSize();
-    mVertexStateDescriptor.cAttributes[1].format            = wgpu::VertexFormat::Float3;
-    mVertexStateDescriptor.cAttributes[1].shaderLocation    = 1;
-    mVertexStateDescriptor.cAttributes[1].offset            = 0;
-    mVertexStateDescriptor.cVertexBuffers[1].attributes = &mVertexStateDescriptor.cAttributes[1];
-    mVertexStateDescriptor.cVertexBuffers[2].attributeCount = 1;
-    mVertexStateDescriptor.cVertexBuffers[2].arrayStride    = mTexCoordBuffer->getDataSize();
-    mVertexStateDescriptor.cAttributes[2].format            = wgpu::VertexFormat::Float2;
-    mVertexStateDescriptor.cAttributes[2].shaderLocation    = 2;
-    mVertexStateDescriptor.cAttributes[2].offset            = 0;
-    mVertexStateDescriptor.cVertexBuffers[2].attributes = &mVertexStateDescriptor.cAttributes[2];
-    mVertexStateDescriptor.cVertexBuffers[3].attributeCount = 1;
-    mVertexStateDescriptor.cVertexBuffers[3].arrayStride    = mTangentBuffer->getDataSize();
-    mVertexStateDescriptor.cAttributes[3].format            = wgpu::VertexFormat::Float3;
-    mVertexStateDescriptor.cAttributes[3].shaderLocation    = 3;
-    mVertexStateDescriptor.cAttributes[3].offset            = 0;
-    mVertexStateDescriptor.cVertexBuffers[3].attributes = &mVertexStateDescriptor.cAttributes[3];
-    mVertexStateDescriptor.cVertexBuffers[4].attributeCount = 1;
-    mVertexStateDescriptor.cVertexBuffers[4].arrayStride    = mBiNormalBuffer->getDataSize();
-    mVertexStateDescriptor.cAttributes[4].format            = wgpu::VertexFormat::Float3;
-    mVertexStateDescriptor.cAttributes[4].shaderLocation    = 4;
-    mVertexStateDescriptor.cAttributes[4].offset            = 0;
-    mVertexStateDescriptor.cVertexBuffers[4].attributes = &mVertexStateDescriptor.cAttributes[4];
-    mVertexStateDescriptor.vertexBufferCount            = 5;
-    mVertexStateDescriptor.indexFormat                  = wgpu::IndexFormat::Uint16;
+  mVertexStateDescriptor.cVertexBuffers[0].attributeCount = 1;
+  mVertexStateDescriptor.cVertexBuffers[0].arrayStride =
+      mPositionBuffer->getDataSize();
+  mVertexStateDescriptor.cAttributes[0].format = wgpu::VertexFormat::Float3;
+  mVertexStateDescriptor.cAttributes[0].shaderLocation = 0;
+  mVertexStateDescriptor.cAttributes[0].offset         = 0;
+  mVertexStateDescriptor.cVertexBuffers[0].attributes =
+      &mVertexStateDescriptor.cAttributes[0];
+  mVertexStateDescriptor.cVertexBuffers[1].attributeCount = 1;
+  mVertexStateDescriptor.cVertexBuffers[1].arrayStride =
+      mNormalBuffer->getDataSize();
+  mVertexStateDescriptor.cAttributes[1].format = wgpu::VertexFormat::Float3;
+  mVertexStateDescriptor.cAttributes[1].shaderLocation = 1;
+  mVertexStateDescriptor.cAttributes[1].offset         = 0;
+  mVertexStateDescriptor.cVertexBuffers[1].attributes =
+      &mVertexStateDescriptor.cAttributes[1];
+  mVertexStateDescriptor.cVertexBuffers[2].attributeCount = 1;
+  mVertexStateDescriptor.cVertexBuffers[2].arrayStride =
+      mTexCoordBuffer->getDataSize();
+  mVertexStateDescriptor.cAttributes[2].format = wgpu::VertexFormat::Float2;
+  mVertexStateDescriptor.cAttributes[2].shaderLocation = 2;
+  mVertexStateDescriptor.cAttributes[2].offset         = 0;
+  mVertexStateDescriptor.cVertexBuffers[2].attributes =
+      &mVertexStateDescriptor.cAttributes[2];
+  mVertexStateDescriptor.cVertexBuffers[3].attributeCount = 1;
+  mVertexStateDescriptor.cVertexBuffers[3].arrayStride =
+      mTangentBuffer->getDataSize();
+  mVertexStateDescriptor.cAttributes[3].format = wgpu::VertexFormat::Float3;
+  mVertexStateDescriptor.cAttributes[3].shaderLocation = 3;
+  mVertexStateDescriptor.cAttributes[3].offset         = 0;
+  mVertexStateDescriptor.cVertexBuffers[3].attributes =
+      &mVertexStateDescriptor.cAttributes[3];
+  mVertexStateDescriptor.cVertexBuffers[4].attributeCount = 1;
+  mVertexStateDescriptor.cVertexBuffers[4].arrayStride =
+      mBiNormalBuffer->getDataSize();
+  mVertexStateDescriptor.cAttributes[4].format = wgpu::VertexFormat::Float3;
+  mVertexStateDescriptor.cAttributes[4].shaderLocation = 4;
+  mVertexStateDescriptor.cAttributes[4].offset         = 0;
+  mVertexStateDescriptor.cVertexBuffers[4].attributes =
+      &mVertexStateDescriptor.cAttributes[4];
+  mVertexStateDescriptor.vertexBufferCount = 5;
+  mVertexStateDescriptor.indexFormat       = wgpu::IndexFormat::Uint16;
 
-    if (mSkyboxTexture && mReflectionTexture)
-    {
-        mGroupLayoutModel = mContextDawn->MakeBindGroupLayout({
-            {0, wgpu::ShaderStage::Vertex, wgpu::BindingType::UniformBuffer},
-            {1, wgpu::ShaderStage::Fragment, wgpu::BindingType::UniformBuffer},
-            {2, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
-            {3, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
-            {4, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false, false,
-             wgpu::TextureViewDimension::e2D, wgpu::TextureComponentType::Float},
-            {5, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false, false,
-             wgpu::TextureViewDimension::e2D, wgpu::TextureComponentType::Float},
-            {6, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false, false,
-             wgpu::TextureViewDimension::e2D, wgpu::TextureComponentType::Float},
-            {7, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false, false,
-             wgpu::TextureViewDimension::Cube, wgpu::TextureComponentType::Float},
-        });
-    }
-    else
-    {
-        mGroupLayoutModel = mContextDawn->MakeBindGroupLayout({
-            {0, wgpu::ShaderStage::Vertex, wgpu::BindingType::UniformBuffer},
-            {1, wgpu::ShaderStage::Fragment, wgpu::BindingType::UniformBuffer},
-            {2, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
-            {3, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false, false,
-             wgpu::TextureViewDimension::e2D, wgpu::TextureComponentType::Float},
-            {4, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false, false,
-             wgpu::TextureViewDimension::e2D, wgpu::TextureComponentType::Float},
-        });
-    }
-
-    mPipelineLayout = mContextDawn->MakeBasicPipelineLayout({
-        mContextDawn->groupLayoutGeneral,
-        mContextDawn->groupLayoutWorld,
-        mGroupLayoutModel,
-        mContextDawn->groupLayoutFishPer,
+  if (mSkyboxTexture && mReflectionTexture)
+  {
+    mGroupLayoutModel = mContextDawn->MakeBindGroupLayout({
+        {0, wgpu::ShaderStage::Vertex, wgpu::BindingType::UniformBuffer},
+        {1, wgpu::ShaderStage::Fragment, wgpu::BindingType::UniformBuffer},
+        {2, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
+        {3, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
+        {4, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture,
+         false, false, wgpu::TextureViewDimension::e2D,
+         wgpu::TextureComponentType::Float},
+        {5, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture,
+         false, false, wgpu::TextureViewDimension::e2D,
+         wgpu::TextureComponentType::Float},
+        {6, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture,
+         false, false, wgpu::TextureViewDimension::e2D,
+         wgpu::TextureComponentType::Float},
+        {7, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture,
+         false, false, wgpu::TextureViewDimension::Cube,
+         wgpu::TextureComponentType::Float},
     });
+  }
+  else
+  {
+    mGroupLayoutModel = mContextDawn->MakeBindGroupLayout({
+        {0, wgpu::ShaderStage::Vertex, wgpu::BindingType::UniformBuffer},
+        {1, wgpu::ShaderStage::Fragment, wgpu::BindingType::UniformBuffer},
+        {2, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
+        {3, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture,
+         false, false, wgpu::TextureViewDimension::e2D,
+         wgpu::TextureComponentType::Float},
+        {4, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture,
+         false, false, wgpu::TextureViewDimension::e2D,
+         wgpu::TextureComponentType::Float},
+    });
+  }
 
-    mPipeline = mContextDawn->createRenderPipeline(mPipelineLayout, mProgramDawn,
-                                                   mVertexStateDescriptor, mBlend);
+  mPipelineLayout = mContextDawn->MakeBasicPipelineLayout({
+      mContextDawn->groupLayoutGeneral,
+      mContextDawn->groupLayoutWorld,
+      mGroupLayoutModel,
+      mContextDawn->groupLayoutFishPer,
+  });
 
-    mFishVertexBuffer = mContextDawn->createBufferFromData(
-        &mFishVertexUniforms, sizeof(FishVertexUniforms), sizeof(FishVertexUniforms),
-        wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
-    mLightFactorBuffer = mContextDawn->createBufferFromData(
-        &mLightFactorUniforms, sizeof(LightFactorUniforms), sizeof(LightFactorUniforms),
-        wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
+  mPipeline = mContextDawn->createRenderPipeline(
+      mPipelineLayout, mProgramDawn, mVertexStateDescriptor, mBlend);
 
-    // Fish models includes small, medium and big. Some of them contains reflection and skybox
-    // texture, but some doesn't.
-    if (mSkyboxTexture && mReflectionTexture)
-    {
-        mBindGroupModel = mContextDawn->makeBindGroup(
-            mGroupLayoutModel, {{0, mFishVertexBuffer, 0, sizeof(FishVertexUniforms)},
-                                {1, mLightFactorBuffer, 0, sizeof(LightFactorUniforms)},
-                                {2, mReflectionTexture->getSampler()},
-                                {3, mSkyboxTexture->getSampler()},
-                                {4, mDiffuseTexture->getTextureView()},
-                                {5, mNormalTexture->getTextureView()},
-                                {6, mReflectionTexture->getTextureView()},
-                                {7, mSkyboxTexture->getTextureView()}});
-    }
-    else
-    {
-        mBindGroupModel = mContextDawn->makeBindGroup(
-            mGroupLayoutModel, {{0, mFishVertexBuffer, 0, sizeof(FishVertexUniforms)},
-                                {1, mLightFactorBuffer, 0, sizeof(LightFactorUniforms)},
-                                {2, mDiffuseTexture->getSampler()},
-                                {3, mDiffuseTexture->getTextureView()},
-                                {4, mNormalTexture->getTextureView()}});
-    }
+  mFishVertexBuffer = mContextDawn->createBufferFromData(
+      &mFishVertexUniforms, sizeof(FishVertexUniforms),
+      sizeof(FishVertexUniforms),
+      wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
+  mLightFactorBuffer = mContextDawn->createBufferFromData(
+      &mLightFactorUniforms, sizeof(LightFactorUniforms),
+      sizeof(LightFactorUniforms),
+      wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
 
-    mContextDawn->setBufferData(mLightFactorBuffer, sizeof(LightFactorUniforms),
-                                &mLightFactorUniforms, sizeof(LightFactorUniforms));
-    mContextDawn->setBufferData(mFishVertexBuffer, sizeof(FishVertexUniforms), &mFishVertexUniforms,
-                                sizeof(LightFactorUniforms));
+  // Fish models includes small, medium and big. Some of them contains
+  // reflection and skybox texture, but some doesn't.
+  if (mSkyboxTexture && mReflectionTexture)
+  {
+    mBindGroupModel = mContextDawn->makeBindGroup(
+        mGroupLayoutModel,
+        {{0, mFishVertexBuffer, 0, sizeof(FishVertexUniforms)},
+         {1, mLightFactorBuffer, 0, sizeof(LightFactorUniforms)},
+         {2, mReflectionTexture->getSampler()},
+         {3, mSkyboxTexture->getSampler()},
+         {4, mDiffuseTexture->getTextureView()},
+         {5, mNormalTexture->getTextureView()},
+         {6, mReflectionTexture->getTextureView()},
+         {7, mSkyboxTexture->getTextureView()}});
+  }
+  else
+  {
+    mBindGroupModel = mContextDawn->makeBindGroup(
+        mGroupLayoutModel,
+        {{0, mFishVertexBuffer, 0, sizeof(FishVertexUniforms)},
+         {1, mLightFactorBuffer, 0, sizeof(LightFactorUniforms)},
+         {2, mDiffuseTexture->getSampler()},
+         {3, mDiffuseTexture->getTextureView()},
+         {4, mNormalTexture->getTextureView()}});
+  }
+
+  mContextDawn->setBufferData(mLightFactorBuffer, sizeof(LightFactorUniforms),
+                              &mLightFactorUniforms,
+                              sizeof(LightFactorUniforms));
+  mContextDawn->setBufferData(mFishVertexBuffer, sizeof(FishVertexUniforms),
+                              &mFishVertexUniforms,
+                              sizeof(LightFactorUniforms));
 }
 
 void FishModelDawn::draw()
 {
-    if (mCurInstance == 0)
-        return;
+  if (mCurInstance == 0)
+    return;
 
-    wgpu::RenderPassEncoder pass = mContextDawn->getRenderPass();
-    pass.SetPipeline(mPipeline);
-    pass.SetBindGroup(0, mContextDawn->bindGroupGeneral, 0, nullptr);
-    pass.SetBindGroup(1, mContextDawn->bindGroupWorld, 0, nullptr);
-    pass.SetBindGroup(2, mBindGroupModel, 0, nullptr);
-    pass.SetVertexBuffer(0, mPositionBuffer->getBuffer());
-    pass.SetVertexBuffer(1, mNormalBuffer->getBuffer());
-    pass.SetVertexBuffer(2, mTexCoordBuffer->getBuffer());
-    pass.SetVertexBuffer(3, mTangentBuffer->getBuffer());
-    pass.SetVertexBuffer(4, mBiNormalBuffer->getBuffer());
-    pass.SetIndexBuffer(mIndicesBuffer->getBuffer(), 0);
+  wgpu::RenderPassEncoder pass = mContextDawn->getRenderPass();
+  pass.SetPipeline(mPipeline);
+  pass.SetBindGroup(0, mContextDawn->bindGroupGeneral, 0, nullptr);
+  pass.SetBindGroup(1, mContextDawn->bindGroupWorld, 0, nullptr);
+  pass.SetBindGroup(2, mBindGroupModel, 0, nullptr);
+  pass.SetVertexBuffer(0, mPositionBuffer->getBuffer());
+  pass.SetVertexBuffer(1, mNormalBuffer->getBuffer());
+  pass.SetVertexBuffer(2, mTexCoordBuffer->getBuffer());
+  pass.SetVertexBuffer(3, mTangentBuffer->getBuffer());
+  pass.SetVertexBuffer(4, mBiNormalBuffer->getBuffer());
+  pass.SetIndexBuffer(mIndicesBuffer->getBuffer(), 0);
 
-    if (mEnableDynamicBufferOffset)
+  if (mEnableDynamicBufferOffset)
+  {
+    for (int i = 0; i < mCurInstance; i++)
     {
-        for (int i = 0; i < mCurInstance; i++)
-        {
-            uint32_t offset = 256u * (i + mFishPerOffset);
-            pass.SetBindGroup(3, mContextDawn->bindGroupFishPers[0], 1, &offset);
-            pass.DrawIndexed(mIndicesBuffer->getTotalComponents(), 1, 0, 0, 0);
-        }
+      uint32_t offset = 256u * (i + mFishPerOffset);
+      pass.SetBindGroup(3, mContextDawn->bindGroupFishPers[0], 1, &offset);
+      pass.DrawIndexed(mIndicesBuffer->getTotalComponents(), 1, 0, 0, 0);
     }
-    else
+  }
+  else
+  {
+    for (int i = 0; i < mCurInstance; i++)
     {
-        for (int i = 0; i < mCurInstance; i++)
-        {
-            pass.SetBindGroup(3, mContextDawn->bindGroupFishPers[i + mFishPerOffset], 0, nullptr);
-            pass.DrawIndexed(mIndicesBuffer->getTotalComponents(), 1, 0, 0, 0);
-        }
+      pass.SetBindGroup(3, mContextDawn->bindGroupFishPers[i + mFishPerOffset],
+                        0, nullptr);
+      pass.DrawIndexed(mIndicesBuffer->getTotalComponents(), 1, 0, 0, 0);
     }
+  }
 }
 
-void FishModelDawn::updatePerInstanceUniforms(const WorldUniforms &worldUniforms) {}
+void FishModelDawn::updatePerInstanceUniforms(
+    const WorldUniforms &worldUniforms)
+{
+}
 
 void FishModelDawn::updateFishPerUniforms(float x,
                                           float y,
@@ -209,23 +236,23 @@ void FishModelDawn::updateFishPerUniforms(float x,
                                           float time,
                                           int index)
 {
-    index += mFishPerOffset;
-    mContextDawn->fishPers[index].worldPosition[0] = x;
-    mContextDawn->fishPers[index].worldPosition[1] = y;
-    mContextDawn->fishPers[index].worldPosition[2] = z;
-    mContextDawn->fishPers[index].nextPosition[0]  = nextX;
-    mContextDawn->fishPers[index].nextPosition[1]  = nextY;
-    mContextDawn->fishPers[index].nextPosition[2]  = nextZ;
-    mContextDawn->fishPers[index].scale            = scale;
-    mContextDawn->fishPers[index].time             = time;
+  index += mFishPerOffset;
+  mContextDawn->fishPers[index].worldPosition[0] = x;
+  mContextDawn->fishPers[index].worldPosition[1] = y;
+  mContextDawn->fishPers[index].worldPosition[2] = z;
+  mContextDawn->fishPers[index].nextPosition[0]  = nextX;
+  mContextDawn->fishPers[index].nextPosition[1]  = nextY;
+  mContextDawn->fishPers[index].nextPosition[2]  = nextZ;
+  mContextDawn->fishPers[index].scale            = scale;
+  mContextDawn->fishPers[index].time             = time;
 }
 
 FishModelDawn::~FishModelDawn()
 {
-    mPipeline          = nullptr;
-    mGroupLayoutModel  = nullptr;
-    mPipelineLayout    = nullptr;
-    mBindGroupModel    = nullptr;
-    mFishVertexBuffer  = nullptr;
-    mLightFactorBuffer = nullptr;
+  mPipeline          = nullptr;
+  mGroupLayoutModel  = nullptr;
+  mPipelineLayout    = nullptr;
+  mBindGroupModel    = nullptr;
+  mFishVertexBuffer  = nullptr;
+  mLightFactorBuffer = nullptr;
 }

--- a/src/aquarium-optimized/dawn/FishModelDawn.h
+++ b/src/aquarium-optimized/dawn/FishModelDawn.h
@@ -19,70 +19,70 @@ struct FishPer;
 
 class FishModelDawn : public FishModel
 {
-  public:
-    FishModelDawn(Context *context,
-                  Aquarium *aquarium,
-                  MODELGROUP type,
-                  MODELNAME name,
-                  bool blend);
-    ~FishModelDawn();
+public:
+  FishModelDawn(Context *context,
+                Aquarium *aquarium,
+                MODELGROUP type,
+                MODELNAME name,
+                bool blend);
+  ~FishModelDawn();
 
-    void init() override;
-    void draw() override;
+  void init() override;
+  void draw() override;
 
-    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
-    void updateFishPerUniforms(float x,
-                               float y,
-                               float z,
-                               float nextX,
-                               float nextY,
-                               float nextZ,
-                               float scale,
-                               float time,
-                               int index) override;
+  void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
+  void updateFishPerUniforms(float x,
+                             float y,
+                             float z,
+                             float nextX,
+                             float nextY,
+                             float nextZ,
+                             float scale,
+                             float time,
+                             int index) override;
 
-    struct FishVertexUniforms
-    {
-        float fishLength;
-        float fishWaveLength;
-        float fishBendAmount;
-    } mFishVertexUniforms;
+  struct FishVertexUniforms
+  {
+    float fishLength;
+    float fishWaveLength;
+    float fishBendAmount;
+  } mFishVertexUniforms;
 
-    struct LightFactorUniforms
-    {
-        float shininess;
-        float specularFactor;
-    } mLightFactorUniforms;
+  struct LightFactorUniforms
+  {
+    float shininess;
+    float specularFactor;
+  } mLightFactorUniforms;
 
-    TextureDawn *mDiffuseTexture;
-    TextureDawn *mNormalTexture;
-    TextureDawn *mReflectionTexture;
-    TextureDawn *mSkyboxTexture;
+  TextureDawn *mDiffuseTexture;
+  TextureDawn *mNormalTexture;
+  TextureDawn *mReflectionTexture;
+  TextureDawn *mSkyboxTexture;
 
-    BufferDawn *mPositionBuffer;
-    BufferDawn *mNormalBuffer;
-    BufferDawn *mTexCoordBuffer;
-    BufferDawn *mTangentBuffer;
-    BufferDawn *mBiNormalBuffer;
+  BufferDawn *mPositionBuffer;
+  BufferDawn *mNormalBuffer;
+  BufferDawn *mTexCoordBuffer;
+  BufferDawn *mTangentBuffer;
+  BufferDawn *mBiNormalBuffer;
 
-    BufferDawn *mIndicesBuffer;
+  BufferDawn *mIndicesBuffer;
 
-  private:
-    utils::ComboVertexStateDescriptor mVertexStateDescriptor;
-    wgpu::RenderPipeline mPipeline;
+private:
+  utils::ComboVertexStateDescriptor mVertexStateDescriptor;
+  wgpu::RenderPipeline mPipeline;
 
-    wgpu::BindGroupLayout mGroupLayoutModel;
-    wgpu::PipelineLayout mPipelineLayout;
+  wgpu::BindGroupLayout mGroupLayoutModel;
+  wgpu::PipelineLayout mPipelineLayout;
 
-    wgpu::BindGroup mBindGroupModel;
+  wgpu::BindGroup mBindGroupModel;
 
-    wgpu::Buffer mFishVertexBuffer;
-    wgpu::Buffer mLightFactorBuffer;
+  wgpu::Buffer mFishVertexBuffer;
+  wgpu::Buffer mLightFactorBuffer;
 
-    ProgramDawn *mProgramDawn;
-    ContextDawn *mContextDawn;
+  ProgramDawn *mProgramDawn;
+  ContextDawn *mContextDawn;
 
-    bool mEnableDynamicBufferOffset;
+  bool mEnableDynamicBufferOffset;
 };
 
 #endif  // FISHMODELDAWN_H

--- a/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.cpp
+++ b/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.cpp
@@ -16,198 +16,229 @@ FishModelInstancedDrawDawn::FishModelInstancedDrawDawn(Context *context,
                                                        bool blend)
     : FishModel(type, name, blend, aquarium), instance(0)
 {
-    mContextDawn = static_cast<ContextDawn *>(context);
+  mContextDawn = static_cast<ContextDawn *>(context);
 
-    mLightFactorUniforms.shininess      = 5.0f;
-    mLightFactorUniforms.specularFactor = 0.3f;
+  mLightFactorUniforms.shininess      = 5.0f;
+  mLightFactorUniforms.specularFactor = 0.3f;
 
-    const Fish &fishInfo               = fishTable[name - MODELNAME::MODELSMALLFISHAINSTANCEDDRAWS];
-    mFishVertexUniforms.fishLength     = fishInfo.fishLength;
-    mFishVertexUniforms.fishBendAmount = fishInfo.fishBendAmount;
-    mFishVertexUniforms.fishWaveLength = fishInfo.fishWaveLength;
+  const Fish &fishInfo =
+      fishTable[name - MODELNAME::MODELSMALLFISHAINSTANCEDDRAWS];
+  mFishVertexUniforms.fishLength     = fishInfo.fishLength;
+  mFishVertexUniforms.fishBendAmount = fishInfo.fishBendAmount;
+  mFishVertexUniforms.fishWaveLength = fishInfo.fishWaveLength;
 
-    instance  = aquarium->fishCount[fishInfo.modelName - MODELNAME::MODELSMALLFISHA];
-    mFishPers = new FishPer[instance];
+  instance =
+      aquarium->fishCount[fishInfo.modelName - MODELNAME::MODELSMALLFISHA];
+  mFishPers = new FishPer[instance];
 }
 
 void FishModelInstancedDrawDawn::init()
 {
-    if (instance == 0)
-        return;
+  if (instance == 0)
+    return;
 
-    mProgramDawn = static_cast<ProgramDawn *>(mProgram);
+  mProgramDawn = static_cast<ProgramDawn *>(mProgram);
 
-    mDiffuseTexture    = static_cast<TextureDawn *>(textureMap["diffuse"]);
-    mNormalTexture     = static_cast<TextureDawn *>(textureMap["normalMap"]);
-    mReflectionTexture = static_cast<TextureDawn *>(textureMap["reflectionMap"]);
-    mSkyboxTexture     = static_cast<TextureDawn *>(textureMap["skybox"]);
+  mDiffuseTexture    = static_cast<TextureDawn *>(textureMap["diffuse"]);
+  mNormalTexture     = static_cast<TextureDawn *>(textureMap["normalMap"]);
+  mReflectionTexture = static_cast<TextureDawn *>(textureMap["reflectionMap"]);
+  mSkyboxTexture     = static_cast<TextureDawn *>(textureMap["skybox"]);
 
-    mPositionBuffer = static_cast<BufferDawn *>(bufferMap["position"]);
-    mNormalBuffer   = static_cast<BufferDawn *>(bufferMap["normal"]);
-    mTexCoordBuffer = static_cast<BufferDawn *>(bufferMap["texCoord"]);
-    mTangentBuffer  = static_cast<BufferDawn *>(bufferMap["tangent"]);
-    mBiNormalBuffer = static_cast<BufferDawn *>(bufferMap["binormal"]);
-    mIndicesBuffer  = static_cast<BufferDawn *>(bufferMap["indices"]);
+  mPositionBuffer = static_cast<BufferDawn *>(bufferMap["position"]);
+  mNormalBuffer   = static_cast<BufferDawn *>(bufferMap["normal"]);
+  mTexCoordBuffer = static_cast<BufferDawn *>(bufferMap["texCoord"]);
+  mTangentBuffer  = static_cast<BufferDawn *>(bufferMap["tangent"]);
+  mBiNormalBuffer = static_cast<BufferDawn *>(bufferMap["binormal"]);
+  mIndicesBuffer  = static_cast<BufferDawn *>(bufferMap["indices"]);
 
-    mFishPersBuffer = mContextDawn->createBuffer(
-        sizeof(FishPer) * instance, wgpu::BufferUsage::Vertex | wgpu::BufferUsage::CopyDst);
+  mFishPersBuffer = mContextDawn->createBuffer(
+      sizeof(FishPer) * instance,
+      wgpu::BufferUsage::Vertex | wgpu::BufferUsage::CopyDst);
 
-    mVertexStateDescriptor.cVertexBuffers[0].attributeCount = 1;
-    mVertexStateDescriptor.cVertexBuffers[0].arrayStride    = mPositionBuffer->getDataSize();
-    mVertexStateDescriptor.cAttributes[0].format            = wgpu::VertexFormat::Float3;
-    mVertexStateDescriptor.cAttributes[0].shaderLocation    = 0;
-    mVertexStateDescriptor.cAttributes[0].offset            = 0;
-    mVertexStateDescriptor.cVertexBuffers[0].attributes = &mVertexStateDescriptor.cAttributes[0];
-    mVertexStateDescriptor.cVertexBuffers[1].attributeCount = 1;
-    mVertexStateDescriptor.cVertexBuffers[1].arrayStride    = mNormalBuffer->getDataSize();
-    mVertexStateDescriptor.cAttributes[1].format            = wgpu::VertexFormat::Float3;
-    mVertexStateDescriptor.cAttributes[1].shaderLocation    = 1;
-    mVertexStateDescriptor.cAttributes[1].offset            = 0;
-    mVertexStateDescriptor.cVertexBuffers[1].attributes = &mVertexStateDescriptor.cAttributes[1];
-    mVertexStateDescriptor.cVertexBuffers[2].attributeCount = 1;
-    mVertexStateDescriptor.cVertexBuffers[2].arrayStride    = mTexCoordBuffer->getDataSize();
-    mVertexStateDescriptor.cAttributes[2].format            = wgpu::VertexFormat::Float2;
-    mVertexStateDescriptor.cAttributes[2].shaderLocation    = 2;
-    mVertexStateDescriptor.cAttributes[2].offset            = 0;
-    mVertexStateDescriptor.cVertexBuffers[2].attributes = &mVertexStateDescriptor.cAttributes[2];
-    mVertexStateDescriptor.cVertexBuffers[3].attributeCount = 1;
-    mVertexStateDescriptor.cVertexBuffers[3].arrayStride    = mTangentBuffer->getDataSize();
-    mVertexStateDescriptor.cAttributes[3].format            = wgpu::VertexFormat::Float3;
-    mVertexStateDescriptor.cAttributes[3].shaderLocation    = 3;
-    mVertexStateDescriptor.cAttributes[3].offset            = 0;
-    mVertexStateDescriptor.cVertexBuffers[3].attributes = &mVertexStateDescriptor.cAttributes[3];
-    mVertexStateDescriptor.cVertexBuffers[4].attributeCount = 1;
-    mVertexStateDescriptor.cVertexBuffers[4].arrayStride    = mBiNormalBuffer->getDataSize();
-    mVertexStateDescriptor.cAttributes[4].format            = wgpu::VertexFormat::Float3;
-    mVertexStateDescriptor.cAttributes[4].shaderLocation    = 4;
-    mVertexStateDescriptor.cAttributes[4].offset            = offsetof(FishPer, worldPosition);
-    mVertexStateDescriptor.cVertexBuffers[4].attributes = &mVertexStateDescriptor.cAttributes[4];
-    mVertexStateDescriptor.cVertexBuffers[5].attributeCount = 4;
-    mVertexStateDescriptor.cVertexBuffers[5].arrayStride    = sizeof(FishPer);
-    mVertexStateDescriptor.cAttributes[5].format            = wgpu::VertexFormat::Float3;
-    mVertexStateDescriptor.cAttributes[5].shaderLocation    = 5;
-    mVertexStateDescriptor.cAttributes[5].offset            = 0;
-    mVertexStateDescriptor.cAttributes[6].format            = wgpu::VertexFormat::Float;
-    mVertexStateDescriptor.cAttributes[6].shaderLocation    = 6;
-    mVertexStateDescriptor.cAttributes[6].offset            = offsetof(FishPer, scale);
-    mVertexStateDescriptor.cAttributes[7].format            = wgpu::VertexFormat::Float3;
-    mVertexStateDescriptor.cAttributes[7].shaderLocation    = 7;
-    mVertexStateDescriptor.cAttributes[7].offset            = offsetof(FishPer, nextPosition);
-    mVertexStateDescriptor.cAttributes[8].format            = wgpu::VertexFormat::Float;
-    mVertexStateDescriptor.cAttributes[8].shaderLocation    = 8;
-    mVertexStateDescriptor.cAttributes[9].offset            = offsetof(FishPer, time);
-    mVertexStateDescriptor.cVertexBuffers[5].attributes = &mVertexStateDescriptor.cAttributes[5];
-    mVertexStateDescriptor.cVertexBuffers[5].stepMode   = wgpu::InputStepMode::Instance;
-    mVertexStateDescriptor.vertexBufferCount            = 6;
-    mVertexStateDescriptor.indexFormat                  = wgpu::IndexFormat::Uint16;
+  mVertexStateDescriptor.cVertexBuffers[0].attributeCount = 1;
+  mVertexStateDescriptor.cVertexBuffers[0].arrayStride =
+      mPositionBuffer->getDataSize();
+  mVertexStateDescriptor.cAttributes[0].format = wgpu::VertexFormat::Float3;
+  mVertexStateDescriptor.cAttributes[0].shaderLocation = 0;
+  mVertexStateDescriptor.cAttributes[0].offset         = 0;
+  mVertexStateDescriptor.cVertexBuffers[0].attributes =
+      &mVertexStateDescriptor.cAttributes[0];
+  mVertexStateDescriptor.cVertexBuffers[1].attributeCount = 1;
+  mVertexStateDescriptor.cVertexBuffers[1].arrayStride =
+      mNormalBuffer->getDataSize();
+  mVertexStateDescriptor.cAttributes[1].format = wgpu::VertexFormat::Float3;
+  mVertexStateDescriptor.cAttributes[1].shaderLocation = 1;
+  mVertexStateDescriptor.cAttributes[1].offset         = 0;
+  mVertexStateDescriptor.cVertexBuffers[1].attributes =
+      &mVertexStateDescriptor.cAttributes[1];
+  mVertexStateDescriptor.cVertexBuffers[2].attributeCount = 1;
+  mVertexStateDescriptor.cVertexBuffers[2].arrayStride =
+      mTexCoordBuffer->getDataSize();
+  mVertexStateDescriptor.cAttributes[2].format = wgpu::VertexFormat::Float2;
+  mVertexStateDescriptor.cAttributes[2].shaderLocation = 2;
+  mVertexStateDescriptor.cAttributes[2].offset         = 0;
+  mVertexStateDescriptor.cVertexBuffers[2].attributes =
+      &mVertexStateDescriptor.cAttributes[2];
+  mVertexStateDescriptor.cVertexBuffers[3].attributeCount = 1;
+  mVertexStateDescriptor.cVertexBuffers[3].arrayStride =
+      mTangentBuffer->getDataSize();
+  mVertexStateDescriptor.cAttributes[3].format = wgpu::VertexFormat::Float3;
+  mVertexStateDescriptor.cAttributes[3].shaderLocation = 3;
+  mVertexStateDescriptor.cAttributes[3].offset         = 0;
+  mVertexStateDescriptor.cVertexBuffers[3].attributes =
+      &mVertexStateDescriptor.cAttributes[3];
+  mVertexStateDescriptor.cVertexBuffers[4].attributeCount = 1;
+  mVertexStateDescriptor.cVertexBuffers[4].arrayStride =
+      mBiNormalBuffer->getDataSize();
+  mVertexStateDescriptor.cAttributes[4].format = wgpu::VertexFormat::Float3;
+  mVertexStateDescriptor.cAttributes[4].shaderLocation = 4;
+  mVertexStateDescriptor.cAttributes[4].offset =
+      offsetof(FishPer, worldPosition);
+  mVertexStateDescriptor.cVertexBuffers[4].attributes =
+      &mVertexStateDescriptor.cAttributes[4];
+  mVertexStateDescriptor.cVertexBuffers[5].attributeCount = 4;
+  mVertexStateDescriptor.cVertexBuffers[5].arrayStride    = sizeof(FishPer);
+  mVertexStateDescriptor.cAttributes[5].format = wgpu::VertexFormat::Float3;
+  mVertexStateDescriptor.cAttributes[5].shaderLocation = 5;
+  mVertexStateDescriptor.cAttributes[5].offset         = 0;
+  mVertexStateDescriptor.cAttributes[6].format = wgpu::VertexFormat::Float;
+  mVertexStateDescriptor.cAttributes[6].shaderLocation = 6;
+  mVertexStateDescriptor.cAttributes[6].offset = offsetof(FishPer, scale);
+  mVertexStateDescriptor.cAttributes[7].format = wgpu::VertexFormat::Float3;
+  mVertexStateDescriptor.cAttributes[7].shaderLocation = 7;
+  mVertexStateDescriptor.cAttributes[7].offset =
+      offsetof(FishPer, nextPosition);
+  mVertexStateDescriptor.cAttributes[8].format = wgpu::VertexFormat::Float;
+  mVertexStateDescriptor.cAttributes[8].shaderLocation = 8;
+  mVertexStateDescriptor.cAttributes[9].offset = offsetof(FishPer, time);
+  mVertexStateDescriptor.cVertexBuffers[5].attributes =
+      &mVertexStateDescriptor.cAttributes[5];
+  mVertexStateDescriptor.cVertexBuffers[5].stepMode =
+      wgpu::InputStepMode::Instance;
+  mVertexStateDescriptor.vertexBufferCount = 6;
+  mVertexStateDescriptor.indexFormat       = wgpu::IndexFormat::Uint16;
 
-    if (mSkyboxTexture && mReflectionTexture)
-    {
-        mGroupLayoutModel = mContextDawn->MakeBindGroupLayout({
-            {0, wgpu::ShaderStage::Vertex, wgpu::BindingType::UniformBuffer},
-            {1, wgpu::ShaderStage::Fragment, wgpu::BindingType::UniformBuffer},
-            {2, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
-            {3, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
-            {4, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false, false,
-             wgpu::TextureViewDimension::e2D, wgpu::TextureComponentType::Float},
-            {5, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false, false,
-             wgpu::TextureViewDimension::e2D, wgpu::TextureComponentType::Float},
-            {6, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false, false,
-             wgpu::TextureViewDimension::e2D, wgpu::TextureComponentType::Float},
-            {7, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false, false,
-             wgpu::TextureViewDimension::Cube, wgpu::TextureComponentType::Float},
-        });
-    }
-    else
-    {
-        mGroupLayoutModel = mContextDawn->MakeBindGroupLayout({
-            {0, wgpu::ShaderStage::Vertex, wgpu::BindingType::UniformBuffer},
-            {1, wgpu::ShaderStage::Fragment, wgpu::BindingType::UniformBuffer},
-            {2, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
-            {3, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false, false,
-             wgpu::TextureViewDimension::e2D, wgpu::TextureComponentType::Float},
-            {4, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false, false,
-             wgpu::TextureViewDimension::e2D, wgpu::TextureComponentType::Float},
-        });
-    }
-
-    mGroupLayoutPer = mContextDawn->MakeBindGroupLayout({
+  if (mSkyboxTexture && mReflectionTexture)
+  {
+    mGroupLayoutModel = mContextDawn->MakeBindGroupLayout({
         {0, wgpu::ShaderStage::Vertex, wgpu::BindingType::UniformBuffer},
+        {1, wgpu::ShaderStage::Fragment, wgpu::BindingType::UniformBuffer},
+        {2, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
+        {3, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
+        {4, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture,
+         false, false, wgpu::TextureViewDimension::e2D,
+         wgpu::TextureComponentType::Float},
+        {5, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture,
+         false, false, wgpu::TextureViewDimension::e2D,
+         wgpu::TextureComponentType::Float},
+        {6, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture,
+         false, false, wgpu::TextureViewDimension::e2D,
+         wgpu::TextureComponentType::Float},
+        {7, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture,
+         false, false, wgpu::TextureViewDimension::Cube,
+         wgpu::TextureComponentType::Float},
     });
+  }
+  else
+  {
+    mGroupLayoutModel = mContextDawn->MakeBindGroupLayout({
+        {0, wgpu::ShaderStage::Vertex, wgpu::BindingType::UniformBuffer},
+        {1, wgpu::ShaderStage::Fragment, wgpu::BindingType::UniformBuffer},
+        {2, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
+        {3, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture,
+         false, false, wgpu::TextureViewDimension::e2D,
+         wgpu::TextureComponentType::Float},
+        {4, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture,
+         false, false, wgpu::TextureViewDimension::e2D,
+         wgpu::TextureComponentType::Float},
+    });
+  }
 
-    mPipelineLayout = mContextDawn->MakeBasicPipelineLayout({
-        mContextDawn->groupLayoutGeneral,
-        mContextDawn->groupLayoutWorld,
+  mGroupLayoutPer = mContextDawn->MakeBindGroupLayout({
+      {0, wgpu::ShaderStage::Vertex, wgpu::BindingType::UniformBuffer},
+  });
+
+  mPipelineLayout = mContextDawn->MakeBasicPipelineLayout({
+      mContextDawn->groupLayoutGeneral,
+      mContextDawn->groupLayoutWorld,
+      mGroupLayoutModel,
+      mGroupLayoutPer,
+  });
+
+  mPipeline = mContextDawn->createRenderPipeline(
+      mPipelineLayout, mProgramDawn, mVertexStateDescriptor, mBlend);
+
+  mFishVertexBuffer = mContextDawn->createBufferFromData(
+      &mFishVertexUniforms, sizeof(FishVertexUniforms),
+      sizeof(FishVertexUniforms),
+      wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
+  mLightFactorBuffer = mContextDawn->createBufferFromData(
+      &mLightFactorUniforms, sizeof(LightFactorUniforms),
+      sizeof(LightFactorUniforms),
+      wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
+
+  // Fish models includes small, medium and big. Some of them contains
+  // reflection and skybox texture, but some doesn't.
+  if (mSkyboxTexture && mReflectionTexture)
+  {
+    mBindGroupModel = mContextDawn->makeBindGroup(
         mGroupLayoutModel,
-        mGroupLayoutPer,
-    });
+        {{0, mFishVertexBuffer, 0, sizeof(FishVertexUniforms)},
+         {1, mLightFactorBuffer, 0, sizeof(LightFactorUniforms)},
+         {2, mReflectionTexture->getSampler()},
+         {3, mSkyboxTexture->getSampler()},
+         {4, mDiffuseTexture->getTextureView()},
+         {5, mNormalTexture->getTextureView()},
+         {6, mReflectionTexture->getTextureView()},
+         {7, mSkyboxTexture->getTextureView()}});
+  }
+  else
+  {
+    mBindGroupModel = mContextDawn->makeBindGroup(
+        mGroupLayoutModel,
+        {{0, mFishVertexBuffer, 0, sizeof(FishVertexUniforms)},
+         {1, mLightFactorBuffer, 0, sizeof(LightFactorUniforms)},
+         {2, mDiffuseTexture->getSampler()},
+         {3, mDiffuseTexture->getTextureView()},
+         {4, mNormalTexture->getTextureView()}});
+  }
 
-    mPipeline = mContextDawn->createRenderPipeline(mPipelineLayout, mProgramDawn,
-                                                   mVertexStateDescriptor, mBlend);
-
-    mFishVertexBuffer = mContextDawn->createBufferFromData(
-        &mFishVertexUniforms, sizeof(FishVertexUniforms), sizeof(FishVertexUniforms),
-        wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
-    mLightFactorBuffer = mContextDawn->createBufferFromData(
-        &mLightFactorUniforms, sizeof(LightFactorUniforms), sizeof(LightFactorUniforms),
-        wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
-
-    // Fish models includes small, medium and big. Some of them contains reflection and skybox
-    // texture, but some doesn't.
-    if (mSkyboxTexture && mReflectionTexture)
-    {
-        mBindGroupModel = mContextDawn->makeBindGroup(
-            mGroupLayoutModel, {{0, mFishVertexBuffer, 0, sizeof(FishVertexUniforms)},
-                                {1, mLightFactorBuffer, 0, sizeof(LightFactorUniforms)},
-                                {2, mReflectionTexture->getSampler()},
-                                {3, mSkyboxTexture->getSampler()},
-                                {4, mDiffuseTexture->getTextureView()},
-                                {5, mNormalTexture->getTextureView()},
-                                {6, mReflectionTexture->getTextureView()},
-                                {7, mSkyboxTexture->getTextureView()}});
-    }
-    else
-    {
-        mBindGroupModel = mContextDawn->makeBindGroup(
-            mGroupLayoutModel, {{0, mFishVertexBuffer, 0, sizeof(FishVertexUniforms)},
-                                {1, mLightFactorBuffer, 0, sizeof(LightFactorUniforms)},
-                                {2, mDiffuseTexture->getSampler()},
-                                {3, mDiffuseTexture->getTextureView()},
-                                {4, mNormalTexture->getTextureView()}});
-    }
-
-    mContextDawn->setBufferData(mLightFactorBuffer, sizeof(LightFactorUniforms),
-                                &mLightFactorUniforms, sizeof(LightFactorUniforms));
-    mContextDawn->setBufferData(mFishVertexBuffer, sizeof(FishVertexUniforms), &mFishVertexUniforms,
-                                sizeof(FishVertexUniforms));
+  mContextDawn->setBufferData(mLightFactorBuffer, sizeof(LightFactorUniforms),
+                              &mLightFactorUniforms,
+                              sizeof(LightFactorUniforms));
+  mContextDawn->setBufferData(mFishVertexBuffer, sizeof(FishVertexUniforms),
+                              &mFishVertexUniforms, sizeof(FishVertexUniforms));
 }
 
 void FishModelInstancedDrawDawn::prepareForDraw() {}
 
 void FishModelInstancedDrawDawn::draw()
 {
-    if (instance == 0)
-        return;
+  if (instance == 0)
+    return;
 
-    mContextDawn->setBufferData(mFishPersBuffer, sizeof(FishPer) * instance, mFishPers,
-                                sizeof(FishPer) * instance);
+  mContextDawn->setBufferData(mFishPersBuffer, sizeof(FishPer) * instance,
+                              mFishPers, sizeof(FishPer) * instance);
 
-    wgpu::RenderPassEncoder pass = mContextDawn->getRenderPass();
-    pass.SetPipeline(mPipeline);
-    pass.SetBindGroup(0, mContextDawn->bindGroupGeneral, 0, nullptr);
-    pass.SetBindGroup(1, mContextDawn->bindGroupWorld, 0, nullptr);
-    pass.SetBindGroup(2, mBindGroupModel, 0, nullptr);
-    pass.SetVertexBuffer(0, mPositionBuffer->getBuffer());
-    pass.SetVertexBuffer(1, mNormalBuffer->getBuffer());
-    pass.SetVertexBuffer(2, mTexCoordBuffer->getBuffer());
-    pass.SetVertexBuffer(3, mTangentBuffer->getBuffer());
-    pass.SetVertexBuffer(4, mBiNormalBuffer->getBuffer());
-    pass.SetVertexBuffer(5, mFishPersBuffer);
-    pass.SetIndexBuffer(mIndicesBuffer->getBuffer(), 0);
-    pass.DrawIndexed(mIndicesBuffer->getTotalComponents(), instance, 0, 0, 0);
+  wgpu::RenderPassEncoder pass = mContextDawn->getRenderPass();
+  pass.SetPipeline(mPipeline);
+  pass.SetBindGroup(0, mContextDawn->bindGroupGeneral, 0, nullptr);
+  pass.SetBindGroup(1, mContextDawn->bindGroupWorld, 0, nullptr);
+  pass.SetBindGroup(2, mBindGroupModel, 0, nullptr);
+  pass.SetVertexBuffer(0, mPositionBuffer->getBuffer());
+  pass.SetVertexBuffer(1, mNormalBuffer->getBuffer());
+  pass.SetVertexBuffer(2, mTexCoordBuffer->getBuffer());
+  pass.SetVertexBuffer(3, mTangentBuffer->getBuffer());
+  pass.SetVertexBuffer(4, mBiNormalBuffer->getBuffer());
+  pass.SetVertexBuffer(5, mFishPersBuffer);
+  pass.SetIndexBuffer(mIndicesBuffer->getBuffer(), 0);
+  pass.DrawIndexed(mIndicesBuffer->getTotalComponents(), instance, 0, 0, 0);
 }
 
-void FishModelInstancedDrawDawn::updatePerInstanceUniforms(const WorldUniforms &worldUniforms) {}
+void FishModelInstancedDrawDawn::updatePerInstanceUniforms(
+    const WorldUniforms &worldUniforms)
+{
+}
 
 void FishModelInstancedDrawDawn::updateFishPerUniforms(float x,
                                                        float y,
@@ -219,26 +250,26 @@ void FishModelInstancedDrawDawn::updateFishPerUniforms(float x,
                                                        float time,
                                                        int index)
 {
-    mFishPers[index].worldPosition[0] = x;
-    mFishPers[index].worldPosition[1] = y;
-    mFishPers[index].worldPosition[2] = z;
-    mFishPers[index].nextPosition[0]  = nextX;
-    mFishPers[index].nextPosition[1]  = nextY;
-    mFishPers[index].nextPosition[2]  = nextZ;
-    mFishPers[index].scale            = scale;
-    mFishPers[index].time             = time;
+  mFishPers[index].worldPosition[0] = x;
+  mFishPers[index].worldPosition[1] = y;
+  mFishPers[index].worldPosition[2] = z;
+  mFishPers[index].nextPosition[0]  = nextX;
+  mFishPers[index].nextPosition[1]  = nextY;
+  mFishPers[index].nextPosition[2]  = nextZ;
+  mFishPers[index].scale            = scale;
+  mFishPers[index].time             = time;
 }
 
 FishModelInstancedDrawDawn::~FishModelInstancedDrawDawn()
 {
-    mPipeline          = nullptr;
-    mGroupLayoutModel  = nullptr;
-    mGroupLayoutPer    = nullptr;
-    mPipelineLayout    = nullptr;
-    mBindGroupModel    = nullptr;
-    mBindGroupPer      = nullptr;
-    mFishVertexBuffer  = nullptr;
-    mLightFactorBuffer = nullptr;
-    mFishPersBuffer    = nullptr;
-    delete mFishPers;
+  mPipeline          = nullptr;
+  mGroupLayoutModel  = nullptr;
+  mGroupLayoutPer    = nullptr;
+  mPipelineLayout    = nullptr;
+  mBindGroupModel    = nullptr;
+  mBindGroupPer      = nullptr;
+  mFishVertexBuffer  = nullptr;
+  mLightFactorBuffer = nullptr;
+  mFishPersBuffer    = nullptr;
+  delete mFishPers;
 }

--- a/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.h
+++ b/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.h
@@ -17,84 +17,84 @@
 
 class FishModelInstancedDrawDawn : public FishModel
 {
-  public:
-    FishModelInstancedDrawDawn(Context *context,
-                               Aquarium *aquarium,
-                               MODELGROUP type,
-                               MODELNAME name,
-                               bool blend);
-    ~FishModelInstancedDrawDawn();
+public:
+  FishModelInstancedDrawDawn(Context *context,
+                             Aquarium *aquarium,
+                             MODELGROUP type,
+                             MODELNAME name,
+                             bool blend);
+  ~FishModelInstancedDrawDawn();
 
-    void init() override;
-    void prepareForDraw() override;
-    void draw() override;
+  void init() override;
+  void prepareForDraw() override;
+  void draw() override;
 
-    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
-    void updateFishPerUniforms(float x,
-                               float y,
-                               float z,
-                               float nextX,
-                               float nextY,
-                               float nextZ,
-                               float scale,
-                               float time,
-                               int index) override;
+  void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
+  void updateFishPerUniforms(float x,
+                             float y,
+                             float z,
+                             float nextX,
+                             float nextY,
+                             float nextZ,
+                             float scale,
+                             float time,
+                             int index) override;
 
-    struct FishVertexUniforms
-    {
-        float fishLength;
-        float fishWaveLength;
-        float fishBendAmount;
-    } mFishVertexUniforms;
+  struct FishVertexUniforms
+  {
+    float fishLength;
+    float fishWaveLength;
+    float fishBendAmount;
+  } mFishVertexUniforms;
 
-    struct LightFactorUniforms
-    {
-        float shininess;
-        float specularFactor;
-    } mLightFactorUniforms;
+  struct LightFactorUniforms
+  {
+    float shininess;
+    float specularFactor;
+  } mLightFactorUniforms;
 
-    struct FishPer
-    {
-        float worldPosition[3];
-        float scale;
-        float nextPosition[3];
-        float time;
-    };
-    FishPer *mFishPers;
+  struct FishPer
+  {
+    float worldPosition[3];
+    float scale;
+    float nextPosition[3];
+    float time;
+  };
+  FishPer *mFishPers;
 
-    TextureDawn *mDiffuseTexture;
-    TextureDawn *mNormalTexture;
-    TextureDawn *mReflectionTexture;
-    TextureDawn *mSkyboxTexture;
+  TextureDawn *mDiffuseTexture;
+  TextureDawn *mNormalTexture;
+  TextureDawn *mReflectionTexture;
+  TextureDawn *mSkyboxTexture;
 
-    BufferDawn *mPositionBuffer;
-    BufferDawn *mNormalBuffer;
-    BufferDawn *mTexCoordBuffer;
-    BufferDawn *mTangentBuffer;
-    BufferDawn *mBiNormalBuffer;
+  BufferDawn *mPositionBuffer;
+  BufferDawn *mNormalBuffer;
+  BufferDawn *mTexCoordBuffer;
+  BufferDawn *mTangentBuffer;
+  BufferDawn *mBiNormalBuffer;
 
-    BufferDawn *mIndicesBuffer;
+  BufferDawn *mIndicesBuffer;
 
-  private:
-    utils::ComboVertexStateDescriptor mVertexStateDescriptor;
-    wgpu::RenderPipeline mPipeline;
+private:
+  utils::ComboVertexStateDescriptor mVertexStateDescriptor;
+  wgpu::RenderPipeline mPipeline;
 
-    wgpu::BindGroupLayout mGroupLayoutModel;
-    wgpu::BindGroupLayout mGroupLayoutPer;
-    wgpu::PipelineLayout mPipelineLayout;
+  wgpu::BindGroupLayout mGroupLayoutModel;
+  wgpu::BindGroupLayout mGroupLayoutPer;
+  wgpu::PipelineLayout mPipelineLayout;
 
-    wgpu::BindGroup mBindGroupModel;
-    wgpu::BindGroup mBindGroupPer;
+  wgpu::BindGroup mBindGroupModel;
+  wgpu::BindGroup mBindGroupPer;
 
-    wgpu::Buffer mFishVertexBuffer;
-    wgpu::Buffer mLightFactorBuffer;
+  wgpu::Buffer mFishVertexBuffer;
+  wgpu::Buffer mLightFactorBuffer;
 
-    wgpu::Buffer mFishPersBuffer;
+  wgpu::Buffer mFishPersBuffer;
 
-    int instance;
+  int instance;
 
-    ProgramDawn *mProgramDawn;
-    ContextDawn *mContextDawn;
+  ProgramDawn *mProgramDawn;
+  ContextDawn *mContextDawn;
 };
 
 #endif  // FISHMODELINSTANCEDDRAWDAWN_H

--- a/src/aquarium-optimized/dawn/GenericModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/GenericModelDawn.cpp
@@ -15,242 +15,265 @@ GenericModelDawn::GenericModelDawn(Context *context,
                                    bool blend)
     : Model(type, name, blend), instance(0)
 {
-    mContextDawn = static_cast<ContextDawn *>(context);
+  mContextDawn = static_cast<ContextDawn *>(context);
 
-    mLightFactorUniforms.shininess      = 50.0f;
-    mLightFactorUniforms.specularFactor = 1.0f;
+  mLightFactorUniforms.shininess      = 50.0f;
+  mLightFactorUniforms.specularFactor = 1.0f;
 }
 
 GenericModelDawn::~GenericModelDawn()
 {
-    mPipeline          = nullptr;
-    mGroupLayoutModel  = nullptr;
-    mGroupLayoutPer    = nullptr;
-    mPipelineLayout    = nullptr;
-    mBindGroupModel    = nullptr;
-    mBindGroupPer      = nullptr;
-    mLightFactorBuffer = nullptr;
-    mWorldBuffer       = nullptr;
+  mPipeline          = nullptr;
+  mGroupLayoutModel  = nullptr;
+  mGroupLayoutPer    = nullptr;
+  mPipelineLayout    = nullptr;
+  mBindGroupModel    = nullptr;
+  mBindGroupPer      = nullptr;
+  mLightFactorBuffer = nullptr;
+  mWorldBuffer       = nullptr;
 }
 
 void GenericModelDawn::init()
 {
-    mProgramDawn = static_cast<ProgramDawn *>(mProgram);
+  mProgramDawn = static_cast<ProgramDawn *>(mProgram);
 
-    mDiffuseTexture    = static_cast<TextureDawn *>(textureMap["diffuse"]);
-    mNormalTexture     = static_cast<TextureDawn *>(textureMap["normalMap"]);
-    mReflectionTexture = static_cast<TextureDawn *>(textureMap["reflectionMap"]);
-    mSkyboxTexture     = static_cast<TextureDawn *>(textureMap["skybox"]);
+  mDiffuseTexture    = static_cast<TextureDawn *>(textureMap["diffuse"]);
+  mNormalTexture     = static_cast<TextureDawn *>(textureMap["normalMap"]);
+  mReflectionTexture = static_cast<TextureDawn *>(textureMap["reflectionMap"]);
+  mSkyboxTexture     = static_cast<TextureDawn *>(textureMap["skybox"]);
 
-    mPositionBuffer = static_cast<BufferDawn *>(bufferMap["position"]);
-    mNormalBuffer   = static_cast<BufferDawn *>(bufferMap["normal"]);
-    mTexCoordBuffer = static_cast<BufferDawn *>(bufferMap["texCoord"]);
-    mTangentBuffer  = static_cast<BufferDawn *>(bufferMap["tangent"]);
-    mBiNormalBuffer = static_cast<BufferDawn *>(bufferMap["binormal"]);
-    mIndicesBuffer  = static_cast<BufferDawn *>(bufferMap["indices"]);
+  mPositionBuffer = static_cast<BufferDawn *>(bufferMap["position"]);
+  mNormalBuffer   = static_cast<BufferDawn *>(bufferMap["normal"]);
+  mTexCoordBuffer = static_cast<BufferDawn *>(bufferMap["texCoord"]);
+  mTangentBuffer  = static_cast<BufferDawn *>(bufferMap["tangent"]);
+  mBiNormalBuffer = static_cast<BufferDawn *>(bufferMap["binormal"]);
+  mIndicesBuffer  = static_cast<BufferDawn *>(bufferMap["indices"]);
 
-    // Generic models use reflection, normal or diffuse shaders, of which groupLayouts are
-    // diiferent in texture binding.  MODELGLOBEBASE use diffuse shader though it contains
-    // normal and reflection textures.
-    if (mNormalTexture && mName != MODELNAME::MODELGLOBEBASE)
-    {
-        mVertexStateDescriptor.cVertexBuffers[0].attributeCount = 1;
-        mVertexStateDescriptor.cVertexBuffers[0].arrayStride    = mPositionBuffer->getDataSize();
-        mVertexStateDescriptor.cAttributes[0].format            = wgpu::VertexFormat::Float3;
-        mVertexStateDescriptor.cAttributes[0].shaderLocation    = 0;
-        mVertexStateDescriptor.cAttributes[0].offset            = 0;
-        mVertexStateDescriptor.cVertexBuffers[0].attributes =
-            &mVertexStateDescriptor.cAttributes[0];
-        mVertexStateDescriptor.cVertexBuffers[1].attributeCount = 1;
-        mVertexStateDescriptor.cVertexBuffers[1].arrayStride    = mNormalBuffer->getDataSize();
-        mVertexStateDescriptor.cAttributes[1].format            = wgpu::VertexFormat::Float3;
-        mVertexStateDescriptor.cAttributes[1].shaderLocation    = 1;
-        mVertexStateDescriptor.cAttributes[1].offset            = 0;
-        mVertexStateDescriptor.cVertexBuffers[1].attributes =
-            &mVertexStateDescriptor.cAttributes[1];
-        mVertexStateDescriptor.cVertexBuffers[2].attributeCount = 1;
-        mVertexStateDescriptor.cVertexBuffers[2].arrayStride    = mTexCoordBuffer->getDataSize();
-        mVertexStateDescriptor.cAttributes[2].format            = wgpu::VertexFormat::Float2;
-        mVertexStateDescriptor.cAttributes[2].shaderLocation    = 2;
-        mVertexStateDescriptor.cAttributes[2].offset            = 0;
-        mVertexStateDescriptor.cVertexBuffers[2].attributes =
-            &mVertexStateDescriptor.cAttributes[2];
-        mVertexStateDescriptor.cVertexBuffers[3].attributeCount = 1;
-        mVertexStateDescriptor.cVertexBuffers[3].arrayStride    = mTangentBuffer->getDataSize();
-        mVertexStateDescriptor.cAttributes[3].format            = wgpu::VertexFormat::Float3;
-        mVertexStateDescriptor.cAttributes[3].shaderLocation    = 3;
-        mVertexStateDescriptor.cAttributes[3].offset            = 0;
-        mVertexStateDescriptor.cVertexBuffers[3].attributes =
-            &mVertexStateDescriptor.cAttributes[3];
-        mVertexStateDescriptor.cVertexBuffers[4].attributeCount = 1;
-        mVertexStateDescriptor.cVertexBuffers[4].arrayStride    = mBiNormalBuffer->getDataSize();
-        mVertexStateDescriptor.cAttributes[4].format            = wgpu::VertexFormat::Float3;
-        mVertexStateDescriptor.cAttributes[4].shaderLocation    = 4;
-        mVertexStateDescriptor.cAttributes[4].offset            = 0;
-        mVertexStateDescriptor.cVertexBuffers[4].attributes =
-            &mVertexStateDescriptor.cAttributes[4];
-        mVertexStateDescriptor.vertexBufferCount = 5;
-        mVertexStateDescriptor.indexFormat       = wgpu::IndexFormat::Uint16;
-    }
-    else
-    {
-        mVertexStateDescriptor.cVertexBuffers[0].attributeCount = 1;
-        mVertexStateDescriptor.cVertexBuffers[0].arrayStride    = mPositionBuffer->getDataSize();
-        mVertexStateDescriptor.cAttributes[0].format            = wgpu::VertexFormat::Float3;
-        mVertexStateDescriptor.cAttributes[0].shaderLocation    = 0;
-        mVertexStateDescriptor.cAttributes[0].offset            = 0;
-        mVertexStateDescriptor.cVertexBuffers[0].attributes =
-            &mVertexStateDescriptor.cAttributes[0];
-        mVertexStateDescriptor.cVertexBuffers[1].attributeCount = 1;
-        mVertexStateDescriptor.cVertexBuffers[1].arrayStride    = mNormalBuffer->getDataSize();
-        mVertexStateDescriptor.cAttributes[1].format            = wgpu::VertexFormat::Float3;
-        mVertexStateDescriptor.cAttributes[1].shaderLocation    = 1;
-        mVertexStateDescriptor.cAttributes[1].offset            = 0;
-        mVertexStateDescriptor.cVertexBuffers[1].attributes =
-            &mVertexStateDescriptor.cAttributes[1];
-        mVertexStateDescriptor.cVertexBuffers[2].attributeCount = 1;
-        mVertexStateDescriptor.cVertexBuffers[2].arrayStride    = mTexCoordBuffer->getDataSize();
-        mVertexStateDescriptor.cAttributes[2].format            = wgpu::VertexFormat::Float2;
-        mVertexStateDescriptor.cAttributes[2].shaderLocation    = 2;
-        mVertexStateDescriptor.cAttributes[2].offset            = 0;
-        mVertexStateDescriptor.cVertexBuffers[2].attributes =
-            &mVertexStateDescriptor.cAttributes[2];
-        mVertexStateDescriptor.vertexBufferCount = 3;
-        mVertexStateDescriptor.indexFormat       = wgpu::IndexFormat::Uint16;
-    }
+  // Generic models use reflection, normal or diffuse shaders, of which
+  // groupLayouts are diiferent in texture binding.  MODELGLOBEBASE use diffuse
+  // shader though it contains normal and reflection textures.
+  if (mNormalTexture && mName != MODELNAME::MODELGLOBEBASE)
+  {
+    mVertexStateDescriptor.cVertexBuffers[0].attributeCount = 1;
+    mVertexStateDescriptor.cVertexBuffers[0].arrayStride =
+        mPositionBuffer->getDataSize();
+    mVertexStateDescriptor.cAttributes[0].format = wgpu::VertexFormat::Float3;
+    mVertexStateDescriptor.cAttributes[0].shaderLocation = 0;
+    mVertexStateDescriptor.cAttributes[0].offset         = 0;
+    mVertexStateDescriptor.cVertexBuffers[0].attributes =
+        &mVertexStateDescriptor.cAttributes[0];
+    mVertexStateDescriptor.cVertexBuffers[1].attributeCount = 1;
+    mVertexStateDescriptor.cVertexBuffers[1].arrayStride =
+        mNormalBuffer->getDataSize();
+    mVertexStateDescriptor.cAttributes[1].format = wgpu::VertexFormat::Float3;
+    mVertexStateDescriptor.cAttributes[1].shaderLocation = 1;
+    mVertexStateDescriptor.cAttributes[1].offset         = 0;
+    mVertexStateDescriptor.cVertexBuffers[1].attributes =
+        &mVertexStateDescriptor.cAttributes[1];
+    mVertexStateDescriptor.cVertexBuffers[2].attributeCount = 1;
+    mVertexStateDescriptor.cVertexBuffers[2].arrayStride =
+        mTexCoordBuffer->getDataSize();
+    mVertexStateDescriptor.cAttributes[2].format = wgpu::VertexFormat::Float2;
+    mVertexStateDescriptor.cAttributes[2].shaderLocation = 2;
+    mVertexStateDescriptor.cAttributes[2].offset         = 0;
+    mVertexStateDescriptor.cVertexBuffers[2].attributes =
+        &mVertexStateDescriptor.cAttributes[2];
+    mVertexStateDescriptor.cVertexBuffers[3].attributeCount = 1;
+    mVertexStateDescriptor.cVertexBuffers[3].arrayStride =
+        mTangentBuffer->getDataSize();
+    mVertexStateDescriptor.cAttributes[3].format = wgpu::VertexFormat::Float3;
+    mVertexStateDescriptor.cAttributes[3].shaderLocation = 3;
+    mVertexStateDescriptor.cAttributes[3].offset         = 0;
+    mVertexStateDescriptor.cVertexBuffers[3].attributes =
+        &mVertexStateDescriptor.cAttributes[3];
+    mVertexStateDescriptor.cVertexBuffers[4].attributeCount = 1;
+    mVertexStateDescriptor.cVertexBuffers[4].arrayStride =
+        mBiNormalBuffer->getDataSize();
+    mVertexStateDescriptor.cAttributes[4].format = wgpu::VertexFormat::Float3;
+    mVertexStateDescriptor.cAttributes[4].shaderLocation = 4;
+    mVertexStateDescriptor.cAttributes[4].offset         = 0;
+    mVertexStateDescriptor.cVertexBuffers[4].attributes =
+        &mVertexStateDescriptor.cAttributes[4];
+    mVertexStateDescriptor.vertexBufferCount = 5;
+    mVertexStateDescriptor.indexFormat       = wgpu::IndexFormat::Uint16;
+  }
+  else
+  {
+    mVertexStateDescriptor.cVertexBuffers[0].attributeCount = 1;
+    mVertexStateDescriptor.cVertexBuffers[0].arrayStride =
+        mPositionBuffer->getDataSize();
+    mVertexStateDescriptor.cAttributes[0].format = wgpu::VertexFormat::Float3;
+    mVertexStateDescriptor.cAttributes[0].shaderLocation = 0;
+    mVertexStateDescriptor.cAttributes[0].offset         = 0;
+    mVertexStateDescriptor.cVertexBuffers[0].attributes =
+        &mVertexStateDescriptor.cAttributes[0];
+    mVertexStateDescriptor.cVertexBuffers[1].attributeCount = 1;
+    mVertexStateDescriptor.cVertexBuffers[1].arrayStride =
+        mNormalBuffer->getDataSize();
+    mVertexStateDescriptor.cAttributes[1].format = wgpu::VertexFormat::Float3;
+    mVertexStateDescriptor.cAttributes[1].shaderLocation = 1;
+    mVertexStateDescriptor.cAttributes[1].offset         = 0;
+    mVertexStateDescriptor.cVertexBuffers[1].attributes =
+        &mVertexStateDescriptor.cAttributes[1];
+    mVertexStateDescriptor.cVertexBuffers[2].attributeCount = 1;
+    mVertexStateDescriptor.cVertexBuffers[2].arrayStride =
+        mTexCoordBuffer->getDataSize();
+    mVertexStateDescriptor.cAttributes[2].format = wgpu::VertexFormat::Float2;
+    mVertexStateDescriptor.cAttributes[2].shaderLocation = 2;
+    mVertexStateDescriptor.cAttributes[2].offset         = 0;
+    mVertexStateDescriptor.cVertexBuffers[2].attributes =
+        &mVertexStateDescriptor.cAttributes[2];
+    mVertexStateDescriptor.vertexBufferCount = 3;
+    mVertexStateDescriptor.indexFormat       = wgpu::IndexFormat::Uint16;
+  }
 
-    if (mSkyboxTexture && mReflectionTexture && mName != MODELNAME::MODELGLOBEBASE)
-    {
-        mGroupLayoutModel = mContextDawn->MakeBindGroupLayout({
-            {0, wgpu::ShaderStage::Fragment, wgpu::BindingType::UniformBuffer},
-            {1, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
-            {2, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
-            {3, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false, false,
-             wgpu::TextureViewDimension::e2D, wgpu::TextureComponentType::Float},
-            {4, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false, false,
-             wgpu::TextureViewDimension::e2D, wgpu::TextureComponentType::Float},
-            {5, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false, false,
-             wgpu::TextureViewDimension::e2D, wgpu::TextureComponentType::Float},
-            {6, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false, false,
-             wgpu::TextureViewDimension::Cube, wgpu::TextureComponentType::Float},
-        });
-    }
-    else if (mNormalTexture && mName != MODELNAME::MODELGLOBEBASE)
-    {
-        mGroupLayoutModel = mContextDawn->MakeBindGroupLayout({
-            {0, wgpu::ShaderStage::Fragment, wgpu::BindingType::UniformBuffer},
-            {1, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
-            {2, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false, false,
-             wgpu::TextureViewDimension::e2D, wgpu::TextureComponentType::Float},
-            {3, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false, false,
-             wgpu::TextureViewDimension::e2D, wgpu::TextureComponentType::Float},
-        });
-    }
-    else
-    {
-        mGroupLayoutModel = mContextDawn->MakeBindGroupLayout({
-            {0, wgpu::ShaderStage::Fragment, wgpu::BindingType::UniformBuffer},
-            {1, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
-            {2, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false, false,
-             wgpu::TextureViewDimension::e2D, wgpu::TextureComponentType::Float},
-        });
-    }
-
-    mGroupLayoutPer = mContextDawn->MakeBindGroupLayout({
-        {0, wgpu::ShaderStage::Vertex, wgpu::BindingType::UniformBuffer},
+  if (mSkyboxTexture && mReflectionTexture &&
+      mName != MODELNAME::MODELGLOBEBASE)
+  {
+    mGroupLayoutModel = mContextDawn->MakeBindGroupLayout({
+        {0, wgpu::ShaderStage::Fragment, wgpu::BindingType::UniformBuffer},
+        {1, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
+        {2, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
+        {3, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture,
+         false, false, wgpu::TextureViewDimension::e2D,
+         wgpu::TextureComponentType::Float},
+        {4, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture,
+         false, false, wgpu::TextureViewDimension::e2D,
+         wgpu::TextureComponentType::Float},
+        {5, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture,
+         false, false, wgpu::TextureViewDimension::e2D,
+         wgpu::TextureComponentType::Float},
+        {6, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture,
+         false, false, wgpu::TextureViewDimension::Cube,
+         wgpu::TextureComponentType::Float},
     });
+  }
+  else if (mNormalTexture && mName != MODELNAME::MODELGLOBEBASE)
+  {
+    mGroupLayoutModel = mContextDawn->MakeBindGroupLayout({
+        {0, wgpu::ShaderStage::Fragment, wgpu::BindingType::UniformBuffer},
+        {1, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
+        {2, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture,
+         false, false, wgpu::TextureViewDimension::e2D,
+         wgpu::TextureComponentType::Float},
+        {3, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture,
+         false, false, wgpu::TextureViewDimension::e2D,
+         wgpu::TextureComponentType::Float},
+    });
+  }
+  else
+  {
+    mGroupLayoutModel = mContextDawn->MakeBindGroupLayout({
+        {0, wgpu::ShaderStage::Fragment, wgpu::BindingType::UniformBuffer},
+        {1, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
+        {2, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture,
+         false, false, wgpu::TextureViewDimension::e2D,
+         wgpu::TextureComponentType::Float},
+    });
+  }
 
-    mPipelineLayout = mContextDawn->MakeBasicPipelineLayout({
-        mContextDawn->groupLayoutGeneral,
-        mContextDawn->groupLayoutWorld,
+  mGroupLayoutPer = mContextDawn->MakeBindGroupLayout({
+      {0, wgpu::ShaderStage::Vertex, wgpu::BindingType::UniformBuffer},
+  });
+
+  mPipelineLayout = mContextDawn->MakeBasicPipelineLayout({
+      mContextDawn->groupLayoutGeneral,
+      mContextDawn->groupLayoutWorld,
+      mGroupLayoutModel,
+      mGroupLayoutPer,
+  });
+
+  mPipeline = mContextDawn->createRenderPipeline(
+      mPipelineLayout, mProgramDawn, mVertexStateDescriptor, mBlend);
+
+  mLightFactorBuffer = mContextDawn->createBufferFromData(
+      &mLightFactorUniforms, sizeof(mLightFactorUniforms),
+      sizeof(mLightFactorUniforms),
+      wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
+  mWorldBuffer = mContextDawn->createBufferFromData(
+      &mWorldUniformPer, sizeof(mWorldUniformPer), sizeof(mWorldUniformPer),
+      wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
+
+  // Generic models use reflection, normal or diffuse shaders, of which
+  // grouplayouts are diiferent in texture binding. MODELGLOBEBASE use diffuse
+  // shader though it contains normal and reflection textures.
+  if (mSkyboxTexture && mReflectionTexture &&
+      mName != MODELNAME::MODELGLOBEBASE)
+  {
+    mBindGroupModel = mContextDawn->makeBindGroup(
         mGroupLayoutModel,
-        mGroupLayoutPer,
-    });
+        {{0, mLightFactorBuffer, 0, sizeof(LightFactorUniforms)},
+         {1, mReflectionTexture->getSampler()},
+         {2, mSkyboxTexture->getSampler()},
+         {3, mDiffuseTexture->getTextureView()},
+         {4, mNormalTexture->getTextureView()},
+         {5, mReflectionTexture->getTextureView()},
+         {6, mSkyboxTexture->getTextureView()}});
+  }
+  else if (mNormalTexture && mName != MODELNAME::MODELGLOBEBASE)
+  {
+    mBindGroupModel = mContextDawn->makeBindGroup(
+        mGroupLayoutModel,
+        {
+            {0, mLightFactorBuffer, 0, sizeof(LightFactorUniforms)},
+            {1, mDiffuseTexture->getSampler()},
+            {2, mDiffuseTexture->getTextureView()},
+            {3, mNormalTexture->getTextureView()},
+        });
+  }
+  else
+  {
+    mBindGroupModel = mContextDawn->makeBindGroup(
+        mGroupLayoutModel,
+        {
+            {0, mLightFactorBuffer, 0, sizeof(LightFactorUniforms)},
+            {1, mDiffuseTexture->getSampler()},
+            {2, mDiffuseTexture->getTextureView()},
+        });
+  }
 
-    mPipeline = mContextDawn->createRenderPipeline(mPipelineLayout, mProgramDawn,
-                                                   mVertexStateDescriptor, mBlend);
+  mBindGroupPer = mContextDawn->makeBindGroup(
+      mGroupLayoutPer, {
+                           {0, mWorldBuffer, 0, sizeof(WorldUniformPer)},
+                       });
 
-    mLightFactorBuffer = mContextDawn->createBufferFromData(
-        &mLightFactorUniforms, sizeof(mLightFactorUniforms), sizeof(mLightFactorUniforms),
-        wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
-    mWorldBuffer = mContextDawn->createBufferFromData(
-        &mWorldUniformPer, sizeof(mWorldUniformPer), sizeof(mWorldUniformPer),
-        wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
-
-    // Generic models use reflection, normal or diffuse shaders, of which grouplayouts are
-    // diiferent in texture binding. MODELGLOBEBASE use diffuse shader though it contains
-    // normal and reflection textures.
-    if (mSkyboxTexture && mReflectionTexture && mName != MODELNAME::MODELGLOBEBASE)
-    {
-        mBindGroupModel = mContextDawn->makeBindGroup(
-            mGroupLayoutModel, {{0, mLightFactorBuffer, 0, sizeof(LightFactorUniforms)},
-                                {1, mReflectionTexture->getSampler()},
-                                {2, mSkyboxTexture->getSampler()},
-                                {3, mDiffuseTexture->getTextureView()},
-                                {4, mNormalTexture->getTextureView()},
-                                {5, mReflectionTexture->getTextureView()},
-                                {6, mSkyboxTexture->getTextureView()}});
-    }
-    else if (mNormalTexture && mName != MODELNAME::MODELGLOBEBASE)
-    {
-        mBindGroupModel = mContextDawn->makeBindGroup(
-            mGroupLayoutModel, {
-                                   {0, mLightFactorBuffer, 0, sizeof(LightFactorUniforms)},
-                                   {1, mDiffuseTexture->getSampler()},
-                                   {2, mDiffuseTexture->getTextureView()},
-                                   {3, mNormalTexture->getTextureView()},
-                               });
-    }
-    else
-    {
-        mBindGroupModel = mContextDawn->makeBindGroup(
-            mGroupLayoutModel, {
-                                   {0, mLightFactorBuffer, 0, sizeof(LightFactorUniforms)},
-                                   {1, mDiffuseTexture->getSampler()},
-                                   {2, mDiffuseTexture->getTextureView()},
-                               });
-    }
-
-    mBindGroupPer = mContextDawn->makeBindGroup(mGroupLayoutPer,
-                                                {
-                                                    {0, mWorldBuffer, 0, sizeof(WorldUniformPer)},
-                                                });
-
-    mContextDawn->setBufferData(mLightFactorBuffer, sizeof(LightFactorUniforms),
-                                &mLightFactorUniforms, sizeof(LightFactorUniforms));
+  mContextDawn->setBufferData(mLightFactorBuffer, sizeof(LightFactorUniforms),
+                              &mLightFactorUniforms,
+                              sizeof(LightFactorUniforms));
 }
 
 void GenericModelDawn::prepareForDraw()
 {
-    mContextDawn->updateBufferData(mWorldBuffer, sizeof(WorldUniformPer), &mWorldUniformPer,
-                                   sizeof(WorldUniformPer));
+  mContextDawn->updateBufferData(mWorldBuffer, sizeof(WorldUniformPer),
+                                 &mWorldUniformPer, sizeof(WorldUniformPer));
 }
 
 void GenericModelDawn::draw()
 {
-    wgpu::RenderPassEncoder pass = mContextDawn->getRenderPass();
-    pass.SetPipeline(mPipeline);
-    pass.SetBindGroup(0, mContextDawn->bindGroupGeneral, 0, nullptr);
-    pass.SetBindGroup(1, mContextDawn->bindGroupWorld, 0, nullptr);
-    pass.SetBindGroup(2, mBindGroupModel, 0, nullptr);
-    pass.SetBindGroup(3, mBindGroupPer, 0, nullptr);
-    pass.SetVertexBuffer(0, mPositionBuffer->getBuffer());
-    pass.SetVertexBuffer(1, mNormalBuffer->getBuffer());
-    pass.SetVertexBuffer(2, mTexCoordBuffer->getBuffer());
-    // diffuseShader doesn't have to input tangent buffer or binormal buffer.
-    if (mTangentBuffer && mBiNormalBuffer && mName != MODELNAME::MODELGLOBEBASE)
-    {
-        pass.SetVertexBuffer(3, mTangentBuffer->getBuffer());
-        pass.SetVertexBuffer(4, mBiNormalBuffer->getBuffer());
-    }
-    pass.SetIndexBuffer(mIndicesBuffer->getBuffer(), 0);
-    pass.DrawIndexed(mIndicesBuffer->getTotalComponents(), instance, 0, 0, 0);
-    instance = 0;
+  wgpu::RenderPassEncoder pass = mContextDawn->getRenderPass();
+  pass.SetPipeline(mPipeline);
+  pass.SetBindGroup(0, mContextDawn->bindGroupGeneral, 0, nullptr);
+  pass.SetBindGroup(1, mContextDawn->bindGroupWorld, 0, nullptr);
+  pass.SetBindGroup(2, mBindGroupModel, 0, nullptr);
+  pass.SetBindGroup(3, mBindGroupPer, 0, nullptr);
+  pass.SetVertexBuffer(0, mPositionBuffer->getBuffer());
+  pass.SetVertexBuffer(1, mNormalBuffer->getBuffer());
+  pass.SetVertexBuffer(2, mTexCoordBuffer->getBuffer());
+  // diffuseShader doesn't have to input tangent buffer or binormal buffer.
+  if (mTangentBuffer && mBiNormalBuffer && mName != MODELNAME::MODELGLOBEBASE)
+  {
+    pass.SetVertexBuffer(3, mTangentBuffer->getBuffer());
+    pass.SetVertexBuffer(4, mBiNormalBuffer->getBuffer());
+  }
+  pass.SetIndexBuffer(mIndicesBuffer->getBuffer(), 0);
+  pass.DrawIndexed(mIndicesBuffer->getTotalComponents(), instance, 0, 0, 0);
+  instance = 0;
 }
 
-void GenericModelDawn::updatePerInstanceUniforms(const WorldUniforms &worldUniforms)
+void GenericModelDawn::updatePerInstanceUniforms(
+    const WorldUniforms &worldUniforms)
 {
-    mWorldUniformPer.WorldUniforms[instance] = worldUniforms;
+  mWorldUniformPer.WorldUniforms[instance] = worldUniforms;
 
-    instance++;
+  instance++;
 }

--- a/src/aquarium-optimized/dawn/GenericModelDawn.h
+++ b/src/aquarium-optimized/dawn/GenericModelDawn.h
@@ -17,63 +17,63 @@
 
 class GenericModelDawn : public Model
 {
-  public:
-    GenericModelDawn(Context *context,
-                     Aquarium *aquarium,
-                     MODELGROUP type,
-                     MODELNAME name,
-                     bool blend);
-    ~GenericModelDawn();
+public:
+  GenericModelDawn(Context *context,
+                   Aquarium *aquarium,
+                   MODELGROUP type,
+                   MODELNAME name,
+                   bool blend);
+  ~GenericModelDawn();
 
-    void init() override;
-    void prepareForDraw() override;
-    void draw() override;
+  void init() override;
+  void prepareForDraw() override;
+  void draw() override;
 
-    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
+  void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
 
-    TextureDawn *mDiffuseTexture;
-    TextureDawn *mNormalTexture;
-    TextureDawn *mReflectionTexture;
-    TextureDawn *mSkyboxTexture;
+  TextureDawn *mDiffuseTexture;
+  TextureDawn *mNormalTexture;
+  TextureDawn *mReflectionTexture;
+  TextureDawn *mSkyboxTexture;
 
-    BufferDawn *mPositionBuffer;
-    BufferDawn *mNormalBuffer;
-    BufferDawn *mTexCoordBuffer;
-    BufferDawn *mTangentBuffer;
-    BufferDawn *mBiNormalBuffer;
+  BufferDawn *mPositionBuffer;
+  BufferDawn *mNormalBuffer;
+  BufferDawn *mTexCoordBuffer;
+  BufferDawn *mTangentBuffer;
+  BufferDawn *mBiNormalBuffer;
 
-    BufferDawn *mIndicesBuffer;
+  BufferDawn *mIndicesBuffer;
 
-    struct LightFactorUniforms
-    {
-        float shininess;
-        float specularFactor;
-    } mLightFactorUniforms;
+  struct LightFactorUniforms
+  {
+    float shininess;
+    float specularFactor;
+  } mLightFactorUniforms;
 
-    struct WorldUniformPer
-    {
-        WorldUniforms WorldUniforms[20];
-    };
-    WorldUniformPer mWorldUniformPer;
+  struct WorldUniformPer
+  {
+    WorldUniforms WorldUniforms[20];
+  };
+  WorldUniformPer mWorldUniformPer;
 
-  private:
-    utils::ComboVertexStateDescriptor mVertexStateDescriptor;
-    wgpu::RenderPipeline mPipeline;
+private:
+  utils::ComboVertexStateDescriptor mVertexStateDescriptor;
+  wgpu::RenderPipeline mPipeline;
 
-    wgpu::BindGroupLayout mGroupLayoutModel;
-    wgpu::BindGroupLayout mGroupLayoutPer;
-    wgpu::PipelineLayout mPipelineLayout;
+  wgpu::BindGroupLayout mGroupLayoutModel;
+  wgpu::BindGroupLayout mGroupLayoutPer;
+  wgpu::PipelineLayout mPipelineLayout;
 
-    wgpu::BindGroup mBindGroupModel;
-    wgpu::BindGroup mBindGroupPer;
+  wgpu::BindGroup mBindGroupModel;
+  wgpu::BindGroup mBindGroupPer;
 
-    wgpu::Buffer mLightFactorBuffer;
-    wgpu::Buffer mWorldBuffer;
+  wgpu::Buffer mLightFactorBuffer;
+  wgpu::Buffer mWorldBuffer;
 
-    ContextDawn *mContextDawn;
-    ProgramDawn *mProgramDawn;
+  ContextDawn *mContextDawn;
+  ProgramDawn *mProgramDawn;
 
-    int instance;
+  int instance;
 };
 
 #endif  // GENERICMODELDAWN_H

--- a/src/aquarium-optimized/dawn/InnerModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/InnerModelDawn.cpp
@@ -14,153 +14,170 @@ InnerModelDawn::InnerModelDawn(Context *context,
                                bool blend)
     : Model(type, name, blend)
 {
-    mContextDawn = static_cast<ContextDawn *>(context);
+  mContextDawn = static_cast<ContextDawn *>(context);
 
-    mInnerUniforms.eta             = 1.0f;
-    mInnerUniforms.tankColorFudge  = 0.796f;
-    mInnerUniforms.refractionFudge = 3.0f;
+  mInnerUniforms.eta             = 1.0f;
+  mInnerUniforms.tankColorFudge  = 0.796f;
+  mInnerUniforms.refractionFudge = 3.0f;
 }
 
 InnerModelDawn::~InnerModelDawn()
 {
-    mPipeline         = nullptr;
-    mGroupLayoutModel = nullptr;
-    mGroupLayoutPer   = nullptr;
-    mPipelineLayout   = nullptr;
-    mBindGroupModel   = nullptr;
-    mBindGroupPer     = nullptr;
-    mInnerBuffer      = nullptr;
-    mViewBuffer       = nullptr;
+  mPipeline         = nullptr;
+  mGroupLayoutModel = nullptr;
+  mGroupLayoutPer   = nullptr;
+  mPipelineLayout   = nullptr;
+  mBindGroupModel   = nullptr;
+  mBindGroupPer     = nullptr;
+  mInnerBuffer      = nullptr;
+  mViewBuffer       = nullptr;
 }
 
 void InnerModelDawn::init()
 {
-    mProgramDawn = static_cast<ProgramDawn *>(mProgram);
+  mProgramDawn = static_cast<ProgramDawn *>(mProgram);
 
-    mDiffuseTexture    = static_cast<TextureDawn *>(textureMap["diffuse"]);
-    mNormalTexture     = static_cast<TextureDawn *>(textureMap["normalMap"]);
-    mReflectionTexture = static_cast<TextureDawn *>(textureMap["reflectionMap"]);
-    mSkyboxTexture     = static_cast<TextureDawn *>(textureMap["skybox"]);
+  mDiffuseTexture    = static_cast<TextureDawn *>(textureMap["diffuse"]);
+  mNormalTexture     = static_cast<TextureDawn *>(textureMap["normalMap"]);
+  mReflectionTexture = static_cast<TextureDawn *>(textureMap["reflectionMap"]);
+  mSkyboxTexture     = static_cast<TextureDawn *>(textureMap["skybox"]);
 
-    mPositionBuffer = static_cast<BufferDawn *>(bufferMap["position"]);
-    mNormalBuffer   = static_cast<BufferDawn *>(bufferMap["normal"]);
-    mTexCoordBuffer = static_cast<BufferDawn *>(bufferMap["texCoord"]);
-    mTangentBuffer  = static_cast<BufferDawn *>(bufferMap["tangent"]);
-    mBiNormalBuffer = static_cast<BufferDawn *>(bufferMap["binormal"]);
-    mIndicesBuffer  = static_cast<BufferDawn *>(bufferMap["indices"]);
+  mPositionBuffer = static_cast<BufferDawn *>(bufferMap["position"]);
+  mNormalBuffer   = static_cast<BufferDawn *>(bufferMap["normal"]);
+  mTexCoordBuffer = static_cast<BufferDawn *>(bufferMap["texCoord"]);
+  mTangentBuffer  = static_cast<BufferDawn *>(bufferMap["tangent"]);
+  mBiNormalBuffer = static_cast<BufferDawn *>(bufferMap["binormal"]);
+  mIndicesBuffer  = static_cast<BufferDawn *>(bufferMap["indices"]);
 
-    mVertexStateDescriptor.cVertexBuffers[0].attributeCount = 1;
-    mVertexStateDescriptor.cVertexBuffers[0].arrayStride    = mPositionBuffer->getDataSize();
-    mVertexStateDescriptor.cAttributes[0].format            = wgpu::VertexFormat::Float3;
-    mVertexStateDescriptor.cAttributes[0].shaderLocation    = 0;
-    mVertexStateDescriptor.cAttributes[0].offset            = 0;
-    mVertexStateDescriptor.cVertexBuffers[0].attributes = &mVertexStateDescriptor.cAttributes[0];
-    mVertexStateDescriptor.cVertexBuffers[1].attributeCount = 1;
-    mVertexStateDescriptor.cVertexBuffers[1].arrayStride    = mNormalBuffer->getDataSize();
-    mVertexStateDescriptor.cAttributes[1].format            = wgpu::VertexFormat::Float3;
-    mVertexStateDescriptor.cAttributes[1].shaderLocation    = 1;
-    mVertexStateDescriptor.cAttributes[1].offset            = 0;
-    mVertexStateDescriptor.cVertexBuffers[1].attributes = &mVertexStateDescriptor.cAttributes[1];
-    mVertexStateDescriptor.cVertexBuffers[2].attributeCount = 1;
-    mVertexStateDescriptor.cVertexBuffers[2].arrayStride    = mTexCoordBuffer->getDataSize();
-    mVertexStateDescriptor.cAttributes[2].format            = wgpu::VertexFormat::Float2;
-    mVertexStateDescriptor.cAttributes[2].shaderLocation    = 2;
-    mVertexStateDescriptor.cAttributes[2].offset            = 0;
-    mVertexStateDescriptor.cVertexBuffers[2].attributes = &mVertexStateDescriptor.cAttributes[2];
-    mVertexStateDescriptor.cVertexBuffers[3].attributeCount = 1;
-    mVertexStateDescriptor.cVertexBuffers[3].arrayStride    = mTangentBuffer->getDataSize();
-    mVertexStateDescriptor.cAttributes[3].format            = wgpu::VertexFormat::Float3;
-    mVertexStateDescriptor.cAttributes[3].shaderLocation    = 3;
-    mVertexStateDescriptor.cAttributes[3].offset            = 0;
-    mVertexStateDescriptor.cVertexBuffers[3].attributes = &mVertexStateDescriptor.cAttributes[3];
-    mVertexStateDescriptor.cVertexBuffers[4].attributeCount = 1;
-    mVertexStateDescriptor.cVertexBuffers[4].arrayStride    = mBiNormalBuffer->getDataSize();
-    mVertexStateDescriptor.cAttributes[4].format            = wgpu::VertexFormat::Float3;
-    mVertexStateDescriptor.cAttributes[4].shaderLocation    = 4;
-    mVertexStateDescriptor.cAttributes[4].offset            = 0;
-    mVertexStateDescriptor.cVertexBuffers[4].attributes = &mVertexStateDescriptor.cAttributes[4];
-    mVertexStateDescriptor.vertexBufferCount            = 5;
-    mVertexStateDescriptor.indexFormat                  = wgpu::IndexFormat::Uint16;
+  mVertexStateDescriptor.cVertexBuffers[0].attributeCount = 1;
+  mVertexStateDescriptor.cVertexBuffers[0].arrayStride =
+      mPositionBuffer->getDataSize();
+  mVertexStateDescriptor.cAttributes[0].format = wgpu::VertexFormat::Float3;
+  mVertexStateDescriptor.cAttributes[0].shaderLocation = 0;
+  mVertexStateDescriptor.cAttributes[0].offset         = 0;
+  mVertexStateDescriptor.cVertexBuffers[0].attributes =
+      &mVertexStateDescriptor.cAttributes[0];
+  mVertexStateDescriptor.cVertexBuffers[1].attributeCount = 1;
+  mVertexStateDescriptor.cVertexBuffers[1].arrayStride =
+      mNormalBuffer->getDataSize();
+  mVertexStateDescriptor.cAttributes[1].format = wgpu::VertexFormat::Float3;
+  mVertexStateDescriptor.cAttributes[1].shaderLocation = 1;
+  mVertexStateDescriptor.cAttributes[1].offset         = 0;
+  mVertexStateDescriptor.cVertexBuffers[1].attributes =
+      &mVertexStateDescriptor.cAttributes[1];
+  mVertexStateDescriptor.cVertexBuffers[2].attributeCount = 1;
+  mVertexStateDescriptor.cVertexBuffers[2].arrayStride =
+      mTexCoordBuffer->getDataSize();
+  mVertexStateDescriptor.cAttributes[2].format = wgpu::VertexFormat::Float2;
+  mVertexStateDescriptor.cAttributes[2].shaderLocation = 2;
+  mVertexStateDescriptor.cAttributes[2].offset         = 0;
+  mVertexStateDescriptor.cVertexBuffers[2].attributes =
+      &mVertexStateDescriptor.cAttributes[2];
+  mVertexStateDescriptor.cVertexBuffers[3].attributeCount = 1;
+  mVertexStateDescriptor.cVertexBuffers[3].arrayStride =
+      mTangentBuffer->getDataSize();
+  mVertexStateDescriptor.cAttributes[3].format = wgpu::VertexFormat::Float3;
+  mVertexStateDescriptor.cAttributes[3].shaderLocation = 3;
+  mVertexStateDescriptor.cAttributes[3].offset         = 0;
+  mVertexStateDescriptor.cVertexBuffers[3].attributes =
+      &mVertexStateDescriptor.cAttributes[3];
+  mVertexStateDescriptor.cVertexBuffers[4].attributeCount = 1;
+  mVertexStateDescriptor.cVertexBuffers[4].arrayStride =
+      mBiNormalBuffer->getDataSize();
+  mVertexStateDescriptor.cAttributes[4].format = wgpu::VertexFormat::Float3;
+  mVertexStateDescriptor.cAttributes[4].shaderLocation = 4;
+  mVertexStateDescriptor.cAttributes[4].offset         = 0;
+  mVertexStateDescriptor.cVertexBuffers[4].attributes =
+      &mVertexStateDescriptor.cAttributes[4];
+  mVertexStateDescriptor.vertexBufferCount = 5;
+  mVertexStateDescriptor.indexFormat       = wgpu::IndexFormat::Uint16;
 
-    mGroupLayoutModel = mContextDawn->MakeBindGroupLayout({
-        {0, wgpu::ShaderStage::Fragment, wgpu::BindingType::UniformBuffer},
-        {1, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
-        {2, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
-        {3, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false, false,
-         wgpu::TextureViewDimension::e2D, wgpu::TextureComponentType::Float},
-        {4, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false, false,
-         wgpu::TextureViewDimension::e2D, wgpu::TextureComponentType::Float},
-        {5, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false, false,
-         wgpu::TextureViewDimension::e2D, wgpu::TextureComponentType::Float},
-        {6, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false, false,
-         wgpu::TextureViewDimension::Cube, wgpu::TextureComponentType::Float},
-    });
+  mGroupLayoutModel = mContextDawn->MakeBindGroupLayout({
+      {0, wgpu::ShaderStage::Fragment, wgpu::BindingType::UniformBuffer},
+      {1, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
+      {2, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
+      {3, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false,
+       false, wgpu::TextureViewDimension::e2D,
+       wgpu::TextureComponentType::Float},
+      {4, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false,
+       false, wgpu::TextureViewDimension::e2D,
+       wgpu::TextureComponentType::Float},
+      {5, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false,
+       false, wgpu::TextureViewDimension::e2D,
+       wgpu::TextureComponentType::Float},
+      {6, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false,
+       false, wgpu::TextureViewDimension::Cube,
+       wgpu::TextureComponentType::Float},
+  });
 
-    mGroupLayoutPer = mContextDawn->MakeBindGroupLayout({
-        {0, wgpu::ShaderStage::Vertex, wgpu::BindingType::UniformBuffer},
-    });
+  mGroupLayoutPer = mContextDawn->MakeBindGroupLayout({
+      {0, wgpu::ShaderStage::Vertex, wgpu::BindingType::UniformBuffer},
+  });
 
-    mPipelineLayout = mContextDawn->MakeBasicPipelineLayout({
-        mContextDawn->groupLayoutGeneral,
-        mContextDawn->groupLayoutWorld,
-        mGroupLayoutModel,
-        mGroupLayoutPer,
-    });
+  mPipelineLayout = mContextDawn->MakeBasicPipelineLayout({
+      mContextDawn->groupLayoutGeneral,
+      mContextDawn->groupLayoutWorld,
+      mGroupLayoutModel,
+      mGroupLayoutPer,
+  });
 
-    mPipeline = mContextDawn->createRenderPipeline(mPipelineLayout, mProgramDawn,
-                                                   mVertexStateDescriptor, mBlend);
+  mPipeline = mContextDawn->createRenderPipeline(
+      mPipelineLayout, mProgramDawn, mVertexStateDescriptor, mBlend);
 
-    mInnerBuffer = mContextDawn->createBufferFromData(
-        &mInnerUniforms, sizeof(mInnerUniforms), sizeof(mInnerUniforms),
-        wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
-    mViewBuffer = mContextDawn->createBufferFromData(
-        &mWorldUniformPer, sizeof(WorldUniforms),
-        mContextDawn->CalcConstantBufferByteSize(sizeof(WorldUniforms)),
-        wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
+  mInnerBuffer = mContextDawn->createBufferFromData(
+      &mInnerUniforms, sizeof(mInnerUniforms), sizeof(mInnerUniforms),
+      wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
+  mViewBuffer = mContextDawn->createBufferFromData(
+      &mWorldUniformPer, sizeof(WorldUniforms),
+      mContextDawn->CalcConstantBufferByteSize(sizeof(WorldUniforms)),
+      wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
 
-    mBindGroupModel =
-        mContextDawn->makeBindGroup(mGroupLayoutModel, {{0, mInnerBuffer, 0, sizeof(InnerUniforms)},
-                                                        {1, mReflectionTexture->getSampler()},
-                                                        {2, mSkyboxTexture->getSampler()},
-                                                        {3, mDiffuseTexture->getTextureView()},
-                                                        {4, mNormalTexture->getTextureView()},
-                                                        {5, mReflectionTexture->getTextureView()},
-                                                        {6, mSkyboxTexture->getTextureView()}});
+  mBindGroupModel = mContextDawn->makeBindGroup(
+      mGroupLayoutModel, {{0, mInnerBuffer, 0, sizeof(InnerUniforms)},
+                          {1, mReflectionTexture->getSampler()},
+                          {2, mSkyboxTexture->getSampler()},
+                          {3, mDiffuseTexture->getTextureView()},
+                          {4, mNormalTexture->getTextureView()},
+                          {5, mReflectionTexture->getTextureView()},
+                          {6, mSkyboxTexture->getTextureView()}});
 
-    mBindGroupPer = mContextDawn->makeBindGroup(
-        mGroupLayoutPer,
-        {
-            {0, mViewBuffer, 0, mContextDawn->CalcConstantBufferByteSize(sizeof(WorldUniforms))},
-        });
+  mBindGroupPer = mContextDawn->makeBindGroup(
+      mGroupLayoutPer,
+      {
+          {0, mViewBuffer, 0,
+           mContextDawn->CalcConstantBufferByteSize(sizeof(WorldUniforms))},
+      });
 
-    mContextDawn->setBufferData(mInnerBuffer, sizeof(InnerUniforms), &mInnerUniforms,
-                                sizeof(InnerUniforms));
+  mContextDawn->setBufferData(mInnerBuffer, sizeof(InnerUniforms),
+                              &mInnerUniforms, sizeof(InnerUniforms));
 }
 
 void InnerModelDawn::prepareForDraw() {}
 
 void InnerModelDawn::draw()
 {
-    wgpu::RenderPassEncoder pass = mContextDawn->getRenderPass();
-    pass.SetPipeline(mPipeline);
-    pass.SetBindGroup(0, mContextDawn->bindGroupGeneral, 0, nullptr);
-    pass.SetBindGroup(1, mContextDawn->bindGroupWorld, 0, nullptr);
-    pass.SetBindGroup(2, mBindGroupModel, 0, nullptr);
-    pass.SetBindGroup(3, mBindGroupPer, 0, nullptr);
-    pass.SetVertexBuffer(0, mPositionBuffer->getBuffer());
-    pass.SetVertexBuffer(1, mNormalBuffer->getBuffer());
-    pass.SetVertexBuffer(2, mTexCoordBuffer->getBuffer());
-    pass.SetVertexBuffer(3, mTangentBuffer->getBuffer());
-    pass.SetVertexBuffer(4, mBiNormalBuffer->getBuffer());
-    pass.SetIndexBuffer(mIndicesBuffer->getBuffer(), 0);
-    pass.DrawIndexed(mIndicesBuffer->getTotalComponents(), 1, 0, 0, 0);
+  wgpu::RenderPassEncoder pass = mContextDawn->getRenderPass();
+  pass.SetPipeline(mPipeline);
+  pass.SetBindGroup(0, mContextDawn->bindGroupGeneral, 0, nullptr);
+  pass.SetBindGroup(1, mContextDawn->bindGroupWorld, 0, nullptr);
+  pass.SetBindGroup(2, mBindGroupModel, 0, nullptr);
+  pass.SetBindGroup(3, mBindGroupPer, 0, nullptr);
+  pass.SetVertexBuffer(0, mPositionBuffer->getBuffer());
+  pass.SetVertexBuffer(1, mNormalBuffer->getBuffer());
+  pass.SetVertexBuffer(2, mTexCoordBuffer->getBuffer());
+  pass.SetVertexBuffer(3, mTangentBuffer->getBuffer());
+  pass.SetVertexBuffer(4, mBiNormalBuffer->getBuffer());
+  pass.SetIndexBuffer(mIndicesBuffer->getBuffer(), 0);
+  pass.DrawIndexed(mIndicesBuffer->getTotalComponents(), 1, 0, 0, 0);
 }
 
-void InnerModelDawn::updatePerInstanceUniforms(const WorldUniforms &worldUniforms)
+void InnerModelDawn::updatePerInstanceUniforms(
+    const WorldUniforms &worldUniforms)
 {
-    std::memcpy(&mWorldUniformPer, &worldUniforms, sizeof(WorldUniforms));
+  std::memcpy(&mWorldUniformPer, &worldUniforms, sizeof(WorldUniforms));
 
-    mContextDawn->updateBufferData(mViewBuffer,
-                                   mContextDawn->CalcConstantBufferByteSize(sizeof(WorldUniforms)),
-                                   &mWorldUniformPer, sizeof(WorldUniforms));
+  mContextDawn->updateBufferData(
+      mViewBuffer,
+      mContextDawn->CalcConstantBufferByteSize(sizeof(WorldUniforms)),
+      &mWorldUniformPer, sizeof(WorldUniforms));
 }

--- a/src/aquarium-optimized/dawn/InnerModelDawn.h
+++ b/src/aquarium-optimized/dawn/InnerModelDawn.h
@@ -17,58 +17,58 @@
 
 class InnerModelDawn : public Model
 {
-  public:
-    InnerModelDawn(Context *context,
-                   Aquarium *aquarium,
-                   MODELGROUP type,
-                   MODELNAME name,
-                   bool blend);
-    ~InnerModelDawn();
+public:
+  InnerModelDawn(Context *context,
+                 Aquarium *aquarium,
+                 MODELGROUP type,
+                 MODELNAME name,
+                 bool blend);
+  ~InnerModelDawn();
 
-    void init() override;
-    void prepareForDraw() override;
-    void draw() override;
-    void updatePerInstanceUniforms(const WorldUniforms &WorldUniforms) override;
+  void init() override;
+  void prepareForDraw() override;
+  void draw() override;
+  void updatePerInstanceUniforms(const WorldUniforms &WorldUniforms) override;
 
-    struct InnerUniforms
-    {
-        float eta;
-        float tankColorFudge;
-        float refractionFudge;
-        float padding;
-    } mInnerUniforms;
+  struct InnerUniforms
+  {
+    float eta;
+    float tankColorFudge;
+    float refractionFudge;
+    float padding;
+  } mInnerUniforms;
 
-    WorldUniforms mWorldUniformPer;
+  WorldUniforms mWorldUniformPer;
 
-    TextureDawn *mDiffuseTexture;
-    TextureDawn *mNormalTexture;
-    TextureDawn *mReflectionTexture;
-    TextureDawn *mSkyboxTexture;
+  TextureDawn *mDiffuseTexture;
+  TextureDawn *mNormalTexture;
+  TextureDawn *mReflectionTexture;
+  TextureDawn *mSkyboxTexture;
 
-    BufferDawn *mPositionBuffer;
-    BufferDawn *mNormalBuffer;
-    BufferDawn *mTexCoordBuffer;
-    BufferDawn *mTangentBuffer;
-    BufferDawn *mBiNormalBuffer;
+  BufferDawn *mPositionBuffer;
+  BufferDawn *mNormalBuffer;
+  BufferDawn *mTexCoordBuffer;
+  BufferDawn *mTangentBuffer;
+  BufferDawn *mBiNormalBuffer;
 
-    BufferDawn *mIndicesBuffer;
+  BufferDawn *mIndicesBuffer;
 
-  private:
-    utils::ComboVertexStateDescriptor mVertexStateDescriptor;
-    wgpu::RenderPipeline mPipeline;
+private:
+  utils::ComboVertexStateDescriptor mVertexStateDescriptor;
+  wgpu::RenderPipeline mPipeline;
 
-    wgpu::BindGroupLayout mGroupLayoutModel;
-    wgpu::BindGroupLayout mGroupLayoutPer;
-    wgpu::PipelineLayout mPipelineLayout;
+  wgpu::BindGroupLayout mGroupLayoutModel;
+  wgpu::BindGroupLayout mGroupLayoutPer;
+  wgpu::PipelineLayout mPipelineLayout;
 
-    wgpu::BindGroup mBindGroupModel;
-    wgpu::BindGroup mBindGroupPer;
+  wgpu::BindGroup mBindGroupModel;
+  wgpu::BindGroup mBindGroupPer;
 
-    wgpu::Buffer mInnerBuffer;
-    wgpu::Buffer mViewBuffer;
+  wgpu::Buffer mInnerBuffer;
+  wgpu::Buffer mViewBuffer;
 
-    ContextDawn *mContextDawn;
-    ProgramDawn *mProgramDawn;
+  ContextDawn *mContextDawn;
+  ProgramDawn *mProgramDawn;
 };
 
 #endif  // INNERMODELDAWN_H

--- a/src/aquarium-optimized/dawn/OutsideModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/OutsideModelDawn.cpp
@@ -13,147 +13,163 @@ OutsideModelDawn::OutsideModelDawn(Context *context,
                                    bool blend)
     : Model(type, name, blend)
 {
-    mContextDawn = static_cast<ContextDawn *>(context);
+  mContextDawn = static_cast<ContextDawn *>(context);
 
-    mLightFactorUniforms.shininess      = 50.0f;
-    mLightFactorUniforms.specularFactor = 0.0f;
+  mLightFactorUniforms.shininess      = 50.0f;
+  mLightFactorUniforms.specularFactor = 0.0f;
 }
 
 OutsideModelDawn::~OutsideModelDawn()
 {
-    mPipeline          = nullptr;
-    mGroupLayoutModel  = nullptr;
-    mGroupLayoutPer    = nullptr;
-    mPipelineLayout    = nullptr;
-    mBindGroupModel    = nullptr;
-    mBindGroupPer      = nullptr;
-    mLightFactorBuffer = nullptr;
-    mViewBuffer        = nullptr;
+  mPipeline          = nullptr;
+  mGroupLayoutModel  = nullptr;
+  mGroupLayoutPer    = nullptr;
+  mPipelineLayout    = nullptr;
+  mBindGroupModel    = nullptr;
+  mBindGroupPer      = nullptr;
+  mLightFactorBuffer = nullptr;
+  mViewBuffer        = nullptr;
 }
 
 void OutsideModelDawn::init()
 {
-    mProgramDawn = static_cast<ProgramDawn *>(mProgram);
+  mProgramDawn = static_cast<ProgramDawn *>(mProgram);
 
-    mDiffuseTexture    = static_cast<TextureDawn *>(textureMap["diffuse"]);
-    mNormalTexture     = static_cast<TextureDawn *>(textureMap["normalMap"]);
-    mReflectionTexture = static_cast<TextureDawn *>(textureMap["reflectionMap"]);
-    mSkyboxTexture     = static_cast<TextureDawn *>(textureMap["skybox"]);
+  mDiffuseTexture    = static_cast<TextureDawn *>(textureMap["diffuse"]);
+  mNormalTexture     = static_cast<TextureDawn *>(textureMap["normalMap"]);
+  mReflectionTexture = static_cast<TextureDawn *>(textureMap["reflectionMap"]);
+  mSkyboxTexture     = static_cast<TextureDawn *>(textureMap["skybox"]);
 
-    mPositionBuffer = static_cast<BufferDawn *>(bufferMap["position"]);
-    mNormalBuffer   = static_cast<BufferDawn *>(bufferMap["normal"]);
-    mTexCoordBuffer = static_cast<BufferDawn *>(bufferMap["texCoord"]);
-    mTangentBuffer  = static_cast<BufferDawn *>(bufferMap["tangent"]);
-    mBiNormalBuffer = static_cast<BufferDawn *>(bufferMap["binormal"]);
-    mIndicesBuffer  = static_cast<BufferDawn *>(bufferMap["indices"]);
+  mPositionBuffer = static_cast<BufferDawn *>(bufferMap["position"]);
+  mNormalBuffer   = static_cast<BufferDawn *>(bufferMap["normal"]);
+  mTexCoordBuffer = static_cast<BufferDawn *>(bufferMap["texCoord"]);
+  mTangentBuffer  = static_cast<BufferDawn *>(bufferMap["tangent"]);
+  mBiNormalBuffer = static_cast<BufferDawn *>(bufferMap["binormal"]);
+  mIndicesBuffer  = static_cast<BufferDawn *>(bufferMap["indices"]);
 
-    mVertexStateDescriptor.cVertexBuffers[0].attributeCount = 1;
-    mVertexStateDescriptor.cVertexBuffers[0].arrayStride    = mPositionBuffer->getDataSize();
-    mVertexStateDescriptor.cAttributes[0].format            = wgpu::VertexFormat::Float3;
-    mVertexStateDescriptor.cAttributes[0].shaderLocation    = 0;
-    mVertexStateDescriptor.cAttributes[0].offset            = 0;
-    mVertexStateDescriptor.cVertexBuffers[0].attributes = &mVertexStateDescriptor.cAttributes[0];
-    mVertexStateDescriptor.cVertexBuffers[1].attributeCount = 1;
-    mVertexStateDescriptor.cVertexBuffers[1].arrayStride    = mNormalBuffer->getDataSize();
-    mVertexStateDescriptor.cAttributes[1].format            = wgpu::VertexFormat::Float3;
-    mVertexStateDescriptor.cAttributes[1].shaderLocation    = 1;
-    mVertexStateDescriptor.cAttributes[1].offset            = 0;
-    mVertexStateDescriptor.cVertexBuffers[1].attributes = &mVertexStateDescriptor.cAttributes[1];
-    mVertexStateDescriptor.cVertexBuffers[2].attributeCount = 1;
-    mVertexStateDescriptor.cVertexBuffers[2].arrayStride    = mTexCoordBuffer->getDataSize();
-    mVertexStateDescriptor.cAttributes[2].format            = wgpu::VertexFormat::Float2;
-    mVertexStateDescriptor.cAttributes[2].shaderLocation    = 2;
-    mVertexStateDescriptor.cAttributes[2].offset            = 0;
-    mVertexStateDescriptor.cVertexBuffers[2].attributes = &mVertexStateDescriptor.cAttributes[2];
-    mVertexStateDescriptor.cVertexBuffers[3].attributeCount = 1;
-    mVertexStateDescriptor.cVertexBuffers[3].arrayStride    = mTangentBuffer->getDataSize();
-    mVertexStateDescriptor.cAttributes[3].format            = wgpu::VertexFormat::Float3;
-    mVertexStateDescriptor.cAttributes[3].shaderLocation    = 3;
-    mVertexStateDescriptor.cAttributes[3].offset            = 0;
-    mVertexStateDescriptor.cVertexBuffers[3].attributes = &mVertexStateDescriptor.cAttributes[3];
-    mVertexStateDescriptor.cVertexBuffers[4].attributeCount = 1;
-    mVertexStateDescriptor.cVertexBuffers[4].arrayStride    = mBiNormalBuffer->getDataSize();
-    mVertexStateDescriptor.cAttributes[4].format            = wgpu::VertexFormat::Float3;
-    mVertexStateDescriptor.cAttributes[4].shaderLocation    = 4;
-    mVertexStateDescriptor.cAttributes[4].offset            = 0;
-    mVertexStateDescriptor.cVertexBuffers[4].attributes = &mVertexStateDescriptor.cAttributes[4];
-    mVertexStateDescriptor.vertexBufferCount            = 5;
-    mVertexStateDescriptor.indexFormat                  = wgpu::IndexFormat::Uint16;
+  mVertexStateDescriptor.cVertexBuffers[0].attributeCount = 1;
+  mVertexStateDescriptor.cVertexBuffers[0].arrayStride =
+      mPositionBuffer->getDataSize();
+  mVertexStateDescriptor.cAttributes[0].format = wgpu::VertexFormat::Float3;
+  mVertexStateDescriptor.cAttributes[0].shaderLocation = 0;
+  mVertexStateDescriptor.cAttributes[0].offset         = 0;
+  mVertexStateDescriptor.cVertexBuffers[0].attributes =
+      &mVertexStateDescriptor.cAttributes[0];
+  mVertexStateDescriptor.cVertexBuffers[1].attributeCount = 1;
+  mVertexStateDescriptor.cVertexBuffers[1].arrayStride =
+      mNormalBuffer->getDataSize();
+  mVertexStateDescriptor.cAttributes[1].format = wgpu::VertexFormat::Float3;
+  mVertexStateDescriptor.cAttributes[1].shaderLocation = 1;
+  mVertexStateDescriptor.cAttributes[1].offset         = 0;
+  mVertexStateDescriptor.cVertexBuffers[1].attributes =
+      &mVertexStateDescriptor.cAttributes[1];
+  mVertexStateDescriptor.cVertexBuffers[2].attributeCount = 1;
+  mVertexStateDescriptor.cVertexBuffers[2].arrayStride =
+      mTexCoordBuffer->getDataSize();
+  mVertexStateDescriptor.cAttributes[2].format = wgpu::VertexFormat::Float2;
+  mVertexStateDescriptor.cAttributes[2].shaderLocation = 2;
+  mVertexStateDescriptor.cAttributes[2].offset         = 0;
+  mVertexStateDescriptor.cVertexBuffers[2].attributes =
+      &mVertexStateDescriptor.cAttributes[2];
+  mVertexStateDescriptor.cVertexBuffers[3].attributeCount = 1;
+  mVertexStateDescriptor.cVertexBuffers[3].arrayStride =
+      mTangentBuffer->getDataSize();
+  mVertexStateDescriptor.cAttributes[3].format = wgpu::VertexFormat::Float3;
+  mVertexStateDescriptor.cAttributes[3].shaderLocation = 3;
+  mVertexStateDescriptor.cAttributes[3].offset         = 0;
+  mVertexStateDescriptor.cVertexBuffers[3].attributes =
+      &mVertexStateDescriptor.cAttributes[3];
+  mVertexStateDescriptor.cVertexBuffers[4].attributeCount = 1;
+  mVertexStateDescriptor.cVertexBuffers[4].arrayStride =
+      mBiNormalBuffer->getDataSize();
+  mVertexStateDescriptor.cAttributes[4].format = wgpu::VertexFormat::Float3;
+  mVertexStateDescriptor.cAttributes[4].shaderLocation = 4;
+  mVertexStateDescriptor.cAttributes[4].offset         = 0;
+  mVertexStateDescriptor.cVertexBuffers[4].attributes =
+      &mVertexStateDescriptor.cAttributes[4];
+  mVertexStateDescriptor.vertexBufferCount = 5;
+  mVertexStateDescriptor.indexFormat       = wgpu::IndexFormat::Uint16;
 
-    mGroupLayoutPer = mContextDawn->MakeBindGroupLayout({
-        {0, wgpu::ShaderStage::Vertex, wgpu::BindingType::UniformBuffer},
-    });
+  mGroupLayoutPer = mContextDawn->MakeBindGroupLayout({
+      {0, wgpu::ShaderStage::Vertex, wgpu::BindingType::UniformBuffer},
+  });
 
-    // Outside models use diffuse shaders.
-    mGroupLayoutModel = mContextDawn->MakeBindGroupLayout({
-        {0, wgpu::ShaderStage::Fragment, wgpu::BindingType::UniformBuffer},
-        {1, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
-        {2, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture},
-    });
+  // Outside models use diffuse shaders.
+  mGroupLayoutModel = mContextDawn->MakeBindGroupLayout({
+      {0, wgpu::ShaderStage::Fragment, wgpu::BindingType::UniformBuffer},
+      {1, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
+      {2, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture},
+  });
 
-    mPipelineLayout = mContextDawn->MakeBasicPipelineLayout({
-        mContextDawn->groupLayoutGeneral,
-        mContextDawn->groupLayoutWorld,
-        mGroupLayoutModel,
-        mGroupLayoutPer,
-    });
+  mPipelineLayout = mContextDawn->MakeBasicPipelineLayout({
+      mContextDawn->groupLayoutGeneral,
+      mContextDawn->groupLayoutWorld,
+      mGroupLayoutModel,
+      mGroupLayoutPer,
+  });
 
-    mPipeline = mContextDawn->createRenderPipeline(mPipelineLayout, mProgramDawn,
-                                                   mVertexStateDescriptor, mBlend);
+  mPipeline = mContextDawn->createRenderPipeline(
+      mPipelineLayout, mProgramDawn, mVertexStateDescriptor, mBlend);
 
-    mLightFactorBuffer = mContextDawn->createBufferFromData(
-        &mLightFactorUniforms, sizeof(mLightFactorUniforms), sizeof(mLightFactorUniforms),
-        wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
-    mViewBuffer = mContextDawn->createBufferFromData(
-        &mWorldUniformPer, sizeof(WorldUniforms) * 20,
-        mContextDawn->CalcConstantBufferByteSize(sizeof(WorldUniforms) * 20),
-        wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
+  mLightFactorBuffer = mContextDawn->createBufferFromData(
+      &mLightFactorUniforms, sizeof(mLightFactorUniforms),
+      sizeof(mLightFactorUniforms),
+      wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
+  mViewBuffer = mContextDawn->createBufferFromData(
+      &mWorldUniformPer, sizeof(WorldUniforms) * 20,
+      mContextDawn->CalcConstantBufferByteSize(sizeof(WorldUniforms) * 20),
+      wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
 
-    mBindGroupModel = mContextDawn->makeBindGroup(
-        mGroupLayoutModel, {
-                               {0, mLightFactorBuffer, 0, sizeof(LightFactorUniforms)},
-                               {1, mDiffuseTexture->getSampler()},
-                               {2, mDiffuseTexture->getTextureView()},
-                           });
+  mBindGroupModel = mContextDawn->makeBindGroup(
+      mGroupLayoutModel,
+      {
+          {0, mLightFactorBuffer, 0, sizeof(LightFactorUniforms)},
+          {1, mDiffuseTexture->getSampler()},
+          {2, mDiffuseTexture->getTextureView()},
+      });
 
-    mBindGroupPer = mContextDawn->makeBindGroup(
-        mGroupLayoutPer, {
-                             {0, mViewBuffer, 0,
-                              mContextDawn->CalcConstantBufferByteSize(sizeof(WorldUniforms) * 20)},
-                         });
+  mBindGroupPer = mContextDawn->makeBindGroup(
+      mGroupLayoutPer, {
+                           {0, mViewBuffer, 0,
+                            mContextDawn->CalcConstantBufferByteSize(
+                                sizeof(WorldUniforms) * 20)},
+                       });
 
-    mContextDawn->setBufferData(mLightFactorBuffer, sizeof(LightFactorUniforms),
-                                &mLightFactorUniforms, sizeof(LightFactorUniforms));
+  mContextDawn->setBufferData(mLightFactorBuffer, sizeof(LightFactorUniforms),
+                              &mLightFactorUniforms,
+                              sizeof(LightFactorUniforms));
 }
 
 void OutsideModelDawn::prepareForDraw() {}
 
 void OutsideModelDawn::draw()
 {
-    wgpu::RenderPassEncoder pass = mContextDawn->getRenderPass();
-    pass.SetPipeline(mPipeline);
-    pass.SetBindGroup(0, mContextDawn->bindGroupGeneral, 0, nullptr);
-    pass.SetBindGroup(1, mContextDawn->bindGroupWorld, 0, nullptr);
-    pass.SetBindGroup(2, mBindGroupModel, 0, nullptr);
-    pass.SetBindGroup(3, mBindGroupPer, 0, nullptr);
-    pass.SetVertexBuffer(0, mPositionBuffer->getBuffer());
-    pass.SetVertexBuffer(1, mNormalBuffer->getBuffer());
-    pass.SetVertexBuffer(2, mTexCoordBuffer->getBuffer());
-    // diffuseShader doesn't have to input tangent buffer or binormal buffer.
-    if (mTangentBuffer && mBiNormalBuffer)
-    {
-        pass.SetVertexBuffer(3, mTangentBuffer->getBuffer());
-        pass.SetVertexBuffer(4, mBiNormalBuffer->getBuffer());
-    }
-    pass.SetIndexBuffer(mIndicesBuffer->getBuffer(), 0);
-    pass.DrawIndexed(mIndicesBuffer->getTotalComponents(), 1, 0, 0, 0);
+  wgpu::RenderPassEncoder pass = mContextDawn->getRenderPass();
+  pass.SetPipeline(mPipeline);
+  pass.SetBindGroup(0, mContextDawn->bindGroupGeneral, 0, nullptr);
+  pass.SetBindGroup(1, mContextDawn->bindGroupWorld, 0, nullptr);
+  pass.SetBindGroup(2, mBindGroupModel, 0, nullptr);
+  pass.SetBindGroup(3, mBindGroupPer, 0, nullptr);
+  pass.SetVertexBuffer(0, mPositionBuffer->getBuffer());
+  pass.SetVertexBuffer(1, mNormalBuffer->getBuffer());
+  pass.SetVertexBuffer(2, mTexCoordBuffer->getBuffer());
+  // diffuseShader doesn't have to input tangent buffer or binormal buffer.
+  if (mTangentBuffer && mBiNormalBuffer)
+  {
+    pass.SetVertexBuffer(3, mTangentBuffer->getBuffer());
+    pass.SetVertexBuffer(4, mBiNormalBuffer->getBuffer());
+  }
+  pass.SetIndexBuffer(mIndicesBuffer->getBuffer(), 0);
+  pass.DrawIndexed(mIndicesBuffer->getTotalComponents(), 1, 0, 0, 0);
 }
 
-void OutsideModelDawn::updatePerInstanceUniforms(const WorldUniforms &worldUniforms)
+void OutsideModelDawn::updatePerInstanceUniforms(
+    const WorldUniforms &worldUniforms)
 {
-    memcpy(&mWorldUniformPer, &worldUniforms, sizeof(WorldUniforms));
+  memcpy(&mWorldUniformPer, &worldUniforms, sizeof(WorldUniforms));
 
-    mContextDawn->updateBufferData(
-        mViewBuffer, mContextDawn->CalcConstantBufferByteSize(sizeof(WorldUniforms) * 20),
-        &mWorldUniformPer, sizeof(WorldUniforms));
+  mContextDawn->updateBufferData(
+      mViewBuffer,
+      mContextDawn->CalcConstantBufferByteSize(sizeof(WorldUniforms) * 20),
+      &mWorldUniformPer, sizeof(WorldUniforms));
 }

--- a/src/aquarium-optimized/dawn/OutsideModelDawn.h
+++ b/src/aquarium-optimized/dawn/OutsideModelDawn.h
@@ -17,57 +17,57 @@
 
 class OutsideModelDawn : public Model
 {
-  public:
-    OutsideModelDawn(Context *context,
-                     Aquarium *aquarium,
-                     MODELGROUP type,
-                     MODELNAME name,
-                     bool blend);
-    ~OutsideModelDawn();
+public:
+  OutsideModelDawn(Context *context,
+                   Aquarium *aquarium,
+                   MODELGROUP type,
+                   MODELNAME name,
+                   bool blend);
+  ~OutsideModelDawn();
 
-    void init() override;
-    void prepareForDraw() override;
-    void draw() override;
+  void init() override;
+  void prepareForDraw() override;
+  void draw() override;
 
-    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
+  void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
 
-    TextureDawn *mDiffuseTexture;
-    TextureDawn *mNormalTexture;
-    TextureDawn *mReflectionTexture;
-    TextureDawn *mSkyboxTexture;
+  TextureDawn *mDiffuseTexture;
+  TextureDawn *mNormalTexture;
+  TextureDawn *mReflectionTexture;
+  TextureDawn *mSkyboxTexture;
 
-    BufferDawn *mPositionBuffer;
-    BufferDawn *mNormalBuffer;
-    BufferDawn *mTexCoordBuffer;
-    BufferDawn *mTangentBuffer;
-    BufferDawn *mBiNormalBuffer;
+  BufferDawn *mPositionBuffer;
+  BufferDawn *mNormalBuffer;
+  BufferDawn *mTexCoordBuffer;
+  BufferDawn *mTangentBuffer;
+  BufferDawn *mBiNormalBuffer;
 
-    BufferDawn *mIndicesBuffer;
+  BufferDawn *mIndicesBuffer;
 
-    struct LightFactorUniforms
-    {
-        float shininess;
-        float specularFactor;
-    } mLightFactorUniforms;
+  struct LightFactorUniforms
+  {
+    float shininess;
+    float specularFactor;
+  } mLightFactorUniforms;
 
-    WorldUniforms mWorldUniformPer[20];
+  WorldUniforms mWorldUniformPer[20];
 
-  private:
-    utils::ComboVertexStateDescriptor mVertexStateDescriptor;
-    wgpu::RenderPipeline mPipeline;
+private:
+  utils::ComboVertexStateDescriptor mVertexStateDescriptor;
+  wgpu::RenderPipeline mPipeline;
 
-    wgpu::BindGroupLayout mGroupLayoutModel;
-    wgpu::BindGroupLayout mGroupLayoutPer;
-    wgpu::PipelineLayout mPipelineLayout;
+  wgpu::BindGroupLayout mGroupLayoutModel;
+  wgpu::BindGroupLayout mGroupLayoutPer;
+  wgpu::PipelineLayout mPipelineLayout;
 
-    wgpu::BindGroup mBindGroupModel;
-    wgpu::BindGroup mBindGroupPer;
+  wgpu::BindGroup mBindGroupModel;
+  wgpu::BindGroup mBindGroupPer;
 
-    wgpu::Buffer mLightFactorBuffer;
-    wgpu::Buffer mViewBuffer;
+  wgpu::Buffer mLightFactorBuffer;
+  wgpu::Buffer mViewBuffer;
 
-    ContextDawn *mContextDawn;
-    ProgramDawn *mProgramDawn;
+  ContextDawn *mContextDawn;
+  ProgramDawn *mProgramDawn;
 };
 
 #endif  // OUTSIDEMODELDAWN_H

--- a/src/aquarium-optimized/dawn/ProgramDawn.cpp
+++ b/src/aquarium-optimized/dawn/ProgramDawn.cpp
@@ -13,32 +13,39 @@
 #include "ContextDawn.h"
 #include "common/AQUARIUM_ASSERT.h"
 
-ProgramDawn::ProgramDawn(ContextDawn *context, const std::string &mVId, const std::string &mFId)
-    : Program(mVId, mFId), mVsModule(nullptr), mFsModule(nullptr), context(context)
+ProgramDawn::ProgramDawn(ContextDawn *context,
+                         const std::string &mVId,
+                         const std::string &mFId)
+    : Program(mVId, mFId),
+      mVsModule(nullptr),
+      mFsModule(nullptr),
+      context(context)
 {
 }
 
 ProgramDawn::~ProgramDawn()
 {
-    mVsModule = nullptr;
-    mFsModule = nullptr;
+  mVsModule = nullptr;
+  mFsModule = nullptr;
 }
 
 void ProgramDawn::compileProgram(bool enableBlending, const std::string &alpha)
 {
-    loadProgram();
+  loadProgram();
 
-    FragmentShaderCode =
-        std::regex_replace(FragmentShaderCode, std::regex(R"(\n.*?// #noReflection)"), "");
-    FragmentShaderCode =
-        std::regex_replace(FragmentShaderCode, std::regex(R"(\n.*?// #noNormalMap)"), "");
+  FragmentShaderCode = std::regex_replace(
+      FragmentShaderCode, std::regex(R"(\n.*?// #noReflection)"), "");
+  FragmentShaderCode = std::regex_replace(
+      FragmentShaderCode, std::regex(R"(\n.*?// #noNormalMap)"), "");
 
-    if (enableBlending)
-    {
-        FragmentShaderCode =
-            std::regex_replace(FragmentShaderCode, std::regex(R"(diffuseColor.a)"), alpha);
-    }
+  if (enableBlending)
+  {
+    FragmentShaderCode = std::regex_replace(
+        FragmentShaderCode, std::regex(R"(diffuseColor.a)"), alpha);
+  }
 
-    mVsModule = context->createShaderModule(utils::SingleShaderStage::Vertex, VertexShaderCode);
-    mFsModule = context->createShaderModule(utils::SingleShaderStage::Fragment, FragmentShaderCode);
+  mVsModule = context->createShaderModule(utils::SingleShaderStage::Vertex,
+                                          VertexShaderCode);
+  mFsModule = context->createShaderModule(utils::SingleShaderStage::Fragment,
+                                          FragmentShaderCode);
 }

--- a/src/aquarium-optimized/dawn/ProgramDawn.h
+++ b/src/aquarium-optimized/dawn/ProgramDawn.h
@@ -21,20 +21,23 @@ class ContextDawn;
 
 class ProgramDawn : public Program
 {
-  public:
-    ProgramDawn() {}
-    ProgramDawn(ContextDawn *context, const std::string &mVId, const std::string &mFId);
-    ~ProgramDawn() override;
+public:
+  ProgramDawn() {}
+  ProgramDawn(ContextDawn *context,
+              const std::string &mVId,
+              const std::string &mFId);
+  ~ProgramDawn() override;
 
-    void compileProgram(bool enableAlphaBlending, const std::string &alpha) override;
-    wgpu::ShaderModule getVSModule() { return mVsModule; }
-    wgpu::ShaderModule getFSModule() { return mFsModule; }
+  void compileProgram(bool enableAlphaBlending,
+                      const std::string &alpha) override;
+  wgpu::ShaderModule getVSModule() { return mVsModule; }
+  wgpu::ShaderModule getFSModule() { return mFsModule; }
 
-  private:
-    wgpu::ShaderModule mVsModule;
-    wgpu::ShaderModule mFsModule;
+private:
+  wgpu::ShaderModule mVsModule;
+  wgpu::ShaderModule mFsModule;
 
-    ContextDawn *context;
+  ContextDawn *context;
 };
 
 #endif  // PROGRAMDAWN_H

--- a/src/aquarium-optimized/dawn/SeaweedModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/SeaweedModelDawn.cpp
@@ -14,145 +14,160 @@ SeaweedModelDawn::SeaweedModelDawn(Context *context,
                                    bool blend)
     : SeaweedModel(type, name, blend), instance(0)
 {
-    mContextDawn = static_cast<ContextDawn *>(context);
-    mAquarium    = aquarium;
+  mContextDawn = static_cast<ContextDawn *>(context);
+  mAquarium    = aquarium;
 
-    mLightFactorUniforms.shininess      = 50.0f;
-    mLightFactorUniforms.specularFactor = 1.0f;
+  mLightFactorUniforms.shininess      = 50.0f;
+  mLightFactorUniforms.specularFactor = 1.0f;
 }
 
 SeaweedModelDawn::~SeaweedModelDawn()
 {
-    mPipeline          = nullptr;
-    mGroupLayoutModel  = nullptr;
-    mGroupLayoutPer    = nullptr;
-    mPipelineLayout    = nullptr;
-    mBindGroupModel    = nullptr;
-    mBindGroupPer      = nullptr;
-    mLightFactorBuffer = nullptr;
-    mViewBuffer        = nullptr;
-    mTimeBuffer        = nullptr;
+  mPipeline          = nullptr;
+  mGroupLayoutModel  = nullptr;
+  mGroupLayoutPer    = nullptr;
+  mPipelineLayout    = nullptr;
+  mBindGroupModel    = nullptr;
+  mBindGroupPer      = nullptr;
+  mLightFactorBuffer = nullptr;
+  mViewBuffer        = nullptr;
+  mTimeBuffer        = nullptr;
 }
 
 void SeaweedModelDawn::init()
 {
-    mProgramDawn = static_cast<ProgramDawn *>(mProgram);
+  mProgramDawn = static_cast<ProgramDawn *>(mProgram);
 
-    mDiffuseTexture    = static_cast<TextureDawn *>(textureMap["diffuse"]);
-    mNormalTexture     = static_cast<TextureDawn *>(textureMap["normalMap"]);
-    mReflectionTexture = static_cast<TextureDawn *>(textureMap["reflectionMap"]);
-    mSkyboxTexture     = static_cast<TextureDawn *>(textureMap["skybox"]);
+  mDiffuseTexture    = static_cast<TextureDawn *>(textureMap["diffuse"]);
+  mNormalTexture     = static_cast<TextureDawn *>(textureMap["normalMap"]);
+  mReflectionTexture = static_cast<TextureDawn *>(textureMap["reflectionMap"]);
+  mSkyboxTexture     = static_cast<TextureDawn *>(textureMap["skybox"]);
 
-    mPositionBuffer = static_cast<BufferDawn *>(bufferMap["position"]);
-    mNormalBuffer   = static_cast<BufferDawn *>(bufferMap["normal"]);
-    mTexCoordBuffer = static_cast<BufferDawn *>(bufferMap["texCoord"]);
-    mIndicesBuffer  = static_cast<BufferDawn *>(bufferMap["indices"]);
+  mPositionBuffer = static_cast<BufferDawn *>(bufferMap["position"]);
+  mNormalBuffer   = static_cast<BufferDawn *>(bufferMap["normal"]);
+  mTexCoordBuffer = static_cast<BufferDawn *>(bufferMap["texCoord"]);
+  mIndicesBuffer  = static_cast<BufferDawn *>(bufferMap["indices"]);
 
-    mVertexStateDescriptor.cVertexBuffers[0].attributeCount = 1;
-    mVertexStateDescriptor.cVertexBuffers[0].arrayStride    = mPositionBuffer->getDataSize();
-    mVertexStateDescriptor.cAttributes[0].format            = wgpu::VertexFormat::Float3;
-    mVertexStateDescriptor.cAttributes[0].shaderLocation    = 0;
-    mVertexStateDescriptor.cAttributes[0].offset            = 0;
-    mVertexStateDescriptor.cVertexBuffers[0].attributes = &mVertexStateDescriptor.cAttributes[0];
-    mVertexStateDescriptor.cVertexBuffers[1].attributeCount = 1;
-    mVertexStateDescriptor.cVertexBuffers[1].arrayStride    = mNormalBuffer->getDataSize();
-    mVertexStateDescriptor.cAttributes[1].format            = wgpu::VertexFormat::Float3;
-    mVertexStateDescriptor.cAttributes[1].shaderLocation    = 1;
-    mVertexStateDescriptor.cAttributes[1].offset            = 0;
-    mVertexStateDescriptor.cVertexBuffers[1].attributes = &mVertexStateDescriptor.cAttributes[1];
-    mVertexStateDescriptor.cVertexBuffers[2].attributeCount = 1;
-    mVertexStateDescriptor.cVertexBuffers[2].arrayStride    = mTexCoordBuffer->getDataSize();
-    mVertexStateDescriptor.cAttributes[2].format            = wgpu::VertexFormat::Float2;
-    mVertexStateDescriptor.cAttributes[2].shaderLocation    = 2;
-    mVertexStateDescriptor.cAttributes[2].offset            = 0;
-    mVertexStateDescriptor.cVertexBuffers[2].attributes = &mVertexStateDescriptor.cAttributes[2];
-    mVertexStateDescriptor.vertexBufferCount            = 3;
-    mVertexStateDescriptor.indexFormat                  = wgpu::IndexFormat::Uint16;
+  mVertexStateDescriptor.cVertexBuffers[0].attributeCount = 1;
+  mVertexStateDescriptor.cVertexBuffers[0].arrayStride =
+      mPositionBuffer->getDataSize();
+  mVertexStateDescriptor.cAttributes[0].format = wgpu::VertexFormat::Float3;
+  mVertexStateDescriptor.cAttributes[0].shaderLocation = 0;
+  mVertexStateDescriptor.cAttributes[0].offset         = 0;
+  mVertexStateDescriptor.cVertexBuffers[0].attributes =
+      &mVertexStateDescriptor.cAttributes[0];
+  mVertexStateDescriptor.cVertexBuffers[1].attributeCount = 1;
+  mVertexStateDescriptor.cVertexBuffers[1].arrayStride =
+      mNormalBuffer->getDataSize();
+  mVertexStateDescriptor.cAttributes[1].format = wgpu::VertexFormat::Float3;
+  mVertexStateDescriptor.cAttributes[1].shaderLocation = 1;
+  mVertexStateDescriptor.cAttributes[1].offset         = 0;
+  mVertexStateDescriptor.cVertexBuffers[1].attributes =
+      &mVertexStateDescriptor.cAttributes[1];
+  mVertexStateDescriptor.cVertexBuffers[2].attributeCount = 1;
+  mVertexStateDescriptor.cVertexBuffers[2].arrayStride =
+      mTexCoordBuffer->getDataSize();
+  mVertexStateDescriptor.cAttributes[2].format = wgpu::VertexFormat::Float2;
+  mVertexStateDescriptor.cAttributes[2].shaderLocation = 2;
+  mVertexStateDescriptor.cAttributes[2].offset         = 0;
+  mVertexStateDescriptor.cVertexBuffers[2].attributes =
+      &mVertexStateDescriptor.cAttributes[2];
+  mVertexStateDescriptor.vertexBufferCount = 3;
+  mVertexStateDescriptor.indexFormat       = wgpu::IndexFormat::Uint16;
 
-    mGroupLayoutModel = mContextDawn->MakeBindGroupLayout({
-        {0, wgpu::ShaderStage::Fragment, wgpu::BindingType::UniformBuffer},
-        {1, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
-        {2, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false, false,
-         wgpu::TextureViewDimension::e2D, wgpu::TextureComponentType::Float},
-    });
+  mGroupLayoutModel = mContextDawn->MakeBindGroupLayout({
+      {0, wgpu::ShaderStage::Fragment, wgpu::BindingType::UniformBuffer},
+      {1, wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
+      {2, wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture, false,
+       false, wgpu::TextureViewDimension::e2D,
+       wgpu::TextureComponentType::Float},
+  });
 
-    mGroupLayoutPer = mContextDawn->MakeBindGroupLayout({
-        {0, wgpu::ShaderStage::Vertex, wgpu::BindingType::UniformBuffer},
-        {1, wgpu::ShaderStage::Vertex, wgpu::BindingType::UniformBuffer},
-    });
+  mGroupLayoutPer = mContextDawn->MakeBindGroupLayout({
+      {0, wgpu::ShaderStage::Vertex, wgpu::BindingType::UniformBuffer},
+      {1, wgpu::ShaderStage::Vertex, wgpu::BindingType::UniformBuffer},
+  });
 
-    mPipelineLayout = mContextDawn->MakeBasicPipelineLayout({
-        mContextDawn->groupLayoutGeneral,
-        mContextDawn->groupLayoutWorld,
-        mGroupLayoutModel,
-        mGroupLayoutPer,
-    });
+  mPipelineLayout = mContextDawn->MakeBasicPipelineLayout({
+      mContextDawn->groupLayoutGeneral,
+      mContextDawn->groupLayoutWorld,
+      mGroupLayoutModel,
+      mGroupLayoutPer,
+  });
 
-    mPipeline = mContextDawn->createRenderPipeline(mPipelineLayout, mProgramDawn,
-                                                   mVertexStateDescriptor, mBlend);
+  mPipeline = mContextDawn->createRenderPipeline(
+      mPipelineLayout, mProgramDawn, mVertexStateDescriptor, mBlend);
 
-    mLightFactorBuffer = mContextDawn->createBufferFromData(
-        &mLightFactorUniforms, sizeof(mLightFactorUniforms), sizeof(mLightFactorUniforms),
-        wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
-    mTimeBuffer = mContextDawn->createBufferFromData(
-        &mSeaweedPer, sizeof(mSeaweedPer),
-        mContextDawn->CalcConstantBufferByteSize(sizeof(mSeaweedPer) * 4),
-        wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
-    mViewBuffer = mContextDawn->createBufferFromData(
-        &mWorldUniformPer, sizeof(WorldUniformPer),
-        mContextDawn->CalcConstantBufferByteSize(sizeof(WorldUniformPer)),
-        wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
+  mLightFactorBuffer = mContextDawn->createBufferFromData(
+      &mLightFactorUniforms, sizeof(mLightFactorUniforms),
+      sizeof(mLightFactorUniforms),
+      wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
+  mTimeBuffer = mContextDawn->createBufferFromData(
+      &mSeaweedPer, sizeof(mSeaweedPer),
+      mContextDawn->CalcConstantBufferByteSize(sizeof(mSeaweedPer) * 4),
+      wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
+  mViewBuffer = mContextDawn->createBufferFromData(
+      &mWorldUniformPer, sizeof(WorldUniformPer),
+      mContextDawn->CalcConstantBufferByteSize(sizeof(WorldUniformPer)),
+      wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
 
-    mBindGroupModel = mContextDawn->makeBindGroup(
-        mGroupLayoutModel, {
-                               {0, mLightFactorBuffer, 0, sizeof(LightFactorUniforms)},
-                               {1, mDiffuseTexture->getSampler()},
-                               {2, mDiffuseTexture->getTextureView()},
-                           });
+  mBindGroupModel = mContextDawn->makeBindGroup(
+      mGroupLayoutModel,
+      {
+          {0, mLightFactorBuffer, 0, sizeof(LightFactorUniforms)},
+          {1, mDiffuseTexture->getSampler()},
+          {2, mDiffuseTexture->getTextureView()},
+      });
 
-    mBindGroupPer = mContextDawn->makeBindGroup(
-        mGroupLayoutPer,
-        {
-            {0, mViewBuffer, 0, mContextDawn->CalcConstantBufferByteSize(sizeof(WorldUniformPer))},
-            {1, mTimeBuffer, 0, mContextDawn->CalcConstantBufferByteSize(sizeof(SeaweedPer) * 4)},
-        });
+  mBindGroupPer = mContextDawn->makeBindGroup(
+      mGroupLayoutPer,
+      {
+          {0, mViewBuffer, 0,
+           mContextDawn->CalcConstantBufferByteSize(sizeof(WorldUniformPer))},
+          {1, mTimeBuffer, 0,
+           mContextDawn->CalcConstantBufferByteSize(sizeof(SeaweedPer) * 4)},
+      });
 
-    mContextDawn->setBufferData(mLightFactorBuffer, sizeof(mLightFactorUniforms),
-                                &mLightFactorUniforms, sizeof(mLightFactorUniforms));
+  mContextDawn->setBufferData(mLightFactorBuffer, sizeof(mLightFactorUniforms),
+                              &mLightFactorUniforms,
+                              sizeof(mLightFactorUniforms));
 }
 
 void SeaweedModelDawn::prepareForDraw()
 {
-    mContextDawn->updateBufferData(
-        mViewBuffer, mContextDawn->CalcConstantBufferByteSize(sizeof(WorldUniformPer)),
-        &mWorldUniformPer, sizeof(WorldUniformPer));
-    mContextDawn->updateBufferData(mTimeBuffer,
-                                   mContextDawn->CalcConstantBufferByteSize(sizeof(SeaweedPer) * 4),
-                                   &mSeaweedPer, sizeof(SeaweedPer));
+  mContextDawn->updateBufferData(
+      mViewBuffer,
+      mContextDawn->CalcConstantBufferByteSize(sizeof(WorldUniformPer)),
+      &mWorldUniformPer, sizeof(WorldUniformPer));
+  mContextDawn->updateBufferData(
+      mTimeBuffer,
+      mContextDawn->CalcConstantBufferByteSize(sizeof(SeaweedPer) * 4),
+      &mSeaweedPer, sizeof(SeaweedPer));
 }
 
 void SeaweedModelDawn::draw()
 {
-    wgpu::RenderPassEncoder pass = mContextDawn->getRenderPass();
-    pass.SetPipeline(mPipeline);
-    pass.SetBindGroup(0, mContextDawn->bindGroupGeneral, 0, nullptr);
-    pass.SetBindGroup(1, mContextDawn->bindGroupWorld, 0, nullptr);
-    pass.SetBindGroup(2, mBindGroupModel, 0, nullptr);
-    pass.SetBindGroup(3, mBindGroupPer, 0, nullptr);
-    pass.SetVertexBuffer(0, mPositionBuffer->getBuffer());
-    pass.SetVertexBuffer(1, mNormalBuffer->getBuffer());
-    pass.SetVertexBuffer(2, mTexCoordBuffer->getBuffer());
-    pass.SetIndexBuffer(mIndicesBuffer->getBuffer(), 0);
-    pass.DrawIndexed(mIndicesBuffer->getTotalComponents(), instance, 0, 0, 0);
-    instance = 0;
+  wgpu::RenderPassEncoder pass = mContextDawn->getRenderPass();
+  pass.SetPipeline(mPipeline);
+  pass.SetBindGroup(0, mContextDawn->bindGroupGeneral, 0, nullptr);
+  pass.SetBindGroup(1, mContextDawn->bindGroupWorld, 0, nullptr);
+  pass.SetBindGroup(2, mBindGroupModel, 0, nullptr);
+  pass.SetBindGroup(3, mBindGroupPer, 0, nullptr);
+  pass.SetVertexBuffer(0, mPositionBuffer->getBuffer());
+  pass.SetVertexBuffer(1, mNormalBuffer->getBuffer());
+  pass.SetVertexBuffer(2, mTexCoordBuffer->getBuffer());
+  pass.SetIndexBuffer(mIndicesBuffer->getBuffer(), 0);
+  pass.DrawIndexed(mIndicesBuffer->getTotalComponents(), instance, 0, 0, 0);
+  instance = 0;
 }
 
-void SeaweedModelDawn::updatePerInstanceUniforms(const WorldUniforms &worldUniforms)
+void SeaweedModelDawn::updatePerInstanceUniforms(
+    const WorldUniforms &worldUniforms)
 {
-    mWorldUniformPer.worldUniforms[instance] = worldUniforms;
-    mSeaweedPer.time[instance]               = mAquarium->g.mclock + instance;
+  mWorldUniformPer.worldUniforms[instance] = worldUniforms;
+  mSeaweedPer.time[instance]               = mAquarium->g.mclock + instance;
 
-    instance++;
+  instance++;
 }
 
 void SeaweedModelDawn::updateSeaweedModelTime(float time) {}

--- a/src/aquarium-optimized/dawn/SeaweedModelDawn.h
+++ b/src/aquarium-optimized/dawn/SeaweedModelDawn.h
@@ -17,69 +17,69 @@
 
 class SeaweedModelDawn : public SeaweedModel
 {
-  public:
-    SeaweedModelDawn(Context *context,
-                     Aquarium *aquarium,
-                     MODELGROUP type,
-                     MODELNAME name,
-                     bool blend);
-    ~SeaweedModelDawn();
+public:
+  SeaweedModelDawn(Context *context,
+                   Aquarium *aquarium,
+                   MODELGROUP type,
+                   MODELNAME name,
+                   bool blend);
+  ~SeaweedModelDawn();
 
-    void init() override;
-    void prepareForDraw() override;
-    void draw() override;
+  void init() override;
+  void prepareForDraw() override;
+  void draw() override;
 
-    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
+  void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
 
-    TextureDawn *mDiffuseTexture;
-    TextureDawn *mNormalTexture;
-    TextureDawn *mReflectionTexture;
-    TextureDawn *mSkyboxTexture;
+  TextureDawn *mDiffuseTexture;
+  TextureDawn *mNormalTexture;
+  TextureDawn *mReflectionTexture;
+  TextureDawn *mSkyboxTexture;
 
-    BufferDawn *mPositionBuffer;
-    BufferDawn *mNormalBuffer;
-    BufferDawn *mTexCoordBuffer;
+  BufferDawn *mPositionBuffer;
+  BufferDawn *mNormalBuffer;
+  BufferDawn *mTexCoordBuffer;
 
-    BufferDawn *mIndicesBuffer;
-    void updateSeaweedModelTime(float time) override;
+  BufferDawn *mIndicesBuffer;
+  void updateSeaweedModelTime(float time) override;
 
-    struct LightFactorUniforms
-    {
-        float shininess;
-        float specularFactor;
-    } mLightFactorUniforms;
+  struct LightFactorUniforms
+  {
+    float shininess;
+    float specularFactor;
+  } mLightFactorUniforms;
 
-    struct SeaweedPer
-    {
-        float time[20];
-    } mSeaweedPer;
+  struct SeaweedPer
+  {
+    float time[20];
+  } mSeaweedPer;
 
-    struct WorldUniformPer
-    {
-        WorldUniforms worldUniforms[20];
-    };
-    WorldUniformPer mWorldUniformPer;
+  struct WorldUniformPer
+  {
+    WorldUniforms worldUniforms[20];
+  };
+  WorldUniformPer mWorldUniformPer;
 
-  private:
-    utils::ComboVertexStateDescriptor mVertexStateDescriptor;
-    wgpu::RenderPipeline mPipeline;
+private:
+  utils::ComboVertexStateDescriptor mVertexStateDescriptor;
+  wgpu::RenderPipeline mPipeline;
 
-    wgpu::BindGroupLayout mGroupLayoutModel;
-    wgpu::BindGroupLayout mGroupLayoutPer;
-    wgpu::PipelineLayout mPipelineLayout;
+  wgpu::BindGroupLayout mGroupLayoutModel;
+  wgpu::BindGroupLayout mGroupLayoutPer;
+  wgpu::PipelineLayout mPipelineLayout;
 
-    wgpu::BindGroup mBindGroupModel;
-    wgpu::BindGroup mBindGroupPer;
+  wgpu::BindGroup mBindGroupModel;
+  wgpu::BindGroup mBindGroupPer;
 
-    wgpu::Buffer mLightFactorBuffer;
-    wgpu::Buffer mTimeBuffer;
-    wgpu::Buffer mViewBuffer;
+  wgpu::Buffer mLightFactorBuffer;
+  wgpu::Buffer mTimeBuffer;
+  wgpu::Buffer mViewBuffer;
 
-    ContextDawn *mContextDawn;
-    ProgramDawn *mProgramDawn;
-    Aquarium *mAquarium;
+  ContextDawn *mContextDawn;
+  ProgramDawn *mProgramDawn;
+  Aquarium *mAquarium;
 
-    int instance;
+  int instance;
 };
 
 #endif  // SEAWEEDMODELDAWN_H

--- a/src/aquarium-optimized/dawn/TextureDawn.cpp
+++ b/src/aquarium-optimized/dawn/TextureDawn.cpp
@@ -3,7 +3,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 //
-// TextureDawn.cpp: Wrap textures of Dawn. Load image files and wrap into a Dawn texture.
+// TextureDawn.cpp: Wrap textures of Dawn. Load image files and wrap into a Dawn
+// texture.
 
 #include "TextureDawn.h"
 
@@ -16,14 +17,16 @@
 TextureDawn::~TextureDawn()
 {
 
-    DestoryImageData(mPixelVec);
-    DestoryImageData(mResizedVec);
-    mTextureView = nullptr;
-    mTexture     = nullptr;
-    mSampler     = nullptr;
+  DestoryImageData(mPixelVec);
+  DestoryImageData(mResizedVec);
+  mTextureView = nullptr;
+  mTexture     = nullptr;
+  mSampler     = nullptr;
 }
 
-TextureDawn::TextureDawn(ContextDawn *context, const std::string &name, const std::string &url)
+TextureDawn::TextureDawn(ContextDawn *context,
+                         const std::string &name,
+                         const std::string &url)
     : Texture(name, url, true),
       mTextureDimension(wgpu::TextureDimension::e2D),
       mTextureViewDimension(wgpu::TextureViewDimension::e2D),
@@ -48,144 +51,148 @@ TextureDawn::TextureDawn(ContextDawn *context,
 
 void TextureDawn::loadTexture()
 {
-    wgpu::SamplerDescriptor samplerDesc = {};
-    const int kPadding                  = 256;
-    loadImage(mUrls, &mPixelVec);
+  wgpu::SamplerDescriptor samplerDesc = {};
+  const int kPadding                  = 256;
+  loadImage(mUrls, &mPixelVec);
 
-    if (mTextureViewDimension == wgpu::TextureViewDimension::Cube)
+  if (mTextureViewDimension == wgpu::TextureViewDimension::Cube)
+  {
+    wgpu::TextureDescriptor descriptor;
+    descriptor.dimension     = mTextureDimension;
+    descriptor.size.width    = mWidth;
+    descriptor.size.height   = mHeight;
+    descriptor.size.depth    = 6;
+    descriptor.sampleCount   = 1;
+    descriptor.format        = mFormat;
+    descriptor.mipLevelCount = 1;
+    descriptor.usage =
+        wgpu::TextureUsage::CopyDst | wgpu::TextureUsage::Sampled;
+    mTexture = mContext->createTexture(descriptor);
+
+    for (unsigned int i = 0; i < 6; i++)
     {
-        wgpu::TextureDescriptor descriptor;
-        descriptor.dimension     = mTextureDimension;
-        descriptor.size.width    = mWidth;
-        descriptor.size.height   = mHeight;
-        descriptor.size.depth    = 6;
-        descriptor.sampleCount   = 1;
-        descriptor.format        = mFormat;
-        descriptor.mipLevelCount = 1;
-        descriptor.usage         = wgpu::TextureUsage::CopyDst | wgpu::TextureUsage::Sampled;
-        mTexture                 = mContext->createTexture(descriptor);
+      wgpu::CreateBufferMappedResult result = mContext->CreateBufferMapped(
+          wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::MapWrite,
+          mWidth * mHeight * 4);
+      memcpy(result.data, mPixelVec[i], mWidth * mHeight * 4);
+      result.buffer.Unmap();
 
-        for (unsigned int i = 0; i < 6; i++)
-        {
-            wgpu::CreateBufferMappedResult result = mContext->CreateBufferMapped(
-                wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::MapWrite, mWidth * mHeight * 4);
-            memcpy(result.data, mPixelVec[i], mWidth * mHeight * 4);
-            result.buffer.Unmap();
-
-            wgpu::BufferCopyView bufferCopyView =
-                mContext->createBufferCopyView(result.buffer, 0, mWidth * 4, mHeight);
-            wgpu::TextureCopyView textureCopyView =
-                mContext->createTextureCopyView(mTexture, 0, {0, 0, i});
-            wgpu::Extent3D copySize = {static_cast<uint32_t>(mWidth),
-                                       static_cast<uint32_t>(mHeight), 1};
-            mContext->mCommandBuffers.emplace_back(
-                mContext->copyBufferToTexture(bufferCopyView, textureCopyView, copySize));
-        }
-
-        wgpu::TextureViewDescriptor viewDescriptor;
-        viewDescriptor.nextInChain     = nullptr;
-        viewDescriptor.dimension       = wgpu::TextureViewDimension::Cube;
-        viewDescriptor.format          = mFormat;
-        viewDescriptor.baseMipLevel    = 0;
-        viewDescriptor.mipLevelCount   = 1;
-        viewDescriptor.baseArrayLayer  = 0;
-        viewDescriptor.arrayLayerCount = 6;
-
-        mTextureView = mTexture.CreateView(&viewDescriptor);
-
-        samplerDesc.addressModeU = wgpu::AddressMode::ClampToEdge;
-        samplerDesc.addressModeV = wgpu::AddressMode::ClampToEdge;
-        samplerDesc.addressModeW = wgpu::AddressMode::ClampToEdge;
-        samplerDesc.minFilter    = wgpu::FilterMode::Linear;
-        samplerDesc.magFilter    = wgpu::FilterMode::Linear;
-        samplerDesc.mipmapFilter = wgpu::FilterMode::Nearest;
-
-        mSampler = mContext->createSampler(samplerDesc);
-    }
-    else  // wgpu::TextureViewDimension::e2D
-    {
-        int resizedWidth;
-        if (mWidth % kPadding == 0)
-        {
-            resizedWidth = mWidth;
-        }
-        else
-        {
-            resizedWidth = (mWidth / 256 + 1) * 256;
-        }
-        generateMipmap(mPixelVec[0], mWidth, mHeight, 0, mResizedVec, resizedWidth, mHeight, 0, 4,
-                       true);
-
-        wgpu::TextureDescriptor descriptor;
-        descriptor.dimension     = mTextureDimension;
-        descriptor.size.width    = resizedWidth;
-        descriptor.size.height   = mHeight;
-        descriptor.size.depth    = 1;
-        descriptor.sampleCount   = 1;
-        descriptor.format        = mFormat;
-        descriptor.mipLevelCount = static_cast<uint32_t>(std::floor(
-                                       static_cast<float>(std::log2(std::min(mWidth, mHeight))))) +
-                                   1;
-        descriptor.usage = wgpu::TextureUsage::CopyDst | wgpu::TextureUsage::Sampled;
-        mTexture         = mContext->createTexture(descriptor);
-
-        int count = 0;
-        for (unsigned int i = 0; i < descriptor.mipLevelCount; ++i, ++count)
-        {
-            int height = mHeight >> i;
-            int width  = resizedWidth >> i;
-            if (height == 0)
-            {
-                height = 1;
-            }
-
-            wgpu::CreateBufferMappedResult result = mContext->CreateBufferMapped(
-                wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::MapWrite,
-                resizedWidth * height * 4);
-            memcpy(result.data, mResizedVec[i], resizedWidth * height * 4);
-            result.buffer.Unmap();
-
-            wgpu::BufferCopyView bufferCopyView =
-                mContext->createBufferCopyView(result.buffer, 0, resizedWidth * 4, height);
-            wgpu::TextureCopyView textureCopyView =
-                mContext->createTextureCopyView(mTexture, i, {0, 0, 0});
-            wgpu::Extent3D copySize = {static_cast<uint32_t>(width), static_cast<uint32_t>(height),
-                                       1};
-            mContext->mCommandBuffers.emplace_back(
-                mContext->copyBufferToTexture(bufferCopyView, textureCopyView, copySize));
-        }
-
-        wgpu::TextureViewDescriptor viewDescriptor;
-        viewDescriptor.nextInChain  = nullptr;
-        viewDescriptor.dimension    = wgpu::TextureViewDimension::e2D;
-        viewDescriptor.format       = mFormat;
-        viewDescriptor.baseMipLevel = 0;
-        viewDescriptor.mipLevelCount =
-            static_cast<uint32_t>(
-                std::floor(static_cast<float>(std::log2(std::min(mWidth, mHeight))))) +
-            1;
-        viewDescriptor.baseArrayLayer  = 0;
-        viewDescriptor.arrayLayerCount = 1;
-
-        mTextureView = mTexture.CreateView(&viewDescriptor);
-
-        samplerDesc.addressModeU = wgpu::AddressMode::ClampToEdge;
-        samplerDesc.addressModeV = wgpu::AddressMode::ClampToEdge;
-        samplerDesc.addressModeW = wgpu::AddressMode::ClampToEdge;
-        samplerDesc.minFilter    = wgpu::FilterMode::Linear;
-        samplerDesc.magFilter    = wgpu::FilterMode::Linear;
-
-        if (isPowerOf2(mWidth) && isPowerOf2(mHeight))
-        {
-            samplerDesc.mipmapFilter = wgpu::FilterMode::Linear;
-        }
-        else
-        {
-            samplerDesc.mipmapFilter = wgpu::FilterMode::Nearest;
-        }
-
-        mSampler = mContext->createSampler(samplerDesc);
+      wgpu::BufferCopyView bufferCopyView =
+          mContext->createBufferCopyView(result.buffer, 0, mWidth * 4, mHeight);
+      wgpu::TextureCopyView textureCopyView =
+          mContext->createTextureCopyView(mTexture, 0, {0, 0, i});
+      wgpu::Extent3D copySize = {static_cast<uint32_t>(mWidth),
+                                 static_cast<uint32_t>(mHeight), 1};
+      mContext->mCommandBuffers.emplace_back(mContext->copyBufferToTexture(
+          bufferCopyView, textureCopyView, copySize));
     }
 
-    // TODO(yizhou): check if the pixel destory should delay or fence
+    wgpu::TextureViewDescriptor viewDescriptor;
+    viewDescriptor.nextInChain     = nullptr;
+    viewDescriptor.dimension       = wgpu::TextureViewDimension::Cube;
+    viewDescriptor.format          = mFormat;
+    viewDescriptor.baseMipLevel    = 0;
+    viewDescriptor.mipLevelCount   = 1;
+    viewDescriptor.baseArrayLayer  = 0;
+    viewDescriptor.arrayLayerCount = 6;
+
+    mTextureView = mTexture.CreateView(&viewDescriptor);
+
+    samplerDesc.addressModeU = wgpu::AddressMode::ClampToEdge;
+    samplerDesc.addressModeV = wgpu::AddressMode::ClampToEdge;
+    samplerDesc.addressModeW = wgpu::AddressMode::ClampToEdge;
+    samplerDesc.minFilter    = wgpu::FilterMode::Linear;
+    samplerDesc.magFilter    = wgpu::FilterMode::Linear;
+    samplerDesc.mipmapFilter = wgpu::FilterMode::Nearest;
+
+    mSampler = mContext->createSampler(samplerDesc);
+  }
+  else  // wgpu::TextureViewDimension::e2D
+  {
+    int resizedWidth;
+    if (mWidth % kPadding == 0)
+    {
+      resizedWidth = mWidth;
+    }
+    else
+    {
+      resizedWidth = (mWidth / 256 + 1) * 256;
+    }
+    generateMipmap(mPixelVec[0], mWidth, mHeight, 0, mResizedVec, resizedWidth,
+                   mHeight, 0, 4, true);
+
+    wgpu::TextureDescriptor descriptor;
+    descriptor.dimension   = mTextureDimension;
+    descriptor.size.width  = resizedWidth;
+    descriptor.size.height = mHeight;
+    descriptor.size.depth  = 1;
+    descriptor.sampleCount = 1;
+    descriptor.format      = mFormat;
+    descriptor.mipLevelCount =
+        static_cast<uint32_t>(std::floor(
+            static_cast<float>(std::log2(std::min(mWidth, mHeight))))) +
+        1;
+    descriptor.usage =
+        wgpu::TextureUsage::CopyDst | wgpu::TextureUsage::Sampled;
+    mTexture = mContext->createTexture(descriptor);
+
+    int count = 0;
+    for (unsigned int i = 0; i < descriptor.mipLevelCount; ++i, ++count)
+    {
+      int height = mHeight >> i;
+      int width  = resizedWidth >> i;
+      if (height == 0)
+      {
+        height = 1;
+      }
+
+      wgpu::CreateBufferMappedResult result = mContext->CreateBufferMapped(
+          wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::MapWrite,
+          resizedWidth * height * 4);
+      memcpy(result.data, mResizedVec[i], resizedWidth * height * 4);
+      result.buffer.Unmap();
+
+      wgpu::BufferCopyView bufferCopyView = mContext->createBufferCopyView(
+          result.buffer, 0, resizedWidth * 4, height);
+      wgpu::TextureCopyView textureCopyView =
+          mContext->createTextureCopyView(mTexture, i, {0, 0, 0});
+      wgpu::Extent3D copySize = {static_cast<uint32_t>(width),
+                                 static_cast<uint32_t>(height), 1};
+      mContext->mCommandBuffers.emplace_back(mContext->copyBufferToTexture(
+          bufferCopyView, textureCopyView, copySize));
+    }
+
+    wgpu::TextureViewDescriptor viewDescriptor;
+    viewDescriptor.nextInChain  = nullptr;
+    viewDescriptor.dimension    = wgpu::TextureViewDimension::e2D;
+    viewDescriptor.format       = mFormat;
+    viewDescriptor.baseMipLevel = 0;
+    viewDescriptor.mipLevelCount =
+        static_cast<uint32_t>(std::floor(
+            static_cast<float>(std::log2(std::min(mWidth, mHeight))))) +
+        1;
+    viewDescriptor.baseArrayLayer  = 0;
+    viewDescriptor.arrayLayerCount = 1;
+
+    mTextureView = mTexture.CreateView(&viewDescriptor);
+
+    samplerDesc.addressModeU = wgpu::AddressMode::ClampToEdge;
+    samplerDesc.addressModeV = wgpu::AddressMode::ClampToEdge;
+    samplerDesc.addressModeW = wgpu::AddressMode::ClampToEdge;
+    samplerDesc.minFilter    = wgpu::FilterMode::Linear;
+    samplerDesc.magFilter    = wgpu::FilterMode::Linear;
+
+    if (isPowerOf2(mWidth) && isPowerOf2(mHeight))
+    {
+      samplerDesc.mipmapFilter = wgpu::FilterMode::Linear;
+    }
+    else
+    {
+      samplerDesc.mipmapFilter = wgpu::FilterMode::Nearest;
+    }
+
+    mSampler = mContext->createSampler(samplerDesc);
+  }
+
+  // TODO(yizhou): check if the pixel destory should delay or fence
 }

--- a/src/aquarium-optimized/dawn/TextureDawn.h
+++ b/src/aquarium-optimized/dawn/TextureDawn.h
@@ -16,31 +16,36 @@ class ContextDawn;
 
 class TextureDawn : public Texture
 {
-  public:
-    ~TextureDawn() override;
-    TextureDawn(ContextDawn *context, const std::string &name, const std::string &url);
-    TextureDawn(ContextDawn *context,
-                const std::string &name,
-                const std::vector<std::string> &urls);
+public:
+  ~TextureDawn() override;
+  TextureDawn(ContextDawn *context,
+              const std::string &name,
+              const std::string &url);
+  TextureDawn(ContextDawn *context,
+              const std::string &name,
+              const std::vector<std::string> &urls);
 
-    const wgpu::Texture &getTextureId() const { return mTexture; }
-    const wgpu::Sampler &getSampler() const { return mSampler; }
-    wgpu::TextureDimension getTextureDimension() { return mTextureDimension; }
-    wgpu::TextureViewDimension getTextureViewDimension() { return mTextureViewDimension; }
-    wgpu::TextureView getTextureView() { return mTextureView; }
+  const wgpu::Texture &getTextureId() const { return mTexture; }
+  const wgpu::Sampler &getSampler() const { return mSampler; }
+  wgpu::TextureDimension getTextureDimension() { return mTextureDimension; }
+  wgpu::TextureViewDimension getTextureViewDimension()
+  {
+    return mTextureViewDimension;
+  }
+  wgpu::TextureView getTextureView() { return mTextureView; }
 
-    void loadTexture() override;
+  void loadTexture() override;
 
-  private:
-    wgpu::TextureDimension mTextureDimension;  // texture 2D or CubeMap
-    wgpu::TextureViewDimension mTextureViewDimension;
-    wgpu::Texture mTexture;
-    wgpu::Sampler mSampler;
-    wgpu::TextureFormat mFormat;
-    wgpu::TextureView mTextureView;
-    std::vector<unsigned char *> mPixelVec;
-    std::vector<unsigned char *> mResizedVec;
-    ContextDawn *mContext;
+private:
+  wgpu::TextureDimension mTextureDimension;  // texture 2D or CubeMap
+  wgpu::TextureViewDimension mTextureViewDimension;
+  wgpu::Texture mTexture;
+  wgpu::Sampler mSampler;
+  wgpu::TextureFormat mFormat;
+  wgpu::TextureView mTextureView;
+  std::vector<unsigned char *> mPixelVec;
+  std::vector<unsigned char *> mResizedVec;
+  ContextDawn *mContext;
 };
 
 #endif  // TEXTUREDAWN_H

--- a/src/aquarium-optimized/opengl/BufferGL.cpp
+++ b/src/aquarium-optimized/opengl/BufferGL.cpp
@@ -3,7 +3,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 //
-// BufferGL.cpp: Implements the index or vertex buffer wrappers and resource bindings of OpenGL.
+// BufferGL.cpp: Implements the index or vertex buffer wrappers and resource
+// bindings of OpenGL.
 
 #include "BufferGL.h"
 
@@ -26,22 +27,22 @@ BufferGL::BufferGL(ContextGL *context,
       mStride(0),
       mOffset(nullptr)
 {
-    mBuf = mContext->generateBuffer();
+  mBuf = mContext->generateBuffer();
 }
 
 void BufferGL::loadBuffer(const std::vector<float> &buf)
 {
-    mContext->bindBuffer(mTarget, mBuf);
-    mContext->uploadBuffer(mTarget, buf);
+  mContext->bindBuffer(mTarget, mBuf);
+  mContext->uploadBuffer(mTarget, buf);
 }
 
 void BufferGL::loadBuffer(const std::vector<unsigned short> &buf)
 {
-    mContext->bindBuffer(mTarget, mBuf);
-    mContext->uploadBuffer(mTarget, buf);
+  mContext->bindBuffer(mTarget, mBuf);
+  mContext->uploadBuffer(mTarget, buf);
 }
 
 BufferGL::~BufferGL()
 {
-    mContext->deleteBuffer(mBuf);
+  mContext->deleteBuffer(mBuf);
 }

--- a/src/aquarium-optimized/opengl/BufferGL.h
+++ b/src/aquarium-optimized/opengl/BufferGL.h
@@ -30,38 +30,38 @@ class ContextGL;
 
 class BufferGL : public Buffer
 {
-  public:
-    BufferGL(ContextGL *context,
-             int totalCmoponents,
-             int numComponents,
-             bool isIndex,
-             unsigned int type,
-             bool normalize);
-    ~BufferGL() override;
+public:
+  BufferGL(ContextGL *context,
+           int totalCmoponents,
+           int numComponents,
+           bool isIndex,
+           unsigned int type,
+           bool normalize);
+  ~BufferGL() override;
 
-    unsigned int getBuffer() const { return mBuf; }
-    int getNumComponents() const { return mNumComponents; }
-    int getTotalComponents() const { return mTotoalComponents; }
-    int getNumberElements() const { return mNumElements; }
-    unsigned int getType() const { return mType; }
-    bool getNormalize() const { return mNormalize; }
-    int getStride() const { return mStride; }
-    void *getOffset() const { return mOffset; }
-    unsigned int getTarget() const { return mTarget; }
-    void loadBuffer(const std::vector<float> &buf);
-    void loadBuffer(const std::vector<unsigned short> &buf);
+  unsigned int getBuffer() const { return mBuf; }
+  int getNumComponents() const { return mNumComponents; }
+  int getTotalComponents() const { return mTotoalComponents; }
+  int getNumberElements() const { return mNumElements; }
+  unsigned int getType() const { return mType; }
+  bool getNormalize() const { return mNormalize; }
+  int getStride() const { return mStride; }
+  void *getOffset() const { return mOffset; }
+  unsigned int getTarget() const { return mTarget; }
+  void loadBuffer(const std::vector<float> &buf);
+  void loadBuffer(const std::vector<unsigned short> &buf);
 
-  private:
-    ContextGL *mContext;
-    unsigned int mBuf;
-    unsigned int mTarget;
-    int mNumComponents;
-    int mTotoalComponents;
-    int mNumElements;
-    unsigned int mType;
-    bool mNormalize;
-    int mStride;
-    void *mOffset;
+private:
+  ContextGL *mContext;
+  unsigned int mBuf;
+  unsigned int mTarget;
+  int mNumComponents;
+  int mTotoalComponents;
+  int mNumElements;
+  unsigned int mType;
+  bool mNormalize;
+  int mStride;
+  void *mOffset;
 };
 
 #endif  // BUFFERGL_H

--- a/src/aquarium-optimized/opengl/ContextGL.cpp
+++ b/src/aquarium-optimized/opengl/ContextGL.cpp
@@ -32,336 +32,356 @@
 
 ContextGL::ContextGL(BACKENDTYPE backendType) : mWindow(nullptr)
 {
-    initAvailableToggleBitset(backendType);
+  initAvailableToggleBitset(backendType);
 }
 
 ContextGL::~ContextGL()
 {
-    delete mResourceHelper;
-    if (!mDisableControlPanel)
-    {
-        destoryImgUI();
-    }
+  delete mResourceHelper;
+  if (!mDisableControlPanel)
+  {
+    destoryImgUI();
+  }
 }
 
-bool ContextGL::initialize(BACKENDTYPE backend,
-                           const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset,
-                           int windowWidth,
-                           int windowHeight)
+bool ContextGL::initialize(
+    BACKENDTYPE backend,
+    const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset,
+    int windowWidth,
+    int windowHeight)
 {
-    // initialise GLFW
-    if (!glfwInit())
-    {
-        std::cout << "Failed to initialise GLFW" << std::endl;
-        return false;
-    }
+  // initialise GLFW
+  if (!glfwInit())
+  {
+    std::cout << "Failed to initialise GLFW" << std::endl;
+    return false;
+  }
 
 #ifdef GL_GLEXT_PROTOTYPES
-    // TODO(yizhou) : Enable msaa in angle. Render into a multisample Texture and then blit to a
-    // none multisample texture.
-    glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
-    mResourceHelper = new ResourceHelper("opengl", std::string("100"), backend);
+  // TODO(yizhou) : Enable msaa in angle. Render into a multisample Texture and
+  // then blit to a none multisample texture.
+  glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+  mResourceHelper = new ResourceHelper("opengl", std::string("100"), backend);
 #else
-    if (mMSAASampleCount > 1)
-    {
-        glfwWindowHint(GLFW_SAMPLES, mMSAASampleCount);
-    }
-    mDisableControlPanel = (toggleBitset.test(static_cast<TOGGLE>(TOGGLE::DISABLECONTROLPANEL)));
+  if (mMSAASampleCount > 1)
+  {
+    glfwWindowHint(GLFW_SAMPLES, mMSAASampleCount);
+  }
+  mDisableControlPanel =
+      (toggleBitset.test(static_cast<TOGGLE>(TOGGLE::DISABLECONTROLPANEL)));
 
-    mResourceHelper = new ResourceHelper("opengl", "450", backend);
+  mResourceHelper = new ResourceHelper("opengl", "450", backend);
 
 #ifdef __APPLE__
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
-    mGLSLVersion = "#version 410";
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
+  mGLSLVersion = "#version 410";
 #elif _WIN32 || __linux__
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 5);
-    mGLSLVersion = "#version 450";
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 5);
+  mGLSLVersion = "#version 450";
 #endif
-    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
+  glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+  glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
 #endif
 
-    GLFWmonitor *pMonitor   = glfwGetPrimaryMonitor();
-    const GLFWvidmode *mode = glfwGetVideoMode(pMonitor);
-    mClientWidth            = mode->width;
-    mClientHeight           = mode->height;
+  GLFWmonitor *pMonitor   = glfwGetPrimaryMonitor();
+  const GLFWvidmode *mode = glfwGetVideoMode(pMonitor);
+  mClientWidth            = mode->width;
+  mClientHeight           = mode->height;
 
-    setWindowSize(windowWidth, windowHeight);
+  setWindowSize(windowWidth, windowHeight);
 
-    glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
-    if (toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEFULLSCREENMODE)))
-    {
-        mWindow = glfwCreateWindow(mClientWidth, mClientHeight, "Aquarium", pMonitor, nullptr);
-    }
-    else
-    {
-        mWindow = glfwCreateWindow(mClientWidth, mClientHeight, "Aquarium", nullptr, nullptr);
-    }
+  glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+  if (toggleBitset.test(static_cast<size_t>(TOGGLE::ENABLEFULLSCREENMODE)))
+  {
+    mWindow = glfwCreateWindow(mClientWidth, mClientHeight, "Aquarium",
+                               pMonitor, nullptr);
+  }
+  else
+  {
+    mWindow = glfwCreateWindow(mClientWidth, mClientHeight, "Aquarium", nullptr,
+                               nullptr);
+  }
 
-    if (mWindow == nullptr)
-    {
-        std::cout << "Failed to open GLFW window." << std::endl;
-        glfwTerminate();
-        return false;
-    }
+  if (mWindow == nullptr)
+  {
+    std::cout << "Failed to open GLFW window." << std::endl;
+    glfwTerminate();
+    return false;
+  }
 
-    setWindowTitle("Aquarium");
-    glfwSetFramebufferSizeCallback(mWindow, framebufferResizeCallback);
-    glfwSetWindowUserPointer(mWindow, this);
+  setWindowTitle("Aquarium");
+  glfwSetFramebufferSizeCallback(mWindow, framebufferResizeCallback);
+  glfwSetWindowUserPointer(mWindow, this);
 
 #ifndef GL_GLES_PROTOTYPES
-    glfwWindowHint(GLFW_DECORATED, GLFW_FALSE);
-    glfwMakeContextCurrent(mWindow);
+  glfwWindowHint(GLFW_DECORATED, GLFW_FALSE);
+  glfwMakeContextCurrent(mWindow);
 #else
-    mGLSLVersion = "#version 300 es";
+  mGLSLVersion = "#version 300 es";
 
-    std::vector<EGLAttrib> display_attribs;
+  std::vector<EGLAttrib> display_attribs;
 
-    display_attribs.push_back(EGL_PLATFORM_ANGLE_TYPE_ANGLE);
-    // display_attribs.push_back(EGL_PLATFORM_ANGLE_TYPE_OPENGL_ANGLE);
-    display_attribs.push_back(EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE);
-    display_attribs.push_back(EGL_PLATFORM_ANGLE_MAX_VERSION_MAJOR_ANGLE);
-    display_attribs.push_back(-1);
-    display_attribs.push_back(EGL_PLATFORM_ANGLE_MAX_VERSION_MINOR_ANGLE);
-    display_attribs.push_back(-1);
-    display_attribs.push_back(EGL_PLATFORM_ANGLE_DEVICE_TYPE_ANGLE);
-    display_attribs.push_back(EGL_PLATFORM_ANGLE_DEVICE_TYPE_HARDWARE_ANGLE);
-    display_attribs.push_back(EGL_NONE);
+  display_attribs.push_back(EGL_PLATFORM_ANGLE_TYPE_ANGLE);
+  // display_attribs.push_back(EGL_PLATFORM_ANGLE_TYPE_OPENGL_ANGLE);
+  display_attribs.push_back(EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE);
+  display_attribs.push_back(EGL_PLATFORM_ANGLE_MAX_VERSION_MAJOR_ANGLE);
+  display_attribs.push_back(-1);
+  display_attribs.push_back(EGL_PLATFORM_ANGLE_MAX_VERSION_MINOR_ANGLE);
+  display_attribs.push_back(-1);
+  display_attribs.push_back(EGL_PLATFORM_ANGLE_DEVICE_TYPE_ANGLE);
+  display_attribs.push_back(EGL_PLATFORM_ANGLE_DEVICE_TYPE_HARDWARE_ANGLE);
+  display_attribs.push_back(EGL_NONE);
 
-    HWND hwnd = glfwGetWin32Window(mWindow);
-    mDisplay  = eglGetPlatformDisplay(EGL_PLATFORM_ANGLE_ANGLE,
-                                     reinterpret_cast<void *>(GetDC(hwnd)), &display_attribs[0]);
-    if (mDisplay == EGL_NO_DISPLAY)
-    {
-        std::cout << "EGL display query failed with error " << std::endl;
-    }
-    GLint mEGLMajorVersion = 0;
-    GLint mEGLMinorVersion = 0;
-    if (eglInitialize(mDisplay, &mEGLMajorVersion, &mEGLMinorVersion) == EGL_FALSE)
-    {
-        return false;
-    }
+  HWND hwnd = glfwGetWin32Window(mWindow);
+  mDisplay  = eglGetPlatformDisplay(EGL_PLATFORM_ANGLE_ANGLE,
+                                   reinterpret_cast<void *>(GetDC(hwnd)),
+                                   &display_attribs[0]);
+  if (mDisplay == EGL_NO_DISPLAY)
+  {
+    std::cout << "EGL display query failed with error " << std::endl;
+  }
+  GLint mEGLMajorVersion = 0;
+  GLint mEGLMinorVersion = 0;
+  if (eglInitialize(mDisplay, &mEGLMajorVersion, &mEGLMinorVersion) ==
+      EGL_FALSE)
+  {
+    return false;
+  }
 
-    const char *displayExtensions = eglQueryString(mDisplay, EGL_EXTENSIONS);
+  const char *displayExtensions = eglQueryString(mDisplay, EGL_EXTENSIONS);
 
-    std::vector<EGLint> configAttributes = {
-        EGL_RED_SIZE,       8,  EGL_GREEN_SIZE,   8,
-        EGL_BLUE_SIZE,      8,  EGL_ALPHA_SIZE,   8,
-        EGL_DEPTH_SIZE,     24, EGL_STENCIL_SIZE, 8,
-        EGL_SAMPLE_BUFFERS, 0,  EGL_SAMPLES,      EGL_DONT_CARE};
+  std::vector<EGLint> configAttributes = {
+      EGL_RED_SIZE,       8,  EGL_GREEN_SIZE,   8,
+      EGL_BLUE_SIZE,      8,  EGL_ALPHA_SIZE,   8,
+      EGL_DEPTH_SIZE,     24, EGL_STENCIL_SIZE, 8,
+      EGL_SAMPLE_BUFFERS, 0,  EGL_SAMPLES,      EGL_DONT_CARE};
 
-    // Add dynamic attributes
-    bool hasPixelFormatFloat = strstr(displayExtensions, "EGL_EXT_pixel_format_float") != nullptr;
-    if (!hasPixelFormatFloat)
-    {
-        return false;
-    }
-    if (hasPixelFormatFloat)
-    {
-        configAttributes.push_back(EGL_COLOR_COMPONENT_TYPE_EXT);
-        configAttributes.push_back(EGL_COLOR_COMPONENT_TYPE_FIXED_EXT);
-    }
+  // Add dynamic attributes
+  bool hasPixelFormatFloat =
+      strstr(displayExtensions, "EGL_EXT_pixel_format_float") != nullptr;
+  if (!hasPixelFormatFloat)
+  {
+    return false;
+  }
+  if (hasPixelFormatFloat)
+  {
+    configAttributes.push_back(EGL_COLOR_COMPONENT_TYPE_EXT);
+    configAttributes.push_back(EGL_COLOR_COMPONENT_TYPE_FIXED_EXT);
+  }
 
-    // Finish the attribute list
-    configAttributes.push_back(EGL_NONE);
+  // Finish the attribute list
+  configAttributes.push_back(EGL_NONE);
 
-    if (!FindEGLConfig(mDisplay, configAttributes.data(), &mConfig))
-    {
-        std::cout << "Could not find a suitable EGL config!" << std::endl;
-        return false;
-    }
+  if (!FindEGLConfig(mDisplay, configAttributes.data(), &mConfig))
+  {
+    std::cout << "Could not find a suitable EGL config!" << std::endl;
+    return false;
+  }
 
-    GLint mRedBits, mGreenBits, mBlueBits, mSamples, mAlphaBits, mDepthBits, mStencilBits;
-    eglGetConfigAttrib(mDisplay, mConfig, EGL_RED_SIZE, &mRedBits);
-    eglGetConfigAttrib(mDisplay, mConfig, EGL_GREEN_SIZE, &mGreenBits);
-    eglGetConfigAttrib(mDisplay, mConfig, EGL_BLUE_SIZE, &mBlueBits);
-    eglGetConfigAttrib(mDisplay, mConfig, EGL_ALPHA_SIZE, &mAlphaBits);
-    eglGetConfigAttrib(mDisplay, mConfig, EGL_DEPTH_SIZE, &mDepthBits);
-    eglGetConfigAttrib(mDisplay, mConfig, EGL_STENCIL_SIZE, &mStencilBits);
-    eglGetConfigAttrib(mDisplay, mConfig, EGL_SAMPLES, &mSamples);
+  GLint mRedBits, mGreenBits, mBlueBits, mSamples, mAlphaBits, mDepthBits,
+      mStencilBits;
+  eglGetConfigAttrib(mDisplay, mConfig, EGL_RED_SIZE, &mRedBits);
+  eglGetConfigAttrib(mDisplay, mConfig, EGL_GREEN_SIZE, &mGreenBits);
+  eglGetConfigAttrib(mDisplay, mConfig, EGL_BLUE_SIZE, &mBlueBits);
+  eglGetConfigAttrib(mDisplay, mConfig, EGL_ALPHA_SIZE, &mAlphaBits);
+  eglGetConfigAttrib(mDisplay, mConfig, EGL_DEPTH_SIZE, &mDepthBits);
+  eglGetConfigAttrib(mDisplay, mConfig, EGL_STENCIL_SIZE, &mStencilBits);
+  eglGetConfigAttrib(mDisplay, mConfig, EGL_SAMPLES, &mSamples);
 
-    std::vector<EGLint> surfaceAttributes;
-    if (strstr(displayExtensions, "EGL_NV_post_sub_buffer") != nullptr)
-    {
-        surfaceAttributes.push_back(EGL_POST_SUB_BUFFER_SUPPORTED_NV);
-        surfaceAttributes.push_back(EGL_TRUE);
-    }
+  std::vector<EGLint> surfaceAttributes;
+  if (strstr(displayExtensions, "EGL_NV_post_sub_buffer") != nullptr)
+  {
+    surfaceAttributes.push_back(EGL_POST_SUB_BUFFER_SUPPORTED_NV);
+    surfaceAttributes.push_back(EGL_TRUE);
+  }
 
-    surfaceAttributes.push_back(EGL_NONE);
+  surfaceAttributes.push_back(EGL_NONE);
 
-    mSurface = eglCreateWindowSurface(
-        mDisplay, mConfig, reinterpret_cast<EGLNativeWindowType>(hwnd), &surfaceAttributes[0]);
+  mSurface = eglCreateWindowSurface(mDisplay, mConfig,
+                                    reinterpret_cast<EGLNativeWindowType>(hwnd),
+                                    &surfaceAttributes[0]);
 
-    if (eglGetError() != EGL_SUCCESS)
-    {
-        return false;
-    }
-    ASSERT(mSurface != EGL_NO_SURFACE);
+  if (eglGetError() != EGL_SUCCESS)
+  {
+    return false;
+  }
+  ASSERT(mSurface != EGL_NO_SURFACE);
 
-    mContext = createContext(EGL_NO_CONTEXT);
-    if (mContext == EGL_NO_CONTEXT)
-    {
-        return false;
-    }
+  mContext = createContext(EGL_NO_CONTEXT);
+  if (mContext == EGL_NO_CONTEXT)
+  {
+    return false;
+  }
 
-    eglMakeCurrent(mDisplay, mSurface, mSurface, mContext);
-    if (eglGetError() != EGL_SUCCESS)
-    {
-        return false;
-    }
+  eglMakeCurrent(mDisplay, mSurface, mSurface, mContext);
+  if (eglGetError() != EGL_SUCCESS)
+  {
+    return false;
+  }
 
-    eglSwapInterval(mDisplay, 0);
+  eglSwapInterval(mDisplay, 0);
 
 #endif
 
-    // Set the window full screen
-    // glfwSetWindowPos(window, 0, 0);
+  // Set the window full screen
+  // glfwSetWindowPos(window, 0, 0);
 
 #ifndef EGL_EGL_PROTOTYPES
-    if (!gladLoadGL())
-    {
-        std::cout << "Something went wrong!" << std::endl;
-        exit(-1);
-    }
+  if (!gladLoadGL())
+  {
+    std::cout << "Something went wrong!" << std::endl;
+    exit(-1);
+  }
 #endif
 
-    if (!mDisableControlPanel)
-    {
-        // Setup Dear ImGui context
-        IMGUI_CHECKVERSION();
-        ImGui::CreateContext();
-        ImGui::StyleColorsDark();
+  if (!mDisableControlPanel)
+  {
+    // Setup Dear ImGui context
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+    ImGui::StyleColorsDark();
 
-        // Setup Platform/Renderer bindings
-        ImGui_ImplGlfw_InitForOpenGL(mWindow, true);
-        ImGui_ImplOpenGL3_Init(mGLSLVersion.c_str());
-    }
+    // Setup Platform/Renderer bindings
+    ImGui_ImplGlfw_InitForOpenGL(mWindow, true);
+    ImGui_ImplOpenGL3_Init(mGLSLVersion.c_str());
+  }
 
-    std::string renderer((const char *)glGetString(GL_RENDERER));
-    size_t index = renderer.find("/");
-    renderer     = renderer.substr(0, index);
-    std::cout << renderer << std::endl;
-    mResourceHelper->setRenderer(renderer);
+  std::string renderer((const char *)glGetString(GL_RENDERER));
+  size_t index = renderer.find("/");
+  renderer     = renderer.substr(0, index);
+  std::cout << renderer << std::endl;
+  mResourceHelper->setRenderer(renderer);
 
-    return true;
+  return true;
 }
 
 #ifdef GL_GLEXT_PROTOTYPES
 EGLContext ContextGL::createContext(EGLContext share) const
 {
-    const char *displayExtensions = eglQueryString(mDisplay, EGL_EXTENSIONS);
+  const char *displayExtensions = eglQueryString(mDisplay, EGL_EXTENSIONS);
 
-    // EGL_KHR_create_context is required to request a ES3+ context.
-    bool hasKHRCreateContext = strstr(displayExtensions, "EGL_KHR_create_context") != nullptr;
+  // EGL_KHR_create_context is required to request a ES3+ context.
+  bool hasKHRCreateContext =
+      strstr(displayExtensions, "EGL_KHR_create_context") != nullptr;
 
-    eglBindAPI(EGL_OPENGL_ES_API);
-    if (eglGetError() != EGL_SUCCESS)
-    {
-        return EGL_NO_CONTEXT;
-    }
+  eglBindAPI(EGL_OPENGL_ES_API);
+  if (eglGetError() != EGL_SUCCESS)
+  {
+    return EGL_NO_CONTEXT;
+  }
 
-    std::vector<EGLint> contextAttributes;
-    if (hasKHRCreateContext)
-    {
-        contextAttributes.push_back(EGL_CONTEXT_MAJOR_VERSION_KHR);
-        contextAttributes.push_back(3);
+  std::vector<EGLint> contextAttributes;
+  if (hasKHRCreateContext)
+  {
+    contextAttributes.push_back(EGL_CONTEXT_MAJOR_VERSION_KHR);
+    contextAttributes.push_back(3);
 
-        contextAttributes.push_back(EGL_CONTEXT_MINOR_VERSION_KHR);
-        contextAttributes.push_back(0);
+    contextAttributes.push_back(EGL_CONTEXT_MINOR_VERSION_KHR);
+    contextAttributes.push_back(0);
 
-        contextAttributes.push_back(EGL_CONTEXT_OPENGL_DEBUG);
-        contextAttributes.push_back(EGL_TRUE);
+    contextAttributes.push_back(EGL_CONTEXT_OPENGL_DEBUG);
+    contextAttributes.push_back(EGL_TRUE);
 
-        contextAttributes.push_back(EGL_CONTEXT_OPENGL_NO_ERROR_KHR);
-        contextAttributes.push_back(EGL_TRUE);
-    }
-    contextAttributes.push_back(EGL_NONE);
+    contextAttributes.push_back(EGL_CONTEXT_OPENGL_NO_ERROR_KHR);
+    contextAttributes.push_back(EGL_TRUE);
+  }
+  contextAttributes.push_back(EGL_NONE);
 
-    EGLContext context = eglCreateContext(mDisplay, mConfig, nullptr, &contextAttributes[0]);
-    if (eglGetError() != EGL_SUCCESS)
-    {
-        return EGL_NO_CONTEXT;
-    }
+  EGLContext context =
+      eglCreateContext(mDisplay, mConfig, nullptr, &contextAttributes[0]);
+  if (eglGetError() != EGL_SUCCESS)
+  {
+    return EGL_NO_CONTEXT;
+  }
 
-    return context;
+  return context;
 }
 
-EGLBoolean ContextGL::FindEGLConfig(EGLDisplay dpy, const EGLint *attrib_list, EGLConfig *config)
+EGLBoolean ContextGL::FindEGLConfig(EGLDisplay dpy,
+                                    const EGLint *attrib_list,
+                                    EGLConfig *config)
 {
-    EGLint numConfigs = 0;
-    eglGetConfigs(dpy, nullptr, 0, &numConfigs);
-    std::vector<EGLConfig> allConfigs(numConfigs);
-    eglGetConfigs(dpy, allConfigs.data(), static_cast<EGLint>(allConfigs.size()), &numConfigs);
+  EGLint numConfigs = 0;
+  eglGetConfigs(dpy, nullptr, 0, &numConfigs);
+  std::vector<EGLConfig> allConfigs(numConfigs);
+  eglGetConfigs(dpy, allConfigs.data(), static_cast<EGLint>(allConfigs.size()),
+                &numConfigs);
 
-    for (size_t i = 0; i < allConfigs.size(); i++)
+  for (size_t i = 0; i < allConfigs.size(); i++)
+  {
+    bool matchFound = true;
+    for (const EGLint *curAttrib = attrib_list; curAttrib[0] != EGL_NONE;
+         curAttrib += 2)
     {
-        bool matchFound = true;
-        for (const EGLint *curAttrib = attrib_list; curAttrib[0] != EGL_NONE; curAttrib += 2)
-        {
-            if (curAttrib[1] == EGL_DONT_CARE)
-            {
-                continue;
-            }
+      if (curAttrib[1] == EGL_DONT_CARE)
+      {
+        continue;
+      }
 
-            EGLint actualValue = EGL_DONT_CARE;
-            eglGetConfigAttrib(dpy, allConfigs[i], curAttrib[0], &actualValue);
-            if (curAttrib[1] != actualValue)
-            {
-                matchFound = false;
-                break;
-            }
-        }
-
-        if (matchFound)
-        {
-            *config = allConfigs[i];
-            return EGL_TRUE;
-        }
+      EGLint actualValue = EGL_DONT_CARE;
+      eglGetConfigAttrib(dpy, allConfigs[i], curAttrib[0], &actualValue);
+      if (curAttrib[1] != actualValue)
+      {
+        matchFound = false;
+        break;
+      }
     }
 
-    return EGL_FALSE;
+    if (matchFound)
+    {
+      *config = allConfigs[i];
+      return EGL_TRUE;
+    }
+  }
+
+  return EGL_FALSE;
 }
 #endif
 
-void ContextGL::framebufferResizeCallback(GLFWwindow *window, int width, int height)
+void ContextGL::framebufferResizeCallback(GLFWwindow *window,
+                                          int width,
+                                          int height)
 {
-    ContextGL *contextGL     = reinterpret_cast<ContextGL *>(glfwGetWindowUserPointer(window));
-    contextGL->mClientWidth  = width;
-    contextGL->mClientHeight = height;
-    glViewport(0, 0, width, height);
+  ContextGL *contextGL =
+      reinterpret_cast<ContextGL *>(glfwGetWindowUserPointer(window));
+  contextGL->mClientWidth  = width;
+  contextGL->mClientHeight = height;
+  glViewport(0, 0, width, height);
 }
 
-Texture *ContextGL::createTexture(const std::string &name, const std::string &url)
+Texture *ContextGL::createTexture(const std::string &name,
+                                  const std::string &url)
 {
-    TextureGL *texture = new TextureGL(this, name, url);
-    texture->loadTexture();
-    return texture;
+  TextureGL *texture = new TextureGL(this, name, url);
+  texture->loadTexture();
+  return texture;
 }
 
-Texture *ContextGL::createTexture(const std::string &name, const std::vector<std::string> &urls)
+Texture *ContextGL::createTexture(const std::string &name,
+                                  const std::vector<std::string> &urls)
 {
-    TextureGL *texture = new TextureGL(this, name, urls);
-    texture->loadTexture();
-    return texture;
+  TextureGL *texture = new TextureGL(this, name, urls);
+  texture->loadTexture();
+  return texture;
 }
 
 unsigned int ContextGL::generateTexture()
 {
-    unsigned int texture;
-    glGenTextures(1, &texture);
-    return texture;
+  unsigned int texture;
+  glGenTextures(1, &texture);
+  return texture;
 }
 
 void ContextGL::bindTexture(unsigned int target, unsigned int textureId)
 {
-    glBindTexture(target, textureId);
+  glBindTexture(target, textureId);
 }
 
 void ContextGL::deleteTexture(unsigned int texture)
 {
-    glDeleteTextures(1, &texture);
+  glDeleteTextures(1, &texture);
 }
 
 void ContextGL::uploadTexture(unsigned int target,
@@ -370,383 +390,405 @@ void ContextGL::uploadTexture(unsigned int target,
                               int height,
                               unsigned char *pixels)
 {
-    glTexImage2D(target, 0, format, width, height, 0, format, GL_UNSIGNED_BYTE, pixels);
-    ASSERT(glGetError() == GL_NO_ERROR);
+  glTexImage2D(target, 0, format, width, height, 0, format, GL_UNSIGNED_BYTE,
+               pixels);
+  ASSERT(glGetError() == GL_NO_ERROR);
 }
 
 void ContextGL::setParameter(unsigned int target, unsigned int pname, int param)
 {
-    glTexParameteri(target, pname, param);
+  glTexParameteri(target, pname, param);
 }
 
 void ContextGL::generateMipmap(unsigned int target)
 {
-    glGenerateMipmap(target);
+  glGenerateMipmap(target);
 }
 
 void ContextGL::updateAllFishData() {}
 
 void ContextGL::initState()
 {
-    glEnable(GL_DEPTH_TEST);
-    glColorMask(true, true, true, true);
-    glEnable(GL_CULL_FACE);
-    glDepthMask(true);
+  glEnable(GL_DEPTH_TEST);
+  glColorMask(true, true, true, true);
+  glEnable(GL_CULL_FACE);
+  glDepthMask(true);
 }
 
 void ContextGL::initAvailableToggleBitset(BACKENDTYPE backendType)
 {
-    mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::UPATEANDDRAWFOREACHMODEL));
-    mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEFULLSCREENMODE));
+  mAvailableToggleBitset.set(
+      static_cast<size_t>(TOGGLE::UPATEANDDRAWFOREACHMODEL));
+  mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEFULLSCREENMODE));
 }
 
-Buffer *ContextGL::createBuffer(int numComponents, std::vector<float> *buf, bool isIndex)
+Buffer *ContextGL::createBuffer(int numComponents,
+                                std::vector<float> *buf,
+                                bool isIndex)
 {
-    BufferGL *buffer =
-        new BufferGL(this, static_cast<int>(buf->size()), numComponents, isIndex, GL_FLOAT, false);
-    buffer->loadBuffer(*buf);
+  BufferGL *buffer = new BufferGL(this, static_cast<int>(buf->size()),
+                                  numComponents, isIndex, GL_FLOAT, false);
+  buffer->loadBuffer(*buf);
 
-    return buffer;
+  return buffer;
 }
 
-Buffer *ContextGL::createBuffer(int numComponents, std::vector<unsigned short> *buf, bool isIndex)
+Buffer *ContextGL::createBuffer(int numComponents,
+                                std::vector<unsigned short> *buf,
+                                bool isIndex)
 {
-    BufferGL *buffer = new BufferGL(this, static_cast<int>(buf->size()), numComponents, isIndex,
-                                    GL_UNSIGNED_SHORT, true);
-    buffer->loadBuffer(*buf);
+  BufferGL *buffer =
+      new BufferGL(this, static_cast<int>(buf->size()), numComponents, isIndex,
+                   GL_UNSIGNED_SHORT, true);
+  buffer->loadBuffer(*buf);
 
-    return buffer;
+  return buffer;
 }
 
-Program *ContextGL::createProgram(const std::string &mVId, const std::string &mFId)
+Program *ContextGL::createProgram(const std::string &mVId,
+                                  const std::string &mFId)
 {
-    ProgramGL *program = new ProgramGL(this, mVId, mFId);
+  ProgramGL *program = new ProgramGL(this, mVId, mFId);
 
-    return program;
+  return program;
 }
 
 void ContextGL::setWindowTitle(const std::string &text)
 {
-    glfwSetWindowTitle(mWindow, text.c_str());
+  glfwSetWindowTitle(mWindow, text.c_str());
 }
 
 bool ContextGL::ShouldQuit()
 {
-    return glfwWindowShouldClose(mWindow);
+  return glfwWindowShouldClose(mWindow);
 }
 
 void ContextGL::KeyBoardQuit()
 {
-    if (glfwGetKey(mWindow, GLFW_KEY_ESCAPE) == GLFW_PRESS)
-        glfwSetWindowShouldClose(mWindow, GLFW_TRUE);
+  if (glfwGetKey(mWindow, GLFW_KEY_ESCAPE) == GLFW_PRESS)
+    glfwSetWindowShouldClose(mWindow, GLFW_TRUE);
 }
 
-void ContextGL::DoFlush(const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset)
+void ContextGL::DoFlush(
+    const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset)
 {
 #ifdef GL_GLEXT_PROTOTYPES
-    eglSwapBuffers(mDisplay, mSurface);
+  eglSwapBuffers(mDisplay, mSurface);
 #else
-    glfwSwapBuffers(mWindow);
+  glfwSwapBuffers(mWindow);
 #endif
-    glfwPollEvents();
+  glfwPollEvents();
 }
 
 void ContextGL::Terminate()
 {
-    glfwTerminate();
+  glfwTerminate();
 }
 
 void ContextGL::showWindow()
 {
-    glfwGetFramebufferSize(mWindow, &mClientWidth, &mClientHeight);
-    glViewport(0, 0, mClientWidth, mClientHeight);
-    glfwShowWindow(mWindow);
+  glfwGetFramebufferSize(mWindow, &mClientWidth, &mClientHeight);
+  glViewport(0, 0, mClientWidth, mClientHeight);
+  glfwShowWindow(mWindow);
 }
 
-void ContextGL::updateFPS(const FPSTimer &fpsTimer,
-                          int *fishCount,
-                          std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> *toggleBitset)
+void ContextGL::updateFPS(
+    const FPSTimer &fpsTimer,
+    int *fishCount,
+    std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> *toggleBitset)
 {
-    if (mDisableControlPanel)
-    {
-        return;
-    }
-    // Start the Dear ImGui frame
-    ImGui_ImplOpenGL3_NewFrame(
-        mMSAASampleCount, toggleBitset->test(static_cast<TOGGLE>(TOGGLE::ENABLEALPHABLENDING)));
-    renderImgui(fpsTimer, fishCount, toggleBitset);
-    ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+  if (mDisableControlPanel)
+  {
+    return;
+  }
+  // Start the Dear ImGui frame
+  ImGui_ImplOpenGL3_NewFrame(
+      mMSAASampleCount,
+      toggleBitset->test(static_cast<TOGGLE>(TOGGLE::ENABLEALPHABLENDING)));
+  renderImgui(fpsTimer, fishCount, toggleBitset);
+  ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 }
 
 void ContextGL::destoryImgUI()
 {
-    // Cleanup
-    ImGui_ImplOpenGL3_Shutdown();
-    ImGui_ImplGlfw_Shutdown();
-    ImGui::DestroyContext();
+  // Cleanup
+  ImGui_ImplOpenGL3_Shutdown();
+  ImGui_ImplGlfw_Shutdown();
+  ImGui::DestroyContext();
 }
 
-int ContextGL::getUniformLocation(unsigned int programId, const std::string &name) const
+int ContextGL::getUniformLocation(unsigned int programId,
+                                  const std::string &name) const
 {
-    GLint index = glGetUniformLocation(programId, name.c_str());
-    ASSERT(glGetError() == GL_NO_ERROR);
-    return index;
+  GLint index = glGetUniformLocation(programId, name.c_str());
+  ASSERT(glGetError() == GL_NO_ERROR);
+  return index;
 }
 
-int ContextGL::getAttribLocation(unsigned int programId, const std::string &name) const
+int ContextGL::getAttribLocation(unsigned int programId,
+                                 const std::string &name) const
 {
-    GLint index = glGetAttribLocation(programId, name.c_str());
-    ASSERT(glGetError() == GL_NO_ERROR);
-    return index;
+  GLint index = glGetAttribLocation(programId, name.c_str());
+  ASSERT(glGetError() == GL_NO_ERROR);
+  return index;
 }
 
 void ContextGL::enableBlend(bool flag) const
 {
-    if (flag)
-    {
-        glEnable(GL_BLEND);
-        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-        glBlendEquation(GL_FUNC_ADD);
-    }
-    else
-    {
-        glDisable(GL_BLEND);
-    }
+  if (flag)
+  {
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glBlendEquation(GL_FUNC_ADD);
+  }
+  else
+  {
+    glDisable(GL_BLEND);
+  }
 }
 
 void ContextGL::drawElements(const BufferGL &buffer) const
 {
-    GLint totalComponents = buffer.getTotalComponents();
-    GLenum type           = buffer.getType();
-    glDrawElements(GL_TRIANGLES, totalComponents, type, 0);
+  GLint totalComponents = buffer.getTotalComponents();
+  GLenum type           = buffer.getType();
+  glDrawElements(GL_TRIANGLES, totalComponents, type, 0);
 
-    ASSERT(glGetError() == GL_NO_ERROR);
+  ASSERT(glGetError() == GL_NO_ERROR);
 }
 
-Model *ContextGL::createModel(Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend)
+Model *ContextGL::createModel(Aquarium *aquarium,
+                              MODELGROUP type,
+                              MODELNAME name,
+                              bool blend)
 {
-    Model *model;
-    switch (type)
-    {
-        case MODELGROUP::FISH:
-            model = new FishModelGL(this, aquarium, type, name, blend);
-            break;
-        case MODELGROUP::GENERIC:
-            model = new GenericModelGL(this, aquarium, type, name, blend);
-            break;
-        case MODELGROUP::INNER:
-            model = new InnerModelGL(this, aquarium, type, name, blend);
-            break;
-        case MODELGROUP::SEAWEED:
-            model = new SeaweedModelGL(this, aquarium, type, name, blend);
-            break;
-        case MODELGROUP::OUTSIDE:
-            model = new OutsideModelGL(this, aquarium, type, name, blend);
-            break;
-        default:
-            model = nullptr;
-            std::cout << "can not create model type" << std::endl;
-    }
+  Model *model;
+  switch (type)
+  {
+  case MODELGROUP::FISH:
+    model = new FishModelGL(this, aquarium, type, name, blend);
+    break;
+  case MODELGROUP::GENERIC:
+    model = new GenericModelGL(this, aquarium, type, name, blend);
+    break;
+  case MODELGROUP::INNER:
+    model = new InnerModelGL(this, aquarium, type, name, blend);
+    break;
+  case MODELGROUP::SEAWEED:
+    model = new SeaweedModelGL(this, aquarium, type, name, blend);
+    break;
+  case MODELGROUP::OUTSIDE:
+    model = new OutsideModelGL(this, aquarium, type, name, blend);
+    break;
+  default:
+    model = nullptr;
+    std::cout << "can not create model type" << std::endl;
+  }
 
-    return model;
+  return model;
 }
 
 void ContextGL::preFrame()
 {
-    glClearColor(0, 0.8, 1, 0);
-    glEnable(GL_DEPTH_TEST);
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+  glClearColor(0, 0.8, 1, 0);
+  glEnable(GL_DEPTH_TEST);
+  glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 
-    ASSERT(glGetError() == GL_NO_ERROR);
+  ASSERT(glGetError() == GL_NO_ERROR);
 }
 
 void ContextGL::setUniform(int index, const float *v, int type) const
 {
-    ASSERT(index != -1);
-    switch (type)
-    {
-        case GL_FLOAT:
-        {
-            glUniform1f(index, *v);
-            break;
-        }
-        case GL_FLOAT_VEC4:
-        {
-            glUniform4fv(index, 1, v);
-            break;
-        }
-        case GL_FLOAT_VEC3:
-        {
-            glUniform3fv(index, 1, v);
-            break;
-        }
-        case GL_FLOAT_VEC2:
-        {
-            glUniform2fv(index, 1, v);
-            break;
-        }
-        case GL_FLOAT_MAT4:
-        {
-            glUniformMatrix4fv(index, 1, false, v);
-            break;
-        }
-        default:
-        {
-            std::cout << "set uniform error" << std::endl;
-        }
-    }
+  ASSERT(index != -1);
+  switch (type)
+  {
+  case GL_FLOAT:
+  {
+    glUniform1f(index, *v);
+    break;
+  }
+  case GL_FLOAT_VEC4:
+  {
+    glUniform4fv(index, 1, v);
+    break;
+  }
+  case GL_FLOAT_VEC3:
+  {
+    glUniform3fv(index, 1, v);
+    break;
+  }
+  case GL_FLOAT_VEC2:
+  {
+    glUniform2fv(index, 1, v);
+    break;
+  }
+  case GL_FLOAT_MAT4:
+  {
+    glUniformMatrix4fv(index, 1, false, v);
+    break;
+  }
+  default:
+  {
+    std::cout << "set uniform error" << std::endl;
+  }
+  }
 
-    ASSERT(glGetError() == GL_NO_ERROR);
+  ASSERT(glGetError() == GL_NO_ERROR);
 }
 
 void ContextGL::setTexture(const TextureGL &texture, int index, int unit) const
 {
-    ASSERT(index != -1);
-    glUniform1i(index, unit);
-    glActiveTexture(GL_TEXTURE0 + unit);
-    glBindTexture(texture.getTarget(), texture.getTextureId());
+  ASSERT(index != -1);
+  glUniform1i(index, unit);
+  glActiveTexture(GL_TEXTURE0 + unit);
+  glBindTexture(texture.getTarget(), texture.getTextureId());
 
-    ASSERT(glGetError() == GL_NO_ERROR);
+  ASSERT(glGetError() == GL_NO_ERROR);
 }
 
 void ContextGL::setAttribs(const BufferGL &bufferGL, int index) const
 {
-    ASSERT(index != -1);
-    glBindBuffer(bufferGL.getTarget(), bufferGL.getBuffer());
+  ASSERT(index != -1);
+  glBindBuffer(bufferGL.getTarget(), bufferGL.getBuffer());
 
-    glEnableVertexAttribArray(index);
-    glVertexAttribPointer(index, bufferGL.getNumComponents(), bufferGL.getType(),
-                          bufferGL.getNormalize(), bufferGL.getStride(), bufferGL.getOffset());
+  glEnableVertexAttribArray(index);
+  glVertexAttribPointer(index, bufferGL.getNumComponents(), bufferGL.getType(),
+                        bufferGL.getNormalize(), bufferGL.getStride(),
+                        bufferGL.getOffset());
 
-    ASSERT(glGetError() == GL_NO_ERROR);
+  ASSERT(glGetError() == GL_NO_ERROR);
 }
 
 void ContextGL::setIndices(const BufferGL &bufferGL) const
 {
-    glBindBuffer(bufferGL.getTarget(), bufferGL.getBuffer());
+  glBindBuffer(bufferGL.getTarget(), bufferGL.getBuffer());
 }
 
 unsigned int ContextGL::generateVAO()
 {
-    unsigned int vao;
-    glGenVertexArrays(1, &vao);
-    return vao;
+  unsigned int vao;
+  glGenVertexArrays(1, &vao);
+  return vao;
 }
 
 void ContextGL::bindVAO(unsigned int vao) const
 {
-    glBindVertexArray(vao);
+  glBindVertexArray(vao);
 }
 
 void ContextGL::deleteVAO(unsigned int mVAO)
 {
-    glDeleteVertexArrays(1, &mVAO);
+  glDeleteVertexArrays(1, &mVAO);
 }
 
 unsigned int ContextGL::generateBuffer()
 {
-    unsigned int buf;
-    glGenBuffers(1, &buf);
-    return buf;
+  unsigned int buf;
+  glGenBuffers(1, &buf);
+  return buf;
 }
 
 void ContextGL::deleteBuffer(unsigned int buf)
 {
-    glDeleteBuffers(1, &buf);
+  glDeleteBuffers(1, &buf);
 }
 
 void ContextGL::bindBuffer(unsigned int target, unsigned int buf)
 {
-    glBindBuffer(target, buf);
+  glBindBuffer(target, buf);
 }
 
 void ContextGL::uploadBuffer(unsigned int target, const std::vector<float> &buf)
 {
-    glBufferData(target, sizeof(GLfloat) * buf.size(), buf.data(), GL_STATIC_DRAW);
+  glBufferData(target, sizeof(GLfloat) * buf.size(), buf.data(),
+               GL_STATIC_DRAW);
 
-    ASSERT(glGetError() == GL_NO_ERROR);
+  ASSERT(glGetError() == GL_NO_ERROR);
 }
 
-void ContextGL::uploadBuffer(unsigned int target, const std::vector<unsigned short> &buf)
+void ContextGL::uploadBuffer(unsigned int target,
+                             const std::vector<unsigned short> &buf)
 {
-    glBufferData(target, sizeof(GLushort) * buf.size(), buf.data(), GL_STATIC_DRAW);
+  glBufferData(target, sizeof(GLushort) * buf.size(), buf.data(),
+               GL_STATIC_DRAW);
 
-    ASSERT(glGetError() == GL_NO_ERROR);
+  ASSERT(glGetError() == GL_NO_ERROR);
 }
 
 unsigned int ContextGL::generateProgram()
 {
-    return glCreateProgram();
+  return glCreateProgram();
 }
 
 void ContextGL::setProgram(unsigned int program)
 {
-    glUseProgram(program);
+  glUseProgram(program);
 }
 
 void ContextGL::deleteProgram(unsigned int program)
 {
-    glDeleteProgram(program);
+  glDeleteProgram(program);
 }
 
 bool ContextGL::compileProgram(unsigned int programId,
                                const std::string &VertexShaderCode,
                                const std::string &FragmentShaderCode)
 {
-    // Create the shaders
-    GLuint VertexShaderID   = glCreateShader(GL_VERTEX_SHADER);
-    GLuint FragmentShaderID = glCreateShader(GL_FRAGMENT_SHADER);
+  // Create the shaders
+  GLuint VertexShaderID   = glCreateShader(GL_VERTEX_SHADER);
+  GLuint FragmentShaderID = glCreateShader(GL_FRAGMENT_SHADER);
 
-    GLint Result = GL_FALSE;
-    int InfoLogLength;
+  GLint Result = GL_FALSE;
+  int InfoLogLength;
 
-    // Compile Vertex Shader
-    char const *VertexSourcePointer = VertexShaderCode.c_str();
-    glShaderSource(VertexShaderID, 1, &VertexSourcePointer, nullptr);
-    glCompileShader(VertexShaderID);
+  // Compile Vertex Shader
+  char const *VertexSourcePointer = VertexShaderCode.c_str();
+  glShaderSource(VertexShaderID, 1, &VertexSourcePointer, nullptr);
+  glCompileShader(VertexShaderID);
 
-    // Check Vertex Shader
-    glGetShaderiv(VertexShaderID, GL_COMPILE_STATUS, &Result);
-    if (!Result)
-    {
-        glGetShaderiv(VertexShaderID, GL_INFO_LOG_LENGTH, &InfoLogLength);
-        std::vector<char> VertexShaderErrorMessage(InfoLogLength);
-        glGetShaderInfoLog(VertexShaderID, InfoLogLength, nullptr, &VertexShaderErrorMessage[0]);
-        std::cout << stdout << &VertexShaderErrorMessage[0] << std::endl;
-    }
+  // Check Vertex Shader
+  glGetShaderiv(VertexShaderID, GL_COMPILE_STATUS, &Result);
+  if (!Result)
+  {
+    glGetShaderiv(VertexShaderID, GL_INFO_LOG_LENGTH, &InfoLogLength);
+    std::vector<char> VertexShaderErrorMessage(InfoLogLength);
+    glGetShaderInfoLog(VertexShaderID, InfoLogLength, nullptr,
+                       &VertexShaderErrorMessage[0]);
+    std::cout << stdout << &VertexShaderErrorMessage[0] << std::endl;
+  }
 
-    // Compile Fragment Shader
-    char const *FragmentSourcePointer = FragmentShaderCode.c_str();
-    glShaderSource(FragmentShaderID, 1, &FragmentSourcePointer, nullptr);
-    glCompileShader(FragmentShaderID);
+  // Compile Fragment Shader
+  char const *FragmentSourcePointer = FragmentShaderCode.c_str();
+  glShaderSource(FragmentShaderID, 1, &FragmentSourcePointer, nullptr);
+  glCompileShader(FragmentShaderID);
 
-    // Check Fragment Shader
-    glGetShaderiv(FragmentShaderID, GL_COMPILE_STATUS, &Result);
-    if (!Result)
-    {
-        glGetShaderiv(FragmentShaderID, GL_INFO_LOG_LENGTH, &InfoLogLength);
-        std::vector<char> FragmentShaderErrorMessage(InfoLogLength);
-        glGetShaderInfoLog(FragmentShaderID, InfoLogLength, nullptr,
-                           &FragmentShaderErrorMessage[0]);
-        std::cout << stdout << &FragmentShaderErrorMessage[0] << std::endl;
-    }
+  // Check Fragment Shader
+  glGetShaderiv(FragmentShaderID, GL_COMPILE_STATUS, &Result);
+  if (!Result)
+  {
+    glGetShaderiv(FragmentShaderID, GL_INFO_LOG_LENGTH, &InfoLogLength);
+    std::vector<char> FragmentShaderErrorMessage(InfoLogLength);
+    glGetShaderInfoLog(FragmentShaderID, InfoLogLength, nullptr,
+                       &FragmentShaderErrorMessage[0]);
+    std::cout << stdout << &FragmentShaderErrorMessage[0] << std::endl;
+  }
 
-    // Link the program
-    glAttachShader(programId, VertexShaderID);
-    glAttachShader(programId, FragmentShaderID);
-    glLinkProgram(programId);
+  // Link the program
+  glAttachShader(programId, VertexShaderID);
+  glAttachShader(programId, FragmentShaderID);
+  glLinkProgram(programId);
 
-    // Check the program
-    glGetProgramiv(programId, GL_LINK_STATUS, &Result);
-    if (!Result)
-    {
-        glGetProgramiv(programId, GL_INFO_LOG_LENGTH, &InfoLogLength);
-        std::vector<char> ProgramErrorMessage(std::max(InfoLogLength, int(1)));
-        glGetProgramInfoLog(programId, InfoLogLength, nullptr, &ProgramErrorMessage[0]);
-        std::cout << stdout << &ProgramErrorMessage[0] << std::endl;
-    }
-    glDeleteShader(VertexShaderID);
-    glDeleteShader(FragmentShaderID);
+  // Check the program
+  glGetProgramiv(programId, GL_LINK_STATUS, &Result);
+  if (!Result)
+  {
+    glGetProgramiv(programId, GL_INFO_LOG_LENGTH, &InfoLogLength);
+    std::vector<char> ProgramErrorMessage(std::max(InfoLogLength, int(1)));
+    glGetProgramInfoLog(programId, InfoLogLength, nullptr,
+                        &ProgramErrorMessage[0]);
+    std::cout << stdout << &ProgramErrorMessage[0] << std::endl;
+  }
+  glDeleteShader(VertexShaderID);
+  glDeleteShader(FragmentShaderID);
 
-    return true;
+  return true;
 }

--- a/src/aquarium-optimized/opengl/ContextGL.h
+++ b/src/aquarium-optimized/opengl/ContextGL.h
@@ -34,87 +34,103 @@ enum BACKENDTYPE : short;
 
 class ContextGL : public Context
 {
-  public:
-    ContextGL(BACKENDTYPE backendType);
-    ~ContextGL();
-    bool initialize(BACKENDTYPE backend,
-                    const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset,
-                    int windowWidth,
-                    int windowHeight) override;
-    void setWindowTitle(const std::string &text) override;
-    bool ShouldQuit() override;
-    void KeyBoardQuit() override;
-    void DoFlush(const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset) override;
-    void Terminate() override;
-    void showWindow() override;
-    void updateFPS(const FPSTimer &fpsTimer,
-                   int *fishCount,
-                   std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> *toggleBitset) override;
-    void destoryImgUI() override;
+public:
+  ContextGL(BACKENDTYPE backendType);
+  ~ContextGL();
+  bool initialize(
+      BACKENDTYPE backend,
+      const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset,
+      int windowWidth,
+      int windowHeight) override;
+  void setWindowTitle(const std::string &text) override;
+  bool ShouldQuit() override;
+  void KeyBoardQuit() override;
+  void DoFlush(const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)>
+                   &toggleBitset) override;
+  void Terminate() override;
+  void showWindow() override;
+  void updateFPS(const FPSTimer &fpsTimer,
+                 int *fishCount,
+                 std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)>
+                     *toggleBitset) override;
+  void destoryImgUI() override;
 
-    void preFrame() override;
-    void enableBlend(bool flag) const;
+  void preFrame() override;
+  void enableBlend(bool flag) const;
 
-    Model *createModel(Aquarium *aquarium, MODELGROUP type, MODELNAME name, bool blend) override;
-    int getUniformLocation(unsigned int programId, const std::string &name) const;
-    int getAttribLocation(unsigned int programId, const std::string &name) const;
-    void setUniform(int index, const float *v, int type) const;
-    void setTexture(const TextureGL &texture, int index, int unit) const;
-    void setAttribs(const BufferGL &bufferGL, int index) const;
-    void setIndices(const BufferGL &bufferGL) const;
-    void drawElements(const BufferGL &buffer) const;
+  Model *createModel(Aquarium *aquarium,
+                     MODELGROUP type,
+                     MODELNAME name,
+                     bool blend) override;
+  int getUniformLocation(unsigned int programId, const std::string &name) const;
+  int getAttribLocation(unsigned int programId, const std::string &name) const;
+  void setUniform(int index, const float *v, int type) const;
+  void setTexture(const TextureGL &texture, int index, int unit) const;
+  void setAttribs(const BufferGL &bufferGL, int index) const;
+  void setIndices(const BufferGL &bufferGL) const;
+  void drawElements(const BufferGL &buffer) const;
 
-    Buffer *createBuffer(int numComponents, std::vector<float> *buffer, bool isIndex) override;
-    Buffer *createBuffer(int numComponents,
-                         std::vector<unsigned short> *buffer,
-                         bool isIndex) override;
-    unsigned int generateBuffer();
-    void deleteBuffer(unsigned int buf);
-    void bindBuffer(unsigned int target, unsigned int buf);
-    void uploadBuffer(unsigned int target, const std::vector<float> &buf);
-    void uploadBuffer(unsigned int target, const std::vector<unsigned short> &buf);
+  Buffer *createBuffer(int numComponents,
+                       std::vector<float> *buffer,
+                       bool isIndex) override;
+  Buffer *createBuffer(int numComponents,
+                       std::vector<unsigned short> *buffer,
+                       bool isIndex) override;
+  unsigned int generateBuffer();
+  void deleteBuffer(unsigned int buf);
+  void bindBuffer(unsigned int target, unsigned int buf);
+  void uploadBuffer(unsigned int target, const std::vector<float> &buf);
+  void uploadBuffer(unsigned int target,
+                    const std::vector<unsigned short> &buf);
 
-    Program *createProgram(const std::string &mVId, const std::string &mFId) override;
-    unsigned int generateProgram();
-    void setProgram(unsigned int program);
-    void deleteProgram(unsigned int program);
-    bool compileProgram(unsigned int programId,
-                        const std::string &VertexShaderCode,
-                        const std::string &FragmentShaderCode);
-    void bindVAO(unsigned int vao) const;
-    unsigned int generateVAO();
-    void deleteVAO(unsigned int vao);
+  Program *createProgram(const std::string &mVId,
+                         const std::string &mFId) override;
+  unsigned int generateProgram();
+  void setProgram(unsigned int program);
+  void deleteProgram(unsigned int program);
+  bool compileProgram(unsigned int programId,
+                      const std::string &VertexShaderCode,
+                      const std::string &FragmentShaderCode);
+  void bindVAO(unsigned int vao) const;
+  unsigned int generateVAO();
+  void deleteVAO(unsigned int vao);
 
-    Texture *createTexture(const std::string &name, const std::string &url) override;
-    Texture *createTexture(const std::string &name, const std::vector<std::string> &urls) override;
-    unsigned int generateTexture();
-    void bindTexture(unsigned int target, unsigned int texture);
-    void deleteTexture(unsigned int texture);
-    void uploadTexture(unsigned int target,
-                       unsigned int format,
-                       int width,
-                       int height,
-                       unsigned char *pixel);
-    void setParameter(unsigned int target, unsigned int pname, int param);
-    void generateMipmap(unsigned int target);
-    void updateAllFishData() override;
+  Texture *createTexture(const std::string &name,
+                         const std::string &url) override;
+  Texture *createTexture(const std::string &name,
+                         const std::vector<std::string> &urls) override;
+  unsigned int generateTexture();
+  void bindTexture(unsigned int target, unsigned int texture);
+  void deleteTexture(unsigned int texture);
+  void uploadTexture(unsigned int target,
+                     unsigned int format,
+                     int width,
+                     int height,
+                     unsigned char *pixel);
+  void setParameter(unsigned int target, unsigned int pname, int param);
+  void generateMipmap(unsigned int target);
+  void updateAllFishData() override;
 
-  private:
-    void initState();
-    void initAvailableToggleBitset(BACKENDTYPE backendType) override;
-    static void framebufferResizeCallback(GLFWwindow *window, int width, int height);
+private:
+  void initState();
+  void initAvailableToggleBitset(BACKENDTYPE backendType) override;
+  static void framebufferResizeCallback(GLFWwindow *window,
+                                        int width,
+                                        int height);
 
-    GLFWwindow *mWindow;
-    std::string mGLSLVersion;
+  GLFWwindow *mWindow;
+  std::string mGLSLVersion;
 
 #ifdef EGL_EGL_PROTOTYPES
-    EGLBoolean FindEGLConfig(EGLDisplay dpy, const EGLint *attrib_list, EGLConfig *config);
-    EGLContext createContext(EGLContext share) const;
+  EGLBoolean FindEGLConfig(EGLDisplay dpy,
+                           const EGLint *attrib_list,
+                           EGLConfig *config);
+  EGLContext createContext(EGLContext share) const;
 
-    EGLSurface mSurface;
-    EGLContext mContext;
-    EGLDisplay mDisplay;
-    EGLConfig mConfig;
+  EGLSurface mSurface;
+  EGLContext mContext;
+  EGLDisplay mDisplay;
+  EGLConfig mConfig;
 #endif
 };
 

--- a/src/aquarium-optimized/opengl/FishModelGL.cpp
+++ b/src/aquarium-optimized/opengl/FishModelGL.cpp
@@ -17,148 +17,181 @@ FishModelGL::FishModelGL(const ContextGL *mContextGL,
                          bool blend)
     : FishModel(type, name, blend, aquarium), mContextGL(mContextGL)
 {
-    mViewInverseUniform.first    = aquarium->lightWorldPositionUniform.viewInverse;
-    mLightWorldPosUniform.first  = aquarium->lightWorldPositionUniform.lightWorldPos;
-    mLightColorUniform.first     = aquarium->lightUniforms.lightColor;
-    mSpecularUniform.first       = aquarium->lightUniforms.specular;
-    mShininessUniform.first      = 5.0f;
-    mSpecularFactorUniform.first = 0.3f;
-    mAmbientUniform.first        = aquarium->lightUniforms.ambient;
-    mFogPowerUniform.first       = g_fogPower;
-    mFogMultUniform.first        = g_fogMult;
-    mFogOffsetUniform.first      = g_fogOffset;
-    mFogColorUniform.first       = aquarium->fogUniforms.fogColor;
+  mViewInverseUniform.first = aquarium->lightWorldPositionUniform.viewInverse;
+  mLightWorldPosUniform.first =
+      aquarium->lightWorldPositionUniform.lightWorldPos;
+  mLightColorUniform.first     = aquarium->lightUniforms.lightColor;
+  mSpecularUniform.first       = aquarium->lightUniforms.specular;
+  mShininessUniform.first      = 5.0f;
+  mSpecularFactorUniform.first = 0.3f;
+  mAmbientUniform.first        = aquarium->lightUniforms.ambient;
+  mFogPowerUniform.first       = g_fogPower;
+  mFogMultUniform.first        = g_fogMult;
+  mFogOffsetUniform.first      = g_fogOffset;
+  mFogColorUniform.first       = aquarium->fogUniforms.fogColor;
 
-    mViewProjectionUniform.first = aquarium->lightWorldPositionUniform.viewProjection;
-    mScaleUniform.first          = 1;
+  mViewProjectionUniform.first =
+      aquarium->lightWorldPositionUniform.viewProjection;
+  mScaleUniform.first = 1;
 
-    const Fish &fishInfo         = fishTable[name - MODELNAME::MODELSMALLFISHA];
-    mFishLengthUniform.first     = fishInfo.fishLength;
-    mFishBendAmountUniform.first = fishInfo.fishBendAmount;
-    mFishWaveLengthUniform.first = fishInfo.fishWaveLength;
+  const Fish &fishInfo         = fishTable[name - MODELNAME::MODELSMALLFISHA];
+  mFishLengthUniform.first     = fishInfo.fishLength;
+  mFishBendAmountUniform.first = fishInfo.fishBendAmount;
+  mFishWaveLengthUniform.first = fishInfo.fishWaveLength;
 }
 
 void FishModelGL::init()
 {
-    ProgramGL *programGL = static_cast<ProgramGL *>(mProgram);
-    mViewInverseUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "viewInverse");
-    mLightWorldPosUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "lightWorldPos");
-    mLightColorUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "lightColor");
-    mSpecularUniform.second = mContextGL->getUniformLocation(programGL->getProgramId(), "specular");
-    mAmbientUniform.second  = mContextGL->getUniformLocation(programGL->getProgramId(), "ambient");
-    mShininessUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "shininess");
-    mSpecularFactorUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "specularFactor");
+  ProgramGL *programGL = static_cast<ProgramGL *>(mProgram);
+  mViewInverseUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "viewInverse");
+  mLightWorldPosUniform.second = mContextGL->getUniformLocation(
+      programGL->getProgramId(), "lightWorldPos");
+  mLightColorUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "lightColor");
+  mSpecularUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "specular");
+  mAmbientUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "ambient");
+  mShininessUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "shininess");
+  mSpecularFactorUniform.second = mContextGL->getUniformLocation(
+      programGL->getProgramId(), "specularFactor");
 
-    mFogPowerUniform.second = mContextGL->getUniformLocation(programGL->getProgramId(), "fogPower");
-    mFogMultUniform.second  = mContextGL->getUniformLocation(programGL->getProgramId(), "fogMult");
-    mFogOffsetUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "fogOffset");
-    mFogColorUniform.second = mContextGL->getUniformLocation(programGL->getProgramId(), "fogColor");
+  mFogPowerUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "fogPower");
+  mFogMultUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "fogMult");
+  mFogOffsetUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "fogOffset");
+  mFogColorUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "fogColor");
 
-    mViewProjectionUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "viewProjection");
-    mFishLengthUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "fishLength");
-    mFishWaveLengthUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "fishWaveLength");
-    mFishBendAmountUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "fishBendAmount");
+  mViewProjectionUniform.second = mContextGL->getUniformLocation(
+      programGL->getProgramId(), "viewProjection");
+  mFishLengthUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "fishLength");
+  mFishWaveLengthUniform.second = mContextGL->getUniformLocation(
+      programGL->getProgramId(), "fishWaveLength");
+  mFishBendAmountUniform.second = mContextGL->getUniformLocation(
+      programGL->getProgramId(), "fishBendAmount");
 
-    mWorldPositionUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "worldPosition");
-    mNextPositionUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "nextPosition");
-    mScaleUniform.second = mContextGL->getUniformLocation(programGL->getProgramId(), "scale");
-    mTimeUniform.second  = mContextGL->getUniformLocation(programGL->getProgramId(), "time");
+  mWorldPositionUniform.second = mContextGL->getUniformLocation(
+      programGL->getProgramId(), "worldPosition");
+  mNextPositionUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "nextPosition");
+  mScaleUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "scale");
+  mTimeUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "time");
 
-    mDiffuseTexture.first  = static_cast<TextureGL *>(textureMap["diffuse"]);
-    mDiffuseTexture.second = mContextGL->getUniformLocation(programGL->getProgramId(), "diffuse");
-    mNormalTexture.first   = static_cast<TextureGL *>(textureMap["normalMap"]);
-    mNormalTexture.second  = mContextGL->getUniformLocation(programGL->getProgramId(), "normalMap");
-    mReflectionTexture.first = static_cast<TextureGL *>(textureMap["reflectionMap"]);
-    mReflectionTexture.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "reflectionMap");
-    mSkyboxTexture.first  = static_cast<TextureGL *>(textureMap["skybox"]);
-    mSkyboxTexture.second = mContextGL->getUniformLocation(programGL->getProgramId(), "skybox");
+  mDiffuseTexture.first = static_cast<TextureGL *>(textureMap["diffuse"]);
+  mDiffuseTexture.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "diffuse");
+  mNormalTexture.first = static_cast<TextureGL *>(textureMap["normalMap"]);
+  mNormalTexture.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "normalMap");
+  mReflectionTexture.first =
+      static_cast<TextureGL *>(textureMap["reflectionMap"]);
+  mReflectionTexture.second = mContextGL->getUniformLocation(
+      programGL->getProgramId(), "reflectionMap");
+  mSkyboxTexture.first = static_cast<TextureGL *>(textureMap["skybox"]);
+  mSkyboxTexture.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "skybox");
 
-    mPositionBuffer.first  = static_cast<BufferGL *>(bufferMap["position"]);
-    mPositionBuffer.second = mContextGL->getAttribLocation(programGL->getProgramId(), "position");
-    mNormalBuffer.first    = static_cast<BufferGL *>(bufferMap["normal"]);
-    mNormalBuffer.second   = mContextGL->getAttribLocation(programGL->getProgramId(), "normal");
-    mTexCoordBuffer.first  = static_cast<BufferGL *>(bufferMap["texCoord"]);
-    mTexCoordBuffer.second = mContextGL->getAttribLocation(programGL->getProgramId(), "texCoord");
-    mTangentBuffer.first   = static_cast<BufferGL *>(bufferMap["tangent"]);
-    mTangentBuffer.second  = mContextGL->getAttribLocation(programGL->getProgramId(), "tangent");
-    mBiNormalBuffer.first  = static_cast<BufferGL *>(bufferMap["binormal"]);
-    mBiNormalBuffer.second = mContextGL->getAttribLocation(programGL->getProgramId(), "binormal");
+  mPositionBuffer.first = static_cast<BufferGL *>(bufferMap["position"]);
+  mPositionBuffer.second =
+      mContextGL->getAttribLocation(programGL->getProgramId(), "position");
+  mNormalBuffer.first = static_cast<BufferGL *>(bufferMap["normal"]);
+  mNormalBuffer.second =
+      mContextGL->getAttribLocation(programGL->getProgramId(), "normal");
+  mTexCoordBuffer.first = static_cast<BufferGL *>(bufferMap["texCoord"]);
+  mTexCoordBuffer.second =
+      mContextGL->getAttribLocation(programGL->getProgramId(), "texCoord");
+  mTangentBuffer.first = static_cast<BufferGL *>(bufferMap["tangent"]);
+  mTangentBuffer.second =
+      mContextGL->getAttribLocation(programGL->getProgramId(), "tangent");
+  mBiNormalBuffer.first = static_cast<BufferGL *>(bufferMap["binormal"]);
+  mBiNormalBuffer.second =
+      mContextGL->getAttribLocation(programGL->getProgramId(), "binormal");
 
-    mIndicesBuffer = static_cast<BufferGL *>(bufferMap["indices"]);
+  mIndicesBuffer = static_cast<BufferGL *>(bufferMap["indices"]);
 }
 
 void FishModelGL::draw()
 {
-    mContextGL->drawElements(*mIndicesBuffer);
+  mContextGL->drawElements(*mIndicesBuffer);
 }
 
 void FishModelGL::prepareForDraw()
 {
-    mProgram->setProgram();
-    mContextGL->enableBlend(mBlend);
+  mProgram->setProgram();
+  mContextGL->enableBlend(mBlend);
 
-    ProgramGL *programGL = static_cast<ProgramGL *>(mProgram);
-    mContextGL->bindVAO(programGL->getVAOId());
+  ProgramGL *programGL = static_cast<ProgramGL *>(mProgram);
+  mContextGL->bindVAO(programGL->getVAOId());
 
-    mContextGL->setAttribs(*mPositionBuffer.first, mPositionBuffer.second);
-    mContextGL->setAttribs(*mNormalBuffer.first, mNormalBuffer.second);
-    mContextGL->setAttribs(*mTexCoordBuffer.first, mTexCoordBuffer.second);
+  mContextGL->setAttribs(*mPositionBuffer.first, mPositionBuffer.second);
+  mContextGL->setAttribs(*mNormalBuffer.first, mNormalBuffer.second);
+  mContextGL->setAttribs(*mTexCoordBuffer.first, mTexCoordBuffer.second);
 
-    mContextGL->setAttribs(*mTangentBuffer.first, mTangentBuffer.second);
-    mContextGL->setAttribs(*mBiNormalBuffer.first, mBiNormalBuffer.second);
+  mContextGL->setAttribs(*mTangentBuffer.first, mTangentBuffer.second);
+  mContextGL->setAttribs(*mBiNormalBuffer.first, mBiNormalBuffer.second);
 
-    mContextGL->setIndices(*mIndicesBuffer);
+  mContextGL->setIndices(*mIndicesBuffer);
 
-    mContextGL->setUniform(mViewInverseUniform.second, mViewInverseUniform.first, GL_FLOAT_MAT4);
-    mContextGL->setUniform(mLightWorldPosUniform.second, mLightWorldPosUniform.first,
-                           GL_FLOAT_VEC3);
-    mContextGL->setUniform(mLightColorUniform.second, mLightColorUniform.first, GL_FLOAT_VEC4);
-    mContextGL->setUniform(mSpecularUniform.second, mSpecularUniform.first, GL_FLOAT_VEC4);
-    mContextGL->setUniform(mShininessUniform.second, &mShininessUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mSpecularFactorUniform.second, &mSpecularFactorUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mAmbientUniform.second, mAmbientUniform.first, GL_FLOAT_VEC4);
-    mContextGL->setUniform(mFogPowerUniform.second, &mFogPowerUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mFogMultUniform.second, &mFogMultUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mFogOffsetUniform.second, &mFogOffsetUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mFogColorUniform.second, mFogColorUniform.first, GL_FLOAT_VEC4);
+  mContextGL->setUniform(mViewInverseUniform.second, mViewInverseUniform.first,
+                         GL_FLOAT_MAT4);
+  mContextGL->setUniform(mLightWorldPosUniform.second,
+                         mLightWorldPosUniform.first, GL_FLOAT_VEC3);
+  mContextGL->setUniform(mLightColorUniform.second, mLightColorUniform.first,
+                         GL_FLOAT_VEC4);
+  mContextGL->setUniform(mSpecularUniform.second, mSpecularUniform.first,
+                         GL_FLOAT_VEC4);
+  mContextGL->setUniform(mShininessUniform.second, &mShininessUniform.first,
+                         GL_FLOAT);
+  mContextGL->setUniform(mSpecularFactorUniform.second,
+                         &mSpecularFactorUniform.first, GL_FLOAT);
+  mContextGL->setUniform(mAmbientUniform.second, mAmbientUniform.first,
+                         GL_FLOAT_VEC4);
+  mContextGL->setUniform(mFogPowerUniform.second, &mFogPowerUniform.first,
+                         GL_FLOAT);
+  mContextGL->setUniform(mFogMultUniform.second, &mFogMultUniform.first,
+                         GL_FLOAT);
+  mContextGL->setUniform(mFogOffsetUniform.second, &mFogOffsetUniform.first,
+                         GL_FLOAT);
+  mContextGL->setUniform(mFogColorUniform.second, mFogColorUniform.first,
+                         GL_FLOAT_VEC4);
 
-    mContextGL->setUniform(mViewProjectionUniform.second, mViewProjectionUniform.first,
-                           GL_FLOAT_MAT4);
-    mContextGL->setUniform(mFishBendAmountUniform.second, &mFishBendAmountUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mFishLengthUniform.second, &mFishLengthUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mFishWaveLengthUniform.second, &mFishWaveLengthUniform.first, GL_FLOAT);
+  mContextGL->setUniform(mViewProjectionUniform.second,
+                         mViewProjectionUniform.first, GL_FLOAT_MAT4);
+  mContextGL->setUniform(mFishBendAmountUniform.second,
+                         &mFishBendAmountUniform.first, GL_FLOAT);
+  mContextGL->setUniform(mFishLengthUniform.second, &mFishLengthUniform.first,
+                         GL_FLOAT);
+  mContextGL->setUniform(mFishWaveLengthUniform.second,
+                         &mFishWaveLengthUniform.first, GL_FLOAT);
 
-    // Fish models includes small, medium and big. Some of them contains reflection and skybox
-    // texture, but some doesn't.
-    mContextGL->setTexture(*mDiffuseTexture.first, mDiffuseTexture.second, 0);
-    mContextGL->setTexture(*mNormalTexture.first, mNormalTexture.second, 1);
-    if (mSkyboxTexture.second != -1 && mReflectionTexture.second != -1)
-    {
-        mContextGL->setTexture(*mReflectionTexture.first, mReflectionTexture.second, 2);
-        mContextGL->setTexture(*mSkyboxTexture.first, mSkyboxTexture.second, 3);
-    }
+  // Fish models includes small, medium and big. Some of them contains
+  // reflection and skybox texture, but some doesn't.
+  mContextGL->setTexture(*mDiffuseTexture.first, mDiffuseTexture.second, 0);
+  mContextGL->setTexture(*mNormalTexture.first, mNormalTexture.second, 1);
+  if (mSkyboxTexture.second != -1 && mReflectionTexture.second != -1)
+  {
+    mContextGL->setTexture(*mReflectionTexture.first, mReflectionTexture.second,
+                           2);
+    mContextGL->setTexture(*mSkyboxTexture.first, mSkyboxTexture.second, 3);
+  }
 }
 
 void FishModelGL::updatePerInstanceUniforms(const WorldUniforms &WorldUniforms)
 {
-    mContextGL->setUniform(mScaleUniform.second, &mScaleUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mTimeUniform.second, &mTimeUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mWorldPositionUniform.second, mWorldPositionUniform.first,
-                           GL_FLOAT_VEC3);
-    mContextGL->setUniform(mNextPositionUniform.second, mNextPositionUniform.first, GL_FLOAT_VEC3);
+  mContextGL->setUniform(mScaleUniform.second, &mScaleUniform.first, GL_FLOAT);
+  mContextGL->setUniform(mTimeUniform.second, &mTimeUniform.first, GL_FLOAT);
+  mContextGL->setUniform(mWorldPositionUniform.second,
+                         mWorldPositionUniform.first, GL_FLOAT_VEC3);
+  mContextGL->setUniform(mNextPositionUniform.second,
+                         mNextPositionUniform.first, GL_FLOAT_VEC3);
 }
 
 void FishModelGL::updateFishPerUniforms(float x,
@@ -171,12 +204,12 @@ void FishModelGL::updateFishPerUniforms(float x,
                                         float time,
                                         int index)
 {
-    mWorldPositionUniform.first[0] = x;
-    mWorldPositionUniform.first[1] = y;
-    mWorldPositionUniform.first[2] = z;
-    mNextPositionUniform.first[0]  = nextX;
-    mNextPositionUniform.first[1]  = nextY;
-    mNextPositionUniform.first[2]  = nextZ;
-    mScaleUniform.first            = scale;
-    mTimeUniform.first             = time;
+  mWorldPositionUniform.first[0] = x;
+  mWorldPositionUniform.first[1] = y;
+  mWorldPositionUniform.first[2] = z;
+  mNextPositionUniform.first[0]  = nextX;
+  mNextPositionUniform.first[1]  = nextY;
+  mNextPositionUniform.first[2]  = nextZ;
+  mScaleUniform.first            = scale;
+  mTimeUniform.first             = time;
 }

--- a/src/aquarium-optimized/opengl/FishModelGL.h
+++ b/src/aquarium-optimized/opengl/FishModelGL.h
@@ -18,68 +18,68 @@ class TextureGL;
 
 class FishModelGL : public FishModel
 {
-  public:
-    FishModelGL(const ContextGL *context,
-                Aquarium *aquarium,
-                MODELGROUP type,
-                MODELNAME name,
-                bool blend);
-    void prepareForDraw() override;
-    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
+public:
+  FishModelGL(const ContextGL *context,
+              Aquarium *aquarium,
+              MODELGROUP type,
+              MODELNAME name,
+              bool blend);
+  void prepareForDraw() override;
+  void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
 
-    void init() override;
-    void draw() override;
+  void init() override;
+  void draw() override;
 
-    void updateFishPerUniforms(float x,
-                               float y,
-                               float z,
-                               float nextX,
-                               float nextY,
-                               float nextZ,
-                               float scale,
-                               float time,
-                               int index) override;
+  void updateFishPerUniforms(float x,
+                             float y,
+                             float z,
+                             float nextX,
+                             float nextY,
+                             float nextZ,
+                             float scale,
+                             float time,
+                             int index) override;
 
-    std::pair<float *, int> mViewInverseUniform;
-    std::pair<float *, int> mLightWorldPosUniform;
-    std::pair<float *, int> mLightColorUniform;
-    std::pair<float *, int> mSpecularUniform;
-    std::pair<float, int> mShininessUniform;
-    std::pair<float, int> mSpecularFactorUniform;
+  std::pair<float *, int> mViewInverseUniform;
+  std::pair<float *, int> mLightWorldPosUniform;
+  std::pair<float *, int> mLightColorUniform;
+  std::pair<float *, int> mSpecularUniform;
+  std::pair<float, int> mShininessUniform;
+  std::pair<float, int> mSpecularFactorUniform;
 
-    std::pair<float *, int> mAmbientUniform;
+  std::pair<float *, int> mAmbientUniform;
 
-    std::pair<float, int> mFogPowerUniform;
-    std::pair<float, int> mFogMultUniform;
-    std::pair<float, int> mFogOffsetUniform;
-    std::pair<float *, int> mFogColorUniform;
+  std::pair<float, int> mFogPowerUniform;
+  std::pair<float, int> mFogMultUniform;
+  std::pair<float, int> mFogOffsetUniform;
+  std::pair<float *, int> mFogColorUniform;
 
-    std::pair<float *, int> mViewProjectionUniform;
-    std::pair<float, int> mFishLengthUniform;
-    std::pair<float, int> mFishWaveLengthUniform;
-    std::pair<float, int> mFishBendAmountUniform;
+  std::pair<float *, int> mViewProjectionUniform;
+  std::pair<float, int> mFishLengthUniform;
+  std::pair<float, int> mFishWaveLengthUniform;
+  std::pair<float, int> mFishBendAmountUniform;
 
-    std::pair<float[3], int> mWorldPositionUniform;
-    std::pair<float[3], int> mNextPositionUniform;
-    std::pair<float, int> mScaleUniform;
-    std::pair<float, int> mTimeUniform;
+  std::pair<float[3], int> mWorldPositionUniform;
+  std::pair<float[3], int> mNextPositionUniform;
+  std::pair<float, int> mScaleUniform;
+  std::pair<float, int> mTimeUniform;
 
-    std::pair<TextureGL *, int> mDiffuseTexture;
-    std::pair<TextureGL *, int> mNormalTexture;
-    std::pair<TextureGL *, int> mReflectionTexture;
-    std::pair<TextureGL *, int> mSkyboxTexture;
+  std::pair<TextureGL *, int> mDiffuseTexture;
+  std::pair<TextureGL *, int> mNormalTexture;
+  std::pair<TextureGL *, int> mReflectionTexture;
+  std::pair<TextureGL *, int> mSkyboxTexture;
 
-    std::pair<BufferGL *, int> mPositionBuffer;
-    std::pair<BufferGL *, int> mNormalBuffer;
-    std::pair<BufferGL *, int> mTexCoordBuffer;
+  std::pair<BufferGL *, int> mPositionBuffer;
+  std::pair<BufferGL *, int> mNormalBuffer;
+  std::pair<BufferGL *, int> mTexCoordBuffer;
 
-    std::pair<BufferGL *, int> mTangentBuffer;
-    std::pair<BufferGL *, int> mBiNormalBuffer;
+  std::pair<BufferGL *, int> mTangentBuffer;
+  std::pair<BufferGL *, int> mBiNormalBuffer;
 
-    BufferGL *mIndicesBuffer;
+  BufferGL *mIndicesBuffer;
 
-  private:
-    const ContextGL *mContextGL;
+private:
+  const ContextGL *mContextGL;
 };
 
 #endif  // FISHMODELGL_H

--- a/src/aquarium-optimized/opengl/GenericModelGL.cpp
+++ b/src/aquarium-optimized/opengl/GenericModelGL.cpp
@@ -14,123 +14,151 @@ GenericModelGL::GenericModelGL(const ContextGL *context,
                                bool blend)
     : Model(type, name, blend), mContextGL(context)
 {
-    mViewInverseUniform.first           = aquarium->lightWorldPositionUniform.viewInverse;
-    mLightWorldPosUniform.first         = aquarium->lightWorldPositionUniform.lightWorldPos;
-    mLightColorUniform.first            = aquarium->lightUniforms.lightColor;
-    mSpecularUniform.first              = aquarium->lightUniforms.specular;
-    mShininessUniform.first             = 50.0f;
-    mSpecularFactorUniform.first        = 1.0f;
-    mAmbientUniform.first               = aquarium->lightUniforms.ambient;
-    mWorldUniform.first                 = aquarium->worldUniforms.world;
-    mWorldViewProjectionUniform.first   = aquarium->worldUniforms.worldViewProjection;
-    mWorldInverseTransposeUniform.first = aquarium->worldUniforms.worldInverseTranspose;
-    mFogPowerUniform.first              = g_fogPower;
-    mFogMultUniform.first               = g_fogMult;
-    mFogOffsetUniform.first             = g_fogOffset;
-    mFogColorUniform.first              = aquarium->fogUniforms.fogColor;
+  mViewInverseUniform.first = aquarium->lightWorldPositionUniform.viewInverse;
+  mLightWorldPosUniform.first =
+      aquarium->lightWorldPositionUniform.lightWorldPos;
+  mLightColorUniform.first     = aquarium->lightUniforms.lightColor;
+  mSpecularUniform.first       = aquarium->lightUniforms.specular;
+  mShininessUniform.first      = 50.0f;
+  mSpecularFactorUniform.first = 1.0f;
+  mAmbientUniform.first        = aquarium->lightUniforms.ambient;
+  mWorldUniform.first          = aquarium->worldUniforms.world;
+  mWorldViewProjectionUniform.first =
+      aquarium->worldUniforms.worldViewProjection;
+  mWorldInverseTransposeUniform.first =
+      aquarium->worldUniforms.worldInverseTranspose;
+  mFogPowerUniform.first  = g_fogPower;
+  mFogMultUniform.first   = g_fogMult;
+  mFogOffsetUniform.first = g_fogOffset;
+  mFogColorUniform.first  = aquarium->fogUniforms.fogColor;
 }
 
 void GenericModelGL::init()
 {
-    ProgramGL *programGL = static_cast<ProgramGL *>(mProgram);
-    mWorldViewProjectionUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "worldViewProjection");
-    mWorldUniform.second = mContextGL->getUniformLocation(programGL->getProgramId(), "world");
-    mWorldInverseTransposeUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "worldInverseTranspose");
+  ProgramGL *programGL               = static_cast<ProgramGL *>(mProgram);
+  mWorldViewProjectionUniform.second = mContextGL->getUniformLocation(
+      programGL->getProgramId(), "worldViewProjection");
+  mWorldUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "world");
+  mWorldInverseTransposeUniform.second = mContextGL->getUniformLocation(
+      programGL->getProgramId(), "worldInverseTranspose");
 
-    mViewInverseUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "viewInverse");
-    mLightWorldPosUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "lightWorldPos");
-    mLightColorUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "lightColor");
-    mSpecularUniform.second = mContextGL->getUniformLocation(programGL->getProgramId(), "specular");
-    mAmbientUniform.second  = mContextGL->getUniformLocation(programGL->getProgramId(), "ambient");
-    mShininessUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "shininess");
-    mSpecularFactorUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "specularFactor");
+  mViewInverseUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "viewInverse");
+  mLightWorldPosUniform.second = mContextGL->getUniformLocation(
+      programGL->getProgramId(), "lightWorldPos");
+  mLightColorUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "lightColor");
+  mSpecularUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "specular");
+  mAmbientUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "ambient");
+  mShininessUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "shininess");
+  mSpecularFactorUniform.second = mContextGL->getUniformLocation(
+      programGL->getProgramId(), "specularFactor");
 
-    mFogPowerUniform.second = mContextGL->getUniformLocation(programGL->getProgramId(), "fogPower");
-    mFogMultUniform.second  = mContextGL->getUniformLocation(programGL->getProgramId(), "fogMult");
-    mFogOffsetUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "fogOffset");
-    mFogColorUniform.second = mContextGL->getUniformLocation(programGL->getProgramId(), "fogColor");
+  mFogPowerUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "fogPower");
+  mFogMultUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "fogMult");
+  mFogOffsetUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "fogOffset");
+  mFogColorUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "fogColor");
 
-    mDiffuseTexture.first  = static_cast<TextureGL *>(textureMap["diffuse"]);
-    mDiffuseTexture.second = mContextGL->getUniformLocation(programGL->getProgramId(), "diffuse");
-    mNormalTexture.first   = static_cast<TextureGL *>(textureMap["normalMap"]);
-    mNormalTexture.second  = mContextGL->getUniformLocation(programGL->getProgramId(), "normalMap");
+  mDiffuseTexture.first = static_cast<TextureGL *>(textureMap["diffuse"]);
+  mDiffuseTexture.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "diffuse");
+  mNormalTexture.first = static_cast<TextureGL *>(textureMap["normalMap"]);
+  mNormalTexture.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "normalMap");
 
-    mPositionBuffer.first  = static_cast<BufferGL *>(bufferMap["position"]);
-    mPositionBuffer.second = mContextGL->getAttribLocation(programGL->getProgramId(), "position");
-    mNormalBuffer.first    = static_cast<BufferGL *>(bufferMap["normal"]);
-    mNormalBuffer.second   = mContextGL->getAttribLocation(programGL->getProgramId(), "normal");
-    mTexCoordBuffer.first  = static_cast<BufferGL *>(bufferMap["texCoord"]);
-    mTexCoordBuffer.second = mContextGL->getAttribLocation(programGL->getProgramId(), "texCoord");
-    mTangentBuffer.first   = static_cast<BufferGL *>(bufferMap["tangent"]);
-    mTangentBuffer.second  = mContextGL->getAttribLocation(programGL->getProgramId(), "tangent");
-    mBiNormalBuffer.first  = static_cast<BufferGL *>(bufferMap["binormal"]);
-    mBiNormalBuffer.second = mContextGL->getAttribLocation(programGL->getProgramId(), "binormal");
+  mPositionBuffer.first = static_cast<BufferGL *>(bufferMap["position"]);
+  mPositionBuffer.second =
+      mContextGL->getAttribLocation(programGL->getProgramId(), "position");
+  mNormalBuffer.first = static_cast<BufferGL *>(bufferMap["normal"]);
+  mNormalBuffer.second =
+      mContextGL->getAttribLocation(programGL->getProgramId(), "normal");
+  mTexCoordBuffer.first = static_cast<BufferGL *>(bufferMap["texCoord"]);
+  mTexCoordBuffer.second =
+      mContextGL->getAttribLocation(programGL->getProgramId(), "texCoord");
+  mTangentBuffer.first = static_cast<BufferGL *>(bufferMap["tangent"]);
+  mTangentBuffer.second =
+      mContextGL->getAttribLocation(programGL->getProgramId(), "tangent");
+  mBiNormalBuffer.first = static_cast<BufferGL *>(bufferMap["binormal"]);
+  mBiNormalBuffer.second =
+      mContextGL->getAttribLocation(programGL->getProgramId(), "binormal");
 
-    mIndicesBuffer = static_cast<BufferGL *>(bufferMap["indices"]);
+  mIndicesBuffer = static_cast<BufferGL *>(bufferMap["indices"]);
 }
 
 void GenericModelGL::draw()
 {
-    mContextGL->drawElements(*mIndicesBuffer);
+  mContextGL->drawElements(*mIndicesBuffer);
 }
 
 void GenericModelGL::prepareForDraw()
 {
-    mProgram->setProgram();
-    mContextGL->enableBlend(mBlend);
+  mProgram->setProgram();
+  mContextGL->enableBlend(mBlend);
 
-    ProgramGL *programGL = static_cast<ProgramGL *>(mProgram);
-    mContextGL->bindVAO(programGL->getVAOId());
+  ProgramGL *programGL = static_cast<ProgramGL *>(mProgram);
+  mContextGL->bindVAO(programGL->getVAOId());
 
-    mContextGL->setAttribs(*mPositionBuffer.first, mPositionBuffer.second);
-    mContextGL->setAttribs(*mNormalBuffer.first, mNormalBuffer.second);
-    mContextGL->setAttribs(*mTexCoordBuffer.first, mTexCoordBuffer.second);
+  mContextGL->setAttribs(*mPositionBuffer.first, mPositionBuffer.second);
+  mContextGL->setAttribs(*mNormalBuffer.first, mNormalBuffer.second);
+  mContextGL->setAttribs(*mTexCoordBuffer.first, mTexCoordBuffer.second);
 
-    // diffuseVertexShader doesn't contains tangent and binormal but normalMapVertexShader
-    // contains the two buffers.
-    if (mTangentBuffer.second != -1 && mBiNormalBuffer.second != -1)
-    {
-        mContextGL->setAttribs(*mTangentBuffer.first, mTangentBuffer.second);
-        mContextGL->setAttribs(*mBiNormalBuffer.first, mBiNormalBuffer.second);
-    }
+  // diffuseVertexShader doesn't contains tangent and binormal but
+  // normalMapVertexShader contains the two buffers.
+  if (mTangentBuffer.second != -1 && mBiNormalBuffer.second != -1)
+  {
+    mContextGL->setAttribs(*mTangentBuffer.first, mTangentBuffer.second);
+    mContextGL->setAttribs(*mBiNormalBuffer.first, mBiNormalBuffer.second);
+  }
 
-    mContextGL->setIndices(*mIndicesBuffer);
+  mContextGL->setIndices(*mIndicesBuffer);
 
-    mContextGL->setUniform(mViewInverseUniform.second, mViewInverseUniform.first, GL_FLOAT_MAT4);
-    mContextGL->setUniform(mLightWorldPosUniform.second, mLightWorldPosUniform.first,
-                           GL_FLOAT_VEC3);
-    mContextGL->setUniform(mLightColorUniform.second, mLightColorUniform.first, GL_FLOAT_VEC4);
-    mContextGL->setUniform(mSpecularUniform.second, mSpecularUniform.first, GL_FLOAT_VEC4);
-    mContextGL->setUniform(mShininessUniform.second, &mShininessUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mSpecularFactorUniform.second, &mSpecularFactorUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mAmbientUniform.second, mAmbientUniform.first, GL_FLOAT_VEC4);
-    mContextGL->setUniform(mFogPowerUniform.second, &mFogPowerUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mFogMultUniform.second, &mFogMultUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mFogOffsetUniform.second, &mFogOffsetUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mFogColorUniform.second, mFogColorUniform.first, GL_FLOAT_VEC4);
+  mContextGL->setUniform(mViewInverseUniform.second, mViewInverseUniform.first,
+                         GL_FLOAT_MAT4);
+  mContextGL->setUniform(mLightWorldPosUniform.second,
+                         mLightWorldPosUniform.first, GL_FLOAT_VEC3);
+  mContextGL->setUniform(mLightColorUniform.second, mLightColorUniform.first,
+                         GL_FLOAT_VEC4);
+  mContextGL->setUniform(mSpecularUniform.second, mSpecularUniform.first,
+                         GL_FLOAT_VEC4);
+  mContextGL->setUniform(mShininessUniform.second, &mShininessUniform.first,
+                         GL_FLOAT);
+  mContextGL->setUniform(mSpecularFactorUniform.second,
+                         &mSpecularFactorUniform.first, GL_FLOAT);
+  mContextGL->setUniform(mAmbientUniform.second, mAmbientUniform.first,
+                         GL_FLOAT_VEC4);
+  mContextGL->setUniform(mFogPowerUniform.second, &mFogPowerUniform.first,
+                         GL_FLOAT);
+  mContextGL->setUniform(mFogMultUniform.second, &mFogMultUniform.first,
+                         GL_FLOAT);
+  mContextGL->setUniform(mFogOffsetUniform.second, &mFogOffsetUniform.first,
+                         GL_FLOAT);
+  mContextGL->setUniform(mFogColorUniform.second, mFogColorUniform.first,
+                         GL_FLOAT_VEC4);
 
-    mContextGL->setTexture(*mDiffuseTexture.first, mDiffuseTexture.second, 0);
-    // Generic models includes Arch, coral, rock, ship, etc. diffuseFragmentShader doesn't contain
-    // normalMap texture but normalMapFragmentShader contains.
-    if (mNormalTexture.second != -1)
-    {
-        mContextGL->setTexture(*mNormalTexture.first, mNormalTexture.second, 1);
-    }
+  mContextGL->setTexture(*mDiffuseTexture.first, mDiffuseTexture.second, 0);
+  // Generic models includes Arch, coral, rock, ship, etc. diffuseFragmentShader
+  // doesn't contain normalMap texture but normalMapFragmentShader contains.
+  if (mNormalTexture.second != -1)
+  {
+    mContextGL->setTexture(*mNormalTexture.first, mNormalTexture.second, 1);
+  }
 }
 
-void GenericModelGL::updatePerInstanceUniforms(const WorldUniforms &mWorldUniforms)
+void GenericModelGL::updatePerInstanceUniforms(
+    const WorldUniforms &mWorldUniforms)
 {
-    mContextGL->setUniform(mWorldUniform.second, mWorldUniform.first, GL_FLOAT_MAT4);
-    mContextGL->setUniform(mWorldViewProjectionUniform.second, mWorldViewProjectionUniform.first,
-                           GL_FLOAT_MAT4);
-    mContextGL->setUniform(mWorldInverseTransposeUniform.second,
-                           mWorldInverseTransposeUniform.first, GL_FLOAT_MAT4);
+  mContextGL->setUniform(mWorldUniform.second, mWorldUniform.first,
+                         GL_FLOAT_MAT4);
+  mContextGL->setUniform(mWorldViewProjectionUniform.second,
+                         mWorldViewProjectionUniform.first, GL_FLOAT_MAT4);
+  mContextGL->setUniform(mWorldInverseTransposeUniform.second,
+                         mWorldInverseTransposeUniform.first, GL_FLOAT_MAT4);
 }

--- a/src/aquarium-optimized/opengl/GenericModelGL.h
+++ b/src/aquarium-optimized/opengl/GenericModelGL.h
@@ -14,49 +14,49 @@
 
 class GenericModelGL : public Model
 {
-  public:
-    GenericModelGL(const ContextGL *context,
-                   Aquarium *aquarium,
-                   MODELGROUP type,
-                   MODELNAME name,
-                   bool blend);
-    void prepareForDraw() override;
-    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
-    void init() override;
-    void draw() override;
+public:
+  GenericModelGL(const ContextGL *context,
+                 Aquarium *aquarium,
+                 MODELGROUP type,
+                 MODELNAME name,
+                 bool blend);
+  void prepareForDraw() override;
+  void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
+  void init() override;
+  void draw() override;
 
-    std::pair<float *, int> mWorldViewProjectionUniform;
-    std::pair<float *, int> mWorldUniform;
-    std::pair<float *, int> mWorldInverseTransposeUniform;
+  std::pair<float *, int> mWorldViewProjectionUniform;
+  std::pair<float *, int> mWorldUniform;
+  std::pair<float *, int> mWorldInverseTransposeUniform;
 
-    std::pair<float *, int> mViewInverseUniform;
-    std::pair<float *, int> mLightWorldPosUniform;
-    std::pair<float *, int> mLightColorUniform;
-    std::pair<float *, int> mSpecularUniform;
-    std::pair<float, int> mShininessUniform;
-    std::pair<float, int> mSpecularFactorUniform;
+  std::pair<float *, int> mViewInverseUniform;
+  std::pair<float *, int> mLightWorldPosUniform;
+  std::pair<float *, int> mLightColorUniform;
+  std::pair<float *, int> mSpecularUniform;
+  std::pair<float, int> mShininessUniform;
+  std::pair<float, int> mSpecularFactorUniform;
 
-    std::pair<float *, int> mAmbientUniform;
+  std::pair<float *, int> mAmbientUniform;
 
-    std::pair<float, int> mFogPowerUniform;
-    std::pair<float, int> mFogMultUniform;
-    std::pair<float, int> mFogOffsetUniform;
-    std::pair<float *, int> mFogColorUniform;
+  std::pair<float, int> mFogPowerUniform;
+  std::pair<float, int> mFogMultUniform;
+  std::pair<float, int> mFogOffsetUniform;
+  std::pair<float *, int> mFogColorUniform;
 
-    std::pair<TextureGL *, int> mDiffuseTexture;
-    std::pair<TextureGL *, int> mNormalTexture;
+  std::pair<TextureGL *, int> mDiffuseTexture;
+  std::pair<TextureGL *, int> mNormalTexture;
 
-    std::pair<BufferGL *, int> mPositionBuffer;
-    std::pair<BufferGL *, int> mNormalBuffer;
-    std::pair<BufferGL *, int> mTexCoordBuffer;
+  std::pair<BufferGL *, int> mPositionBuffer;
+  std::pair<BufferGL *, int> mNormalBuffer;
+  std::pair<BufferGL *, int> mTexCoordBuffer;
 
-    std::pair<BufferGL *, int> mTangentBuffer;
-    std::pair<BufferGL *, int> mBiNormalBuffer;
+  std::pair<BufferGL *, int> mTangentBuffer;
+  std::pair<BufferGL *, int> mBiNormalBuffer;
 
-    BufferGL *mIndicesBuffer;
+  BufferGL *mIndicesBuffer;
 
-  private:
-    const ContextGL *mContextGL;
+private:
+  const ContextGL *mContextGL;
 };
 
 #endif  // GENERICMODELGL_H

--- a/src/aquarium-optimized/opengl/InnerModelGL.cpp
+++ b/src/aquarium-optimized/opengl/InnerModelGL.cpp
@@ -14,119 +14,145 @@ InnerModelGL::InnerModelGL(const ContextGL *context,
                            bool blend)
     : Model(type, name, blend), mContextGL(context)
 {
-    mViewInverseUniform.first   = aquarium->lightWorldPositionUniform.viewInverse;
-    mLightWorldPosUniform.first = aquarium->lightWorldPositionUniform.lightWorldPos;
+  mViewInverseUniform.first = aquarium->lightWorldPositionUniform.viewInverse;
+  mLightWorldPosUniform.first =
+      aquarium->lightWorldPositionUniform.lightWorldPos;
 
-    mWorldUniform.first                 = aquarium->worldUniforms.world;
-    mWorldViewProjectionUniform.first   = aquarium->worldUniforms.worldViewProjection;
-    mWorldInverseTransposeUniform.first = aquarium->worldUniforms.worldInverseTranspose;
+  mWorldUniform.first = aquarium->worldUniforms.world;
+  mWorldViewProjectionUniform.first =
+      aquarium->worldUniforms.worldViewProjection;
+  mWorldInverseTransposeUniform.first =
+      aquarium->worldUniforms.worldInverseTranspose;
 
-    mEtaUniform.first             = 1.0f;
-    mTankColorFudgeUniform.first  = 0.796f;
-    mRefractionFudgeUniform.first = 3.0f;
+  mEtaUniform.first             = 1.0f;
+  mTankColorFudgeUniform.first  = 0.796f;
+  mRefractionFudgeUniform.first = 3.0f;
 
-    mFogPowerUniform.first  = g_fogPower;
-    mFogMultUniform.first   = g_fogMult;
-    mFogOffsetUniform.first = g_fogOffset;
-    mFogColorUniform.first  = aquarium->fogUniforms.fogColor;
+  mFogPowerUniform.first  = g_fogPower;
+  mFogMultUniform.first   = g_fogMult;
+  mFogOffsetUniform.first = g_fogOffset;
+  mFogColorUniform.first  = aquarium->fogUniforms.fogColor;
 }
 
 void InnerModelGL::init()
 {
-    ProgramGL *programGL = static_cast<ProgramGL *>(mProgram);
-    mWorldViewProjectionUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "worldViewProjection");
-    mWorldUniform.second = mContextGL->getUniformLocation(programGL->getProgramId(), "world");
-    mWorldInverseTransposeUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "worldInverseTranspose");
+  ProgramGL *programGL               = static_cast<ProgramGL *>(mProgram);
+  mWorldViewProjectionUniform.second = mContextGL->getUniformLocation(
+      programGL->getProgramId(), "worldViewProjection");
+  mWorldUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "world");
+  mWorldInverseTransposeUniform.second = mContextGL->getUniformLocation(
+      programGL->getProgramId(), "worldInverseTranspose");
 
-    mViewInverseUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "viewInverse");
-    mLightWorldPosUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "lightWorldPos");
+  mViewInverseUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "viewInverse");
+  mLightWorldPosUniform.second = mContextGL->getUniformLocation(
+      programGL->getProgramId(), "lightWorldPos");
 
-    mFogPowerUniform.second = mContextGL->getUniformLocation(programGL->getProgramId(), "fogPower");
-    mFogMultUniform.second  = mContextGL->getUniformLocation(programGL->getProgramId(), "fogMult");
-    mFogOffsetUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "fogOffset");
-    mFogColorUniform.second = mContextGL->getUniformLocation(programGL->getProgramId(), "fogColor");
+  mFogPowerUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "fogPower");
+  mFogMultUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "fogMult");
+  mFogOffsetUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "fogOffset");
+  mFogColorUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "fogColor");
 
-    mEtaUniform.second = mContextGL->getUniformLocation(programGL->getProgramId(), "eta");
-    mTankColorFudgeUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "tankColorFudge");
-    mRefractionFudgeUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "refractionFudge");
+  mEtaUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "eta");
+  mTankColorFudgeUniform.second = mContextGL->getUniformLocation(
+      programGL->getProgramId(), "tankColorFudge");
+  mRefractionFudgeUniform.second = mContextGL->getUniformLocation(
+      programGL->getProgramId(), "refractionFudge");
 
-    mDiffuseTexture.first  = static_cast<TextureGL *>(textureMap["diffuse"]);
-    mDiffuseTexture.second = mContextGL->getUniformLocation(programGL->getProgramId(), "diffuse");
-    mNormalTexture.first   = static_cast<TextureGL *>(textureMap["normalMap"]);
-    mNormalTexture.second  = mContextGL->getUniformLocation(programGL->getProgramId(), "normalMap");
-    mReflectionTexture.first = static_cast<TextureGL *>(textureMap["reflectionMap"]);
-    mReflectionTexture.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "reflectionMap");
-    mSkyboxTexture.first  = static_cast<TextureGL *>(textureMap["skybox"]);
-    mSkyboxTexture.second = mContextGL->getUniformLocation(programGL->getProgramId(), "skybox");
+  mDiffuseTexture.first = static_cast<TextureGL *>(textureMap["diffuse"]);
+  mDiffuseTexture.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "diffuse");
+  mNormalTexture.first = static_cast<TextureGL *>(textureMap["normalMap"]);
+  mNormalTexture.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "normalMap");
+  mReflectionTexture.first =
+      static_cast<TextureGL *>(textureMap["reflectionMap"]);
+  mReflectionTexture.second = mContextGL->getUniformLocation(
+      programGL->getProgramId(), "reflectionMap");
+  mSkyboxTexture.first = static_cast<TextureGL *>(textureMap["skybox"]);
+  mSkyboxTexture.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "skybox");
 
-    mPositionBuffer.first  = static_cast<BufferGL *>(bufferMap["position"]);
-    mPositionBuffer.second = mContextGL->getAttribLocation(programGL->getProgramId(), "position");
-    mNormalBuffer.first    = static_cast<BufferGL *>(bufferMap["normal"]);
-    mNormalBuffer.second   = mContextGL->getAttribLocation(programGL->getProgramId(), "normal");
-    mTexCoordBuffer.first  = static_cast<BufferGL *>(bufferMap["texCoord"]);
-    mTexCoordBuffer.second = mContextGL->getAttribLocation(programGL->getProgramId(), "texCoord");
-    mTangentBuffer.first   = static_cast<BufferGL *>(bufferMap["tangent"]);
-    mTangentBuffer.second  = mContextGL->getAttribLocation(programGL->getProgramId(), "tangent");
-    mBiNormalBuffer.first  = static_cast<BufferGL *>(bufferMap["binormal"]);
-    mBiNormalBuffer.second = mContextGL->getAttribLocation(programGL->getProgramId(), "binormal");
+  mPositionBuffer.first = static_cast<BufferGL *>(bufferMap["position"]);
+  mPositionBuffer.second =
+      mContextGL->getAttribLocation(programGL->getProgramId(), "position");
+  mNormalBuffer.first = static_cast<BufferGL *>(bufferMap["normal"]);
+  mNormalBuffer.second =
+      mContextGL->getAttribLocation(programGL->getProgramId(), "normal");
+  mTexCoordBuffer.first = static_cast<BufferGL *>(bufferMap["texCoord"]);
+  mTexCoordBuffer.second =
+      mContextGL->getAttribLocation(programGL->getProgramId(), "texCoord");
+  mTangentBuffer.first = static_cast<BufferGL *>(bufferMap["tangent"]);
+  mTangentBuffer.second =
+      mContextGL->getAttribLocation(programGL->getProgramId(), "tangent");
+  mBiNormalBuffer.first = static_cast<BufferGL *>(bufferMap["binormal"]);
+  mBiNormalBuffer.second =
+      mContextGL->getAttribLocation(programGL->getProgramId(), "binormal");
 
-    mIndicesBuffer = static_cast<BufferGL *>(bufferMap["indices"]);
+  mIndicesBuffer = static_cast<BufferGL *>(bufferMap["indices"]);
 }
 
 void InnerModelGL::draw()
 {
-    mContextGL->drawElements(*mIndicesBuffer);
+  mContextGL->drawElements(*mIndicesBuffer);
 }
 
 void InnerModelGL::prepareForDraw()
 {
-    mProgram->setProgram();
-    mContextGL->enableBlend(mBlend);
+  mProgram->setProgram();
+  mContextGL->enableBlend(mBlend);
 
-    ProgramGL *programGL = static_cast<ProgramGL *>(mProgram);
-    mContextGL->bindVAO(programGL->getVAOId());
+  ProgramGL *programGL = static_cast<ProgramGL *>(mProgram);
+  mContextGL->bindVAO(programGL->getVAOId());
 
-    mContextGL->setAttribs(*mPositionBuffer.first, mPositionBuffer.second);
-    mContextGL->setAttribs(*mNormalBuffer.first, mNormalBuffer.second);
-    mContextGL->setAttribs(*mTexCoordBuffer.first, mTexCoordBuffer.second);
+  mContextGL->setAttribs(*mPositionBuffer.first, mPositionBuffer.second);
+  mContextGL->setAttribs(*mNormalBuffer.first, mNormalBuffer.second);
+  mContextGL->setAttribs(*mTexCoordBuffer.first, mTexCoordBuffer.second);
 
-    mContextGL->setAttribs(*mTangentBuffer.first, mTangentBuffer.second);
-    mContextGL->setAttribs(*mBiNormalBuffer.first, mBiNormalBuffer.second);
+  mContextGL->setAttribs(*mTangentBuffer.first, mTangentBuffer.second);
+  mContextGL->setAttribs(*mBiNormalBuffer.first, mBiNormalBuffer.second);
 
-    mContextGL->setIndices(*mIndicesBuffer);
+  mContextGL->setIndices(*mIndicesBuffer);
 
-    mContextGL->setUniform(mViewInverseUniform.second, mViewInverseUniform.first, GL_FLOAT_MAT4);
-    // lightWorldPosition is optimized away on mesa because it's not used by shader
-    // mContextGL->setUniform(mLightWorldPosUniform.second, mLightWorldPosUniform.first,
-    // GL_FLOAT_VEC3);
-    mContextGL->setUniform(mFogPowerUniform.second, &mFogPowerUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mFogMultUniform.second, &mFogMultUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mFogOffsetUniform.second, &mFogOffsetUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mFogColorUniform.second, mFogColorUniform.first, GL_FLOAT_VEC4);
-    mContextGL->setUniform(mEtaUniform.second, &mEtaUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mTankColorFudgeUniform.second, &mTankColorFudgeUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mRefractionFudgeUniform.second, &mRefractionFudgeUniform.first,
-                           GL_FLOAT);
+  mContextGL->setUniform(mViewInverseUniform.second, mViewInverseUniform.first,
+                         GL_FLOAT_MAT4);
+  // lightWorldPosition is optimized away on mesa because it's not used by
+  // shader mContextGL->setUniform(mLightWorldPosUniform.second,
+  // mLightWorldPosUniform.first, GL_FLOAT_VEC3);
+  mContextGL->setUniform(mFogPowerUniform.second, &mFogPowerUniform.first,
+                         GL_FLOAT);
+  mContextGL->setUniform(mFogMultUniform.second, &mFogMultUniform.first,
+                         GL_FLOAT);
+  mContextGL->setUniform(mFogOffsetUniform.second, &mFogOffsetUniform.first,
+                         GL_FLOAT);
+  mContextGL->setUniform(mFogColorUniform.second, mFogColorUniform.first,
+                         GL_FLOAT_VEC4);
+  mContextGL->setUniform(mEtaUniform.second, &mEtaUniform.first, GL_FLOAT);
+  mContextGL->setUniform(mTankColorFudgeUniform.second,
+                         &mTankColorFudgeUniform.first, GL_FLOAT);
+  mContextGL->setUniform(mRefractionFudgeUniform.second,
+                         &mRefractionFudgeUniform.first, GL_FLOAT);
 
-    mContextGL->setTexture(*mDiffuseTexture.first, mDiffuseTexture.second, 0);
-    mContextGL->setTexture(*mNormalTexture.first, mNormalTexture.second, 1);
-    mContextGL->setTexture(*mReflectionTexture.first, mReflectionTexture.second, 2);
-    mContextGL->setTexture(*mSkyboxTexture.first, mSkyboxTexture.second, 3);
+  mContextGL->setTexture(*mDiffuseTexture.first, mDiffuseTexture.second, 0);
+  mContextGL->setTexture(*mNormalTexture.first, mNormalTexture.second, 1);
+  mContextGL->setTexture(*mReflectionTexture.first, mReflectionTexture.second,
+                         2);
+  mContextGL->setTexture(*mSkyboxTexture.first, mSkyboxTexture.second, 3);
 }
 
-void InnerModelGL::updatePerInstanceUniforms(const WorldUniforms &mWorldUniforms)
+void InnerModelGL::updatePerInstanceUniforms(
+    const WorldUniforms &mWorldUniforms)
 {
-    mContextGL->setUniform(mWorldUniform.second, mWorldUniform.first, GL_FLOAT_MAT4);
-    mContextGL->setUniform(mWorldViewProjectionUniform.second, mWorldViewProjectionUniform.first,
-                           GL_FLOAT_MAT4);
-    mContextGL->setUniform(mWorldInverseTransposeUniform.second,
-                           mWorldInverseTransposeUniform.first, GL_FLOAT_MAT4);
+  mContextGL->setUniform(mWorldUniform.second, mWorldUniform.first,
+                         GL_FLOAT_MAT4);
+  mContextGL->setUniform(mWorldViewProjectionUniform.second,
+                         mWorldViewProjectionUniform.first, GL_FLOAT_MAT4);
+  mContextGL->setUniform(mWorldInverseTransposeUniform.second,
+                         mWorldInverseTransposeUniform.first, GL_FLOAT_MAT4);
 }

--- a/src/aquarium-optimized/opengl/InnerModelGL.h
+++ b/src/aquarium-optimized/opengl/InnerModelGL.h
@@ -14,50 +14,50 @@
 
 class InnerModelGL : public Model
 {
-  public:
-    InnerModelGL(const ContextGL *context,
-                 Aquarium *aquarium,
-                 MODELGROUP type,
-                 MODELNAME name,
-                 bool blend);
-    void prepareForDraw() override;
-    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
-    void init() override;
-    void draw() override;
+public:
+  InnerModelGL(const ContextGL *context,
+               Aquarium *aquarium,
+               MODELGROUP type,
+               MODELNAME name,
+               bool blend);
+  void prepareForDraw() override;
+  void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
+  void init() override;
+  void draw() override;
 
-    std::pair<float *, int> mWorldViewProjectionUniform;
-    std::pair<float *, int> mWorldUniform;
-    std::pair<float *, int> mWorldInverseUniform;
-    std::pair<float *, int> mWorldInverseTransposeUniform;
+  std::pair<float *, int> mWorldViewProjectionUniform;
+  std::pair<float *, int> mWorldUniform;
+  std::pair<float *, int> mWorldInverseUniform;
+  std::pair<float *, int> mWorldInverseTransposeUniform;
 
-    std::pair<float *, int> mViewInverseUniform;
-    std::pair<float *, int> mLightWorldPosUniform;
+  std::pair<float *, int> mViewInverseUniform;
+  std::pair<float *, int> mLightWorldPosUniform;
 
-    std::pair<float, int> mEtaUniform;
-    std::pair<float, int> mTankColorFudgeUniform;
-    std::pair<float, int> mRefractionFudgeUniform;
+  std::pair<float, int> mEtaUniform;
+  std::pair<float, int> mTankColorFudgeUniform;
+  std::pair<float, int> mRefractionFudgeUniform;
 
-    std::pair<float, int> mFogPowerUniform;
-    std::pair<float, int> mFogMultUniform;
-    std::pair<float, int> mFogOffsetUniform;
-    std::pair<float *, int> mFogColorUniform;
+  std::pair<float, int> mFogPowerUniform;
+  std::pair<float, int> mFogMultUniform;
+  std::pair<float, int> mFogOffsetUniform;
+  std::pair<float *, int> mFogColorUniform;
 
-    std::pair<TextureGL *, int> mDiffuseTexture;
-    std::pair<TextureGL *, int> mNormalTexture;
-    std::pair<TextureGL *, int> mReflectionTexture;
-    std::pair<TextureGL *, int> mSkyboxTexture;
+  std::pair<TextureGL *, int> mDiffuseTexture;
+  std::pair<TextureGL *, int> mNormalTexture;
+  std::pair<TextureGL *, int> mReflectionTexture;
+  std::pair<TextureGL *, int> mSkyboxTexture;
 
-    std::pair<BufferGL *, int> mPositionBuffer;
-    std::pair<BufferGL *, int> mNormalBuffer;
-    std::pair<BufferGL *, int> mTexCoordBuffer;
+  std::pair<BufferGL *, int> mPositionBuffer;
+  std::pair<BufferGL *, int> mNormalBuffer;
+  std::pair<BufferGL *, int> mTexCoordBuffer;
 
-    std::pair<BufferGL *, int> mTangentBuffer;
-    std::pair<BufferGL *, int> mBiNormalBuffer;
+  std::pair<BufferGL *, int> mTangentBuffer;
+  std::pair<BufferGL *, int> mBiNormalBuffer;
 
-    BufferGL *mIndicesBuffer;
+  BufferGL *mIndicesBuffer;
 
-  private:
-    const ContextGL *mContextGL;
+private:
+  const ContextGL *mContextGL;
 };
 
 #endif  // INNERMODELGL_H

--- a/src/aquarium-optimized/opengl/OutsideModelGL.cpp
+++ b/src/aquarium-optimized/opengl/OutsideModelGL.cpp
@@ -14,103 +14,128 @@ OutsideModelGL::OutsideModelGL(const ContextGL *context,
                                bool blend)
     : Model(type, name, blend), mContextGL(context)
 {
-    mViewInverseUniform.first           = aquarium->lightWorldPositionUniform.viewInverse;
-    mLightWorldPosUniform.first         = aquarium->lightWorldPositionUniform.lightWorldPos;
-    mLightColorUniform.first            = aquarium->lightUniforms.lightColor;
-    mSpecularUniform.first              = aquarium->lightUniforms.specular;
-    mShininessUniform.first             = 50.0f;
-    mSpecularFactorUniform.first        = 0.0f;
-    mAmbientUniform.first               = aquarium->lightUniforms.ambient;
-    mWorldUniform.first                 = aquarium->worldUniforms.world;
-    mWorldViewProjectionUniform.first   = aquarium->worldUniforms.worldViewProjection;
-    mWorldInverseTransposeUniform.first = aquarium->worldUniforms.worldInverseTranspose;
-    mFogPowerUniform.first              = 0;
-    mFogMultUniform.first               = 0;
-    mFogOffsetUniform.first             = 0;
-    mFogColorUniform.first              = aquarium->fogUniforms.fogColor;
+  mViewInverseUniform.first = aquarium->lightWorldPositionUniform.viewInverse;
+  mLightWorldPosUniform.first =
+      aquarium->lightWorldPositionUniform.lightWorldPos;
+  mLightColorUniform.first     = aquarium->lightUniforms.lightColor;
+  mSpecularUniform.first       = aquarium->lightUniforms.specular;
+  mShininessUniform.first      = 50.0f;
+  mSpecularFactorUniform.first = 0.0f;
+  mAmbientUniform.first        = aquarium->lightUniforms.ambient;
+  mWorldUniform.first          = aquarium->worldUniforms.world;
+  mWorldViewProjectionUniform.first =
+      aquarium->worldUniforms.worldViewProjection;
+  mWorldInverseTransposeUniform.first =
+      aquarium->worldUniforms.worldInverseTranspose;
+  mFogPowerUniform.first  = 0;
+  mFogMultUniform.first   = 0;
+  mFogOffsetUniform.first = 0;
+  mFogColorUniform.first  = aquarium->fogUniforms.fogColor;
 }
 
 void OutsideModelGL::init()
 {
-    ProgramGL *programGL = static_cast<ProgramGL *>(mProgram);
-    mWorldViewProjectionUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "worldViewProjection");
-    mWorldUniform.second = mContextGL->getUniformLocation(programGL->getProgramId(), "world");
-    mWorldInverseTransposeUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "worldInverseTranspose");
+  ProgramGL *programGL               = static_cast<ProgramGL *>(mProgram);
+  mWorldViewProjectionUniform.second = mContextGL->getUniformLocation(
+      programGL->getProgramId(), "worldViewProjection");
+  mWorldUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "world");
+  mWorldInverseTransposeUniform.second = mContextGL->getUniformLocation(
+      programGL->getProgramId(), "worldInverseTranspose");
 
-    mViewInverseUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "viewInverse");
-    mLightWorldPosUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "lightWorldPos");
-    mLightColorUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "lightColor");
-    mSpecularUniform.second = mContextGL->getUniformLocation(programGL->getProgramId(), "specular");
-    mAmbientUniform.second  = mContextGL->getUniformLocation(programGL->getProgramId(), "ambient");
-    mShininessUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "shininess");
-    mSpecularFactorUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "specularFactor");
+  mViewInverseUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "viewInverse");
+  mLightWorldPosUniform.second = mContextGL->getUniformLocation(
+      programGL->getProgramId(), "lightWorldPos");
+  mLightColorUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "lightColor");
+  mSpecularUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "specular");
+  mAmbientUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "ambient");
+  mShininessUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "shininess");
+  mSpecularFactorUniform.second = mContextGL->getUniformLocation(
+      programGL->getProgramId(), "specularFactor");
 
-    mFogPowerUniform.second = mContextGL->getUniformLocation(programGL->getProgramId(), "fogPower");
-    mFogMultUniform.second  = mContextGL->getUniformLocation(programGL->getProgramId(), "fogMult");
-    mFogOffsetUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "fogOffset");
-    mFogColorUniform.second = mContextGL->getUniformLocation(programGL->getProgramId(), "fogColor");
+  mFogPowerUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "fogPower");
+  mFogMultUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "fogMult");
+  mFogOffsetUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "fogOffset");
+  mFogColorUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "fogColor");
 
-    mDiffuseTexture.first  = static_cast<TextureGL *>(textureMap["diffuse"]);
-    mDiffuseTexture.second = mContextGL->getUniformLocation(programGL->getProgramId(), "diffuse");
+  mDiffuseTexture.first = static_cast<TextureGL *>(textureMap["diffuse"]);
+  mDiffuseTexture.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "diffuse");
 
-    mPositionBuffer.first  = static_cast<BufferGL *>(bufferMap["position"]);
-    mPositionBuffer.second = mContextGL->getAttribLocation(programGL->getProgramId(), "position");
-    mNormalBuffer.first    = static_cast<BufferGL *>(bufferMap["normal"]);
-    mNormalBuffer.second   = mContextGL->getAttribLocation(programGL->getProgramId(), "normal");
-    mTexCoordBuffer.first  = static_cast<BufferGL *>(bufferMap["texCoord"]);
-    mTexCoordBuffer.second = mContextGL->getAttribLocation(programGL->getProgramId(), "texCoord");
+  mPositionBuffer.first = static_cast<BufferGL *>(bufferMap["position"]);
+  mPositionBuffer.second =
+      mContextGL->getAttribLocation(programGL->getProgramId(), "position");
+  mNormalBuffer.first = static_cast<BufferGL *>(bufferMap["normal"]);
+  mNormalBuffer.second =
+      mContextGL->getAttribLocation(programGL->getProgramId(), "normal");
+  mTexCoordBuffer.first = static_cast<BufferGL *>(bufferMap["texCoord"]);
+  mTexCoordBuffer.second =
+      mContextGL->getAttribLocation(programGL->getProgramId(), "texCoord");
 
-    mIndicesBuffer = static_cast<BufferGL *>(bufferMap["indices"]);
+  mIndicesBuffer = static_cast<BufferGL *>(bufferMap["indices"]);
 }
 
 void OutsideModelGL::draw()
 {
-    mContextGL->drawElements(*mIndicesBuffer);
+  mContextGL->drawElements(*mIndicesBuffer);
 }
 
 void OutsideModelGL::prepareForDraw()
 {
-    mProgram->setProgram();
-    mContextGL->enableBlend(mBlend);
+  mProgram->setProgram();
+  mContextGL->enableBlend(mBlend);
 
-    ProgramGL *programGL = static_cast<ProgramGL *>(mProgram);
-    mContextGL->bindVAO(programGL->getVAOId());
+  ProgramGL *programGL = static_cast<ProgramGL *>(mProgram);
+  mContextGL->bindVAO(programGL->getVAOId());
 
-    mContextGL->setAttribs(*mPositionBuffer.first, mPositionBuffer.second);
-    mContextGL->setAttribs(*mNormalBuffer.first, mNormalBuffer.second);
-    mContextGL->setAttribs(*mTexCoordBuffer.first, mTexCoordBuffer.second);
+  mContextGL->setAttribs(*mPositionBuffer.first, mPositionBuffer.second);
+  mContextGL->setAttribs(*mNormalBuffer.first, mNormalBuffer.second);
+  mContextGL->setAttribs(*mTexCoordBuffer.first, mTexCoordBuffer.second);
 
-    mContextGL->setIndices(*mIndicesBuffer);
+  mContextGL->setIndices(*mIndicesBuffer);
 
-    mContextGL->setUniform(mViewInverseUniform.second, mViewInverseUniform.first, GL_FLOAT_MAT4);
-    mContextGL->setUniform(mLightWorldPosUniform.second, mLightWorldPosUniform.first,
-                           GL_FLOAT_VEC3);
-    mContextGL->setUniform(mLightColorUniform.second, mLightColorUniform.first, GL_FLOAT_VEC4);
-    mContextGL->setUniform(mSpecularUniform.second, mSpecularUniform.first, GL_FLOAT_VEC4);
-    mContextGL->setUniform(mShininessUniform.second, &mShininessUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mSpecularFactorUniform.second, &mSpecularFactorUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mAmbientUniform.second, mAmbientUniform.first, GL_FLOAT_VEC4);
-    mContextGL->setUniform(mFogPowerUniform.second, &mFogPowerUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mFogMultUniform.second, &mFogMultUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mFogOffsetUniform.second, &mFogOffsetUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mFogColorUniform.second, mFogColorUniform.first, GL_FLOAT_VEC4);
+  mContextGL->setUniform(mViewInverseUniform.second, mViewInverseUniform.first,
+                         GL_FLOAT_MAT4);
+  mContextGL->setUniform(mLightWorldPosUniform.second,
+                         mLightWorldPosUniform.first, GL_FLOAT_VEC3);
+  mContextGL->setUniform(mLightColorUniform.second, mLightColorUniform.first,
+                         GL_FLOAT_VEC4);
+  mContextGL->setUniform(mSpecularUniform.second, mSpecularUniform.first,
+                         GL_FLOAT_VEC4);
+  mContextGL->setUniform(mShininessUniform.second, &mShininessUniform.first,
+                         GL_FLOAT);
+  mContextGL->setUniform(mSpecularFactorUniform.second,
+                         &mSpecularFactorUniform.first, GL_FLOAT);
+  mContextGL->setUniform(mAmbientUniform.second, mAmbientUniform.first,
+                         GL_FLOAT_VEC4);
+  mContextGL->setUniform(mFogPowerUniform.second, &mFogPowerUniform.first,
+                         GL_FLOAT);
+  mContextGL->setUniform(mFogMultUniform.second, &mFogMultUniform.first,
+                         GL_FLOAT);
+  mContextGL->setUniform(mFogOffsetUniform.second, &mFogOffsetUniform.first,
+                         GL_FLOAT);
+  mContextGL->setUniform(mFogColorUniform.second, mFogColorUniform.first,
+                         GL_FLOAT_VEC4);
 
-    mContextGL->setTexture(*mDiffuseTexture.first, mDiffuseTexture.second, 0);
+  mContextGL->setTexture(*mDiffuseTexture.first, mDiffuseTexture.second, 0);
 }
 
-void OutsideModelGL::updatePerInstanceUniforms(const WorldUniforms &worldUniforms)
+void OutsideModelGL::updatePerInstanceUniforms(
+    const WorldUniforms &worldUniforms)
 {
-    mContextGL->setUniform(mWorldUniform.second, mWorldUniform.first, GL_FLOAT_MAT4);
-    mContextGL->setUniform(mWorldViewProjectionUniform.second, mWorldViewProjectionUniform.first,
-                           GL_FLOAT_MAT4);
-    mContextGL->setUniform(mWorldInverseTransposeUniform.second,
-                           mWorldInverseTransposeUniform.first, GL_FLOAT_MAT4);
+  mContextGL->setUniform(mWorldUniform.second, mWorldUniform.first,
+                         GL_FLOAT_MAT4);
+  mContextGL->setUniform(mWorldViewProjectionUniform.second,
+                         mWorldViewProjectionUniform.first, GL_FLOAT_MAT4);
+  mContextGL->setUniform(mWorldInverseTransposeUniform.second,
+                         mWorldInverseTransposeUniform.first, GL_FLOAT_MAT4);
 }

--- a/src/aquarium-optimized/opengl/OutsideModelGL.h
+++ b/src/aquarium-optimized/opengl/OutsideModelGL.h
@@ -14,45 +14,45 @@
 
 class OutsideModelGL : public Model
 {
-  public:
-    OutsideModelGL(const ContextGL *context,
-                   Aquarium *aquarium,
-                   MODELGROUP type,
-                   MODELNAME name,
-                   bool blend);
-    void prepareForDraw() override;
-    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
-    void init() override;
-    void draw() override;
+public:
+  OutsideModelGL(const ContextGL *context,
+                 Aquarium *aquarium,
+                 MODELGROUP type,
+                 MODELNAME name,
+                 bool blend);
+  void prepareForDraw() override;
+  void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
+  void init() override;
+  void draw() override;
 
-    std::pair<float *, int> mWorldViewProjectionUniform;
-    std::pair<float *, int> mWorldUniform;
-    std::pair<float *, int> mWorldInverseTransposeUniform;
+  std::pair<float *, int> mWorldViewProjectionUniform;
+  std::pair<float *, int> mWorldUniform;
+  std::pair<float *, int> mWorldInverseTransposeUniform;
 
-    std::pair<float *, int> mViewInverseUniform;
-    std::pair<float *, int> mLightWorldPosUniform;
-    std::pair<float *, int> mLightColorUniform;
-    std::pair<float *, int> mSpecularUniform;
-    std::pair<float, int> mShininessUniform;
-    std::pair<float, int> mSpecularFactorUniform;
+  std::pair<float *, int> mViewInverseUniform;
+  std::pair<float *, int> mLightWorldPosUniform;
+  std::pair<float *, int> mLightColorUniform;
+  std::pair<float *, int> mSpecularUniform;
+  std::pair<float, int> mShininessUniform;
+  std::pair<float, int> mSpecularFactorUniform;
 
-    std::pair<float *, int> mAmbientUniform;
+  std::pair<float *, int> mAmbientUniform;
 
-    std::pair<float, int> mFogPowerUniform;
-    std::pair<float, int> mFogMultUniform;
-    std::pair<float, int> mFogOffsetUniform;
-    std::pair<float *, int> mFogColorUniform;
+  std::pair<float, int> mFogPowerUniform;
+  std::pair<float, int> mFogMultUniform;
+  std::pair<float, int> mFogOffsetUniform;
+  std::pair<float *, int> mFogColorUniform;
 
-    std::pair<TextureGL *, int> mDiffuseTexture;
+  std::pair<TextureGL *, int> mDiffuseTexture;
 
-    std::pair<BufferGL *, int> mPositionBuffer;
-    std::pair<BufferGL *, int> mNormalBuffer;
-    std::pair<BufferGL *, int> mTexCoordBuffer;
+  std::pair<BufferGL *, int> mPositionBuffer;
+  std::pair<BufferGL *, int> mNormalBuffer;
+  std::pair<BufferGL *, int> mTexCoordBuffer;
 
-    BufferGL *mIndicesBuffer;
+  BufferGL *mIndicesBuffer;
 
-  private:
-    const ContextGL *mContextGL;
+private:
+  const ContextGL *mContextGL;
 };
 
 #endif  // OUTSIDEMODELGL_H

--- a/src/aquarium-optimized/opengl/ProgramGL.cpp
+++ b/src/aquarium-optimized/opengl/ProgramGL.cpp
@@ -36,62 +36,65 @@
 ProgramGL::ProgramGL(ContextGL *context, std::string mVId, std::string mFId)
     : Program(mVId, mFId), mProgramId(0u), mContext(context)
 {
-    mProgramId = context->generateProgram();
-    mVAO       = context->generateVAO();
+  mProgramId = context->generateProgram();
+  mVAO       = context->generateVAO();
 }
 
 ProgramGL::~ProgramGL()
 {
-    mContext->deleteVAO(mVAO);
-    mContext->deleteProgram(mProgramId);
+  mContext->deleteVAO(mVAO);
+  mContext->deleteProgram(mProgramId);
 }
 
 void ProgramGL::compileProgram(bool enableBlending, const std::string &alpha)
 {
-    loadProgram();
+  loadProgram();
 
-    const std::string fogUniforms =
-        R"(uniform float fogPower;
+  const std::string fogUniforms =
+      R"(uniform float fogPower;
         uniform float fogMult;
         uniform float fogOffset;
         uniform vec4 fogColor;)";
-    const std::string fogCode =
-        R"(outColor = mix(outColor, vec4(fogColor.rgb, diffuseColor.a),
+  const std::string fogCode =
+      R"(outColor = mix(outColor, vec4(fogColor.rgb, diffuseColor.a),
         clamp(pow((v_position.z / v_position.w), fogPower) * fogMult - fogOffset,0.0,1.0));)";
 
 #ifdef __APPLE__
-    VertexShaderCode   = std::regex_replace(VertexShaderCode, std::regex(R"(#version 450 core)"),
-                                          R"(#version 410 core)");
-    FragmentShaderCode = std::regex_replace(FragmentShaderCode, std::regex(R"(#version 450 core)"),
-                                            R"(#version 410 core)");
+  VertexShaderCode =
+      std::regex_replace(VertexShaderCode, std::regex(R"(#version 450 core)"),
+                         R"(#version 410 core)");
+  FragmentShaderCode =
+      std::regex_replace(FragmentShaderCode, std::regex(R"(#version 450 core)"),
+                         R"(#version 410 core)");
 #endif
 
-    // enable fog, reflection and normalMaps
-    FragmentShaderCode =
-        std::regex_replace(FragmentShaderCode, std::regex(R"(// #fogUniforms)"), fogUniforms);
-    FragmentShaderCode =
-        std::regex_replace(FragmentShaderCode, std::regex(R"(// #fogCode)"), fogCode);
+  // enable fog, reflection and normalMaps
+  FragmentShaderCode = std::regex_replace(
+      FragmentShaderCode, std::regex(R"(// #fogUniforms)"), fogUniforms);
+  FragmentShaderCode = std::regex_replace(
+      FragmentShaderCode, std::regex(R"(// #fogCode)"), fogCode);
 
-    FragmentShaderCode =
-        std::regex_replace(FragmentShaderCode, std::regex(R"(\n.*?// #noReflection)"), "");
-    FragmentShaderCode =
-        std::regex_replace(FragmentShaderCode, std::regex(R"(\n.*?// #noNormalMap)"), "");
+  FragmentShaderCode = std::regex_replace(
+      FragmentShaderCode, std::regex(R"(\n.*?// #noReflection)"), "");
+  FragmentShaderCode = std::regex_replace(
+      FragmentShaderCode, std::regex(R"(\n.*?// #noNormalMap)"), "");
 
-    if (enableBlending)
-    {
-        FragmentShaderCode =
-            std::regex_replace(FragmentShaderCode, std::regex(R"(diffuseColor.a)"), alpha);
-    }
+  if (enableBlending)
+  {
+    FragmentShaderCode = std::regex_replace(
+        FragmentShaderCode, std::regex(R"(diffuseColor.a)"), alpha);
+  }
 
-    bool status = mContext->compileProgram(mProgramId, VertexShaderCode, FragmentShaderCode);
-    ASSERT(status);
-    if (!status)
-    {
-        std::cout << "Error occurs in compiling program!" << std::endl;
-    }
+  bool status = mContext->compileProgram(mProgramId, VertexShaderCode,
+                                         FragmentShaderCode);
+  ASSERT(status);
+  if (!status)
+  {
+    std::cout << "Error occurs in compiling program!" << std::endl;
+  }
 }
 
 void ProgramGL::setProgram()
 {
-    mContext->setProgram(mProgramId);
+  mContext->setProgram(mProgramId);
 }

--- a/src/aquarium-optimized/opengl/ProgramGL.h
+++ b/src/aquarium-optimized/opengl/ProgramGL.h
@@ -22,21 +22,22 @@
 
 class ProgramGL : public Program
 {
-  public:
-    ProgramGL() {}
-    ProgramGL(ContextGL *, std::string mVId, std::string mFId);
-    ~ProgramGL() override;
+public:
+  ProgramGL() {}
+  ProgramGL(ContextGL *, std::string mVId, std::string mFId);
+  ~ProgramGL() override;
 
-    void setProgram() override;
-    GLuint getProgramId() const { return mProgramId; }
-    GLuint getVAOId() { return mVAO; }
-    void compileProgram(bool enableAlphaBlending, const std::string &alpha) override;
+  void setProgram() override;
+  GLuint getProgramId() const { return mProgramId; }
+  GLuint getVAOId() { return mVAO; }
+  void compileProgram(bool enableAlphaBlending,
+                      const std::string &alpha) override;
 
-  private:
-    GLuint mProgramId;
-    GLuint mVAO;
+private:
+  GLuint mProgramId;
+  GLuint mVAO;
 
-    ContextGL *mContext;
+  ContextGL *mContext;
 };
 
 #endif  // PROGRAMGL_H

--- a/src/aquarium-optimized/opengl/SeaweedModelGL.cpp
+++ b/src/aquarium-optimized/opengl/SeaweedModelGL.cpp
@@ -14,106 +14,131 @@ SeaweedModelGL::SeaweedModelGL(const ContextGL *context,
                                bool blend)
     : SeaweedModel(type, name, blend), mContextGL(context)
 {
-    mViewInverseUniform.first    = aquarium->lightWorldPositionUniform.viewInverse;
-    mLightWorldPosUniform.first  = aquarium->lightWorldPositionUniform.lightWorldPos;
-    mLightColorUniform.first     = aquarium->lightUniforms.lightColor;
-    mSpecularUniform.first       = aquarium->lightUniforms.specular;
-    mShininessUniform.first      = 50.0f;
-    mSpecularFactorUniform.first = 1.0f;
-    mAmbientUniform.first        = aquarium->lightUniforms.ambient;
-    mWorldUniform.first          = aquarium->worldUniforms.world;
-    mFogPowerUniform.first       = g_fogPower;
-    mFogMultUniform.first        = g_fogMult;
-    mFogOffsetUniform.first      = g_fogOffset;
-    mFogColorUniform.first       = aquarium->fogUniforms.fogColor;
-    mViewProjectionUniform.first = aquarium->lightWorldPositionUniform.viewProjection;
+  mViewInverseUniform.first = aquarium->lightWorldPositionUniform.viewInverse;
+  mLightWorldPosUniform.first =
+      aquarium->lightWorldPositionUniform.lightWorldPos;
+  mLightColorUniform.first     = aquarium->lightUniforms.lightColor;
+  mSpecularUniform.first       = aquarium->lightUniforms.specular;
+  mShininessUniform.first      = 50.0f;
+  mSpecularFactorUniform.first = 1.0f;
+  mAmbientUniform.first        = aquarium->lightUniforms.ambient;
+  mWorldUniform.first          = aquarium->worldUniforms.world;
+  mFogPowerUniform.first       = g_fogPower;
+  mFogMultUniform.first        = g_fogMult;
+  mFogOffsetUniform.first      = g_fogOffset;
+  mFogColorUniform.first       = aquarium->fogUniforms.fogColor;
+  mViewProjectionUniform.first =
+      aquarium->lightWorldPositionUniform.viewProjection;
 }
 
 void SeaweedModelGL::init()
 {
-    ProgramGL *programGL = static_cast<ProgramGL *>(mProgram);
-    mWorldUniform.second = mContextGL->getUniformLocation(programGL->getProgramId(), "world");
+  ProgramGL *programGL = static_cast<ProgramGL *>(mProgram);
+  mWorldUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "world");
 
-    mViewInverseUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "viewInverse");
-    mLightWorldPosUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "lightWorldPos");
-    mLightColorUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "lightColor");
-    mSpecularUniform.second = mContextGL->getUniformLocation(programGL->getProgramId(), "specular");
-    mAmbientUniform.second  = mContextGL->getUniformLocation(programGL->getProgramId(), "ambient");
-    mShininessUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "shininess");
-    mSpecularFactorUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "specularFactor");
+  mViewInverseUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "viewInverse");
+  mLightWorldPosUniform.second = mContextGL->getUniformLocation(
+      programGL->getProgramId(), "lightWorldPos");
+  mLightColorUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "lightColor");
+  mSpecularUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "specular");
+  mAmbientUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "ambient");
+  mShininessUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "shininess");
+  mSpecularFactorUniform.second = mContextGL->getUniformLocation(
+      programGL->getProgramId(), "specularFactor");
 
-    mFogPowerUniform.second = mContextGL->getUniformLocation(programGL->getProgramId(), "fogPower");
-    mFogMultUniform.second  = mContextGL->getUniformLocation(programGL->getProgramId(), "fogMult");
-    mFogOffsetUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "fogOffset");
-    mFogColorUniform.second = mContextGL->getUniformLocation(programGL->getProgramId(), "fogColor");
+  mFogPowerUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "fogPower");
+  mFogMultUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "fogMult");
+  mFogOffsetUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "fogOffset");
+  mFogColorUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "fogColor");
 
-    mViewProjectionUniform.second =
-        mContextGL->getUniformLocation(programGL->getProgramId(), "viewProjection");
-    mTimeUniform.second = mContextGL->getUniformLocation(programGL->getProgramId(), "time");
+  mViewProjectionUniform.second = mContextGL->getUniformLocation(
+      programGL->getProgramId(), "viewProjection");
+  mTimeUniform.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "time");
 
-    mDiffuseTexture.first  = static_cast<TextureGL *>(textureMap["diffuse"]);
-    mDiffuseTexture.second = mContextGL->getUniformLocation(programGL->getProgramId(), "diffuse");
+  mDiffuseTexture.first = static_cast<TextureGL *>(textureMap["diffuse"]);
+  mDiffuseTexture.second =
+      mContextGL->getUniformLocation(programGL->getProgramId(), "diffuse");
 
-    mPositionBuffer.first  = static_cast<BufferGL *>(bufferMap["position"]);
-    mPositionBuffer.second = mContextGL->getAttribLocation(programGL->getProgramId(), "position");
-    mNormalBuffer.first    = static_cast<BufferGL *>(bufferMap["normal"]);
-    mNormalBuffer.second   = mContextGL->getAttribLocation(programGL->getProgramId(), "normal");
-    mTexCoordBuffer.first  = static_cast<BufferGL *>(bufferMap["texCoord"]);
-    mTexCoordBuffer.second = mContextGL->getAttribLocation(programGL->getProgramId(), "texCoord");
+  mPositionBuffer.first = static_cast<BufferGL *>(bufferMap["position"]);
+  mPositionBuffer.second =
+      mContextGL->getAttribLocation(programGL->getProgramId(), "position");
+  mNormalBuffer.first = static_cast<BufferGL *>(bufferMap["normal"]);
+  mNormalBuffer.second =
+      mContextGL->getAttribLocation(programGL->getProgramId(), "normal");
+  mTexCoordBuffer.first = static_cast<BufferGL *>(bufferMap["texCoord"]);
+  mTexCoordBuffer.second =
+      mContextGL->getAttribLocation(programGL->getProgramId(), "texCoord");
 
-    mIndicesBuffer = static_cast<BufferGL *>(bufferMap["indices"]);
+  mIndicesBuffer = static_cast<BufferGL *>(bufferMap["indices"]);
 }
 
 void SeaweedModelGL::draw()
 {
-    mContextGL->drawElements(*mIndicesBuffer);
+  mContextGL->drawElements(*mIndicesBuffer);
 }
 
 void SeaweedModelGL::prepareForDraw()
 {
-    mProgram->setProgram();
-    mContextGL->enableBlend(mBlend);
+  mProgram->setProgram();
+  mContextGL->enableBlend(mBlend);
 
-    ProgramGL *programGL = static_cast<ProgramGL *>(mProgram);
-    mContextGL->bindVAO(programGL->getVAOId());
+  ProgramGL *programGL = static_cast<ProgramGL *>(mProgram);
+  mContextGL->bindVAO(programGL->getVAOId());
 
-    mContextGL->setAttribs(*mPositionBuffer.first, mPositionBuffer.second);
-    mContextGL->setAttribs(*mNormalBuffer.first, mNormalBuffer.second);
-    mContextGL->setAttribs(*mTexCoordBuffer.first, mTexCoordBuffer.second);
+  mContextGL->setAttribs(*mPositionBuffer.first, mPositionBuffer.second);
+  mContextGL->setAttribs(*mNormalBuffer.first, mNormalBuffer.second);
+  mContextGL->setAttribs(*mTexCoordBuffer.first, mTexCoordBuffer.second);
 
-    mContextGL->setIndices(*mIndicesBuffer);
+  mContextGL->setIndices(*mIndicesBuffer);
 
-    mContextGL->setUniform(mViewInverseUniform.second, mViewInverseUniform.first, GL_FLOAT_MAT4);
-    mContextGL->setUniform(mLightWorldPosUniform.second, mLightWorldPosUniform.first,
-                           GL_FLOAT_VEC3);
-    mContextGL->setUniform(mLightColorUniform.second, mLightColorUniform.first, GL_FLOAT_VEC4);
-    mContextGL->setUniform(mSpecularUniform.second, mSpecularUniform.first, GL_FLOAT_VEC4);
-    mContextGL->setUniform(mShininessUniform.second, &mShininessUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mSpecularFactorUniform.second, &mSpecularFactorUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mAmbientUniform.second, mAmbientUniform.first, GL_FLOAT_VEC4);
-    mContextGL->setUniform(mFogPowerUniform.second, &mFogPowerUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mFogMultUniform.second, &mFogMultUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mFogOffsetUniform.second, &mFogOffsetUniform.first, GL_FLOAT);
-    mContextGL->setUniform(mFogColorUniform.second, mFogColorUniform.first, GL_FLOAT_VEC4);
-    mContextGL->setUniform(mViewProjectionUniform.second, mViewProjectionUniform.first,
-                           GL_FLOAT_MAT4);
+  mContextGL->setUniform(mViewInverseUniform.second, mViewInverseUniform.first,
+                         GL_FLOAT_MAT4);
+  mContextGL->setUniform(mLightWorldPosUniform.second,
+                         mLightWorldPosUniform.first, GL_FLOAT_VEC3);
+  mContextGL->setUniform(mLightColorUniform.second, mLightColorUniform.first,
+                         GL_FLOAT_VEC4);
+  mContextGL->setUniform(mSpecularUniform.second, mSpecularUniform.first,
+                         GL_FLOAT_VEC4);
+  mContextGL->setUniform(mShininessUniform.second, &mShininessUniform.first,
+                         GL_FLOAT);
+  mContextGL->setUniform(mSpecularFactorUniform.second,
+                         &mSpecularFactorUniform.first, GL_FLOAT);
+  mContextGL->setUniform(mAmbientUniform.second, mAmbientUniform.first,
+                         GL_FLOAT_VEC4);
+  mContextGL->setUniform(mFogPowerUniform.second, &mFogPowerUniform.first,
+                         GL_FLOAT);
+  mContextGL->setUniform(mFogMultUniform.second, &mFogMultUniform.first,
+                         GL_FLOAT);
+  mContextGL->setUniform(mFogOffsetUniform.second, &mFogOffsetUniform.first,
+                         GL_FLOAT);
+  mContextGL->setUniform(mFogColorUniform.second, mFogColorUniform.first,
+                         GL_FLOAT_VEC4);
+  mContextGL->setUniform(mViewProjectionUniform.second,
+                         mViewProjectionUniform.first, GL_FLOAT_MAT4);
 
-    mContextGL->setTexture(*mDiffuseTexture.first, mDiffuseTexture.second, 0);
+  mContextGL->setTexture(*mDiffuseTexture.first, mDiffuseTexture.second, 0);
 }
 
-void SeaweedModelGL::updatePerInstanceUniforms(const WorldUniforms &worldUniforms)
+void SeaweedModelGL::updatePerInstanceUniforms(
+    const WorldUniforms &worldUniforms)
 {
-    mContextGL->setUniform(mWorldUniform.second, mWorldUniform.first, GL_FLOAT_MAT4);
-    mContextGL->setUniform(mTimeUniform.second, &mTimeUniform.first, GL_FLOAT);
+  mContextGL->setUniform(mWorldUniform.second, mWorldUniform.first,
+                         GL_FLOAT_MAT4);
+  mContextGL->setUniform(mTimeUniform.second, &mTimeUniform.first, GL_FLOAT);
 }
 
 void SeaweedModelGL::updateSeaweedModelTime(float time)
 {
-    mTimeUniform.first = time;
+  mTimeUniform.first = time;
 }

--- a/src/aquarium-optimized/opengl/SeaweedModelGL.h
+++ b/src/aquarium-optimized/opengl/SeaweedModelGL.h
@@ -14,48 +14,48 @@
 
 class SeaweedModelGL : public SeaweedModel
 {
-  public:
-    SeaweedModelGL(const ContextGL *context,
-                   Aquarium *aquarium,
-                   MODELGROUP type,
-                   MODELNAME name,
-                   bool blend);
-    void prepareForDraw() override;
-    void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
-    void init() override;
-    void draw() override;
+public:
+  SeaweedModelGL(const ContextGL *context,
+                 Aquarium *aquarium,
+                 MODELGROUP type,
+                 MODELNAME name,
+                 bool blend);
+  void prepareForDraw() override;
+  void updatePerInstanceUniforms(const WorldUniforms &worldUniforms) override;
+  void init() override;
+  void draw() override;
 
-    void updateSeaweedModelTime(float time) override;
+  void updateSeaweedModelTime(float time) override;
 
-    std::pair<float *, int> mWorldUniform;
+  std::pair<float *, int> mWorldUniform;
 
-    std::pair<float *, int> mViewInverseUniform;
-    std::pair<float *, int> mLightWorldPosUniform;
-    std::pair<float *, int> mLightColorUniform;
-    std::pair<float *, int> mSpecularUniform;
-    std::pair<float, int> mShininessUniform;
-    std::pair<float, int> mSpecularFactorUniform;
+  std::pair<float *, int> mViewInverseUniform;
+  std::pair<float *, int> mLightWorldPosUniform;
+  std::pair<float *, int> mLightColorUniform;
+  std::pair<float *, int> mSpecularUniform;
+  std::pair<float, int> mShininessUniform;
+  std::pair<float, int> mSpecularFactorUniform;
 
-    std::pair<float *, int> mAmbientUniform;
+  std::pair<float *, int> mAmbientUniform;
 
-    std::pair<float, int> mFogPowerUniform;
-    std::pair<float, int> mFogMultUniform;
-    std::pair<float, int> mFogOffsetUniform;
-    std::pair<float *, int> mFogColorUniform;
+  std::pair<float, int> mFogPowerUniform;
+  std::pair<float, int> mFogMultUniform;
+  std::pair<float, int> mFogOffsetUniform;
+  std::pair<float *, int> mFogColorUniform;
 
-    std::pair<float *, int> mViewProjectionUniform;
-    std::pair<float, int> mTimeUniform;
+  std::pair<float *, int> mViewProjectionUniform;
+  std::pair<float, int> mTimeUniform;
 
-    std::pair<TextureGL *, int> mDiffuseTexture;
+  std::pair<TextureGL *, int> mDiffuseTexture;
 
-    std::pair<BufferGL *, int> mPositionBuffer;
-    std::pair<BufferGL *, int> mNormalBuffer;
-    std::pair<BufferGL *, int> mTexCoordBuffer;
+  std::pair<BufferGL *, int> mPositionBuffer;
+  std::pair<BufferGL *, int> mNormalBuffer;
+  std::pair<BufferGL *, int> mTexCoordBuffer;
 
-    BufferGL *mIndicesBuffer;
+  BufferGL *mIndicesBuffer;
 
-  private:
-    const ContextGL *mContextGL;
+private:
+  const ContextGL *mContextGL;
 };
 
 #endif  // SEAWEEDMODELGL_H

--- a/src/aquarium-optimized/opengl/TextureGL.cpp
+++ b/src/aquarium-optimized/opengl/TextureGL.cpp
@@ -3,7 +3,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 //
-// TextureGL.cpp. Wrap textures of OpenGL. Load image files and wrap into an OpenGL texture.
+// TextureGL.cpp. Wrap textures of OpenGL. Load image files and wrap into an
+// OpenGL texture.
 
 #include "TextureGL.h"
 
@@ -11,61 +12,70 @@
 
 // initializs texture 2d
 TextureGL::TextureGL(ContextGL *context, std::string name, std::string url)
-    : Texture(name, url, true), mTarget(GL_TEXTURE_2D), mFormat(GL_RGBA), mContext(context)
+    : Texture(name, url, true),
+      mTarget(GL_TEXTURE_2D),
+      mFormat(GL_RGBA),
+      mContext(context)
 {
-    mTextureId = context->generateTexture();
+  mTextureId = context->generateTexture();
 }
 
 // initializs cube map
-TextureGL::TextureGL(ContextGL *context, std::string name, const std::vector<std::string> &urls)
-    : Texture(name, urls, false), mTarget(GL_TEXTURE_CUBE_MAP), mFormat(GL_RGBA), mContext(context)
+TextureGL::TextureGL(ContextGL *context,
+                     std::string name,
+                     const std::vector<std::string> &urls)
+    : Texture(name, urls, false),
+      mTarget(GL_TEXTURE_CUBE_MAP),
+      mFormat(GL_RGBA),
+      mContext(context)
 {
-    ASSERT(urls.size() == 6);
-    mTextureId = context->generateTexture();
+  ASSERT(urls.size() == 6);
+  mTextureId = context->generateTexture();
 }
 
 void TextureGL::loadTexture()
 {
-    mContext->bindTexture(mTarget, mTextureId);
+  mContext->bindTexture(mTarget, mTextureId);
 
-    std::vector<unsigned char *> pixelVec;
-    loadImage(mUrls, &pixelVec);
+  std::vector<unsigned char *> pixelVec;
+  loadImage(mUrls, &pixelVec);
 
-    if (mTarget == GL_TEXTURE_CUBE_MAP)
+  if (mTarget == GL_TEXTURE_CUBE_MAP)
+  {
+    for (unsigned int i = 0; i < 6; i++)
     {
-        for (unsigned int i = 0; i < 6; i++)
-        {
-            mContext->uploadTexture(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, mFormat, mWidth, mHeight,
-                                    pixelVec[i]);
-        }
-
-        mContext->setParameter(mTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-        mContext->setParameter(mTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-        mContext->setParameter(mTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        mContext->setParameter(mTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    }
-    else  // GL_TEXTURE_2D
-    {
-        mContext->uploadTexture(mTarget, mFormat, mWidth, mHeight, pixelVec[0]);
-
-        if (isPowerOf2(mWidth) && isPowerOf2(mHeight))
-        {
-            mContext->setParameter(mTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-            mContext->generateMipmap(mTarget);
-        }
-        else
-        {
-            mContext->setParameter(mTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-            mContext->setParameter(mTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-            mContext->setParameter(mTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-        }
-        mContext->setParameter(mTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+      mContext->uploadTexture(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, mFormat,
+                              mWidth, mHeight, pixelVec[i]);
     }
 
-    DestoryImageData(pixelVec);
+    mContext->setParameter(mTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    mContext->setParameter(mTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    mContext->setParameter(mTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    mContext->setParameter(mTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  }
+  else  // GL_TEXTURE_2D
+  {
+    mContext->uploadTexture(mTarget, mFormat, mWidth, mHeight, pixelVec[0]);
+
+    if (isPowerOf2(mWidth) && isPowerOf2(mHeight))
+    {
+      mContext->setParameter(mTarget, GL_TEXTURE_MIN_FILTER,
+                             GL_LINEAR_MIPMAP_LINEAR);
+      mContext->generateMipmap(mTarget);
+    }
+    else
+    {
+      mContext->setParameter(mTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+      mContext->setParameter(mTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+      mContext->setParameter(mTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    }
+    mContext->setParameter(mTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  }
+
+  DestoryImageData(pixelVec);
 }
 
 TextureGL::~TextureGL()
 {
-    mContext->deleteTexture(mTextureId);
+  mContext->deleteTexture(mTextureId);
 }

--- a/src/aquarium-optimized/opengl/TextureGL.h
+++ b/src/aquarium-optimized/opengl/TextureGL.h
@@ -32,22 +32,24 @@ class ContextGL;
 
 class TextureGL : public Texture
 {
-  public:
-    ~TextureGL() override;
-    TextureGL(ContextGL *context, std::string name, std::string url);
-    TextureGL(ContextGL *context, std::string name, const std::vector<std::string> &urls);
+public:
+  ~TextureGL() override;
+  TextureGL(ContextGL *context, std::string name, std::string url);
+  TextureGL(ContextGL *context,
+            std::string name,
+            const std::vector<std::string> &urls);
 
-    unsigned int getTextureId() const { return mTextureId; }
-    unsigned int getTarget() const { return mTarget; }
-    void setTextureId(unsigned int texId) { mTextureId = texId; }
+  unsigned int getTextureId() const { return mTextureId; }
+  unsigned int getTarget() const { return mTarget; }
+  void setTextureId(unsigned int texId) { mTextureId = texId; }
 
-    void loadTexture() override;
+  void loadTexture() override;
 
-  private:
-    unsigned int mTarget;
-    unsigned int mTextureId;
-    unsigned int mFormat;
-    ContextGL *mContext;
+private:
+  unsigned int mTarget;
+  unsigned int mTextureId;
+  unsigned int mFormat;
+  ContextGL *mContext;
 };
 
 #endif  // TEXTUREGL_H

--- a/src/common/AQUARIUM_ASSERT.h
+++ b/src/common/AQUARIUM_ASSERT.h
@@ -11,28 +11,28 @@
 
 // TODO(yizhou) : replace this ASSERT by the code template of ANGLE or Chromium
 #ifndef NDEBUG
-#define ASSERT(expression)                                                                \
-    {                                                                                     \
-        if (!(expression))                                                                \
-        {                                                                                 \
-            printf("Assertion(%s) failed: file \"%s\", line %d\n", #expression, __FILE__, \
-                   __LINE__);                                                             \
-            abort();                                                                      \
-        }                                                                                 \
-    }
+#define ASSERT(expression)                                                \
+  {                                                                       \
+    if (!(expression))                                                    \
+    {                                                                     \
+      printf("Assertion(%s) failed: file \"%s\", line %d\n", #expression, \
+             __FILE__, __LINE__);                                         \
+      abort();                                                            \
+    }                                                                     \
+  }
 #else
 #define ASSERT(expression) NULL;
 #endif
 
 #ifndef NDEBUG
-#define SWALLOW_ERROR(expression)                                                         \
-    {                                                                                     \
-        if (!(expression))                                                                \
-        {                                                                                 \
-            printf("Assertion(%s) failed: file \"%s\", line %d\n", #expression, __FILE__, \
-                   __LINE__);                                                             \
-        }                                                                                 \
-    }
+#define SWALLOW_ERROR(expression)                                         \
+  {                                                                       \
+    if (!(expression))                                                    \
+    {                                                                     \
+      printf("Assertion(%s) failed: file \"%s\", line %d\n", #expression, \
+             __FILE__, __LINE__);                                         \
+    }                                                                     \
+  }
 #else
 #define SWALLOW_ERROR(expression) expression
 #endif

--- a/src/common/FPSTimer.cpp
+++ b/src/common/FPSTimer.cpp
@@ -24,52 +24,53 @@ FPSTimer::FPSTimer()
 
 void FPSTimer::update(double elapsedTime, double renderingTime, int testTime)
 {
-    mTotalTime += elapsedTime - mTimeTable[mTimeTableCursor];
-    mTimeTable[mTimeTableCursor] = elapsedTime;
+  mTotalTime += elapsedTime - mTimeTable[mTimeTableCursor];
+  mTimeTable[mTimeTableCursor] = elapsedTime;
 
-    ++mTimeTableCursor;
-    if (mTimeTableCursor == NUM_FRAMES_TO_AVERAGE)
-    {
-        mTimeTableCursor = 0;
-    }
+  ++mTimeTableCursor;
+  if (mTimeTableCursor == NUM_FRAMES_TO_AVERAGE)
+  {
+    mTimeTableCursor = 0;
+  }
 
-    mAverageFPS = floor((1.0f / (mTotalTime / static_cast<double>(NUM_FRAMES_TO_AVERAGE))) + 0.5);
+  mAverageFPS = floor(
+      (1.0f / (mTotalTime / static_cast<double>(NUM_FRAMES_TO_AVERAGE))) + 0.5);
 
-    for (int i = 0; i < NUM_HISTORY_DATA - 1; i++)
-    {
-        mHistoryFPS[i]       = mHistoryFPS[i + 1];
-        mHistoryFrameTime[i] = mHistoryFrameTime[i + 1];
-    }
-    mHistoryFPS[NUM_HISTORY_DATA - 1]       = mAverageFPS;
-    mHistoryFrameTime[NUM_HISTORY_DATA - 1] = 1000.0 / mAverageFPS;
+  for (int i = 0; i < NUM_HISTORY_DATA - 1; i++)
+  {
+    mHistoryFPS[i]       = mHistoryFPS[i + 1];
+    mHistoryFrameTime[i] = mHistoryFrameTime[i + 1];
+  }
+  mHistoryFPS[NUM_HISTORY_DATA - 1]       = mAverageFPS;
+  mHistoryFrameTime[NUM_HISTORY_DATA - 1] = 1000.0 / mAverageFPS;
 
-    if (testTime - renderingTime > 5 && testTime - renderingTime < 25)
-    {
-        mLogFPS.push_back(mAverageFPS);
-    }
+  if (testTime - renderingTime > 5 && testTime - renderingTime < 25)
+  {
+    mLogFPS.push_back(mAverageFPS);
+  }
 }
 
 int FPSTimer::variance() const
 {
-    float avg = 0.f;
+  float avg = 0.f;
 
-    for (size_t i = 0; i < mLogFPS.size(); i++)
-    {
-        avg += mLogFPS[i];
-    }
-    avg /= mLogFPS.size();
+  for (size_t i = 0; i < mLogFPS.size(); i++)
+  {
+    avg += mLogFPS[i];
+  }
+  avg /= mLogFPS.size();
 
-    float var = 0.f;
-    for (size_t i = 0; i < mLogFPS.size(); i++)
-    {
-        var += pow(mLogFPS[i] - avg, 2);
-    }
-    var /= mLogFPS.size();
+  float var = 0.f;
+  for (size_t i = 0; i < mLogFPS.size(); i++)
+  {
+    var += pow(mLogFPS[i] - avg, 2);
+  }
+  var /= mLogFPS.size();
 
-    if (var < FPS_VALID_THRESHOLD)
-    {
-        return ceil(avg);
-    }
+  if (var < FPS_VALID_THRESHOLD)
+  {
+    return ceil(avg);
+  }
 
-    return 0;
+  return 0;
 }

--- a/src/common/FPSTimer.h
+++ b/src/common/FPSTimer.h
@@ -16,25 +16,25 @@ constexpr int FPS_VALID_THRESHOLD   = 5;
 
 class FPSTimer
 {
-  public:
-    FPSTimer();
+public:
+  FPSTimer();
 
-    void update(double elapsedTime, double renderingTime, int testTime);
-    double getAverageFPS() const { return mAverageFPS; }
-    const float *getHistoryFps() const { return mHistoryFPS.data(); }
-    const float *getHistoryFrameTime() const { return mHistoryFrameTime.data(); }
-    int variance() const;
+  void update(double elapsedTime, double renderingTime, int testTime);
+  double getAverageFPS() const { return mAverageFPS; }
+  const float *getHistoryFps() const { return mHistoryFPS.data(); }
+  const float *getHistoryFrameTime() const { return mHistoryFrameTime.data(); }
+  int variance() const;
 
-  private:
-    double mTotalTime;
-    std::vector<double> mTimeTable;
-    int mTimeTableCursor;
+private:
+  double mTotalTime;
+  std::vector<double> mTimeTable;
+  int mTimeTableCursor;
 
-    std::vector<float> mHistoryFPS;
-    std::vector<float> mHistoryFrameTime;
-    std::vector<float> mLogFPS;
+  std::vector<float> mHistoryFPS;
+  std::vector<float> mHistoryFrameTime;
+  std::vector<float> mLogFPS;
 
-    double mAverageFPS;
+  double mAverageFPS;
 };
 
 #endif  // FPSTIMER_H


### PR DESCRIPTION
For historical reasons, 80 is used as the default column width in most of today's virtual terminals. To accommodate that, also reduce the indentation so that the available space of a line won't be too small for nested blocks.

**This pull request is opened using a shared GitHub account. Please find the actual author in the git log, and use "Rebase and merge" for correct attribution. The author may have no access to this account, so please do not assume there will be replies from a real human. But you can still leave a comment, and code will be updated here once addressed. - Your Sincere Bot**
