### PR TITLE
Prefer to centralize the definition of GLFW_EXPOSE_NATIVE_* in BUILD.gn

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -66,6 +66,15 @@ executable("aquarium") {
     "CXXOPTS_NO_EXCEPTIONS",
     "CXXOPTS_NO_RTTI",
   ]
+  if (is_win) {
+    defines += [ "GLFW_EXPOSE_NATIVE_WIN32" ]
+  }
+  if (is_linux && !is_chromeos) {
+    defines += [ "GLFW_EXPOSE_NATIVE_X11" ]
+  }
+  if (is_mac) {
+    defines += [ "GLFW_EXPOSE_NATIVE_COCOA" ]
+  }
 
   if (enable_angle || enable_opengl) {
     sources += [

--- a/src/aquarium-optimized/d3d12/ContextD3D12.cpp
+++ b/src/aquarium-optimized/d3d12/ContextD3D12.cpp
@@ -9,9 +9,7 @@
 #include <iostream>
 #include <sstream>
 
-#define GLFW_EXPOSE_NATIVE_WIN32
 #include "GLFW/glfw3native.h"
-
 #include "imgui.h"
 #include "imgui_impl_glfw.h"
 

--- a/src/aquarium-optimized/opengl/ContextGL.cpp
+++ b/src/aquarium-optimized/opengl/ContextGL.cpp
@@ -16,7 +16,6 @@
 #include "imgui_impl_glfw.h"
 
 #ifdef EGL_EGL_PROTOTYPES
-#define GLFW_EXPOSE_NATIVE_WIN32
 #include "GLFW/glfw3native.h"
 #endif
 


### PR DESCRIPTION
Suppose glfw3native.h is included by multiple files, this avoids defining them again and again.
