### PR TITLE
Clean up forward declarations

### DIFF
--- a/src/aquarium-direct-map/Globals.h
+++ b/src/aquarium-direct-map/Globals.h
@@ -29,8 +29,8 @@ const std::string slash = "\\";
 const std::string slash = "/";
 #endif
 
-class Scene;
 class Program;
+class Scene;
 class Texture;
 
 static FPSTimer g_fpsTimer;  // object to measure frames per second;

--- a/src/aquarium-optimized/Aquarium.h
+++ b/src/aquarium-optimized/Aquarium.h
@@ -19,11 +19,11 @@
 #include "Behavior.h"
 #include "common/FPSTimer.h"
 
-class ContextFactory;
 class Context;
-class Texture;
-class Program;
+class ContextFactory;
 class Model;
+class Program;
+class Texture;
 
 #if defined(OS_WIN)
 #define M_PI 3.141592653589793

--- a/src/aquarium-optimized/Behavior.h
+++ b/src/aquarium-optimized/Behavior.h
@@ -10,8 +10,6 @@
 
 #include <string>
 
-enum UNIFORMNAME : short;
-
 class Behavior {
 public:
   Behavior() {}

--- a/src/aquarium-optimized/Context.h
+++ b/src/aquarium-optimized/Context.h
@@ -17,12 +17,11 @@
 #include "common/FPSTimer.h"
 
 class Aquarium;
-class Program;
 class Buffer;
-class Texture;
 class Model;
+class Program;
+class Texture;
 
-struct Global;
 static char fishCountInputBuffer[64];
 
 class Context {

--- a/src/aquarium-optimized/ContextFactory.h
+++ b/src/aquarium-optimized/ContextFactory.h
@@ -10,6 +10,7 @@
 #include "Aquarium.h"
 
 class Context;
+
 class ContextFactory {
 public:
   ContextFactory();

--- a/src/aquarium-optimized/Model.h
+++ b/src/aquarium-optimized/Model.h
@@ -16,14 +16,13 @@
 
 #include "Aquarium.h"
 
-class Program;
-class Context;
-class Texture;
 class Buffer;
+class Program;
+class Texture;
+struct WorldUniforms;
 
 enum MODELGROUP : short;
 enum MODELNAME : short;
-struct WorldUniforms;
 
 class Model {
 public:

--- a/src/aquarium-optimized/Program.h
+++ b/src/aquarium-optimized/Program.h
@@ -10,8 +10,6 @@
 
 #include <string>
 
-enum UNIFORMNAME : short;
-
 class Program {
 public:
   Program() {}

--- a/src/aquarium-optimized/dawn/ContextDawn.h
+++ b/src/aquarium-optimized/dawn/ContextDawn.h
@@ -23,11 +23,8 @@
 #include "../Context.h"
 #include "BufferManagerDawn.h"
 
-class TextureDawn;
-class BufferDawn;
-class ProgramDawn;
-class RingBufferDawn;
 class BufferManagerDawn;
+class ProgramDawn;
 
 class ContextDawn : public Context {
 public:

--- a/src/aquarium-optimized/dawn/FishModelDawn.h
+++ b/src/aquarium-optimized/dawn/FishModelDawn.h
@@ -14,8 +14,6 @@
 #include "ContextDawn.h"
 #include "ProgramDawn.h"
 
-struct FishPer;
-
 class FishModelDawn : public FishModel {
 public:
   FishModelDawn(Context *context,


### PR DESCRIPTION
Unreferenced forward declarations are deleted if no build error will be triggered. The remaining ones are sorted alphabetically.
