### PR TITLE
Roll buildtools

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,7 +8,7 @@
 BasedOnStyle: Chromium
 
 # Allow double brackets such as std::vector<std::vector<int>>.
-Standard: Cpp11
+Standard: c++11
 
 # Do not merge top level empty functions
 AllowShortFunctionsOnASingleLine: InlineOnly

--- a/DEPS
+++ b/DEPS
@@ -13,7 +13,7 @@ vars = {
   'angle_revision': '6c824a1bc17b286b86cf05a0228ec549875351eb',
   'glslang_revision': 'b5f003d7a3ece37db45578a8a3140b370036fc64',
   'build_revision': '896323eeda1bd1b01156b70625d5e14de225ebc3',
-  'buildtools_revision': '74cfb57006f83cfe050817526db359d5c8a11628',
+  'buildtools_revision': '2c41dfb19abe40908834803b6fed797b0f341fe1',
   'tools_clang_revision': '698732d5db36040c07d5cc5f9137fcc943494c11',
   'spirv_tools_revision': '85f3e93d13f32d45bd7f9999aa51baddf2452aae',
   'jsoncpp_revision': '571788934b5ee8643d53e5d054534abbe6006168',


### PR DESCRIPTION
This brings a much newer version of clang-format (11.0.0). In .clang-format, Cpp11 is deprecated for language standard now, and c++11 should be used instead.

**This pull request is opened using a shared GitHub account. Please find the actual author in the git log, and use "Rebase and merge" for correct attribution. The author may have no access to this account, so please do not assume there will be replies from a real human. But you can still leave a comment, and code will be updated here once addressed. - Your Sincere Bot**
