### PR TITLE
"Narrow cast" total execution time when checking against the deadline

### DIFF
--- a/src/aquarium-optimized/Aquarium.cpp
+++ b/src/aquarium-optimized/Aquarium.cpp
@@ -362,10 +362,6 @@ bool Aquarium::init(int argc, char **argv) {
     toggleBitset.set(static_cast<size_t>(TOGGLE::SIMULATINGFISHCOMEANDGO));
   }
 
-  if (result.count("test-time")) {
-    toggleBitset.set(static_cast<size_t>(TOGGLE::AUTOSTOP));
-  }
-
   if (result.count("turn-off-vsync")) {
     if (!availableToggleBitset.test(
             static_cast<size_t>(TOGGLE::TURNOFFVSYNC))) {
@@ -436,8 +432,7 @@ void Aquarium::display() {
     auto totalTime = std::chrono::duration_cast<
         std::chrono::duration<std::chrono::steady_clock::duration::rep>>(
         g.then - g.start);
-    if (toggleBitset.test(static_cast<size_t>(TOGGLE::AUTOSTOP)) &&
-        totalTime.count() > mTestTime) {
+    if ((totalTime.count() & INT_MAX) > mTestTime) {
       break;
     }
   }

--- a/src/aquarium-optimized/Aquarium.h
+++ b/src/aquarium-optimized/Aquarium.h
@@ -114,8 +114,6 @@ struct G_sceneInfo {
 enum FISHENUM : short { BIG, MEDIUM, SMALL, MAX };
 
 enum TOGGLE : short {
-  // Stop rendering after specified time
-  AUTOSTOP,
   // Enable alpha blending
   ENABLEALPHABLENDING,
   // Go through instanced draw


### PR DESCRIPTION
This saves the need for the AUTOSTOP toggle, with no perceptible behavior change in 99.9% cases:

* If --test-time is not given, then it defaults to INT_MAX, so the test always fails and Aquarium will keep running forever.

* If --test-time is given but the user-specified value is far less than INT_MAX seconds (≈ 68 years), Aquarium should quit automatically as it used to do.
