### PR TITLE
Roll Dawn

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -8,7 +8,7 @@ vars = {
   'chromium_git': 'https://chromium.googlesource.com',
   'github_git': 'https://github.com',
   'dawn_git': 'https://dawn.googlesource.com',
-  'dawn_revision': '984493d0ac077cccbe4e5b83ab6028aaa5d40357',
+  'dawn_revision': 'b2ea1915d450343158c25389c5328e64f1d3ac77',
   'angle_root': 'third_party/angle',
   'angle_revision': '6c824a1bc17b286b86cf05a0228ec549875351eb',
   'glslang_revision': 'b5f003d7a3ece37db45578a8a3140b370036fc64',

--- a/src/aquarium-optimized/dawn/BufferDawn.cpp
+++ b/src/aquarium-optimized/dawn/BufferDawn.cpp
@@ -21,10 +21,15 @@ BufferDawn::BufferDawn(ContextDawn *context,
       mStride(0),
       mOffset(nullptr) {
   mSize = numComponents * sizeof(float);
+
   // Create buffer for vertex buffer. Because float is multiple of 4 bytes,
   // dummy padding isnt' needed.
   int bufferSize = sizeof(float) * static_cast<int>(buffer->size());
-  mBuf = context->createBuffer(bufferSize, mUsage | wgpu::BufferUsage::CopyDst);
+  wgpu::BufferDescriptor descriptor;
+  descriptor.usage = mUsage | wgpu::BufferUsage::CopyDst;
+  descriptor.size = bufferSize;
+  descriptor.mappedAtCreation = false;
+  mBuf = context->createBuffer(descriptor);
 
   context->setBufferData(mBuf, bufferSize, buffer->data(), bufferSize);
 }
@@ -47,7 +52,11 @@ BufferDawn::BufferDawn(ContextDawn *context,
   }
 
   int bufferSize = sizeof(unsigned short) * static_cast<int>(buffer->size());
-  mBuf = context->createBuffer(bufferSize, mUsage | wgpu::BufferUsage::CopyDst);
+  wgpu::BufferDescriptor descriptor;
+  descriptor.usage = mUsage | wgpu::BufferUsage::CopyDst;
+  descriptor.size = bufferSize;
+  descriptor.mappedAtCreation = false;
+  mBuf = context->createBuffer(descriptor);
 
   context->setBufferData(mBuf, bufferSize, buffer->data(), bufferSize);
 }

--- a/src/aquarium-optimized/dawn/BufferManagerDawn.h
+++ b/src/aquarium-optimized/dawn/BufferManagerDawn.h
@@ -42,7 +42,7 @@ private:
                                uint64_t,
                                void *userdata);
 
-  wgpu::CreateBufferMappedResult mBufferMappedResult;
+  wgpu::Buffer mBuf;
 
   BufferManagerDawn *mBufferManager;
   void *mappedData;

--- a/src/aquarium-optimized/dawn/ContextDawn.h
+++ b/src/aquarium-optimized/dawn/ContextDawn.h
@@ -111,7 +111,7 @@ public:
       bool enableBlend) const;
   wgpu::TextureView createMultisampledRenderTargetView() const;
   wgpu::TextureView createDepthStencilView() const;
-  wgpu::Buffer createBuffer(uint32_t size, wgpu::BufferUsage bit) const;
+  wgpu::Buffer createBuffer(const wgpu::BufferDescriptor &descriptor) const;
   void setBufferData(const wgpu::Buffer &buffer,
                      uint32_t bufferSize,
                      const void *data,
@@ -134,8 +134,6 @@ public:
                         size_t bufferSize,
                         void *data,
                         size_t dataSize) const;
-  wgpu::CreateBufferMappedResult CreateBufferMapped(wgpu::BufferUsage usage,
-                                                    uint64_t size) const;
   void WaitABit();
   wgpu::CommandEncoder createCommandEncoder() const;
   size_t CalcConstantBufferByteSize(size_t byteSize) const;

