### PR TITLE
Create backend contexts via helpers

### DIFF
--- a/src/aquarium-optimized/ContextFactory.cpp
+++ b/src/aquarium-optimized/ContextFactory.cpp
@@ -25,19 +25,19 @@ ContextFactory::~ContextFactory() {
 Context *ContextFactory::createContext(BACKENDTYPE backendType) {
   if (backendType & BACKENDTYPE::BACKENDTYPEANGLE) {
 #if defined(ENABLE_ANGLE_BACKEND)
-    mContext = new ContextGL(backendType);
+    mContext = ContextGL::create(backendType);
 #endif
   } else if (backendType & BACKENDTYPE::BACKENDTYPEDAWN) {
 #if defined(ENABLE_DAWN_BACKEND)
-      mContext = new ContextDawn(backendType);
+      mContext = ContextDawn::create(backendType);
 #endif
   } else if (backendType & BACKENDTYPE::BACKENDTYPED3D12) {
 #if defined(ENABLE_D3D12_BACKEND)
-      mContext = new ContextD3D12(backendType);
+      mContext = ContextD3D12::create(backendType);
 #endif
   } else if (backendType & BACKENDTYPE::BACKENDTYPEOPENGL) {
 #if defined(ENABLE_OPENGL_BACKEND)
-    mContext = new ContextGL(backendType);
+    mContext = ContextGL::create(backendType);
 #endif
   }
   return mContext;

--- a/src/aquarium-optimized/d3d12/ContextD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.cpp
@@ -78,6 +78,10 @@ ContextD3D12::~ContextD3D12() {
   destoryFishResource();
 }
 
+ContextD3D12 *ContextD3D12::create(BACKENDTYPE backendType) {
+  return new ContextD3D12(backendType);
+}
+
 bool ContextD3D12::initialize(
     BACKENDTYPE backend,
     const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset,

--- a/src/aquarium-optimized/d3d12/ContextD3D12.h
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.h
@@ -21,8 +21,10 @@ constexpr int cbvsrvCount = 88;
 
 class ContextD3D12 : public Context {
 public:
-  ContextD3D12(BACKENDTYPE backendType);
-  ~ContextD3D12();
+  static ContextD3D12 *create(BACKENDTYPE backendType);
+
+  ~ContextD3D12() override;
+
   bool initialize(
       BACKENDTYPE backend,
       const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset,
@@ -148,6 +150,9 @@ public:
   ComPtr<ID3D12Resource> mFishPersBuffer;
   ComPtr<ID3D12Resource> stagingBuffer;
   FishPer *fishPers;
+
+protected:
+  explicit ContextD3D12(BACKENDTYPE backendType);
 
 private:
   bool GetHardwareAdapter(

--- a/src/aquarium-optimized/dawn/ContextDawn.cpp
+++ b/src/aquarium-optimized/dawn/ContextDawn.cpp
@@ -111,6 +111,23 @@ ContextDawn::~ContextDawn() {
   mDevice = nullptr;
 }
 
+ContextDawn *ContextDawn::create(BACKENDTYPE backendType) {
+  if (backendType & BACKENDTYPE::BACKENDTYPED3D12) {
+#ifdef DAWN_ENABLE_BACKEND_D3D12
+    return new ContextDawn(backendType);
+#endif
+  } else if (backendType & BACKENDTYPE::BACKENDTYPEMETAL) {
+#ifdef DAWN_ENABLE_BACKEND_METAL
+    return new ContextDawn(backendType);
+#endif
+  } else if (backendType & BACKENDTYPE::BACKENDTYPEVULKAN) {
+#ifdef DAWN_ENABLE_BACKEND_VULKAN
+    return new ContextDawn(backendType);
+#endif
+  }
+  return nullptr;
+}
+
 bool ContextDawn::initialize(
     BACKENDTYPE backend,
     const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset,

--- a/src/aquarium-optimized/dawn/ContextDawn.h
+++ b/src/aquarium-optimized/dawn/ContextDawn.h
@@ -31,8 +31,10 @@ class BufferManagerDawn;
 
 class ContextDawn : public Context {
 public:
-  ContextDawn(BACKENDTYPE backendType);
-  ~ContextDawn();
+  static ContextDawn *create(BACKENDTYPE backendType);
+
+  ~ContextDawn() override;
+
   bool initialize(
       BACKENDTYPE backend,
       const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset,
@@ -151,6 +153,9 @@ public:
   FishPer *fishPers;
 
   wgpu::Device mDevice;
+
+protected:
+  explicit ContextDawn(BACKENDTYPE backendType);
 
 private:
   bool GetHardwareAdapter(

--- a/src/aquarium-optimized/opengl/ContextGL.cpp
+++ b/src/aquarium-optimized/opengl/ContextGL.cpp
@@ -42,6 +42,10 @@ ContextGL::~ContextGL() {
   }
 }
 
+ContextGL *ContextGL::create(BACKENDTYPE backendType) {
+  return new ContextGL(backendType);
+}
+
 bool ContextGL::initialize(
     BACKENDTYPE backend,
     const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset,

--- a/src/aquarium-optimized/opengl/ContextGL.h
+++ b/src/aquarium-optimized/opengl/ContextGL.h
@@ -34,8 +34,10 @@ class TextureGL;
 
 class ContextGL : public Context {
 public:
-  ContextGL(BACKENDTYPE backendType);
-  ~ContextGL();
+  static ContextGL *create(BACKENDTYPE backendType);
+
+  ~ContextGL() override;
+
   bool initialize(
       BACKENDTYPE backend,
       const std::bitset<static_cast<size_t>(TOGGLE::TOGGLEMAX)> &toggleBitset,
@@ -109,6 +111,9 @@ public:
   void setParameter(unsigned int target, unsigned int pname, int param);
   void generateMipmap(unsigned int target);
   void updateAllFishData() override;
+
+protected:
+  explicit ContextGL(BACKENDTYPE backendType);
 
 private:
   void initState();


### PR DESCRIPTION
This is a preparation for deprecating the usage of dawn_bindings, and a following patch will implement the complexity of window system binding. Depending on the backend, ContextDawn will be sub-classed in a .cpp or .mm file, and instantiated with the factory pattern.
