### PR TITLE
Use std::chrono where appropriate

### DIFF
--- a/src/aquarium-optimized/Aquarium.h
+++ b/src/aquarium-optimized/Aquarium.h
@@ -10,6 +10,7 @@
 #define AQUARIUM_H
 
 #include <bitset>
+#include <chrono>
 #include <queue>
 #include <string>
 #include <unordered_map>
@@ -441,8 +442,8 @@ struct Global {
   float m4t2[16];
   float m4t3[16];
   float colorMult[4] = {1, 1, 1, 1};
-  double then;
-  double start;
+  std::chrono::steady_clock::time_point start;
+  std::chrono::steady_clock::time_point then;
   float mclock;
   float eyeClock;
   std::string alpha;
@@ -514,7 +515,7 @@ private:
   void updateGlobalUniforms();
 
   BACKENDTYPE getBackendType(const std::string &backendPath);
-  double getElapsedTime();
+  std::chrono::steady_clock::duration getElapsedTime();
   void printAvgFps();
   void resetFpsTime();
   void updateAndDraw();

--- a/src/common/FPSTimer.cpp
+++ b/src/common/FPSTimer.cpp
@@ -13,15 +13,17 @@
 #include "AQUARIUM_ASSERT.h"
 
 FPSTimer::FPSTimer()
-    : mTotalTime(static_cast<double>(NUM_FRAMES_TO_AVERAGE)),
-      mTimeTable(NUM_FRAMES_TO_AVERAGE, 1.0f),
+    : mTotalTime(millisecondToDuration(NUM_FRAMES_TO_AVERAGE * 1000)),
+      mTimeTable(NUM_FRAMES_TO_AVERAGE, millisecondToDuration(1000)),
       mTimeTableCursor(0),
       mHistoryFPS(NUM_HISTORY_DATA, 1.0f),
       mHistoryFrameTime(NUM_HISTORY_DATA, 100.0f),
       mAverageFPS(0.0) {
 }
 
-void FPSTimer::update(double elapsedTime, double renderingTime, int testTime) {
+void FPSTimer::update(Duration elapsedTime,
+                      Duration renderingTime,
+                      Duration testTime) {
   mTotalTime += elapsedTime - mTimeTable[mTimeTableCursor];
   mTimeTable[mTimeTableCursor] = elapsedTime;
 
@@ -30,8 +32,8 @@ void FPSTimer::update(double elapsedTime, double renderingTime, int testTime) {
     mTimeTableCursor = 0;
   }
 
-  mAverageFPS = floor(
-      (1.0f / (mTotalTime / static_cast<double>(NUM_FRAMES_TO_AVERAGE))) + 0.5);
+  Duration frameTime = mTotalTime / NUM_FRAMES_TO_AVERAGE;
+  mAverageFPS = floor(1000.0 / durationToMillisecond<double>(frameTime) + 0.5);
 
   for (int i = 0; i < NUM_HISTORY_DATA - 1; i++) {
     mHistoryFPS[i] = mHistoryFPS[i + 1];
@@ -40,7 +42,8 @@ void FPSTimer::update(double elapsedTime, double renderingTime, int testTime) {
   mHistoryFPS[NUM_HISTORY_DATA - 1] = mAverageFPS;
   mHistoryFrameTime[NUM_HISTORY_DATA - 1] = 1000.0 / mAverageFPS;
 
-  if (testTime - renderingTime > 5 && testTime - renderingTime < 25) {
+  if (testTime - renderingTime > millisecondToDuration(5000) &&
+      testTime - renderingTime < millisecondToDuration(25000)) {
     mLogFPS.push_back(mAverageFPS);
   }
 }


### PR DESCRIPTION
* clock() returns processor time, which is a nonsense for FPS calculation and it also causes inconsistent fish speed on different backends.

* Time duration arithmetics are now primarily performed in integral/fixed-point-like manners, which perhaps sounds better than floats from precision and performance perspectives.

* std::chrono also brings the benefit of sharing the same interface among OSes.
