### PR TITLE
End the battle of OS probers

### DIFF
--- a/src/aquarium-direct-map/Globals.h
+++ b/src/aquarium-direct-map/Globals.h
@@ -15,14 +15,17 @@
 #include <unordered_map>
 #include <vector>
 
+#include "build/build_config.h"
+
 #include "Scene.h"
 #include "common/FPSTimer.h"
 
-#if defined(WIN32) || defined(_WIN32) || \
-    defined(__WIN32) && !defined(__CYGWIN__)
+#if defined(OS_WIN)
 const std::string slash = "\\";
 #define M_PI 3.141592653589793
-#else
+#endif
+#if (defined(OS_MACOSX) && !defined(OS_IOS)) || \
+    (defined(OS_LINUX) && !defined(OS_CHROMEOS))
 const std::string slash = "/";
 #endif
 

--- a/src/aquarium-direct-map/Program.cpp
+++ b/src/aquarium-direct-map/Program.cpp
@@ -15,6 +15,8 @@
 #include <iostream>
 #include <regex>
 
+#include "build/build_config.h"
+
 #include "common/AQUARIUM_ASSERT.h"
 
 Program::Program(const std::string &vId, const std::string &fId)
@@ -57,7 +59,7 @@ void Program::createProgramFromTags(const std::string &vId,
       R"(outColor = mix(outColor, vec4(fogColor.rgb, diffuseColor.a),
         clamp(pow((v_position.z / v_position.w), fogPower) * fogMult - fogOffset,0.0,1.0));)";
 
-#ifdef __APPLE__
+#if defined(OS_MACOSX) && !defined(OS_IOS)
   VertexShaderCode =
       std::regex_replace(VertexShaderCode, std::regex(R"(#version 450 core)"),
                          R"(#version 410 core)");

--- a/src/aquarium-optimized/Aquarium.h
+++ b/src/aquarium-optimized/Aquarium.h
@@ -14,6 +14,8 @@
 #include <string>
 #include <unordered_map>
 
+#include "build/build_config.h"
+
 #include "Behavior.h"
 #include "common/FPSTimer.h"
 
@@ -23,10 +25,11 @@ class Texture;
 class Program;
 class Model;
 
-#if defined(WIN32) || defined(_WIN32) || \
-    defined(__WIN32) && !defined(__CYGWIN__)
+#if defined(OS_WIN)
 #define M_PI 3.141592653589793
-#else
+#endif
+#if (defined(OS_MACOSX) && !defined(OS_IOS)) || \
+    (defined(OS_LINUX) && !defined(OS_CHROMEOS))
 #include "math.h"
 #endif
 

--- a/src/aquarium-optimized/ResourceHelper.cpp
+++ b/src/aquarium-optimized/ResourceHelper.cpp
@@ -9,14 +9,20 @@
 #include <iostream>
 #include <sstream>
 
-#ifdef _WIN32
+#include "build/build_config.h"
+
+#include "common/AQUARIUM_ASSERT.h"
+
+#if defined(OS_WIN)
 #include <Windows.h>
 #include <direct.h>
 const std::string slash = "\\";
-#elif __APPLE__
+#endif
+#if defined(OS_MACOSX) && !defined(OS_IOS)
 #include <mach-o/dyld.h>
 const std::string slash = "/";
-#else
+#endif
+#if defined(OS_LINUX) && !defined(OS_CHROMEOS)
 #include <unistd.h>
 const std::string slash = "/";
 #endif
@@ -35,20 +41,22 @@ ResourceHelper::ResourceHelper(const std::string &mBackendName,
     : mBackendName(mBackendName),
       mBackendType(backendType),
       mShaderVersion(mShaderVersion) {
-#if defined(WIN32) || defined(_WIN32) || defined(__WIN32)
+#if defined(OS_WIN)
   TCHAR temp[200];
   GetModuleFileName(nullptr, temp, MAX_PATH);
   std::wstring ws(temp);
   mPath = std::string(ws.begin(), ws.end());
-#elif __APPLE__
+#elif defined(OS_MACOSX) && !defined(OS_IOS)
   char temp[200];
   uint32_t size = sizeof(temp);
   _NSGetExecutablePath(temp, &size);
   mPath = std::string(temp);
-#else
+#elif defined(OS_LINUX) && !defined(OS_CHROMEOS)
   char temp[200];
   readlink("/proc/self/exe", temp, sizeof(temp));
   mPath = std::string(temp);
+#else
+  ASSERT(false);
 #endif
 
   size_t nPos = mPath.find_last_of(slash);

--- a/src/aquarium-optimized/opengl/ContextGL.cpp
+++ b/src/aquarium-optimized/opengl/ContextGL.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <sstream>
 
+#include "build/build_config.h"
 #include "imgui.h"
 #include "imgui_impl_glfw.h"
 
@@ -66,14 +67,16 @@ bool ContextGL::initialize(
 
   mResourceHelper = new ResourceHelper("opengl", "450", backend);
 
-#ifdef __APPLE__
+#if defined(OS_MACOSX) && !defined(OS_IOS)
   glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
   glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
   mGLSLVersion = "#version 410";
-#elif _WIN32 || __linux__
+#elif defined(OS_WIN) || (defined(OS_LINUX) && !defined(OS_CHROMEOS))
   glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
   glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 5);
   mGLSLVersion = "#version 450";
+#else
+  ASSERT(false);
 #endif
   glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
   glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);

--- a/src/aquarium-optimized/opengl/ProgramGL.cpp
+++ b/src/aquarium-optimized/opengl/ProgramGL.cpp
@@ -16,6 +16,8 @@
 #include <string>
 #include <vector>
 
+#include "build/build_config.h"
+
 #ifdef EGL_EGL_PROTOTYPES
 #include <memory>
 
@@ -56,7 +58,7 @@ void ProgramGL::compileProgram(bool enableBlending, const std::string &alpha) {
       R"(outColor = mix(outColor, vec4(fogColor.rgb, diffuseColor.a),
         clamp(pow((v_position.z / v_position.w), fogPower) * fogMult - fogOffset,0.0,1.0));)";
 
-#ifdef __APPLE__
+#if defined(OS_MACOSX) && !defined(OS_IOS)
   VertexShaderCode =
       std::regex_replace(VertexShaderCode, std::regex(R"(#version 450 core)"),
                          R"(#version 410 core)");


### PR DESCRIPTION
Instead of fighting among at least 3 styles:

#if defined(WIN32) // or #ifdef WIN32
#if defined(_WIN32) // or #ifdef _WIN32
#if defined(WIN32) || defined(_WIN32)

use the one for Windows now:

  #if defined(OS_WIN)

**This pull request is opened using a shared GitHub account. Please find the actual author in the git log, and use "Rebase and merge" for correct attribution. The author may have no access to this account, so please do not assume there will be replies from a real human. But you can still leave a comment, and code will be updated here once addressed. - Your Sincere Bot**