--- a/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.cpp
+++ b/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.cpp
@@ -49,9 +49,12 @@ void FishModelInstancedDrawDawn::init() {
   mBiNormalBuffer = static_cast<BufferDawn *>(bufferMap["binormal"]);
   mIndicesBuffer = static_cast<BufferDawn *>(bufferMap["indices"]);
 
-  mFishPersBuffer = mContextDawn->createBuffer(
-      sizeof(FishPer) * instance,
-      wgpu::BufferUsage::Vertex | wgpu::BufferUsage::CopyDst);
+  wgpu::BufferDescriptor bufferDescriptor;
+  bufferDescriptor.usage =
+      wgpu::BufferUsage::Vertex | wgpu::BufferUsage::CopyDst;
+  bufferDescriptor.size = sizeof(FishPer) * instance;
+  bufferDescriptor.mappedAtCreation = false;
+  mFishPersBuffer = mContextDawn->createBuffer(bufferDescriptor);
 
   mVertexStateDescriptor.cVertexBuffers[0].attributeCount = 1;
   mVertexStateDescriptor.cVertexBuffers[0].arrayStride =

--- a/src/aquarium-optimized/dawn/TextureDawn.cpp
+++ b/src/aquarium-optimized/dawn/TextureDawn.cpp
@@ -65,14 +65,17 @@ void TextureDawn::loadTexture() {
     mTexture = mContext->createTexture(descriptor);
 
     for (unsigned int i = 0; i < 6; i++) {
-      wgpu::CreateBufferMappedResult result = mContext->CreateBufferMapped(
-          wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::MapWrite,
-          mWidth * mHeight * 4);
-      memcpy(result.data, mPixelVec[i], mWidth * mHeight * 4);
-      result.buffer.Unmap();
+      wgpu::BufferDescriptor descriptor;
+      descriptor.usage =
+          wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::MapWrite;
+      descriptor.size = mWidth * mHeight * 4;
+      descriptor.mappedAtCreation = true;
+      wgpu::Buffer staging = mContext->createBuffer(descriptor);
+      memcpy(staging.GetMappedRange(), mPixelVec[i], mWidth * mHeight * 4);
+      staging.Unmap();
 
       wgpu::BufferCopyView bufferCopyView =
-          mContext->createBufferCopyView(result.buffer, 0, mWidth * 4, mHeight);
+          mContext->createBufferCopyView(staging, 0, mWidth * 4, mHeight);
       wgpu::TextureCopyView textureCopyView =
           mContext->createTextureCopyView(mTexture, 0, {0, 0, i});
       wgpu::Extent3D copySize = {static_cast<uint32_t>(mWidth),
@@ -134,14 +137,18 @@ void TextureDawn::loadTexture() {
         height = 1;
       }
 
-      wgpu::CreateBufferMappedResult result = mContext->CreateBufferMapped(
-          wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::MapWrite,
-          resizedWidth * height * 4);
-      memcpy(result.data, mResizedVec[i], resizedWidth * height * 4);
-      result.buffer.Unmap();
+      wgpu::BufferDescriptor descriptor;
+      descriptor.usage =
+          wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::MapWrite;
+      descriptor.size = resizedWidth * height * 4;
+      descriptor.mappedAtCreation = true;
+      wgpu::Buffer staging = mContext->createBuffer(descriptor);
+      memcpy(staging.GetMappedRange(), mResizedVec[i],
+             resizedWidth * height * 4);
+      staging.Unmap();
 
-      wgpu::BufferCopyView bufferCopyView = mContext->createBufferCopyView(
-          result.buffer, 0, resizedWidth * 4, height);
+      wgpu::BufferCopyView bufferCopyView =
+          mContext->createBufferCopyView(staging, 0, resizedWidth * 4, height);
       wgpu::TextureCopyView textureCopyView =
           mContext->createTextureCopyView(mTexture, i, {0, 0, 0});
       wgpu::Extent3D copySize = {static_cast<uint32_t>(width),

--- a/src/aquarium-optimized/dawn/imgui_impl_dawn.cpp
+++ b/src/aquarium-optimized/dawn/imgui_impl_dawn.cpp
@@ -197,13 +197,16 @@ static void ImGui_ImplDawn_CreateFontsTexture(bool enableAlphaBlending)
         descriptor.usage         = wgpu::TextureUsage::CopyDst | wgpu::TextureUsage::Sampled;
         mTexture                 = mContextDawn->createTexture(descriptor);
 
-        wgpu::CreateBufferMappedResult result = mContextDawn->CreateBufferMapped(
-            wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::MapWrite, width * height * 4);
-        memcpy(result.data, pixels, width * height * 4);
-        result.buffer.Unmap();
+        wgpu::BufferDescriptor bufferDescriptor;
+        bufferDescriptor.usage = wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::MapWrite;
+        bufferDescriptor.size = width * height * 4;
+        bufferDescriptor.mappedAtCreation = true;
+        wgpu::Buffer staging = mContextDawn->createBuffer(bufferDescriptor);
+        memcpy(staging.GetMappedRange(), pixels, width * height * 4);
+        staging.Unmap();
 
         wgpu::BufferCopyView bufferCopyView =
-            mContextDawn->createBufferCopyView(result.buffer, 0, width * 4, height);
+            mContextDawn->createBufferCopyView(staging, 0, width * 4, height);
         wgpu::TextureCopyView textureCopyView =
             mContextDawn->createTextureCopyView(mTexture, 0, {0, 0, 0});
         wgpu::Extent3D copySize = {static_cast<uint32_t>(width), static_cast<uint32_t>(height), 1};


### PR DESCRIPTION
This manual intervention is needed because of recent deprecation of wgpu::Device::CreateBufferMapped():

https://dawn-review.googlesource.com/c/dawn/+/24083

Following the spirit of that change, ContextDawn::createBuffer() and ContextDawn::CreateBufferMapped() are merged as well.

**This pull request is opened using a shared GitHub account. Please find the actual author in the git log, and use "Rebase and merge" for correct attribution. The author may have no access to this account, so please do not assume there will be replies from a real human. But you can still leave a comment, and code will be updated here once addressed. - Your Sincere Bot**
