### PR TITLE
Expose Vulkan WSI extensions for future use

### DIFF
--- a/src/aquarium-optimized/dawn/ContextDawn.h
+++ b/src/aquarium-optimized/dawn/ContextDawn.h
@@ -8,6 +8,23 @@
 #ifndef CONTEXTDAWN_H
 #define CONTEXTDAWN_H
 
+#ifdef GLFW_EXPOSE_NATIVE_X11
+// workaround conflict between poorly named X macro and 3rd-party code
+#include <X11/X.h>
+#undef None
+#undef Success
+#undef Always
+#endif
+
+#ifdef DAWN_ENABLE_BACKEND_VULKAN
+#ifdef GLFW_EXPOSE_NATIVE_WIN32
+#define VK_USE_PLATFORM_WIN32_KHR
+#endif
+#ifdef GLFW_EXPOSE_NATIVE_X11
+#define VK_USE_PLATFORM_XCB_KHR
+#define VK_USE_PLATFORM_XLIB_KHR
+#endif
+#endif
 #ifdef DAWN_ENABLE_BACKEND_VULKAN
 // The Vulkan header is included by VulkanBackend.h, so this should be placed
 // before the GLFW header.


### PR DESCRIPTION
Once dawn_bindings is gone, Vulkan WSI extensions will be required for creating swapchains from native windows.

The VK_USE_PLATFORM_*_KHR macros must be set before the first vulkan.h of each compilation unit, either it's included directly or indirectly. To ensure that, the rule of thumb is to put those defines just before the 3rd-party includes, when any following 3rd-party header potentially uses vulkan.h. For now, the only known user of vulkan.h is VulkanBackend.h.

The X.h workaround is needed anywhere X.h is included by a 3rd-party header. These keywords can be used to find such places:

VK_USE_PLATFORM_XLIB_KHR
glfw3native.h

And here happens to be the first hit.
