### PR TITLE
Rename macros for enabled Dawn backends

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -127,13 +127,13 @@ executable("aquarium") {
       "DAWN_SKIP_ASSERT_SHORTHANDS",
     ]
     if (dawn_enable_d3d12) {
-      defines += [ "DAWN_ENABLE_D3D12_BACKEND" ]
+      defines += [ "DAWN_ENABLE_BACKEND_D3D12" ]
     }
     if (dawn_enable_metal) {
-      defines += [ "DAWN_ENABLE_METAL_BACKEND" ]
+      defines += [ "DAWN_ENABLE_BACKEND_METAL" ]
     }
     if (dawn_enable_vulkan) {
-      defines += [ "DAWN_ENABLE_VULKAN_BACKEND" ]
+      defines += [ "DAWN_ENABLE_BACKEND_VULKAN" ]
     }
 
     include_dirs += [ "third_party/dawn/src" ]

--- a/src/aquarium-optimized/dawn/ContextDawn.h
+++ b/src/aquarium-optimized/dawn/ContextDawn.h
@@ -8,7 +8,7 @@
 #ifndef CONTEXTDAWN_H
 #define CONTEXTDAWN_H
 
-#ifdef DAWN_ENABLE_VULKAN_BACKEND
+#ifdef DAWN_ENABLE_BACKEND_VULKAN
 // The Vulkan header is included by VulkanBackend.h, so this should be placed
 // before the GLFW header.
 #include "dawn_native/VulkanBackend.h"


### PR DESCRIPTION
Dawn headers make use of DAWN_ENABLE_BACKEND_\*, so they should be defined in Aquarium, and this effectively replaces the role of DAWN_ENABLE_\*_BACKEND.

**This pull request is opened using a shared GitHub account. Please find the actual author in the git log, and use "Rebase and merge" for correct attribution. The author may have no access to this account, so please do not assume there will be replies from a real human. But you can still leave a comment, and code will be updated here once addressed. - Your Sincere Bot**
