### PR TITLE
Fix a probable typo of vertex attribute index

### DIFF
--- a/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.cpp
+++ b/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.cpp
@@ -111,7 +111,7 @@ void FishModelInstancedDrawDawn::init() {
       offsetof(FishPer, nextPosition);
   mVertexStateDescriptor.cAttributes[8].format = wgpu::VertexFormat::Float;
   mVertexStateDescriptor.cAttributes[8].shaderLocation = 8;
-  mVertexStateDescriptor.cAttributes[9].offset = offsetof(FishPer, time);
+  mVertexStateDescriptor.cAttributes[8].offset = offsetof(FishPer, time);
   mVertexStateDescriptor.cVertexBuffers[5].attributes =
       &mVertexStateDescriptor.cAttributes[5];
   mVertexStateDescriptor.cVertexBuffers[5].stepMode =


### PR DESCRIPTION
Unfortunately, instanced rendering is completely broken, so there's no way to test this fix at the moment.

**This pull request is opened using a shared GitHub account. Please find the actual author in the git log, and use "Rebase and merge" for correct attribution. The author may have no access to this account, so please do not assume there will be replies from a real human. But you can still leave a comment, and code will be updated here once addressed. - Your Sincere Bot**
