### PR TITLE
Temporarily revert ba8af515dd61137893d78c445ef43e5c5405c78c

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@ vars = {
   'chromium_git': 'https://chromium.googlesource.com',
   'github_git': 'https://github.com',
   'dawn_git': 'https://dawn.googlesource.com',
-  'dawn_revision': '8575cb3ec773d43a86fe68eece70ae02cad6cfc5',
+  'dawn_revision': 'c4c4ff9eb4b51ec22f8608e7f2ef8028ad57f367',
   'angle_root': 'third_party/angle',
   'angle_revision': '6c824a1bc17b286b86cf05a0228ec549875351eb',
   'glslang_revision': 'b5f003d7a3ece37db45578a8a3140b370036fc64',

--- a/src/aquarium-optimized/dawn/ContextDawn.cpp
+++ b/src/aquarium-optimized/dawn/ContextDawn.cpp
@@ -387,6 +387,8 @@ wgpu::BufferCopyView ContextDawn::createBufferCopyView(
   bufferCopyView.layout.bytesPerRow = bytesPerRow;
   bufferCopyView.layout.rowsPerImage = rowsPerImage;
   bufferCopyView.buffer = buffer;
+  bufferCopyView.bytesPerRow = 0;  // This field is deprecated, but it must be
+                                   // zero-initialized to pass Dawn validation.
 
   return bufferCopyView;
 }
@@ -399,7 +401,6 @@ wgpu::TextureCopyView ContextDawn::createTextureCopyView(
   textureCopyView.texture = texture;
   textureCopyView.mipLevel = level;
   textureCopyView.origin = origin;
-  textureCopyView.aspect = wgpu::TextureAspect::All;
 
   return textureCopyView;
 }

--- a/src/aquarium-optimized/dawn/FishModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/FishModelDawn.cpp
@@ -95,6 +95,7 @@ void FishModelDawn::init() {
   mVertexStateDescriptor.vertexBufferCount =
       static_cast<uint32_t>(vertexBufferLayoutDescriptor.size());
   mVertexStateDescriptor.vertexBuffers = vertexBufferLayoutDescriptor.data();
+  mVertexStateDescriptor.indexFormat = wgpu::IndexFormat::Uint16;
 
   if (mSkyboxTexture && mReflectionTexture) {
     mGroupLayoutModel = mContextDawn->MakeBindGroupLayout({
@@ -193,8 +194,7 @@ void FishModelDawn::draw() {
   pass.SetVertexBuffer(2, mTexCoordBuffer->getBuffer());
   pass.SetVertexBuffer(3, mTangentBuffer->getBuffer());
   pass.SetVertexBuffer(4, mBiNormalBuffer->getBuffer());
-  pass.SetIndexBufferWithFormat(mIndicesBuffer->getBuffer(),
-                                wgpu::IndexFormat::Uint16, 0);
+  pass.SetIndexBuffer(mIndicesBuffer->getBuffer(), 0);
 
   if (mEnableDynamicBufferOffset) {
     for (int i = 0; i < mCurInstance; i++) {

--- a/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.cpp
+++ b/src/aquarium-optimized/dawn/FishModelInstancedDrawDawn.cpp
@@ -118,6 +118,7 @@ void FishModelInstancedDrawDawn::init() {
   mVertexStateDescriptor.vertexBufferCount =
       static_cast<uint32_t>(vertexBufferLayoutDescriptor.size());
   mVertexStateDescriptor.vertexBuffers = vertexBufferLayoutDescriptor.data();
+  mVertexStateDescriptor.indexFormat = wgpu::IndexFormat::Uint16;
 
   if (mSkyboxTexture && mReflectionTexture) {
     mGroupLayoutModel = mContextDawn->MakeBindGroupLayout({
@@ -226,8 +227,7 @@ void FishModelInstancedDrawDawn::draw() {
   pass.SetVertexBuffer(3, mTangentBuffer->getBuffer());
   pass.SetVertexBuffer(4, mBiNormalBuffer->getBuffer());
   pass.SetVertexBuffer(5, mFishPersBuffer);
-  pass.SetIndexBufferWithFormat(mIndicesBuffer->getBuffer(),
-                                wgpu::IndexFormat::Uint16, 0);
+  pass.SetIndexBuffer(mIndicesBuffer->getBuffer(), 0);
   pass.DrawIndexed(mIndicesBuffer->getTotalComponents(), instance, 0, 0, 0);
 }
 

--- a/src/aquarium-optimized/dawn/GenericModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/GenericModelDawn.cpp
@@ -132,6 +132,7 @@ void GenericModelDawn::init() {
   mVertexStateDescriptor.vertexBufferCount =
       static_cast<uint32_t>(vertexBufferLayoutDescriptor.size());
   mVertexStateDescriptor.vertexBuffers = vertexBufferLayoutDescriptor.data();
+  mVertexStateDescriptor.indexFormat = wgpu::IndexFormat::Uint16;
 
   if (mSkyboxTexture && mReflectionTexture &&
       mName != MODELNAME::MODELGLOBEBASE) {
@@ -259,8 +260,7 @@ void GenericModelDawn::draw() {
     pass.SetVertexBuffer(3, mTangentBuffer->getBuffer());
     pass.SetVertexBuffer(4, mBiNormalBuffer->getBuffer());
   }
-  pass.SetIndexBufferWithFormat(mIndicesBuffer->getBuffer(),
-                                wgpu::IndexFormat::Uint16, 0);
+  pass.SetIndexBuffer(mIndicesBuffer->getBuffer(), 0);
   pass.DrawIndexed(mIndicesBuffer->getTotalComponents(), instance, 0, 0, 0);
   instance = 0;
 }

--- a/src/aquarium-optimized/dawn/InnerModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/InnerModelDawn.cpp
@@ -92,6 +92,7 @@ void InnerModelDawn::init() {
   mVertexStateDescriptor.vertexBufferCount =
       static_cast<uint32_t>(vertexBufferLayoutDescriptor.size());
   mVertexStateDescriptor.vertexBuffers = vertexBufferLayoutDescriptor.data();
+  mVertexStateDescriptor.indexFormat = wgpu::IndexFormat::Uint16;
 
   mGroupLayoutModel = mContextDawn->MakeBindGroupLayout({
       {0, wgpu::ShaderStage::Fragment, wgpu::BindingType::UniformBuffer},
@@ -173,8 +174,7 @@ void InnerModelDawn::draw() {
   pass.SetVertexBuffer(2, mTexCoordBuffer->getBuffer());
   pass.SetVertexBuffer(3, mTangentBuffer->getBuffer());
   pass.SetVertexBuffer(4, mBiNormalBuffer->getBuffer());
-  pass.SetIndexBufferWithFormat(mIndicesBuffer->getBuffer(),
-                                wgpu::IndexFormat::Uint16, 0);
+  pass.SetIndexBuffer(mIndicesBuffer->getBuffer(), 0);
   pass.DrawIndexed(mIndicesBuffer->getTotalComponents(), 1, 0, 0, 0);
 }
 

--- a/src/aquarium-optimized/dawn/OutsideModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/OutsideModelDawn.cpp
@@ -90,6 +90,7 @@ void OutsideModelDawn::init() {
   mVertexStateDescriptor.vertexBufferCount =
       static_cast<uint32_t>(vertexBufferLayoutDescriptor.size());
   mVertexStateDescriptor.vertexBuffers = vertexBufferLayoutDescriptor.data();
+  mVertexStateDescriptor.indexFormat = wgpu::IndexFormat::Uint16;
 
   mGroupLayoutPer = mContextDawn->MakeBindGroupLayout({
       {0, wgpu::ShaderStage::Vertex, wgpu::BindingType::UniformBuffer},
@@ -163,8 +164,7 @@ void OutsideModelDawn::draw() {
     pass.SetVertexBuffer(3, mTangentBuffer->getBuffer());
     pass.SetVertexBuffer(4, mBiNormalBuffer->getBuffer());
   }
-  pass.SetIndexBufferWithFormat(mIndicesBuffer->getBuffer(),
-                                wgpu::IndexFormat::Uint16, 0);
+  pass.SetIndexBuffer(mIndicesBuffer->getBuffer(), 0);
   pass.DrawIndexed(mIndicesBuffer->getTotalComponents(), 1, 0, 0, 0);
 }
 

--- a/src/aquarium-optimized/dawn/SeaweedModelDawn.cpp
+++ b/src/aquarium-optimized/dawn/SeaweedModelDawn.cpp
@@ -77,6 +77,7 @@ void SeaweedModelDawn::init() {
   mVertexStateDescriptor.vertexBufferCount =
       static_cast<uint32_t>(vertexBufferLayoutDescriptor.size());
   mVertexStateDescriptor.vertexBuffers = vertexBufferLayoutDescriptor.data();
+  mVertexStateDescriptor.indexFormat = wgpu::IndexFormat::Uint16;
 
   mGroupLayoutModel = mContextDawn->MakeBindGroupLayout({
       {0, wgpu::ShaderStage::Fragment, wgpu::BindingType::UniformBuffer},
@@ -164,8 +165,7 @@ void SeaweedModelDawn::draw() {
   pass.SetVertexBuffer(0, mPositionBuffer->getBuffer());
   pass.SetVertexBuffer(1, mNormalBuffer->getBuffer());
   pass.SetVertexBuffer(2, mTexCoordBuffer->getBuffer());
-  pass.SetIndexBufferWithFormat(mIndicesBuffer->getBuffer(),
-                                wgpu::IndexFormat::Uint16, 0);
+  pass.SetIndexBuffer(mIndicesBuffer->getBuffer(), 0);
   pass.DrawIndexed(mIndicesBuffer->getTotalComponents(), instance, 0, 0, 0);
   instance = 0;
 }

--- a/src/aquarium-optimized/dawn/imgui_impl_dawn.cpp
+++ b/src/aquarium-optimized/dawn/imgui_impl_dawn.cpp
@@ -68,7 +68,7 @@ static void ImGui_ImplDawn_SetupRenderState(ImDrawData *draw_data,
     pass.SetPipeline(mPipeline);
     pass.SetBindGroup(0, mBindGroup, 0, nullptr);
     pass.SetVertexBuffer(0, mVertexBuffer);
-    pass.SetIndexBufferWithFormat(mIndexBuffer, wgpu::IndexFormat::Uint16, 0);
+    pass.SetIndexBuffer(mIndexBuffer, 0);
 }
 
 // Render function
@@ -278,6 +278,7 @@ bool ImGui_ImplDawn_CreateDeviceObjects(int MSAASampleCount, bool enableAlphaBle
     mVertexStateDescriptor.vertexBufferCount =
         static_cast<uint32_t>(vertexBufferLayoutDescriptor.size());
     mVertexStateDescriptor.vertexBuffers = vertexBufferLayoutDescriptor.data();
+    mVertexStateDescriptor.indexFormat   = wgpu::IndexFormat::Uint16;
 
     // Create bind group layout
     wgpu::BindGroupLayout layout = mContextDawn->MakeBindGroupLayout(


### PR DESCRIPTION
The plan is to have revisions of 3rd-parties always derived from Chromium, so they are known to work nicely together. Considering Abseil becomes a hard dependency of GoogleTest in latest Chromium, which supersedes cxxopts, relying on both sounds awkward then. But to avoid doing too much in one step, it's highly desired to separate the cxxopts removal from the other overhaul. As a result, a carefully chosen range of Chromium revisions comes out, and that in turn requires the roll-back here.
