### PR TITLE
Unify "draw per frame" and "draw per model" code

### DIFF
--- a/src/aquarium-optimized/Aquarium.h
+++ b/src/aquarium-optimized/Aquarium.h
@@ -121,7 +121,7 @@ enum TOGGLE : short {
   DISCRETEGPU,
   // Update and draw for each model on OpenGL and Angle backend, but draw once
   // per frame on other backend.
-  UPATEANDDRAWFOREACHMODEL,
+  DRAWPERMODEL,
   // Support Full Screen mode
   ENABLEFULLSCREENMODE,
   // Print logs such as avg fps
@@ -529,6 +529,7 @@ private:
   ContextFactory *mFactory;
   std::vector<std::string> mSkyUrls;
   std::queue<Behavior *> mFishBehavior;
+  bool mDrawPerModel;
 };
 
 #endif  // AQUARIUM_H

--- a/src/aquarium-optimized/opengl/ContextGL.cpp
+++ b/src/aquarium-optimized/opengl/ContextGL.cpp
@@ -378,8 +378,7 @@ void ContextGL::initState() {
 }
 
 void ContextGL::initAvailableToggleBitset(BACKENDTYPE backendType) {
-  mAvailableToggleBitset.set(
-      static_cast<size_t>(TOGGLE::UPATEANDDRAWFOREACHMODEL));
+  mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::DRAWPERMODEL));
   mAvailableToggleBitset.set(static_cast<size_t>(TOGGLE::ENABLEFULLSCREENMODE));
 }
 


### PR DESCRIPTION
Previous code uses different functions for draw per frame and draw per
model path, which means many duplications. This patch will simplify
this.