### PR TITLE
Create backend contexts via helpers

### DIFF
--- a/src/aquarium-optimized/ContextFactory.cpp
+++ b/src/aquarium-optimized/ContextFactory.cpp
@@ -28,7 +28,7 @@ Context *ContextFactory::createContext(BACKENDTYPE backendType) {
   case BACKENDTYPE::BACKENDTYPEANGLE:
     {
 #if defined(ENABLE_OPENGL_BACKEND) || defined(ENABLE_ANGLE_BACKEND)
-      mContext = new ContextGL(backendType);
+      mContext = ContextGL::create(backendType);
 #endif
       break;
     }
@@ -37,14 +37,14 @@ Context *ContextFactory::createContext(BACKENDTYPE backendType) {
   case BACKENDTYPE::BACKENDTYPEDAWNVULKAN:
     {
 #if defined(ENABLE_DAWN_BACKEND)
-      mContext = new ContextDawn(backendType);
+      mContext = ContextDawn::create(backendType);
 #endif
       break;
     }
   case BACKENDTYPE::BACKENDTYPED3D12:
     {
 #if defined(ENABLE_D3D12_BACKEND)
-      mContext = new ContextD3D12(backendType);
+      mContext = ContextD3D12::create(backendType);
 #endif
       break;
     }

--- a/src/aquarium-optimized/d3d12/ContextD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.cpp
@@ -78,6 +78,10 @@ ContextD3D12::~ContextD3D12() {
   destoryFishResource();
 }
 
+ContextD3D12 *ContextD3D12::create(BACKENDTYPE backendType) {
+  return new ContextD3D12(backendType);
+}
+
 bool ContextD3D12::initialize(
     BACKENDTYPE backend,
     const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset,

--- a/src/aquarium-optimized/d3d12/ContextD3D12.h
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.h
@@ -22,8 +22,10 @@ constexpr int cbvsrvCount = 88;
 
 class ContextD3D12 : public Context {
 public:
-  ContextD3D12(BACKENDTYPE backendType);
-  ~ContextD3D12();
+  static ContextD3D12 *create(BACKENDTYPE backendType);
+
+  ~ContextD3D12() override;
+
   bool initialize(
       BACKENDTYPE backend,
       const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset,
@@ -149,6 +151,9 @@ public:
   ComPtr<ID3D12Resource> mFishPersBuffer;
   ComPtr<ID3D12Resource> stagingBuffer;
   FishPer *fishPers;
+
+protected:
+  explicit ContextD3D12(BACKENDTYPE backendType);
 
 private:
   bool GetHardwareAdapter(

--- a/src/aquarium-optimized/dawn/ContextDawn.cpp
+++ b/src/aquarium-optimized/dawn/ContextDawn.cpp
@@ -111,6 +111,23 @@ ContextDawn::~ContextDawn() {
   mDevice = nullptr;
 }
 
+ContextDawn *ContextDawn::create(BACKENDTYPE backendType) {
+  switch (backendType) {
+#ifdef DAWN_ENABLE_BACKEND_D3D12
+  case BACKENDTYPE::BACKENDTYPEDAWND3D12:
+#endif
+#ifdef DAWN_ENABLE_BACKEND_VULKAN
+  case BACKENDTYPE::BACKENDTYPEDAWNVULKAN:
+#endif
+#ifdef DAWN_ENABLE_BACKEND_METAL
+  case BACKENDTYPE::BACKENDTYPEDAWNMETAL:
+#endif
+    return new ContextDawn(backendType);
+  default:
+    return nullptr;
+  }
+}
+
 bool ContextDawn::initialize(
     BACKENDTYPE backend,
     const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset,

--- a/src/aquarium-optimized/dawn/ContextDawn.h
+++ b/src/aquarium-optimized/dawn/ContextDawn.h
@@ -31,8 +31,10 @@ enum BACKENDTYPE : short;
 
 class ContextDawn : public Context {
 public:
-  ContextDawn(BACKENDTYPE backendType);
-  ~ContextDawn();
+  static ContextDawn *create(BACKENDTYPE backendType);
+
+  ~ContextDawn() override;
+
   bool initialize(
       BACKENDTYPE backend,
       const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset,
@@ -151,6 +153,9 @@ public:
   FishPer *fishPers;
 
   wgpu::Device mDevice;
+
+protected:
+  explicit ContextDawn(BACKENDTYPE backendType);
 
 private:
   bool GetHardwareAdapter(

--- a/src/aquarium-optimized/opengl/ContextGL.cpp
+++ b/src/aquarium-optimized/opengl/ContextGL.cpp
@@ -42,6 +42,10 @@ ContextGL::~ContextGL() {
   }
 }
 
+ContextGL *ContextGL::create(BACKENDTYPE backendType) {
+  return new ContextGL(backendType);
+}
+
 bool ContextGL::initialize(
     BACKENDTYPE backend,
     const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset,

--- a/src/aquarium-optimized/opengl/ContextGL.h
+++ b/src/aquarium-optimized/opengl/ContextGL.h
@@ -34,8 +34,10 @@ enum BACKENDTYPE : short;
 
 class ContextGL : public Context {
 public:
-  ContextGL(BACKENDTYPE backendType);
-  ~ContextGL();
+  static ContextGL *create(BACKENDTYPE backendType);
+
+  ~ContextGL() override;
+
   bool initialize(
       BACKENDTYPE backend,
       const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset,
@@ -109,6 +111,9 @@ public:
   void setParameter(unsigned int target, unsigned int pname, int param);
   void generateMipmap(unsigned int target);
   void updateAllFishData() override;
+
+protected:
+  explicit ContextGL(BACKENDTYPE backendType);
 
 private:
   void initState();


### PR DESCRIPTION
This is a preparation for deprecating the usage of dawn_bindings. To achieve that, we will add one .cpp file for the dawn_vulkan and dawn_d3d12 backend, and one .mm file for the dawn_metal backend. Each backend will be implemented as a subclass of ContextDawn then and instantiated with the factory pattern.

**This pull request is opened using a shared GitHub account. Please find the actual author in the git log, and use "Rebase and merge" for correct attribution. The author may have no access to this account, so please do not assume there will be replies from a real human. But you can still leave a comment, and code will be updated here once addressed. - Your Sincere Bot**
